### PR TITLE
Cache the regularized form of union types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13457,9 +13457,13 @@ namespace ts {
             return type;
         }
 
+        function getRegularTypeOfUnion(type: UnionType) {
+            return type.regularType || (type.regularType = getUnionType(sameMap((<UnionType>type).types, getRegularTypeOfLiteralType)) as UnionType);
+        }
+
         function getRegularTypeOfLiteralType(type: Type): Type {
             return type.flags & TypeFlags.Literal ? (<LiteralType>type).regularType :
-                type.flags & TypeFlags.Union ? getUnionType(sameMap((<UnionType>type).types, getRegularTypeOfLiteralType)) :
+                type.flags & TypeFlags.Union ? getRegularTypeOfUnion(<UnionType>type) :
                 type;
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13457,13 +13457,9 @@ namespace ts {
             return type;
         }
 
-        function getRegularTypeOfUnion(type: UnionType) {
-            return type.regularType || (type.regularType = getUnionType(sameMap((<UnionType>type).types, getRegularTypeOfLiteralType)) as UnionType);
-        }
-
         function getRegularTypeOfLiteralType(type: Type): Type {
             return type.flags & TypeFlags.Literal ? (<LiteralType>type).regularType :
-                type.flags & TypeFlags.Union ? getRegularTypeOfUnion(<UnionType>type) :
+                type.flags & TypeFlags.Union ? ((<UnionType>type).regularType || ((<UnionType>type).regularType = getUnionType(sameMap((<UnionType>type).types, getRegularTypeOfLiteralType)) as UnionType)) :
                 type;
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4651,6 +4651,8 @@ namespace ts {
     export interface UnionType extends UnionOrIntersectionType {
         /* @internal */
         resolvedReducedType: Type;
+        /* @internal */
+        regularType: UnionType;
     }
 
     export interface IntersectionType extends UnionOrIntersectionType {

--- a/tests/baselines/reference/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.js
+++ b/tests/baselines/reference/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.js
@@ -1,0 +1,8022 @@
+//// [conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts]
+type BigUnion =
+    {
+        name: '0';
+        children: BigUnion[];
+    } |
+    {
+        name: '1';
+        children: BigUnion[];
+    } |
+    {
+        name: '2';
+        children: BigUnion[];
+    } |
+    {
+        name: '3';
+        children: BigUnion[];
+    } |
+    {
+        name: '4';
+        children: BigUnion[];
+    } |
+    {
+        name: '5';
+        children: BigUnion[];
+    } |
+    {
+        name: '6';
+        children: BigUnion[];
+    } |
+    {
+        name: '7';
+        children: BigUnion[];
+    } |
+    {
+        name: '8';
+        children: BigUnion[];
+    } |
+    {
+        name: '9';
+        children: BigUnion[];
+    } |
+    {
+        name: '10';
+        children: BigUnion[];
+    } |
+    {
+        name: '11';
+        children: BigUnion[];
+    } |
+    {
+        name: '12';
+        children: BigUnion[];
+    } |
+    {
+        name: '13';
+        children: BigUnion[];
+    } |
+    {
+        name: '14';
+        children: BigUnion[];
+    } |
+    {
+        name: '15';
+        children: BigUnion[];
+    } |
+    {
+        name: '16';
+        children: BigUnion[];
+    } |
+    {
+        name: '17';
+        children: BigUnion[];
+    } |
+    {
+        name: '18';
+        children: BigUnion[];
+    } |
+    {
+        name: '19';
+        children: BigUnion[];
+    } |
+    {
+        name: '20';
+        children: BigUnion[];
+    } |
+    {
+        name: '21';
+        children: BigUnion[];
+    } |
+    {
+        name: '22';
+        children: BigUnion[];
+    } |
+    {
+        name: '23';
+        children: BigUnion[];
+    } |
+    {
+        name: '24';
+        children: BigUnion[];
+    } |
+    {
+        name: '25';
+        children: BigUnion[];
+    } |
+    {
+        name: '26';
+        children: BigUnion[];
+    } |
+    {
+        name: '27';
+        children: BigUnion[];
+    } |
+    {
+        name: '28';
+        children: BigUnion[];
+    } |
+    {
+        name: '29';
+        children: BigUnion[];
+    } |
+    {
+        name: '30';
+        children: BigUnion[];
+    } |
+    {
+        name: '31';
+        children: BigUnion[];
+    } |
+    {
+        name: '32';
+        children: BigUnion[];
+    } |
+    {
+        name: '33';
+        children: BigUnion[];
+    } |
+    {
+        name: '34';
+        children: BigUnion[];
+    } |
+    {
+        name: '35';
+        children: BigUnion[];
+    } |
+    {
+        name: '36';
+        children: BigUnion[];
+    } |
+    {
+        name: '37';
+        children: BigUnion[];
+    } |
+    {
+        name: '38';
+        children: BigUnion[];
+    } |
+    {
+        name: '39';
+        children: BigUnion[];
+    } |
+    {
+        name: '40';
+        children: BigUnion[];
+    } |
+    {
+        name: '41';
+        children: BigUnion[];
+    } |
+    {
+        name: '42';
+        children: BigUnion[];
+    } |
+    {
+        name: '43';
+        children: BigUnion[];
+    } |
+    {
+        name: '44';
+        children: BigUnion[];
+    } |
+    {
+        name: '45';
+        children: BigUnion[];
+    } |
+    {
+        name: '46';
+        children: BigUnion[];
+    } |
+    {
+        name: '47';
+        children: BigUnion[];
+    } |
+    {
+        name: '48';
+        children: BigUnion[];
+    } |
+    {
+        name: '49';
+        children: BigUnion[];
+    } |
+    {
+        name: '50';
+        children: BigUnion[];
+    } |
+    {
+        name: '51';
+        children: BigUnion[];
+    } |
+    {
+        name: '52';
+        children: BigUnion[];
+    } |
+    {
+        name: '53';
+        children: BigUnion[];
+    } |
+    {
+        name: '54';
+        children: BigUnion[];
+    } |
+    {
+        name: '55';
+        children: BigUnion[];
+    } |
+    {
+        name: '56';
+        children: BigUnion[];
+    } |
+    {
+        name: '57';
+        children: BigUnion[];
+    } |
+    {
+        name: '58';
+        children: BigUnion[];
+    } |
+    {
+        name: '59';
+        children: BigUnion[];
+    } |
+    {
+        name: '60';
+        children: BigUnion[];
+    } |
+    {
+        name: '61';
+        children: BigUnion[];
+    } |
+    {
+        name: '62';
+        children: BigUnion[];
+    } |
+    {
+        name: '63';
+        children: BigUnion[];
+    } |
+    {
+        name: '64';
+        children: BigUnion[];
+    } |
+    {
+        name: '65';
+        children: BigUnion[];
+    } |
+    {
+        name: '66';
+        children: BigUnion[];
+    } |
+    {
+        name: '67';
+        children: BigUnion[];
+    } |
+    {
+        name: '68';
+        children: BigUnion[];
+    } |
+    {
+        name: '69';
+        children: BigUnion[];
+    } |
+    {
+        name: '70';
+        children: BigUnion[];
+    } |
+    {
+        name: '71';
+        children: BigUnion[];
+    } |
+    {
+        name: '72';
+        children: BigUnion[];
+    } |
+    {
+        name: '73';
+        children: BigUnion[];
+    } |
+    {
+        name: '74';
+        children: BigUnion[];
+    } |
+    {
+        name: '75';
+        children: BigUnion[];
+    } |
+    {
+        name: '76';
+        children: BigUnion[];
+    } |
+    {
+        name: '77';
+        children: BigUnion[];
+    } |
+    {
+        name: '78';
+        children: BigUnion[];
+    } |
+    {
+        name: '79';
+        children: BigUnion[];
+    } |
+    {
+        name: '80';
+        children: BigUnion[];
+    } |
+    {
+        name: '81';
+        children: BigUnion[];
+    } |
+    {
+        name: '82';
+        children: BigUnion[];
+    } |
+    {
+        name: '83';
+        children: BigUnion[];
+    } |
+    {
+        name: '84';
+        children: BigUnion[];
+    } |
+    {
+        name: '85';
+        children: BigUnion[];
+    } |
+    {
+        name: '86';
+        children: BigUnion[];
+    } |
+    {
+        name: '87';
+        children: BigUnion[];
+    } |
+    {
+        name: '88';
+        children: BigUnion[];
+    } |
+    {
+        name: '89';
+        children: BigUnion[];
+    } |
+    {
+        name: '90';
+        children: BigUnion[];
+    } |
+    {
+        name: '91';
+        children: BigUnion[];
+    } |
+    {
+        name: '92';
+        children: BigUnion[];
+    } |
+    {
+        name: '93';
+        children: BigUnion[];
+    } |
+    {
+        name: '94';
+        children: BigUnion[];
+    } |
+    {
+        name: '95';
+        children: BigUnion[];
+    } |
+    {
+        name: '96';
+        children: BigUnion[];
+    } |
+    {
+        name: '97';
+        children: BigUnion[];
+    } |
+    {
+        name: '98';
+        children: BigUnion[];
+    } |
+    {
+        name: '99';
+        children: BigUnion[];
+    } |
+    {
+        name: '100';
+        children: BigUnion[];
+    } |
+    {
+        name: '101';
+        children: BigUnion[];
+    } |
+    {
+        name: '102';
+        children: BigUnion[];
+    } |
+    {
+        name: '103';
+        children: BigUnion[];
+    } |
+    {
+        name: '104';
+        children: BigUnion[];
+    } |
+    {
+        name: '105';
+        children: BigUnion[];
+    } |
+    {
+        name: '106';
+        children: BigUnion[];
+    } |
+    {
+        name: '107';
+        children: BigUnion[];
+    } |
+    {
+        name: '108';
+        children: BigUnion[];
+    } |
+    {
+        name: '109';
+        children: BigUnion[];
+    } |
+    {
+        name: '110';
+        children: BigUnion[];
+    } |
+    {
+        name: '111';
+        children: BigUnion[];
+    } |
+    {
+        name: '112';
+        children: BigUnion[];
+    } |
+    {
+        name: '113';
+        children: BigUnion[];
+    } |
+    {
+        name: '114';
+        children: BigUnion[];
+    } |
+    {
+        name: '115';
+        children: BigUnion[];
+    } |
+    {
+        name: '116';
+        children: BigUnion[];
+    } |
+    {
+        name: '117';
+        children: BigUnion[];
+    } |
+    {
+        name: '118';
+        children: BigUnion[];
+    } |
+    {
+        name: '119';
+        children: BigUnion[];
+    } |
+    {
+        name: '120';
+        children: BigUnion[];
+    } |
+    {
+        name: '121';
+        children: BigUnion[];
+    } |
+    {
+        name: '122';
+        children: BigUnion[];
+    } |
+    {
+        name: '123';
+        children: BigUnion[];
+    } |
+    {
+        name: '124';
+        children: BigUnion[];
+    } |
+    {
+        name: '125';
+        children: BigUnion[];
+    } |
+    {
+        name: '126';
+        children: BigUnion[];
+    } |
+    {
+        name: '127';
+        children: BigUnion[];
+    } |
+    {
+        name: '128';
+        children: BigUnion[];
+    } |
+    {
+        name: '129';
+        children: BigUnion[];
+    } |
+    {
+        name: '130';
+        children: BigUnion[];
+    } |
+    {
+        name: '131';
+        children: BigUnion[];
+    } |
+    {
+        name: '132';
+        children: BigUnion[];
+    } |
+    {
+        name: '133';
+        children: BigUnion[];
+    } |
+    {
+        name: '134';
+        children: BigUnion[];
+    } |
+    {
+        name: '135';
+        children: BigUnion[];
+    } |
+    {
+        name: '136';
+        children: BigUnion[];
+    } |
+    {
+        name: '137';
+        children: BigUnion[];
+    } |
+    {
+        name: '138';
+        children: BigUnion[];
+    } |
+    {
+        name: '139';
+        children: BigUnion[];
+    } |
+    {
+        name: '140';
+        children: BigUnion[];
+    } |
+    {
+        name: '141';
+        children: BigUnion[];
+    } |
+    {
+        name: '142';
+        children: BigUnion[];
+    } |
+    {
+        name: '143';
+        children: BigUnion[];
+    } |
+    {
+        name: '144';
+        children: BigUnion[];
+    } |
+    {
+        name: '145';
+        children: BigUnion[];
+    } |
+    {
+        name: '146';
+        children: BigUnion[];
+    } |
+    {
+        name: '147';
+        children: BigUnion[];
+    } |
+    {
+        name: '148';
+        children: BigUnion[];
+    } |
+    {
+        name: '149';
+        children: BigUnion[];
+    } |
+    {
+        name: '150';
+        children: BigUnion[];
+    } |
+    {
+        name: '151';
+        children: BigUnion[];
+    } |
+    {
+        name: '152';
+        children: BigUnion[];
+    } |
+    {
+        name: '153';
+        children: BigUnion[];
+    } |
+    {
+        name: '154';
+        children: BigUnion[];
+    } |
+    {
+        name: '155';
+        children: BigUnion[];
+    } |
+    {
+        name: '156';
+        children: BigUnion[];
+    } |
+    {
+        name: '157';
+        children: BigUnion[];
+    } |
+    {
+        name: '158';
+        children: BigUnion[];
+    } |
+    {
+        name: '159';
+        children: BigUnion[];
+    } |
+    {
+        name: '160';
+        children: BigUnion[];
+    } |
+    {
+        name: '161';
+        children: BigUnion[];
+    } |
+    {
+        name: '162';
+        children: BigUnion[];
+    } |
+    {
+        name: '163';
+        children: BigUnion[];
+    } |
+    {
+        name: '164';
+        children: BigUnion[];
+    } |
+    {
+        name: '165';
+        children: BigUnion[];
+    } |
+    {
+        name: '166';
+        children: BigUnion[];
+    } |
+    {
+        name: '167';
+        children: BigUnion[];
+    } |
+    {
+        name: '168';
+        children: BigUnion[];
+    } |
+    {
+        name: '169';
+        children: BigUnion[];
+    } |
+    {
+        name: '170';
+        children: BigUnion[];
+    } |
+    {
+        name: '171';
+        children: BigUnion[];
+    } |
+    {
+        name: '172';
+        children: BigUnion[];
+    } |
+    {
+        name: '173';
+        children: BigUnion[];
+    } |
+    {
+        name: '174';
+        children: BigUnion[];
+    } |
+    {
+        name: '175';
+        children: BigUnion[];
+    } |
+    {
+        name: '176';
+        children: BigUnion[];
+    } |
+    {
+        name: '177';
+        children: BigUnion[];
+    } |
+    {
+        name: '178';
+        children: BigUnion[];
+    } |
+    {
+        name: '179';
+        children: BigUnion[];
+    } |
+    {
+        name: '180';
+        children: BigUnion[];
+    } |
+    {
+        name: '181';
+        children: BigUnion[];
+    } |
+    {
+        name: '182';
+        children: BigUnion[];
+    } |
+    {
+        name: '183';
+        children: BigUnion[];
+    } |
+    {
+        name: '184';
+        children: BigUnion[];
+    } |
+    {
+        name: '185';
+        children: BigUnion[];
+    } |
+    {
+        name: '186';
+        children: BigUnion[];
+    } |
+    {
+        name: '187';
+        children: BigUnion[];
+    } |
+    {
+        name: '188';
+        children: BigUnion[];
+    } |
+    {
+        name: '189';
+        children: BigUnion[];
+    } |
+    {
+        name: '190';
+        children: BigUnion[];
+    } |
+    {
+        name: '191';
+        children: BigUnion[];
+    } |
+    {
+        name: '192';
+        children: BigUnion[];
+    } |
+    {
+        name: '193';
+        children: BigUnion[];
+    } |
+    {
+        name: '194';
+        children: BigUnion[];
+    } |
+    {
+        name: '195';
+        children: BigUnion[];
+    } |
+    {
+        name: '196';
+        children: BigUnion[];
+    } |
+    {
+        name: '197';
+        children: BigUnion[];
+    } |
+    {
+        name: '198';
+        children: BigUnion[];
+    } |
+    {
+        name: '199';
+        children: BigUnion[];
+    } |
+    {
+        name: '200';
+        children: BigUnion[];
+    } |
+    {
+        name: '201';
+        children: BigUnion[];
+    } |
+    {
+        name: '202';
+        children: BigUnion[];
+    } |
+    {
+        name: '203';
+        children: BigUnion[];
+    } |
+    {
+        name: '204';
+        children: BigUnion[];
+    } |
+    {
+        name: '205';
+        children: BigUnion[];
+    } |
+    {
+        name: '206';
+        children: BigUnion[];
+    } |
+    {
+        name: '207';
+        children: BigUnion[];
+    } |
+    {
+        name: '208';
+        children: BigUnion[];
+    } |
+    {
+        name: '209';
+        children: BigUnion[];
+    } |
+    {
+        name: '210';
+        children: BigUnion[];
+    } |
+    {
+        name: '211';
+        children: BigUnion[];
+    } |
+    {
+        name: '212';
+        children: BigUnion[];
+    } |
+    {
+        name: '213';
+        children: BigUnion[];
+    } |
+    {
+        name: '214';
+        children: BigUnion[];
+    } |
+    {
+        name: '215';
+        children: BigUnion[];
+    } |
+    {
+        name: '216';
+        children: BigUnion[];
+    } |
+    {
+        name: '217';
+        children: BigUnion[];
+    } |
+    {
+        name: '218';
+        children: BigUnion[];
+    } |
+    {
+        name: '219';
+        children: BigUnion[];
+    } |
+    {
+        name: '220';
+        children: BigUnion[];
+    } |
+    {
+        name: '221';
+        children: BigUnion[];
+    } |
+    {
+        name: '222';
+        children: BigUnion[];
+    } |
+    {
+        name: '223';
+        children: BigUnion[];
+    } |
+    {
+        name: '224';
+        children: BigUnion[];
+    } |
+    {
+        name: '225';
+        children: BigUnion[];
+    } |
+    {
+        name: '226';
+        children: BigUnion[];
+    } |
+    {
+        name: '227';
+        children: BigUnion[];
+    } |
+    {
+        name: '228';
+        children: BigUnion[];
+    } |
+    {
+        name: '229';
+        children: BigUnion[];
+    } |
+    {
+        name: '230';
+        children: BigUnion[];
+    } |
+    {
+        name: '231';
+        children: BigUnion[];
+    } |
+    {
+        name: '232';
+        children: BigUnion[];
+    } |
+    {
+        name: '233';
+        children: BigUnion[];
+    } |
+    {
+        name: '234';
+        children: BigUnion[];
+    } |
+    {
+        name: '235';
+        children: BigUnion[];
+    } |
+    {
+        name: '236';
+        children: BigUnion[];
+    } |
+    {
+        name: '237';
+        children: BigUnion[];
+    } |
+    {
+        name: '238';
+        children: BigUnion[];
+    } |
+    {
+        name: '239';
+        children: BigUnion[];
+    } |
+    {
+        name: '240';
+        children: BigUnion[];
+    } |
+    {
+        name: '241';
+        children: BigUnion[];
+    } |
+    {
+        name: '242';
+        children: BigUnion[];
+    } |
+    {
+        name: '243';
+        children: BigUnion[];
+    } |
+    {
+        name: '244';
+        children: BigUnion[];
+    } |
+    {
+        name: '245';
+        children: BigUnion[];
+    } |
+    {
+        name: '246';
+        children: BigUnion[];
+    } |
+    {
+        name: '247';
+        children: BigUnion[];
+    } |
+    {
+        name: '248';
+        children: BigUnion[];
+    } |
+    {
+        name: '249';
+        children: BigUnion[];
+    } |
+    {
+        name: '250';
+        children: BigUnion[];
+    } |
+    {
+        name: '251';
+        children: BigUnion[];
+    } |
+    {
+        name: '252';
+        children: BigUnion[];
+    } |
+    {
+        name: '253';
+        children: BigUnion[];
+    } |
+    {
+        name: '254';
+        children: BigUnion[];
+    } |
+    {
+        name: '255';
+        children: BigUnion[];
+    } |
+    {
+        name: '256';
+        children: BigUnion[];
+    } |
+    {
+        name: '257';
+        children: BigUnion[];
+    } |
+    {
+        name: '258';
+        children: BigUnion[];
+    } |
+    {
+        name: '259';
+        children: BigUnion[];
+    } |
+    {
+        name: '260';
+        children: BigUnion[];
+    } |
+    {
+        name: '261';
+        children: BigUnion[];
+    } |
+    {
+        name: '262';
+        children: BigUnion[];
+    } |
+    {
+        name: '263';
+        children: BigUnion[];
+    } |
+    {
+        name: '264';
+        children: BigUnion[];
+    } |
+    {
+        name: '265';
+        children: BigUnion[];
+    } |
+    {
+        name: '266';
+        children: BigUnion[];
+    } |
+    {
+        name: '267';
+        children: BigUnion[];
+    } |
+    {
+        name: '268';
+        children: BigUnion[];
+    } |
+    {
+        name: '269';
+        children: BigUnion[];
+    } |
+    {
+        name: '270';
+        children: BigUnion[];
+    } |
+    {
+        name: '271';
+        children: BigUnion[];
+    } |
+    {
+        name: '272';
+        children: BigUnion[];
+    } |
+    {
+        name: '273';
+        children: BigUnion[];
+    } |
+    {
+        name: '274';
+        children: BigUnion[];
+    } |
+    {
+        name: '275';
+        children: BigUnion[];
+    } |
+    {
+        name: '276';
+        children: BigUnion[];
+    } |
+    {
+        name: '277';
+        children: BigUnion[];
+    } |
+    {
+        name: '278';
+        children: BigUnion[];
+    } |
+    {
+        name: '279';
+        children: BigUnion[];
+    } |
+    {
+        name: '280';
+        children: BigUnion[];
+    } |
+    {
+        name: '281';
+        children: BigUnion[];
+    } |
+    {
+        name: '282';
+        children: BigUnion[];
+    } |
+    {
+        name: '283';
+        children: BigUnion[];
+    } |
+    {
+        name: '284';
+        children: BigUnion[];
+    } |
+    {
+        name: '285';
+        children: BigUnion[];
+    } |
+    {
+        name: '286';
+        children: BigUnion[];
+    } |
+    {
+        name: '287';
+        children: BigUnion[];
+    } |
+    {
+        name: '288';
+        children: BigUnion[];
+    } |
+    {
+        name: '289';
+        children: BigUnion[];
+    } |
+    {
+        name: '290';
+        children: BigUnion[];
+    } |
+    {
+        name: '291';
+        children: BigUnion[];
+    } |
+    {
+        name: '292';
+        children: BigUnion[];
+    } |
+    {
+        name: '293';
+        children: BigUnion[];
+    } |
+    {
+        name: '294';
+        children: BigUnion[];
+    } |
+    {
+        name: '295';
+        children: BigUnion[];
+    } |
+    {
+        name: '296';
+        children: BigUnion[];
+    } |
+    {
+        name: '297';
+        children: BigUnion[];
+    } |
+    {
+        name: '298';
+        children: BigUnion[];
+    } |
+    {
+        name: '299';
+        children: BigUnion[];
+    } |
+    {
+        name: '300';
+        children: BigUnion[];
+    } |
+    {
+        name: '301';
+        children: BigUnion[];
+    } |
+    {
+        name: '302';
+        children: BigUnion[];
+    } |
+    {
+        name: '303';
+        children: BigUnion[];
+    } |
+    {
+        name: '304';
+        children: BigUnion[];
+    } |
+    {
+        name: '305';
+        children: BigUnion[];
+    } |
+    {
+        name: '306';
+        children: BigUnion[];
+    } |
+    {
+        name: '307';
+        children: BigUnion[];
+    } |
+    {
+        name: '308';
+        children: BigUnion[];
+    } |
+    {
+        name: '309';
+        children: BigUnion[];
+    } |
+    {
+        name: '310';
+        children: BigUnion[];
+    } |
+    {
+        name: '311';
+        children: BigUnion[];
+    } |
+    {
+        name: '312';
+        children: BigUnion[];
+    } |
+    {
+        name: '313';
+        children: BigUnion[];
+    } |
+    {
+        name: '314';
+        children: BigUnion[];
+    } |
+    {
+        name: '315';
+        children: BigUnion[];
+    } |
+    {
+        name: '316';
+        children: BigUnion[];
+    } |
+    {
+        name: '317';
+        children: BigUnion[];
+    } |
+    {
+        name: '318';
+        children: BigUnion[];
+    } |
+    {
+        name: '319';
+        children: BigUnion[];
+    } |
+    {
+        name: '320';
+        children: BigUnion[];
+    } |
+    {
+        name: '321';
+        children: BigUnion[];
+    } |
+    {
+        name: '322';
+        children: BigUnion[];
+    } |
+    {
+        name: '323';
+        children: BigUnion[];
+    } |
+    {
+        name: '324';
+        children: BigUnion[];
+    } |
+    {
+        name: '325';
+        children: BigUnion[];
+    } |
+    {
+        name: '326';
+        children: BigUnion[];
+    } |
+    {
+        name: '327';
+        children: BigUnion[];
+    } |
+    {
+        name: '328';
+        children: BigUnion[];
+    } |
+    {
+        name: '329';
+        children: BigUnion[];
+    } |
+    {
+        name: '330';
+        children: BigUnion[];
+    } |
+    {
+        name: '331';
+        children: BigUnion[];
+    } |
+    {
+        name: '332';
+        children: BigUnion[];
+    } |
+    {
+        name: '333';
+        children: BigUnion[];
+    } |
+    {
+        name: '334';
+        children: BigUnion[];
+    } |
+    {
+        name: '335';
+        children: BigUnion[];
+    } |
+    {
+        name: '336';
+        children: BigUnion[];
+    } |
+    {
+        name: '337';
+        children: BigUnion[];
+    } |
+    {
+        name: '338';
+        children: BigUnion[];
+    } |
+    {
+        name: '339';
+        children: BigUnion[];
+    } |
+    {
+        name: '340';
+        children: BigUnion[];
+    } |
+    {
+        name: '341';
+        children: BigUnion[];
+    } |
+    {
+        name: '342';
+        children: BigUnion[];
+    } |
+    {
+        name: '343';
+        children: BigUnion[];
+    } |
+    {
+        name: '344';
+        children: BigUnion[];
+    } |
+    {
+        name: '345';
+        children: BigUnion[];
+    } |
+    {
+        name: '346';
+        children: BigUnion[];
+    } |
+    {
+        name: '347';
+        children: BigUnion[];
+    } |
+    {
+        name: '348';
+        children: BigUnion[];
+    } |
+    {
+        name: '349';
+        children: BigUnion[];
+    } |
+    {
+        name: '350';
+        children: BigUnion[];
+    } |
+    {
+        name: '351';
+        children: BigUnion[];
+    } |
+    {
+        name: '352';
+        children: BigUnion[];
+    } |
+    {
+        name: '353';
+        children: BigUnion[];
+    } |
+    {
+        name: '354';
+        children: BigUnion[];
+    } |
+    {
+        name: '355';
+        children: BigUnion[];
+    } |
+    {
+        name: '356';
+        children: BigUnion[];
+    } |
+    {
+        name: '357';
+        children: BigUnion[];
+    } |
+    {
+        name: '358';
+        children: BigUnion[];
+    } |
+    {
+        name: '359';
+        children: BigUnion[];
+    } |
+    {
+        name: '360';
+        children: BigUnion[];
+    } |
+    {
+        name: '361';
+        children: BigUnion[];
+    } |
+    {
+        name: '362';
+        children: BigUnion[];
+    } |
+    {
+        name: '363';
+        children: BigUnion[];
+    } |
+    {
+        name: '364';
+        children: BigUnion[];
+    } |
+    {
+        name: '365';
+        children: BigUnion[];
+    } |
+    {
+        name: '366';
+        children: BigUnion[];
+    } |
+    {
+        name: '367';
+        children: BigUnion[];
+    } |
+    {
+        name: '368';
+        children: BigUnion[];
+    } |
+    {
+        name: '369';
+        children: BigUnion[];
+    } |
+    {
+        name: '370';
+        children: BigUnion[];
+    } |
+    {
+        name: '371';
+        children: BigUnion[];
+    } |
+    {
+        name: '372';
+        children: BigUnion[];
+    } |
+    {
+        name: '373';
+        children: BigUnion[];
+    } |
+    {
+        name: '374';
+        children: BigUnion[];
+    } |
+    {
+        name: '375';
+        children: BigUnion[];
+    } |
+    {
+        name: '376';
+        children: BigUnion[];
+    } |
+    {
+        name: '377';
+        children: BigUnion[];
+    } |
+    {
+        name: '378';
+        children: BigUnion[];
+    } |
+    {
+        name: '379';
+        children: BigUnion[];
+    } |
+    {
+        name: '380';
+        children: BigUnion[];
+    } |
+    {
+        name: '381';
+        children: BigUnion[];
+    } |
+    {
+        name: '382';
+        children: BigUnion[];
+    } |
+    {
+        name: '383';
+        children: BigUnion[];
+    } |
+    {
+        name: '384';
+        children: BigUnion[];
+    } |
+    {
+        name: '385';
+        children: BigUnion[];
+    } |
+    {
+        name: '386';
+        children: BigUnion[];
+    } |
+    {
+        name: '387';
+        children: BigUnion[];
+    } |
+    {
+        name: '388';
+        children: BigUnion[];
+    } |
+    {
+        name: '389';
+        children: BigUnion[];
+    } |
+    {
+        name: '390';
+        children: BigUnion[];
+    } |
+    {
+        name: '391';
+        children: BigUnion[];
+    } |
+    {
+        name: '392';
+        children: BigUnion[];
+    } |
+    {
+        name: '393';
+        children: BigUnion[];
+    } |
+    {
+        name: '394';
+        children: BigUnion[];
+    } |
+    {
+        name: '395';
+        children: BigUnion[];
+    } |
+    {
+        name: '396';
+        children: BigUnion[];
+    } |
+    {
+        name: '397';
+        children: BigUnion[];
+    } |
+    {
+        name: '398';
+        children: BigUnion[];
+    } |
+    {
+        name: '399';
+        children: BigUnion[];
+    } |
+    {
+        name: '400';
+        children: BigUnion[];
+    } |
+    {
+        name: '401';
+        children: BigUnion[];
+    } |
+    {
+        name: '402';
+        children: BigUnion[];
+    } |
+    {
+        name: '403';
+        children: BigUnion[];
+    } |
+    {
+        name: '404';
+        children: BigUnion[];
+    } |
+    {
+        name: '405';
+        children: BigUnion[];
+    } |
+    {
+        name: '406';
+        children: BigUnion[];
+    } |
+    {
+        name: '407';
+        children: BigUnion[];
+    } |
+    {
+        name: '408';
+        children: BigUnion[];
+    } |
+    {
+        name: '409';
+        children: BigUnion[];
+    } |
+    {
+        name: '410';
+        children: BigUnion[];
+    } |
+    {
+        name: '411';
+        children: BigUnion[];
+    } |
+    {
+        name: '412';
+        children: BigUnion[];
+    } |
+    {
+        name: '413';
+        children: BigUnion[];
+    } |
+    {
+        name: '414';
+        children: BigUnion[];
+    } |
+    {
+        name: '415';
+        children: BigUnion[];
+    } |
+    {
+        name: '416';
+        children: BigUnion[];
+    } |
+    {
+        name: '417';
+        children: BigUnion[];
+    } |
+    {
+        name: '418';
+        children: BigUnion[];
+    } |
+    {
+        name: '419';
+        children: BigUnion[];
+    } |
+    {
+        name: '420';
+        children: BigUnion[];
+    } |
+    {
+        name: '421';
+        children: BigUnion[];
+    } |
+    {
+        name: '422';
+        children: BigUnion[];
+    } |
+    {
+        name: '423';
+        children: BigUnion[];
+    } |
+    {
+        name: '424';
+        children: BigUnion[];
+    } |
+    {
+        name: '425';
+        children: BigUnion[];
+    } |
+    {
+        name: '426';
+        children: BigUnion[];
+    } |
+    {
+        name: '427';
+        children: BigUnion[];
+    } |
+    {
+        name: '428';
+        children: BigUnion[];
+    } |
+    {
+        name: '429';
+        children: BigUnion[];
+    } |
+    {
+        name: '430';
+        children: BigUnion[];
+    } |
+    {
+        name: '431';
+        children: BigUnion[];
+    } |
+    {
+        name: '432';
+        children: BigUnion[];
+    } |
+    {
+        name: '433';
+        children: BigUnion[];
+    } |
+    {
+        name: '434';
+        children: BigUnion[];
+    } |
+    {
+        name: '435';
+        children: BigUnion[];
+    } |
+    {
+        name: '436';
+        children: BigUnion[];
+    } |
+    {
+        name: '437';
+        children: BigUnion[];
+    } |
+    {
+        name: '438';
+        children: BigUnion[];
+    } |
+    {
+        name: '439';
+        children: BigUnion[];
+    } |
+    {
+        name: '440';
+        children: BigUnion[];
+    } |
+    {
+        name: '441';
+        children: BigUnion[];
+    } |
+    {
+        name: '442';
+        children: BigUnion[];
+    } |
+    {
+        name: '443';
+        children: BigUnion[];
+    } |
+    {
+        name: '444';
+        children: BigUnion[];
+    } |
+    {
+        name: '445';
+        children: BigUnion[];
+    } |
+    {
+        name: '446';
+        children: BigUnion[];
+    } |
+    {
+        name: '447';
+        children: BigUnion[];
+    } |
+    {
+        name: '448';
+        children: BigUnion[];
+    } |
+    {
+        name: '449';
+        children: BigUnion[];
+    } |
+    {
+        name: '450';
+        children: BigUnion[];
+    } |
+    {
+        name: '451';
+        children: BigUnion[];
+    } |
+    {
+        name: '452';
+        children: BigUnion[];
+    } |
+    {
+        name: '453';
+        children: BigUnion[];
+    } |
+    {
+        name: '454';
+        children: BigUnion[];
+    } |
+    {
+        name: '455';
+        children: BigUnion[];
+    } |
+    {
+        name: '456';
+        children: BigUnion[];
+    } |
+    {
+        name: '457';
+        children: BigUnion[];
+    } |
+    {
+        name: '458';
+        children: BigUnion[];
+    } |
+    {
+        name: '459';
+        children: BigUnion[];
+    } |
+    {
+        name: '460';
+        children: BigUnion[];
+    } |
+    {
+        name: '461';
+        children: BigUnion[];
+    } |
+    {
+        name: '462';
+        children: BigUnion[];
+    } |
+    {
+        name: '463';
+        children: BigUnion[];
+    } |
+    {
+        name: '464';
+        children: BigUnion[];
+    } |
+    {
+        name: '465';
+        children: BigUnion[];
+    } |
+    {
+        name: '466';
+        children: BigUnion[];
+    } |
+    {
+        name: '467';
+        children: BigUnion[];
+    } |
+    {
+        name: '468';
+        children: BigUnion[];
+    } |
+    {
+        name: '469';
+        children: BigUnion[];
+    } |
+    {
+        name: '470';
+        children: BigUnion[];
+    } |
+    {
+        name: '471';
+        children: BigUnion[];
+    } |
+    {
+        name: '472';
+        children: BigUnion[];
+    } |
+    {
+        name: '473';
+        children: BigUnion[];
+    } |
+    {
+        name: '474';
+        children: BigUnion[];
+    } |
+    {
+        name: '475';
+        children: BigUnion[];
+    } |
+    {
+        name: '476';
+        children: BigUnion[];
+    } |
+    {
+        name: '477';
+        children: BigUnion[];
+    } |
+    {
+        name: '478';
+        children: BigUnion[];
+    } |
+    {
+        name: '479';
+        children: BigUnion[];
+    } |
+    {
+        name: '480';
+        children: BigUnion[];
+    } |
+    {
+        name: '481';
+        children: BigUnion[];
+    } |
+    {
+        name: '482';
+        children: BigUnion[];
+    } |
+    {
+        name: '483';
+        children: BigUnion[];
+    } |
+    {
+        name: '484';
+        children: BigUnion[];
+    } |
+    {
+        name: '485';
+        children: BigUnion[];
+    } |
+    {
+        name: '486';
+        children: BigUnion[];
+    } |
+    {
+        name: '487';
+        children: BigUnion[];
+    } |
+    {
+        name: '488';
+        children: BigUnion[];
+    } |
+    {
+        name: '489';
+        children: BigUnion[];
+    } |
+    {
+        name: '490';
+        children: BigUnion[];
+    } |
+    {
+        name: '491';
+        children: BigUnion[];
+    } |
+    {
+        name: '492';
+        children: BigUnion[];
+    } |
+    {
+        name: '493';
+        children: BigUnion[];
+    } |
+    {
+        name: '494';
+        children: BigUnion[];
+    } |
+    {
+        name: '495';
+        children: BigUnion[];
+    } |
+    {
+        name: '496';
+        children: BigUnion[];
+    } |
+    {
+        name: '497';
+        children: BigUnion[];
+    } |
+    {
+        name: '498';
+        children: BigUnion[];
+    } |
+    {
+        name: '499';
+        children: BigUnion[];
+    } |
+    {
+        name: '500';
+        children: BigUnion[];
+    } |
+    {
+        name: '501';
+        children: BigUnion[];
+    } |
+    {
+        name: '502';
+        children: BigUnion[];
+    } |
+    {
+        name: '503';
+        children: BigUnion[];
+    } |
+    {
+        name: '504';
+        children: BigUnion[];
+    } |
+    {
+        name: '505';
+        children: BigUnion[];
+    } |
+    {
+        name: '506';
+        children: BigUnion[];
+    } |
+    {
+        name: '507';
+        children: BigUnion[];
+    } |
+    {
+        name: '508';
+        children: BigUnion[];
+    } |
+    {
+        name: '509';
+        children: BigUnion[];
+    } |
+    {
+        name: '510';
+        children: BigUnion[];
+    } |
+    {
+        name: '511';
+        children: BigUnion[];
+    } |
+    {
+        name: '512';
+        children: BigUnion[];
+    } |
+    {
+        name: '513';
+        children: BigUnion[];
+    } |
+    {
+        name: '514';
+        children: BigUnion[];
+    } |
+    {
+        name: '515';
+        children: BigUnion[];
+    } |
+    {
+        name: '516';
+        children: BigUnion[];
+    } |
+    {
+        name: '517';
+        children: BigUnion[];
+    } |
+    {
+        name: '518';
+        children: BigUnion[];
+    } |
+    {
+        name: '519';
+        children: BigUnion[];
+    } |
+    {
+        name: '520';
+        children: BigUnion[];
+    } |
+    {
+        name: '521';
+        children: BigUnion[];
+    } |
+    {
+        name: '522';
+        children: BigUnion[];
+    } |
+    {
+        name: '523';
+        children: BigUnion[];
+    } |
+    {
+        name: '524';
+        children: BigUnion[];
+    } |
+    {
+        name: '525';
+        children: BigUnion[];
+    } |
+    {
+        name: '526';
+        children: BigUnion[];
+    } |
+    {
+        name: '527';
+        children: BigUnion[];
+    } |
+    {
+        name: '528';
+        children: BigUnion[];
+    } |
+    {
+        name: '529';
+        children: BigUnion[];
+    } |
+    {
+        name: '530';
+        children: BigUnion[];
+    } |
+    {
+        name: '531';
+        children: BigUnion[];
+    } |
+    {
+        name: '532';
+        children: BigUnion[];
+    } |
+    {
+        name: '533';
+        children: BigUnion[];
+    } |
+    {
+        name: '534';
+        children: BigUnion[];
+    } |
+    {
+        name: '535';
+        children: BigUnion[];
+    } |
+    {
+        name: '536';
+        children: BigUnion[];
+    } |
+    {
+        name: '537';
+        children: BigUnion[];
+    } |
+    {
+        name: '538';
+        children: BigUnion[];
+    } |
+    {
+        name: '539';
+        children: BigUnion[];
+    } |
+    {
+        name: '540';
+        children: BigUnion[];
+    } |
+    {
+        name: '541';
+        children: BigUnion[];
+    } |
+    {
+        name: '542';
+        children: BigUnion[];
+    } |
+    {
+        name: '543';
+        children: BigUnion[];
+    } |
+    {
+        name: '544';
+        children: BigUnion[];
+    } |
+    {
+        name: '545';
+        children: BigUnion[];
+    } |
+    {
+        name: '546';
+        children: BigUnion[];
+    } |
+    {
+        name: '547';
+        children: BigUnion[];
+    } |
+    {
+        name: '548';
+        children: BigUnion[];
+    } |
+    {
+        name: '549';
+        children: BigUnion[];
+    } |
+    {
+        name: '550';
+        children: BigUnion[];
+    } |
+    {
+        name: '551';
+        children: BigUnion[];
+    } |
+    {
+        name: '552';
+        children: BigUnion[];
+    } |
+    {
+        name: '553';
+        children: BigUnion[];
+    } |
+    {
+        name: '554';
+        children: BigUnion[];
+    } |
+    {
+        name: '555';
+        children: BigUnion[];
+    } |
+    {
+        name: '556';
+        children: BigUnion[];
+    } |
+    {
+        name: '557';
+        children: BigUnion[];
+    } |
+    {
+        name: '558';
+        children: BigUnion[];
+    } |
+    {
+        name: '559';
+        children: BigUnion[];
+    } |
+    {
+        name: '560';
+        children: BigUnion[];
+    } |
+    {
+        name: '561';
+        children: BigUnion[];
+    } |
+    {
+        name: '562';
+        children: BigUnion[];
+    } |
+    {
+        name: '563';
+        children: BigUnion[];
+    } |
+    {
+        name: '564';
+        children: BigUnion[];
+    } |
+    {
+        name: '565';
+        children: BigUnion[];
+    } |
+    {
+        name: '566';
+        children: BigUnion[];
+    } |
+    {
+        name: '567';
+        children: BigUnion[];
+    } |
+    {
+        name: '568';
+        children: BigUnion[];
+    } |
+    {
+        name: '569';
+        children: BigUnion[];
+    } |
+    {
+        name: '570';
+        children: BigUnion[];
+    } |
+    {
+        name: '571';
+        children: BigUnion[];
+    } |
+    {
+        name: '572';
+        children: BigUnion[];
+    } |
+    {
+        name: '573';
+        children: BigUnion[];
+    } |
+    {
+        name: '574';
+        children: BigUnion[];
+    } |
+    {
+        name: '575';
+        children: BigUnion[];
+    } |
+    {
+        name: '576';
+        children: BigUnion[];
+    } |
+    {
+        name: '577';
+        children: BigUnion[];
+    } |
+    {
+        name: '578';
+        children: BigUnion[];
+    } |
+    {
+        name: '579';
+        children: BigUnion[];
+    } |
+    {
+        name: '580';
+        children: BigUnion[];
+    } |
+    {
+        name: '581';
+        children: BigUnion[];
+    } |
+    {
+        name: '582';
+        children: BigUnion[];
+    } |
+    {
+        name: '583';
+        children: BigUnion[];
+    } |
+    {
+        name: '584';
+        children: BigUnion[];
+    } |
+    {
+        name: '585';
+        children: BigUnion[];
+    } |
+    {
+        name: '586';
+        children: BigUnion[];
+    } |
+    {
+        name: '587';
+        children: BigUnion[];
+    } |
+    {
+        name: '588';
+        children: BigUnion[];
+    } |
+    {
+        name: '589';
+        children: BigUnion[];
+    } |
+    {
+        name: '590';
+        children: BigUnion[];
+    } |
+    {
+        name: '591';
+        children: BigUnion[];
+    } |
+    {
+        name: '592';
+        children: BigUnion[];
+    } |
+    {
+        name: '593';
+        children: BigUnion[];
+    } |
+    {
+        name: '594';
+        children: BigUnion[];
+    } |
+    {
+        name: '595';
+        children: BigUnion[];
+    } |
+    {
+        name: '596';
+        children: BigUnion[];
+    } |
+    {
+        name: '597';
+        children: BigUnion[];
+    } |
+    {
+        name: '598';
+        children: BigUnion[];
+    } |
+    {
+        name: '599';
+        children: BigUnion[];
+    } |
+    {
+        name: '600';
+        children: BigUnion[];
+    } |
+    {
+        name: '601';
+        children: BigUnion[];
+    } |
+    {
+        name: '602';
+        children: BigUnion[];
+    } |
+    {
+        name: '603';
+        children: BigUnion[];
+    } |
+    {
+        name: '604';
+        children: BigUnion[];
+    } |
+    {
+        name: '605';
+        children: BigUnion[];
+    } |
+    {
+        name: '606';
+        children: BigUnion[];
+    } |
+    {
+        name: '607';
+        children: BigUnion[];
+    } |
+    {
+        name: '608';
+        children: BigUnion[];
+    } |
+    {
+        name: '609';
+        children: BigUnion[];
+    } |
+    {
+        name: '610';
+        children: BigUnion[];
+    } |
+    {
+        name: '611';
+        children: BigUnion[];
+    } |
+    {
+        name: '612';
+        children: BigUnion[];
+    } |
+    {
+        name: '613';
+        children: BigUnion[];
+    } |
+    {
+        name: '614';
+        children: BigUnion[];
+    } |
+    {
+        name: '615';
+        children: BigUnion[];
+    } |
+    {
+        name: '616';
+        children: BigUnion[];
+    } |
+    {
+        name: '617';
+        children: BigUnion[];
+    } |
+    {
+        name: '618';
+        children: BigUnion[];
+    } |
+    {
+        name: '619';
+        children: BigUnion[];
+    } |
+    {
+        name: '620';
+        children: BigUnion[];
+    } |
+    {
+        name: '621';
+        children: BigUnion[];
+    } |
+    {
+        name: '622';
+        children: BigUnion[];
+    } |
+    {
+        name: '623';
+        children: BigUnion[];
+    } |
+    {
+        name: '624';
+        children: BigUnion[];
+    } |
+    {
+        name: '625';
+        children: BigUnion[];
+    } |
+    {
+        name: '626';
+        children: BigUnion[];
+    } |
+    {
+        name: '627';
+        children: BigUnion[];
+    } |
+    {
+        name: '628';
+        children: BigUnion[];
+    } |
+    {
+        name: '629';
+        children: BigUnion[];
+    } |
+    {
+        name: '630';
+        children: BigUnion[];
+    } |
+    {
+        name: '631';
+        children: BigUnion[];
+    } |
+    {
+        name: '632';
+        children: BigUnion[];
+    } |
+    {
+        name: '633';
+        children: BigUnion[];
+    } |
+    {
+        name: '634';
+        children: BigUnion[];
+    } |
+    {
+        name: '635';
+        children: BigUnion[];
+    } |
+    {
+        name: '636';
+        children: BigUnion[];
+    } |
+    {
+        name: '637';
+        children: BigUnion[];
+    } |
+    {
+        name: '638';
+        children: BigUnion[];
+    } |
+    {
+        name: '639';
+        children: BigUnion[];
+    } |
+    {
+        name: '640';
+        children: BigUnion[];
+    } |
+    {
+        name: '641';
+        children: BigUnion[];
+    } |
+    {
+        name: '642';
+        children: BigUnion[];
+    } |
+    {
+        name: '643';
+        children: BigUnion[];
+    } |
+    {
+        name: '644';
+        children: BigUnion[];
+    } |
+    {
+        name: '645';
+        children: BigUnion[];
+    } |
+    {
+        name: '646';
+        children: BigUnion[];
+    } |
+    {
+        name: '647';
+        children: BigUnion[];
+    } |
+    {
+        name: '648';
+        children: BigUnion[];
+    } |
+    {
+        name: '649';
+        children: BigUnion[];
+    } |
+    {
+        name: '650';
+        children: BigUnion[];
+    } |
+    {
+        name: '651';
+        children: BigUnion[];
+    } |
+    {
+        name: '652';
+        children: BigUnion[];
+    } |
+    {
+        name: '653';
+        children: BigUnion[];
+    } |
+    {
+        name: '654';
+        children: BigUnion[];
+    } |
+    {
+        name: '655';
+        children: BigUnion[];
+    } |
+    {
+        name: '656';
+        children: BigUnion[];
+    } |
+    {
+        name: '657';
+        children: BigUnion[];
+    } |
+    {
+        name: '658';
+        children: BigUnion[];
+    } |
+    {
+        name: '659';
+        children: BigUnion[];
+    } |
+    {
+        name: '660';
+        children: BigUnion[];
+    } |
+    {
+        name: '661';
+        children: BigUnion[];
+    } |
+    {
+        name: '662';
+        children: BigUnion[];
+    } |
+    {
+        name: '663';
+        children: BigUnion[];
+    } |
+    {
+        name: '664';
+        children: BigUnion[];
+    } |
+    {
+        name: '665';
+        children: BigUnion[];
+    } |
+    {
+        name: '666';
+        children: BigUnion[];
+    } |
+    {
+        name: '667';
+        children: BigUnion[];
+    } |
+    {
+        name: '668';
+        children: BigUnion[];
+    } |
+    {
+        name: '669';
+        children: BigUnion[];
+    } |
+    {
+        name: '670';
+        children: BigUnion[];
+    } |
+    {
+        name: '671';
+        children: BigUnion[];
+    } |
+    {
+        name: '672';
+        children: BigUnion[];
+    } |
+    {
+        name: '673';
+        children: BigUnion[];
+    } |
+    {
+        name: '674';
+        children: BigUnion[];
+    } |
+    {
+        name: '675';
+        children: BigUnion[];
+    } |
+    {
+        name: '676';
+        children: BigUnion[];
+    } |
+    {
+        name: '677';
+        children: BigUnion[];
+    } |
+    {
+        name: '678';
+        children: BigUnion[];
+    } |
+    {
+        name: '679';
+        children: BigUnion[];
+    } |
+    {
+        name: '680';
+        children: BigUnion[];
+    } |
+    {
+        name: '681';
+        children: BigUnion[];
+    } |
+    {
+        name: '682';
+        children: BigUnion[];
+    } |
+    {
+        name: '683';
+        children: BigUnion[];
+    } |
+    {
+        name: '684';
+        children: BigUnion[];
+    } |
+    {
+        name: '685';
+        children: BigUnion[];
+    } |
+    {
+        name: '686';
+        children: BigUnion[];
+    } |
+    {
+        name: '687';
+        children: BigUnion[];
+    } |
+    {
+        name: '688';
+        children: BigUnion[];
+    } |
+    {
+        name: '689';
+        children: BigUnion[];
+    } |
+    {
+        name: '690';
+        children: BigUnion[];
+    } |
+    {
+        name: '691';
+        children: BigUnion[];
+    } |
+    {
+        name: '692';
+        children: BigUnion[];
+    } |
+    {
+        name: '693';
+        children: BigUnion[];
+    } |
+    {
+        name: '694';
+        children: BigUnion[];
+    } |
+    {
+        name: '695';
+        children: BigUnion[];
+    } |
+    {
+        name: '696';
+        children: BigUnion[];
+    } |
+    {
+        name: '697';
+        children: BigUnion[];
+    } |
+    {
+        name: '698';
+        children: BigUnion[];
+    } |
+    {
+        name: '699';
+        children: BigUnion[];
+    } |
+    {
+        name: '700';
+        children: BigUnion[];
+    } |
+    {
+        name: '701';
+        children: BigUnion[];
+    } |
+    {
+        name: '702';
+        children: BigUnion[];
+    } |
+    {
+        name: '703';
+        children: BigUnion[];
+    } |
+    {
+        name: '704';
+        children: BigUnion[];
+    } |
+    {
+        name: '705';
+        children: BigUnion[];
+    } |
+    {
+        name: '706';
+        children: BigUnion[];
+    } |
+    {
+        name: '707';
+        children: BigUnion[];
+    } |
+    {
+        name: '708';
+        children: BigUnion[];
+    } |
+    {
+        name: '709';
+        children: BigUnion[];
+    } |
+    {
+        name: '710';
+        children: BigUnion[];
+    } |
+    {
+        name: '711';
+        children: BigUnion[];
+    } |
+    {
+        name: '712';
+        children: BigUnion[];
+    } |
+    {
+        name: '713';
+        children: BigUnion[];
+    } |
+    {
+        name: '714';
+        children: BigUnion[];
+    } |
+    {
+        name: '715';
+        children: BigUnion[];
+    } |
+    {
+        name: '716';
+        children: BigUnion[];
+    } |
+    {
+        name: '717';
+        children: BigUnion[];
+    } |
+    {
+        name: '718';
+        children: BigUnion[];
+    } |
+    {
+        name: '719';
+        children: BigUnion[];
+    } |
+    {
+        name: '720';
+        children: BigUnion[];
+    } |
+    {
+        name: '721';
+        children: BigUnion[];
+    } |
+    {
+        name: '722';
+        children: BigUnion[];
+    } |
+    {
+        name: '723';
+        children: BigUnion[];
+    } |
+    {
+        name: '724';
+        children: BigUnion[];
+    } |
+    {
+        name: '725';
+        children: BigUnion[];
+    } |
+    {
+        name: '726';
+        children: BigUnion[];
+    } |
+    {
+        name: '727';
+        children: BigUnion[];
+    } |
+    {
+        name: '728';
+        children: BigUnion[];
+    } |
+    {
+        name: '729';
+        children: BigUnion[];
+    } |
+    {
+        name: '730';
+        children: BigUnion[];
+    } |
+    {
+        name: '731';
+        children: BigUnion[];
+    } |
+    {
+        name: '732';
+        children: BigUnion[];
+    } |
+    {
+        name: '733';
+        children: BigUnion[];
+    } |
+    {
+        name: '734';
+        children: BigUnion[];
+    } |
+    {
+        name: '735';
+        children: BigUnion[];
+    } |
+    {
+        name: '736';
+        children: BigUnion[];
+    } |
+    {
+        name: '737';
+        children: BigUnion[];
+    } |
+    {
+        name: '738';
+        children: BigUnion[];
+    } |
+    {
+        name: '739';
+        children: BigUnion[];
+    } |
+    {
+        name: '740';
+        children: BigUnion[];
+    } |
+    {
+        name: '741';
+        children: BigUnion[];
+    } |
+    {
+        name: '742';
+        children: BigUnion[];
+    } |
+    {
+        name: '743';
+        children: BigUnion[];
+    } |
+    {
+        name: '744';
+        children: BigUnion[];
+    } |
+    {
+        name: '745';
+        children: BigUnion[];
+    } |
+    {
+        name: '746';
+        children: BigUnion[];
+    } |
+    {
+        name: '747';
+        children: BigUnion[];
+    } |
+    {
+        name: '748';
+        children: BigUnion[];
+    } |
+    {
+        name: '749';
+        children: BigUnion[];
+    } |
+    {
+        name: '750';
+        children: BigUnion[];
+    } |
+    {
+        name: '751';
+        children: BigUnion[];
+    } |
+    {
+        name: '752';
+        children: BigUnion[];
+    } |
+    {
+        name: '753';
+        children: BigUnion[];
+    } |
+    {
+        name: '754';
+        children: BigUnion[];
+    } |
+    {
+        name: '755';
+        children: BigUnion[];
+    } |
+    {
+        name: '756';
+        children: BigUnion[];
+    } |
+    {
+        name: '757';
+        children: BigUnion[];
+    } |
+    {
+        name: '758';
+        children: BigUnion[];
+    } |
+    {
+        name: '759';
+        children: BigUnion[];
+    } |
+    {
+        name: '760';
+        children: BigUnion[];
+    } |
+    {
+        name: '761';
+        children: BigUnion[];
+    } |
+    {
+        name: '762';
+        children: BigUnion[];
+    } |
+    {
+        name: '763';
+        children: BigUnion[];
+    } |
+    {
+        name: '764';
+        children: BigUnion[];
+    } |
+    {
+        name: '765';
+        children: BigUnion[];
+    } |
+    {
+        name: '766';
+        children: BigUnion[];
+    } |
+    {
+        name: '767';
+        children: BigUnion[];
+    } |
+    {
+        name: '768';
+        children: BigUnion[];
+    } |
+    {
+        name: '769';
+        children: BigUnion[];
+    } |
+    {
+        name: '770';
+        children: BigUnion[];
+    } |
+    {
+        name: '771';
+        children: BigUnion[];
+    } |
+    {
+        name: '772';
+        children: BigUnion[];
+    } |
+    {
+        name: '773';
+        children: BigUnion[];
+    } |
+    {
+        name: '774';
+        children: BigUnion[];
+    } |
+    {
+        name: '775';
+        children: BigUnion[];
+    } |
+    {
+        name: '776';
+        children: BigUnion[];
+    } |
+    {
+        name: '777';
+        children: BigUnion[];
+    } |
+    {
+        name: '778';
+        children: BigUnion[];
+    } |
+    {
+        name: '779';
+        children: BigUnion[];
+    } |
+    {
+        name: '780';
+        children: BigUnion[];
+    } |
+    {
+        name: '781';
+        children: BigUnion[];
+    } |
+    {
+        name: '782';
+        children: BigUnion[];
+    } |
+    {
+        name: '783';
+        children: BigUnion[];
+    } |
+    {
+        name: '784';
+        children: BigUnion[];
+    } |
+    {
+        name: '785';
+        children: BigUnion[];
+    } |
+    {
+        name: '786';
+        children: BigUnion[];
+    } |
+    {
+        name: '787';
+        children: BigUnion[];
+    } |
+    {
+        name: '788';
+        children: BigUnion[];
+    } |
+    {
+        name: '789';
+        children: BigUnion[];
+    } |
+    {
+        name: '790';
+        children: BigUnion[];
+    } |
+    {
+        name: '791';
+        children: BigUnion[];
+    } |
+    {
+        name: '792';
+        children: BigUnion[];
+    } |
+    {
+        name: '793';
+        children: BigUnion[];
+    } |
+    {
+        name: '794';
+        children: BigUnion[];
+    } |
+    {
+        name: '795';
+        children: BigUnion[];
+    } |
+    {
+        name: '796';
+        children: BigUnion[];
+    } |
+    {
+        name: '797';
+        children: BigUnion[];
+    } |
+    {
+        name: '798';
+        children: BigUnion[];
+    } |
+    {
+        name: '799';
+        children: BigUnion[];
+    } |
+    {
+        name: '800';
+        children: BigUnion[];
+    } |
+    {
+        name: '801';
+        children: BigUnion[];
+    } |
+    {
+        name: '802';
+        children: BigUnion[];
+    } |
+    {
+        name: '803';
+        children: BigUnion[];
+    } |
+    {
+        name: '804';
+        children: BigUnion[];
+    } |
+    {
+        name: '805';
+        children: BigUnion[];
+    } |
+    {
+        name: '806';
+        children: BigUnion[];
+    } |
+    {
+        name: '807';
+        children: BigUnion[];
+    } |
+    {
+        name: '808';
+        children: BigUnion[];
+    } |
+    {
+        name: '809';
+        children: BigUnion[];
+    } |
+    {
+        name: '810';
+        children: BigUnion[];
+    } |
+    {
+        name: '811';
+        children: BigUnion[];
+    } |
+    {
+        name: '812';
+        children: BigUnion[];
+    } |
+    {
+        name: '813';
+        children: BigUnion[];
+    } |
+    {
+        name: '814';
+        children: BigUnion[];
+    } |
+    {
+        name: '815';
+        children: BigUnion[];
+    } |
+    {
+        name: '816';
+        children: BigUnion[];
+    } |
+    {
+        name: '817';
+        children: BigUnion[];
+    } |
+    {
+        name: '818';
+        children: BigUnion[];
+    } |
+    {
+        name: '819';
+        children: BigUnion[];
+    } |
+    {
+        name: '820';
+        children: BigUnion[];
+    } |
+    {
+        name: '821';
+        children: BigUnion[];
+    } |
+    {
+        name: '822';
+        children: BigUnion[];
+    } |
+    {
+        name: '823';
+        children: BigUnion[];
+    } |
+    {
+        name: '824';
+        children: BigUnion[];
+    } |
+    {
+        name: '825';
+        children: BigUnion[];
+    } |
+    {
+        name: '826';
+        children: BigUnion[];
+    } |
+    {
+        name: '827';
+        children: BigUnion[];
+    } |
+    {
+        name: '828';
+        children: BigUnion[];
+    } |
+    {
+        name: '829';
+        children: BigUnion[];
+    } |
+    {
+        name: '830';
+        children: BigUnion[];
+    } |
+    {
+        name: '831';
+        children: BigUnion[];
+    } |
+    {
+        name: '832';
+        children: BigUnion[];
+    } |
+    {
+        name: '833';
+        children: BigUnion[];
+    } |
+    {
+        name: '834';
+        children: BigUnion[];
+    } |
+    {
+        name: '835';
+        children: BigUnion[];
+    } |
+    {
+        name: '836';
+        children: BigUnion[];
+    } |
+    {
+        name: '837';
+        children: BigUnion[];
+    } |
+    {
+        name: '838';
+        children: BigUnion[];
+    } |
+    {
+        name: '839';
+        children: BigUnion[];
+    } |
+    {
+        name: '840';
+        children: BigUnion[];
+    } |
+    {
+        name: '841';
+        children: BigUnion[];
+    } |
+    {
+        name: '842';
+        children: BigUnion[];
+    } |
+    {
+        name: '843';
+        children: BigUnion[];
+    } |
+    {
+        name: '844';
+        children: BigUnion[];
+    } |
+    {
+        name: '845';
+        children: BigUnion[];
+    } |
+    {
+        name: '846';
+        children: BigUnion[];
+    } |
+    {
+        name: '847';
+        children: BigUnion[];
+    } |
+    {
+        name: '848';
+        children: BigUnion[];
+    } |
+    {
+        name: '849';
+        children: BigUnion[];
+    } |
+    {
+        name: '850';
+        children: BigUnion[];
+    } |
+    {
+        name: '851';
+        children: BigUnion[];
+    } |
+    {
+        name: '852';
+        children: BigUnion[];
+    } |
+    {
+        name: '853';
+        children: BigUnion[];
+    } |
+    {
+        name: '854';
+        children: BigUnion[];
+    } |
+    {
+        name: '855';
+        children: BigUnion[];
+    } |
+    {
+        name: '856';
+        children: BigUnion[];
+    } |
+    {
+        name: '857';
+        children: BigUnion[];
+    } |
+    {
+        name: '858';
+        children: BigUnion[];
+    } |
+    {
+        name: '859';
+        children: BigUnion[];
+    } |
+    {
+        name: '860';
+        children: BigUnion[];
+    } |
+    {
+        name: '861';
+        children: BigUnion[];
+    } |
+    {
+        name: '862';
+        children: BigUnion[];
+    } |
+    {
+        name: '863';
+        children: BigUnion[];
+    } |
+    {
+        name: '864';
+        children: BigUnion[];
+    } |
+    {
+        name: '865';
+        children: BigUnion[];
+    } |
+    {
+        name: '866';
+        children: BigUnion[];
+    } |
+    {
+        name: '867';
+        children: BigUnion[];
+    } |
+    {
+        name: '868';
+        children: BigUnion[];
+    } |
+    {
+        name: '869';
+        children: BigUnion[];
+    } |
+    {
+        name: '870';
+        children: BigUnion[];
+    } |
+    {
+        name: '871';
+        children: BigUnion[];
+    } |
+    {
+        name: '872';
+        children: BigUnion[];
+    } |
+    {
+        name: '873';
+        children: BigUnion[];
+    } |
+    {
+        name: '874';
+        children: BigUnion[];
+    } |
+    {
+        name: '875';
+        children: BigUnion[];
+    } |
+    {
+        name: '876';
+        children: BigUnion[];
+    } |
+    {
+        name: '877';
+        children: BigUnion[];
+    } |
+    {
+        name: '878';
+        children: BigUnion[];
+    } |
+    {
+        name: '879';
+        children: BigUnion[];
+    } |
+    {
+        name: '880';
+        children: BigUnion[];
+    } |
+    {
+        name: '881';
+        children: BigUnion[];
+    } |
+    {
+        name: '882';
+        children: BigUnion[];
+    } |
+    {
+        name: '883';
+        children: BigUnion[];
+    } |
+    {
+        name: '884';
+        children: BigUnion[];
+    } |
+    {
+        name: '885';
+        children: BigUnion[];
+    } |
+    {
+        name: '886';
+        children: BigUnion[];
+    } |
+    {
+        name: '887';
+        children: BigUnion[];
+    } |
+    {
+        name: '888';
+        children: BigUnion[];
+    } |
+    {
+        name: '889';
+        children: BigUnion[];
+    } |
+    {
+        name: '890';
+        children: BigUnion[];
+    } |
+    {
+        name: '891';
+        children: BigUnion[];
+    } |
+    {
+        name: '892';
+        children: BigUnion[];
+    } |
+    {
+        name: '893';
+        children: BigUnion[];
+    } |
+    {
+        name: '894';
+        children: BigUnion[];
+    } |
+    {
+        name: '895';
+        children: BigUnion[];
+    } |
+    {
+        name: '896';
+        children: BigUnion[];
+    } |
+    {
+        name: '897';
+        children: BigUnion[];
+    } |
+    {
+        name: '898';
+        children: BigUnion[];
+    } |
+    {
+        name: '899';
+        children: BigUnion[];
+    } |
+    {
+        name: '900';
+        children: BigUnion[];
+    } |
+    {
+        name: '901';
+        children: BigUnion[];
+    } |
+    {
+        name: '902';
+        children: BigUnion[];
+    } |
+    {
+        name: '903';
+        children: BigUnion[];
+    } |
+    {
+        name: '904';
+        children: BigUnion[];
+    } |
+    {
+        name: '905';
+        children: BigUnion[];
+    } |
+    {
+        name: '906';
+        children: BigUnion[];
+    } |
+    {
+        name: '907';
+        children: BigUnion[];
+    } |
+    {
+        name: '908';
+        children: BigUnion[];
+    } |
+    {
+        name: '909';
+        children: BigUnion[];
+    } |
+    {
+        name: '910';
+        children: BigUnion[];
+    } |
+    {
+        name: '911';
+        children: BigUnion[];
+    } |
+    {
+        name: '912';
+        children: BigUnion[];
+    } |
+    {
+        name: '913';
+        children: BigUnion[];
+    } |
+    {
+        name: '914';
+        children: BigUnion[];
+    } |
+    {
+        name: '915';
+        children: BigUnion[];
+    } |
+    {
+        name: '916';
+        children: BigUnion[];
+    } |
+    {
+        name: '917';
+        children: BigUnion[];
+    } |
+    {
+        name: '918';
+        children: BigUnion[];
+    } |
+    {
+        name: '919';
+        children: BigUnion[];
+    } |
+    {
+        name: '920';
+        children: BigUnion[];
+    } |
+    {
+        name: '921';
+        children: BigUnion[];
+    } |
+    {
+        name: '922';
+        children: BigUnion[];
+    } |
+    {
+        name: '923';
+        children: BigUnion[];
+    } |
+    {
+        name: '924';
+        children: BigUnion[];
+    } |
+    {
+        name: '925';
+        children: BigUnion[];
+    } |
+    {
+        name: '926';
+        children: BigUnion[];
+    } |
+    {
+        name: '927';
+        children: BigUnion[];
+    } |
+    {
+        name: '928';
+        children: BigUnion[];
+    } |
+    {
+        name: '929';
+        children: BigUnion[];
+    } |
+    {
+        name: '930';
+        children: BigUnion[];
+    } |
+    {
+        name: '931';
+        children: BigUnion[];
+    } |
+    {
+        name: '932';
+        children: BigUnion[];
+    } |
+    {
+        name: '933';
+        children: BigUnion[];
+    } |
+    {
+        name: '934';
+        children: BigUnion[];
+    } |
+    {
+        name: '935';
+        children: BigUnion[];
+    } |
+    {
+        name: '936';
+        children: BigUnion[];
+    } |
+    {
+        name: '937';
+        children: BigUnion[];
+    } |
+    {
+        name: '938';
+        children: BigUnion[];
+    } |
+    {
+        name: '939';
+        children: BigUnion[];
+    } |
+    {
+        name: '940';
+        children: BigUnion[];
+    } |
+    {
+        name: '941';
+        children: BigUnion[];
+    } |
+    {
+        name: '942';
+        children: BigUnion[];
+    } |
+    {
+        name: '943';
+        children: BigUnion[];
+    } |
+    {
+        name: '944';
+        children: BigUnion[];
+    } |
+    {
+        name: '945';
+        children: BigUnion[];
+    } |
+    {
+        name: '946';
+        children: BigUnion[];
+    } |
+    {
+        name: '947';
+        children: BigUnion[];
+    } |
+    {
+        name: '948';
+        children: BigUnion[];
+    } |
+    {
+        name: '949';
+        children: BigUnion[];
+    } |
+    {
+        name: '950';
+        children: BigUnion[];
+    } |
+    {
+        name: '951';
+        children: BigUnion[];
+    } |
+    {
+        name: '952';
+        children: BigUnion[];
+    } |
+    {
+        name: '953';
+        children: BigUnion[];
+    } |
+    {
+        name: '954';
+        children: BigUnion[];
+    } |
+    {
+        name: '955';
+        children: BigUnion[];
+    } |
+    {
+        name: '956';
+        children: BigUnion[];
+    } |
+    {
+        name: '957';
+        children: BigUnion[];
+    } |
+    {
+        name: '958';
+        children: BigUnion[];
+    } |
+    {
+        name: '959';
+        children: BigUnion[];
+    } |
+    {
+        name: '960';
+        children: BigUnion[];
+    } |
+    {
+        name: '961';
+        children: BigUnion[];
+    } |
+    {
+        name: '962';
+        children: BigUnion[];
+    } |
+    {
+        name: '963';
+        children: BigUnion[];
+    } |
+    {
+        name: '964';
+        children: BigUnion[];
+    } |
+    {
+        name: '965';
+        children: BigUnion[];
+    } |
+    {
+        name: '966';
+        children: BigUnion[];
+    } |
+    {
+        name: '967';
+        children: BigUnion[];
+    } |
+    {
+        name: '968';
+        children: BigUnion[];
+    } |
+    {
+        name: '969';
+        children: BigUnion[];
+    } |
+    {
+        name: '970';
+        children: BigUnion[];
+    } |
+    {
+        name: '971';
+        children: BigUnion[];
+    } |
+    {
+        name: '972';
+        children: BigUnion[];
+    } |
+    {
+        name: '973';
+        children: BigUnion[];
+    } |
+    {
+        name: '974';
+        children: BigUnion[];
+    } |
+    {
+        name: '975';
+        children: BigUnion[];
+    } |
+    {
+        name: '976';
+        children: BigUnion[];
+    } |
+    {
+        name: '977';
+        children: BigUnion[];
+    } |
+    {
+        name: '978';
+        children: BigUnion[];
+    } |
+    {
+        name: '979';
+        children: BigUnion[];
+    } |
+    {
+        name: '980';
+        children: BigUnion[];
+    } |
+    {
+        name: '981';
+        children: BigUnion[];
+    } |
+    {
+        name: '982';
+        children: BigUnion[];
+    } |
+    {
+        name: '983';
+        children: BigUnion[];
+    } |
+    {
+        name: '984';
+        children: BigUnion[];
+    } |
+    {
+        name: '985';
+        children: BigUnion[];
+    } |
+    {
+        name: '986';
+        children: BigUnion[];
+    } |
+    {
+        name: '987';
+        children: BigUnion[];
+    } |
+    {
+        name: '988';
+        children: BigUnion[];
+    } |
+    {
+        name: '989';
+        children: BigUnion[];
+    } |
+    {
+        name: '990';
+        children: BigUnion[];
+    } |
+    {
+        name: '991';
+        children: BigUnion[];
+    } |
+    {
+        name: '992';
+        children: BigUnion[];
+    } |
+    {
+        name: '993';
+        children: BigUnion[];
+    } |
+    {
+        name: '994';
+        children: BigUnion[];
+    } |
+    {
+        name: '995';
+        children: BigUnion[];
+    } |
+    {
+        name: '996';
+        children: BigUnion[];
+    } |
+    {
+        name: '997';
+        children: BigUnion[];
+    } |
+    {
+        name: '998';
+        children: BigUnion[];
+    } |
+    {
+        name: '999';
+        children: BigUnion[];
+    } |
+    {
+        name: '1000';
+        children: BigUnion[];
+    } |
+    {
+        name: '1001';
+        children: BigUnion[];
+    } |
+    {
+        name: '1002';
+        children: BigUnion[];
+    } |
+    {
+        name: '1003';
+        children: BigUnion[];
+    } |
+    {
+        name: '1004';
+        children: BigUnion[];
+    } |
+    {
+        name: '1005';
+        children: BigUnion[];
+    } |
+    {
+        name: '1006';
+        children: BigUnion[];
+    } |
+    {
+        name: '1007';
+        children: BigUnion[];
+    } |
+    {
+        name: '1008';
+        children: BigUnion[];
+    } |
+    {
+        name: '1009';
+        children: BigUnion[];
+    } |
+    {
+        name: '1010';
+        children: BigUnion[];
+    } |
+    {
+        name: '1011';
+        children: BigUnion[];
+    } |
+    {
+        name: '1012';
+        children: BigUnion[];
+    } |
+    {
+        name: '1013';
+        children: BigUnion[];
+    } |
+    {
+        name: '1014';
+        children: BigUnion[];
+    } |
+    {
+        name: '1015';
+        children: BigUnion[];
+    } |
+    {
+        name: '1016';
+        children: BigUnion[];
+    } |
+    {
+        name: '1017';
+        children: BigUnion[];
+    } |
+    {
+        name: '1018';
+        children: BigUnion[];
+    } |
+    {
+        name: '1019';
+        children: BigUnion[];
+    } |
+    {
+        name: '1020';
+        children: BigUnion[];
+    } |
+    {
+        name: '1021';
+        children: BigUnion[];
+    } |
+    {
+        name: '1022';
+        children: BigUnion[];
+    } |
+    {
+        name: '1023';
+        children: BigUnion[];
+    } |
+    {
+        name: '1024';
+        children: BigUnion[];
+    } |
+    {
+        name: '1025';
+        children: BigUnion[];
+    } |
+    {
+        name: '1026';
+        children: BigUnion[];
+    } |
+    {
+        name: '1027';
+        children: BigUnion[];
+    } |
+    {
+        name: '1028';
+        children: BigUnion[];
+    } |
+    {
+        name: '1029';
+        children: BigUnion[];
+    } |
+    {
+        name: '1030';
+        children: BigUnion[];
+    } |
+    {
+        name: '1031';
+        children: BigUnion[];
+    } |
+    {
+        name: '1032';
+        children: BigUnion[];
+    } |
+    {
+        name: '1033';
+        children: BigUnion[];
+    } |
+    {
+        name: '1034';
+        children: BigUnion[];
+    } |
+    {
+        name: '1035';
+        children: BigUnion[];
+    } |
+    {
+        name: '1036';
+        children: BigUnion[];
+    } |
+    {
+        name: '1037';
+        children: BigUnion[];
+    } |
+    {
+        name: '1038';
+        children: BigUnion[];
+    } |
+    {
+        name: '1039';
+        children: BigUnion[];
+    } |
+    {
+        name: '1040';
+        children: BigUnion[];
+    } |
+    {
+        name: '1041';
+        children: BigUnion[];
+    } |
+    {
+        name: '1042';
+        children: BigUnion[];
+    } |
+    {
+        name: '1043';
+        children: BigUnion[];
+    } |
+    {
+        name: '1044';
+        children: BigUnion[];
+    } |
+    {
+        name: '1045';
+        children: BigUnion[];
+    } |
+    {
+        name: '1046';
+        children: BigUnion[];
+    } |
+    {
+        name: '1047';
+        children: BigUnion[];
+    } |
+    {
+        name: '1048';
+        children: BigUnion[];
+    } |
+    {
+        name: '1049';
+        children: BigUnion[];
+    } |
+    {
+        name: '1050';
+        children: BigUnion[];
+    } |
+    {
+        name: '1051';
+        children: BigUnion[];
+    } |
+    {
+        name: '1052';
+        children: BigUnion[];
+    } |
+    {
+        name: '1053';
+        children: BigUnion[];
+    } |
+    {
+        name: '1054';
+        children: BigUnion[];
+    } |
+    {
+        name: '1055';
+        children: BigUnion[];
+    } |
+    {
+        name: '1056';
+        children: BigUnion[];
+    } |
+    {
+        name: '1057';
+        children: BigUnion[];
+    } |
+    {
+        name: '1058';
+        children: BigUnion[];
+    } |
+    {
+        name: '1059';
+        children: BigUnion[];
+    } |
+    {
+        name: '1060';
+        children: BigUnion[];
+    } |
+    {
+        name: '1061';
+        children: BigUnion[];
+    } |
+    {
+        name: '1062';
+        children: BigUnion[];
+    } |
+    {
+        name: '1063';
+        children: BigUnion[];
+    } |
+    {
+        name: '1064';
+        children: BigUnion[];
+    } |
+    {
+        name: '1065';
+        children: BigUnion[];
+    } |
+    {
+        name: '1066';
+        children: BigUnion[];
+    } |
+    {
+        name: '1067';
+        children: BigUnion[];
+    } |
+    {
+        name: '1068';
+        children: BigUnion[];
+    } |
+    {
+        name: '1069';
+        children: BigUnion[];
+    } |
+    {
+        name: '1070';
+        children: BigUnion[];
+    } |
+    {
+        name: '1071';
+        children: BigUnion[];
+    } |
+    {
+        name: '1072';
+        children: BigUnion[];
+    } |
+    {
+        name: '1073';
+        children: BigUnion[];
+    } |
+    {
+        name: '1074';
+        children: BigUnion[];
+    } |
+    {
+        name: '1075';
+        children: BigUnion[];
+    } |
+    {
+        name: '1076';
+        children: BigUnion[];
+    } |
+    {
+        name: '1077';
+        children: BigUnion[];
+    } |
+    {
+        name: '1078';
+        children: BigUnion[];
+    } |
+    {
+        name: '1079';
+        children: BigUnion[];
+    } |
+    {
+        name: '1080';
+        children: BigUnion[];
+    } |
+    {
+        name: '1081';
+        children: BigUnion[];
+    } |
+    {
+        name: '1082';
+        children: BigUnion[];
+    } |
+    {
+        name: '1083';
+        children: BigUnion[];
+    } |
+    {
+        name: '1084';
+        children: BigUnion[];
+    } |
+    {
+        name: '1085';
+        children: BigUnion[];
+    } |
+    {
+        name: '1086';
+        children: BigUnion[];
+    } |
+    {
+        name: '1087';
+        children: BigUnion[];
+    } |
+    {
+        name: '1088';
+        children: BigUnion[];
+    } |
+    {
+        name: '1089';
+        children: BigUnion[];
+    } |
+    {
+        name: '1090';
+        children: BigUnion[];
+    } |
+    {
+        name: '1091';
+        children: BigUnion[];
+    } |
+    {
+        name: '1092';
+        children: BigUnion[];
+    } |
+    {
+        name: '1093';
+        children: BigUnion[];
+    } |
+    {
+        name: '1094';
+        children: BigUnion[];
+    } |
+    {
+        name: '1095';
+        children: BigUnion[];
+    } |
+    {
+        name: '1096';
+        children: BigUnion[];
+    } |
+    {
+        name: '1097';
+        children: BigUnion[];
+    } |
+    {
+        name: '1098';
+        children: BigUnion[];
+    } |
+    {
+        name: '1099';
+        children: BigUnion[];
+    } |
+    {
+        name: '1100';
+        children: BigUnion[];
+    } |
+    {
+        name: '1101';
+        children: BigUnion[];
+    } |
+    {
+        name: '1102';
+        children: BigUnion[];
+    } |
+    {
+        name: '1103';
+        children: BigUnion[];
+    } |
+    {
+        name: '1104';
+        children: BigUnion[];
+    } |
+    {
+        name: '1105';
+        children: BigUnion[];
+    } |
+    {
+        name: '1106';
+        children: BigUnion[];
+    } |
+    {
+        name: '1107';
+        children: BigUnion[];
+    } |
+    {
+        name: '1108';
+        children: BigUnion[];
+    } |
+    {
+        name: '1109';
+        children: BigUnion[];
+    } |
+    {
+        name: '1110';
+        children: BigUnion[];
+    } |
+    {
+        name: '1111';
+        children: BigUnion[];
+    } |
+    {
+        name: '1112';
+        children: BigUnion[];
+    } |
+    {
+        name: '1113';
+        children: BigUnion[];
+    } |
+    {
+        name: '1114';
+        children: BigUnion[];
+    } |
+    {
+        name: '1115';
+        children: BigUnion[];
+    } |
+    {
+        name: '1116';
+        children: BigUnion[];
+    } |
+    {
+        name: '1117';
+        children: BigUnion[];
+    } |
+    {
+        name: '1118';
+        children: BigUnion[];
+    } |
+    {
+        name: '1119';
+        children: BigUnion[];
+    } |
+    {
+        name: '1120';
+        children: BigUnion[];
+    } |
+    {
+        name: '1121';
+        children: BigUnion[];
+    } |
+    {
+        name: '1122';
+        children: BigUnion[];
+    } |
+    {
+        name: '1123';
+        children: BigUnion[];
+    } |
+    {
+        name: '1124';
+        children: BigUnion[];
+    } |
+    {
+        name: '1125';
+        children: BigUnion[];
+    } |
+    {
+        name: '1126';
+        children: BigUnion[];
+    } |
+    {
+        name: '1127';
+        children: BigUnion[];
+    } |
+    {
+        name: '1128';
+        children: BigUnion[];
+    } |
+    {
+        name: '1129';
+        children: BigUnion[];
+    } |
+    {
+        name: '1130';
+        children: BigUnion[];
+    } |
+    {
+        name: '1131';
+        children: BigUnion[];
+    } |
+    {
+        name: '1132';
+        children: BigUnion[];
+    } |
+    {
+        name: '1133';
+        children: BigUnion[];
+    } |
+    {
+        name: '1134';
+        children: BigUnion[];
+    } |
+    {
+        name: '1135';
+        children: BigUnion[];
+    } |
+    {
+        name: '1136';
+        children: BigUnion[];
+    } |
+    {
+        name: '1137';
+        children: BigUnion[];
+    } |
+    {
+        name: '1138';
+        children: BigUnion[];
+    } |
+    {
+        name: '1139';
+        children: BigUnion[];
+    } |
+    {
+        name: '1140';
+        children: BigUnion[];
+    } |
+    {
+        name: '1141';
+        children: BigUnion[];
+    } |
+    {
+        name: '1142';
+        children: BigUnion[];
+    } |
+    {
+        name: '1143';
+        children: BigUnion[];
+    } |
+    {
+        name: '1144';
+        children: BigUnion[];
+    } |
+    {
+        name: '1145';
+        children: BigUnion[];
+    } |
+    {
+        name: '1146';
+        children: BigUnion[];
+    } |
+    {
+        name: '1147';
+        children: BigUnion[];
+    } |
+    {
+        name: '1148';
+        children: BigUnion[];
+    } |
+    {
+        name: '1149';
+        children: BigUnion[];
+    } |
+    {
+        name: '1150';
+        children: BigUnion[];
+    } |
+    {
+        name: '1151';
+        children: BigUnion[];
+    } |
+    {
+        name: '1152';
+        children: BigUnion[];
+    } |
+    {
+        name: '1153';
+        children: BigUnion[];
+    } |
+    {
+        name: '1154';
+        children: BigUnion[];
+    } |
+    {
+        name: '1155';
+        children: BigUnion[];
+    } |
+    {
+        name: '1156';
+        children: BigUnion[];
+    } |
+    {
+        name: '1157';
+        children: BigUnion[];
+    } |
+    {
+        name: '1158';
+        children: BigUnion[];
+    } |
+    {
+        name: '1159';
+        children: BigUnion[];
+    } |
+    {
+        name: '1160';
+        children: BigUnion[];
+    } |
+    {
+        name: '1161';
+        children: BigUnion[];
+    } |
+    {
+        name: '1162';
+        children: BigUnion[];
+    } |
+    {
+        name: '1163';
+        children: BigUnion[];
+    } |
+    {
+        name: '1164';
+        children: BigUnion[];
+    } |
+    {
+        name: '1165';
+        children: BigUnion[];
+    } |
+    {
+        name: '1166';
+        children: BigUnion[];
+    } |
+    {
+        name: '1167';
+        children: BigUnion[];
+    } |
+    {
+        name: '1168';
+        children: BigUnion[];
+    } |
+    {
+        name: '1169';
+        children: BigUnion[];
+    } |
+    {
+        name: '1170';
+        children: BigUnion[];
+    } |
+    {
+        name: '1171';
+        children: BigUnion[];
+    } |
+    {
+        name: '1172';
+        children: BigUnion[];
+    } |
+    {
+        name: '1173';
+        children: BigUnion[];
+    } |
+    {
+        name: '1174';
+        children: BigUnion[];
+    } |
+    {
+        name: '1175';
+        children: BigUnion[];
+    } |
+    {
+        name: '1176';
+        children: BigUnion[];
+    } |
+    {
+        name: '1177';
+        children: BigUnion[];
+    } |
+    {
+        name: '1178';
+        children: BigUnion[];
+    } |
+    {
+        name: '1179';
+        children: BigUnion[];
+    } |
+    {
+        name: '1180';
+        children: BigUnion[];
+    } |
+    {
+        name: '1181';
+        children: BigUnion[];
+    } |
+    {
+        name: '1182';
+        children: BigUnion[];
+    } |
+    {
+        name: '1183';
+        children: BigUnion[];
+    } |
+    {
+        name: '1184';
+        children: BigUnion[];
+    } |
+    {
+        name: '1185';
+        children: BigUnion[];
+    } |
+    {
+        name: '1186';
+        children: BigUnion[];
+    } |
+    {
+        name: '1187';
+        children: BigUnion[];
+    } |
+    {
+        name: '1188';
+        children: BigUnion[];
+    } |
+    {
+        name: '1189';
+        children: BigUnion[];
+    } |
+    {
+        name: '1190';
+        children: BigUnion[];
+    } |
+    {
+        name: '1191';
+        children: BigUnion[];
+    } |
+    {
+        name: '1192';
+        children: BigUnion[];
+    } |
+    {
+        name: '1193';
+        children: BigUnion[];
+    } |
+    {
+        name: '1194';
+        children: BigUnion[];
+    } |
+    {
+        name: '1195';
+        children: BigUnion[];
+    } |
+    {
+        name: '1196';
+        children: BigUnion[];
+    } |
+    {
+        name: '1197';
+        children: BigUnion[];
+    } |
+    {
+        name: '1198';
+        children: BigUnion[];
+    } |
+    {
+        name: '1199';
+        children: BigUnion[];
+    } |
+    {
+        name: '1200';
+        children: BigUnion[];
+    } |
+    {
+        name: '1201';
+        children: BigUnion[];
+    } |
+    {
+        name: '1202';
+        children: BigUnion[];
+    } |
+    {
+        name: '1203';
+        children: BigUnion[];
+    } |
+    {
+        name: '1204';
+        children: BigUnion[];
+    } |
+    {
+        name: '1205';
+        children: BigUnion[];
+    } |
+    {
+        name: '1206';
+        children: BigUnion[];
+    } |
+    {
+        name: '1207';
+        children: BigUnion[];
+    } |
+    {
+        name: '1208';
+        children: BigUnion[];
+    } |
+    {
+        name: '1209';
+        children: BigUnion[];
+    } |
+    {
+        name: '1210';
+        children: BigUnion[];
+    } |
+    {
+        name: '1211';
+        children: BigUnion[];
+    } |
+    {
+        name: '1212';
+        children: BigUnion[];
+    } |
+    {
+        name: '1213';
+        children: BigUnion[];
+    } |
+    {
+        name: '1214';
+        children: BigUnion[];
+    } |
+    {
+        name: '1215';
+        children: BigUnion[];
+    } |
+    {
+        name: '1216';
+        children: BigUnion[];
+    } |
+    {
+        name: '1217';
+        children: BigUnion[];
+    } |
+    {
+        name: '1218';
+        children: BigUnion[];
+    } |
+    {
+        name: '1219';
+        children: BigUnion[];
+    } |
+    {
+        name: '1220';
+        children: BigUnion[];
+    } |
+    {
+        name: '1221';
+        children: BigUnion[];
+    } |
+    {
+        name: '1222';
+        children: BigUnion[];
+    } |
+    {
+        name: '1223';
+        children: BigUnion[];
+    } |
+    {
+        name: '1224';
+        children: BigUnion[];
+    } |
+    {
+        name: '1225';
+        children: BigUnion[];
+    } |
+    {
+        name: '1226';
+        children: BigUnion[];
+    } |
+    {
+        name: '1227';
+        children: BigUnion[];
+    } |
+    {
+        name: '1228';
+        children: BigUnion[];
+    } |
+    {
+        name: '1229';
+        children: BigUnion[];
+    } |
+    {
+        name: '1230';
+        children: BigUnion[];
+    } |
+    {
+        name: '1231';
+        children: BigUnion[];
+    } |
+    {
+        name: '1232';
+        children: BigUnion[];
+    } |
+    {
+        name: '1233';
+        children: BigUnion[];
+    } |
+    {
+        name: '1234';
+        children: BigUnion[];
+    } |
+    {
+        name: '1235';
+        children: BigUnion[];
+    } |
+    {
+        name: '1236';
+        children: BigUnion[];
+    } |
+    {
+        name: '1237';
+        children: BigUnion[];
+    } |
+    {
+        name: '1238';
+        children: BigUnion[];
+    } |
+    {
+        name: '1239';
+        children: BigUnion[];
+    } |
+    {
+        name: '1240';
+        children: BigUnion[];
+    } |
+    {
+        name: '1241';
+        children: BigUnion[];
+    } |
+    {
+        name: '1242';
+        children: BigUnion[];
+    } |
+    {
+        name: '1243';
+        children: BigUnion[];
+    } |
+    {
+        name: '1244';
+        children: BigUnion[];
+    } |
+    {
+        name: '1245';
+        children: BigUnion[];
+    } |
+    {
+        name: '1246';
+        children: BigUnion[];
+    } |
+    {
+        name: '1247';
+        children: BigUnion[];
+    } |
+    {
+        name: '1248';
+        children: BigUnion[];
+    } |
+    {
+        name: '1249';
+        children: BigUnion[];
+    } |
+    {
+        name: '1250';
+        children: BigUnion[];
+    } |
+    {
+        name: '1251';
+        children: BigUnion[];
+    } |
+    {
+        name: '1252';
+        children: BigUnion[];
+    } |
+    {
+        name: '1253';
+        children: BigUnion[];
+    } |
+    {
+        name: '1254';
+        children: BigUnion[];
+    } |
+    {
+        name: '1255';
+        children: BigUnion[];
+    } |
+    {
+        name: '1256';
+        children: BigUnion[];
+    } |
+    {
+        name: '1257';
+        children: BigUnion[];
+    } |
+    {
+        name: '1258';
+        children: BigUnion[];
+    } |
+    {
+        name: '1259';
+        children: BigUnion[];
+    } |
+    {
+        name: '1260';
+        children: BigUnion[];
+    } |
+    {
+        name: '1261';
+        children: BigUnion[];
+    } |
+    {
+        name: '1262';
+        children: BigUnion[];
+    } |
+    {
+        name: '1263';
+        children: BigUnion[];
+    } |
+    {
+        name: '1264';
+        children: BigUnion[];
+    } |
+    {
+        name: '1265';
+        children: BigUnion[];
+    } |
+    {
+        name: '1266';
+        children: BigUnion[];
+    } |
+    {
+        name: '1267';
+        children: BigUnion[];
+    } |
+    {
+        name: '1268';
+        children: BigUnion[];
+    } |
+    {
+        name: '1269';
+        children: BigUnion[];
+    } |
+    {
+        name: '1270';
+        children: BigUnion[];
+    } |
+    {
+        name: '1271';
+        children: BigUnion[];
+    } |
+    {
+        name: '1272';
+        children: BigUnion[];
+    } |
+    {
+        name: '1273';
+        children: BigUnion[];
+    } |
+    {
+        name: '1274';
+        children: BigUnion[];
+    } |
+    {
+        name: '1275';
+        children: BigUnion[];
+    } |
+    {
+        name: '1276';
+        children: BigUnion[];
+    } |
+    {
+        name: '1277';
+        children: BigUnion[];
+    } |
+    {
+        name: '1278';
+        children: BigUnion[];
+    } |
+    {
+        name: '1279';
+        children: BigUnion[];
+    } |
+    {
+        name: '1280';
+        children: BigUnion[];
+    } |
+    {
+        name: '1281';
+        children: BigUnion[];
+    } |
+    {
+        name: '1282';
+        children: BigUnion[];
+    } |
+    {
+        name: '1283';
+        children: BigUnion[];
+    } |
+    {
+        name: '1284';
+        children: BigUnion[];
+    } |
+    {
+        name: '1285';
+        children: BigUnion[];
+    } |
+    {
+        name: '1286';
+        children: BigUnion[];
+    } |
+    {
+        name: '1287';
+        children: BigUnion[];
+    } |
+    {
+        name: '1288';
+        children: BigUnion[];
+    } |
+    {
+        name: '1289';
+        children: BigUnion[];
+    } |
+    {
+        name: '1290';
+        children: BigUnion[];
+    } |
+    {
+        name: '1291';
+        children: BigUnion[];
+    } |
+    {
+        name: '1292';
+        children: BigUnion[];
+    } |
+    {
+        name: '1293';
+        children: BigUnion[];
+    } |
+    {
+        name: '1294';
+        children: BigUnion[];
+    } |
+    {
+        name: '1295';
+        children: BigUnion[];
+    } |
+    {
+        name: '1296';
+        children: BigUnion[];
+    } |
+    {
+        name: '1297';
+        children: BigUnion[];
+    } |
+    {
+        name: '1298';
+        children: BigUnion[];
+    } |
+    {
+        name: '1299';
+        children: BigUnion[];
+    } |
+    {
+        name: '1300';
+        children: BigUnion[];
+    } |
+    {
+        name: '1301';
+        children: BigUnion[];
+    } |
+    {
+        name: '1302';
+        children: BigUnion[];
+    } |
+    {
+        name: '1303';
+        children: BigUnion[];
+    } |
+    {
+        name: '1304';
+        children: BigUnion[];
+    } |
+    {
+        name: '1305';
+        children: BigUnion[];
+    } |
+    {
+        name: '1306';
+        children: BigUnion[];
+    } |
+    {
+        name: '1307';
+        children: BigUnion[];
+    } |
+    {
+        name: '1308';
+        children: BigUnion[];
+    } |
+    {
+        name: '1309';
+        children: BigUnion[];
+    } |
+    {
+        name: '1310';
+        children: BigUnion[];
+    } |
+    {
+        name: '1311';
+        children: BigUnion[];
+    } |
+    {
+        name: '1312';
+        children: BigUnion[];
+    } |
+    {
+        name: '1313';
+        children: BigUnion[];
+    } |
+    {
+        name: '1314';
+        children: BigUnion[];
+    } |
+    {
+        name: '1315';
+        children: BigUnion[];
+    } |
+    {
+        name: '1316';
+        children: BigUnion[];
+    } |
+    {
+        name: '1317';
+        children: BigUnion[];
+    } |
+    {
+        name: '1318';
+        children: BigUnion[];
+    } |
+    {
+        name: '1319';
+        children: BigUnion[];
+    } |
+    {
+        name: '1320';
+        children: BigUnion[];
+    } |
+    {
+        name: '1321';
+        children: BigUnion[];
+    } |
+    {
+        name: '1322';
+        children: BigUnion[];
+    } |
+    {
+        name: '1323';
+        children: BigUnion[];
+    } |
+    {
+        name: '1324';
+        children: BigUnion[];
+    } |
+    {
+        name: '1325';
+        children: BigUnion[];
+    } |
+    {
+        name: '1326';
+        children: BigUnion[];
+    } |
+    {
+        name: '1327';
+        children: BigUnion[];
+    } |
+    {
+        name: '1328';
+        children: BigUnion[];
+    } |
+    {
+        name: '1329';
+        children: BigUnion[];
+    } |
+    {
+        name: '1330';
+        children: BigUnion[];
+    } |
+    {
+        name: '1331';
+        children: BigUnion[];
+    } |
+    {
+        name: '1332';
+        children: BigUnion[];
+    } |
+    {
+        name: '1333';
+        children: BigUnion[];
+    } |
+    {
+        name: '1334';
+        children: BigUnion[];
+    } |
+    {
+        name: '1335';
+        children: BigUnion[];
+    } |
+    {
+        name: '1336';
+        children: BigUnion[];
+    } |
+    {
+        name: '1337';
+        children: BigUnion[];
+    } |
+    {
+        name: '1338';
+        children: BigUnion[];
+    } |
+    {
+        name: '1339';
+        children: BigUnion[];
+    } |
+    {
+        name: '1340';
+        children: BigUnion[];
+    } |
+    {
+        name: '1341';
+        children: BigUnion[];
+    } |
+    {
+        name: '1342';
+        children: BigUnion[];
+    } |
+    {
+        name: '1343';
+        children: BigUnion[];
+    } |
+    {
+        name: '1344';
+        children: BigUnion[];
+    } |
+    {
+        name: '1345';
+        children: BigUnion[];
+    } |
+    {
+        name: '1346';
+        children: BigUnion[];
+    } |
+    {
+        name: '1347';
+        children: BigUnion[];
+    } |
+    {
+        name: '1348';
+        children: BigUnion[];
+    } |
+    {
+        name: '1349';
+        children: BigUnion[];
+    } |
+    {
+        name: '1350';
+        children: BigUnion[];
+    } |
+    {
+        name: '1351';
+        children: BigUnion[];
+    } |
+    {
+        name: '1352';
+        children: BigUnion[];
+    } |
+    {
+        name: '1353';
+        children: BigUnion[];
+    } |
+    {
+        name: '1354';
+        children: BigUnion[];
+    } |
+    {
+        name: '1355';
+        children: BigUnion[];
+    } |
+    {
+        name: '1356';
+        children: BigUnion[];
+    } |
+    {
+        name: '1357';
+        children: BigUnion[];
+    } |
+    {
+        name: '1358';
+        children: BigUnion[];
+    } |
+    {
+        name: '1359';
+        children: BigUnion[];
+    } |
+    {
+        name: '1360';
+        children: BigUnion[];
+    } |
+    {
+        name: '1361';
+        children: BigUnion[];
+    } |
+    {
+        name: '1362';
+        children: BigUnion[];
+    } |
+    {
+        name: '1363';
+        children: BigUnion[];
+    } |
+    {
+        name: '1364';
+        children: BigUnion[];
+    } |
+    {
+        name: '1365';
+        children: BigUnion[];
+    } |
+    {
+        name: '1366';
+        children: BigUnion[];
+    } |
+    {
+        name: '1367';
+        children: BigUnion[];
+    } |
+    {
+        name: '1368';
+        children: BigUnion[];
+    } |
+    {
+        name: '1369';
+        children: BigUnion[];
+    } |
+    {
+        name: '1370';
+        children: BigUnion[];
+    } |
+    {
+        name: '1371';
+        children: BigUnion[];
+    } |
+    {
+        name: '1372';
+        children: BigUnion[];
+    } |
+    {
+        name: '1373';
+        children: BigUnion[];
+    } |
+    {
+        name: '1374';
+        children: BigUnion[];
+    } |
+    {
+        name: '1375';
+        children: BigUnion[];
+    } |
+    {
+        name: '1376';
+        children: BigUnion[];
+    } |
+    {
+        name: '1377';
+        children: BigUnion[];
+    } |
+    {
+        name: '1378';
+        children: BigUnion[];
+    } |
+    {
+        name: '1379';
+        children: BigUnion[];
+    } |
+    {
+        name: '1380';
+        children: BigUnion[];
+    } |
+    {
+        name: '1381';
+        children: BigUnion[];
+    } |
+    {
+        name: '1382';
+        children: BigUnion[];
+    } |
+    {
+        name: '1383';
+        children: BigUnion[];
+    } |
+    {
+        name: '1384';
+        children: BigUnion[];
+    } |
+    {
+        name: '1385';
+        children: BigUnion[];
+    } |
+    {
+        name: '1386';
+        children: BigUnion[];
+    } |
+    {
+        name: '1387';
+        children: BigUnion[];
+    } |
+    {
+        name: '1388';
+        children: BigUnion[];
+    } |
+    {
+        name: '1389';
+        children: BigUnion[];
+    } |
+    {
+        name: '1390';
+        children: BigUnion[];
+    } |
+    {
+        name: '1391';
+        children: BigUnion[];
+    } |
+    {
+        name: '1392';
+        children: BigUnion[];
+    } |
+    {
+        name: '1393';
+        children: BigUnion[];
+    } |
+    {
+        name: '1394';
+        children: BigUnion[];
+    } |
+    {
+        name: '1395';
+        children: BigUnion[];
+    } |
+    {
+        name: '1396';
+        children: BigUnion[];
+    } |
+    {
+        name: '1397';
+        children: BigUnion[];
+    } |
+    {
+        name: '1398';
+        children: BigUnion[];
+    } |
+    {
+        name: '1399';
+        children: BigUnion[];
+    } |
+    {
+        name: '1400';
+        children: BigUnion[];
+    } |
+    {
+        name: '1401';
+        children: BigUnion[];
+    } |
+    {
+        name: '1402';
+        children: BigUnion[];
+    } |
+    {
+        name: '1403';
+        children: BigUnion[];
+    } |
+    {
+        name: '1404';
+        children: BigUnion[];
+    } |
+    {
+        name: '1405';
+        children: BigUnion[];
+    } |
+    {
+        name: '1406';
+        children: BigUnion[];
+    } |
+    {
+        name: '1407';
+        children: BigUnion[];
+    } |
+    {
+        name: '1408';
+        children: BigUnion[];
+    } |
+    {
+        name: '1409';
+        children: BigUnion[];
+    } |
+    {
+        name: '1410';
+        children: BigUnion[];
+    } |
+    {
+        name: '1411';
+        children: BigUnion[];
+    } |
+    {
+        name: '1412';
+        children: BigUnion[];
+    } |
+    {
+        name: '1413';
+        children: BigUnion[];
+    } |
+    {
+        name: '1414';
+        children: BigUnion[];
+    } |
+    {
+        name: '1415';
+        children: BigUnion[];
+    } |
+    {
+        name: '1416';
+        children: BigUnion[];
+    } |
+    {
+        name: '1417';
+        children: BigUnion[];
+    } |
+    {
+        name: '1418';
+        children: BigUnion[];
+    } |
+    {
+        name: '1419';
+        children: BigUnion[];
+    } |
+    {
+        name: '1420';
+        children: BigUnion[];
+    } |
+    {
+        name: '1421';
+        children: BigUnion[];
+    } |
+    {
+        name: '1422';
+        children: BigUnion[];
+    } |
+    {
+        name: '1423';
+        children: BigUnion[];
+    } |
+    {
+        name: '1424';
+        children: BigUnion[];
+    } |
+    {
+        name: '1425';
+        children: BigUnion[];
+    } |
+    {
+        name: '1426';
+        children: BigUnion[];
+    } |
+    {
+        name: '1427';
+        children: BigUnion[];
+    } |
+    {
+        name: '1428';
+        children: BigUnion[];
+    } |
+    {
+        name: '1429';
+        children: BigUnion[];
+    } |
+    {
+        name: '1430';
+        children: BigUnion[];
+    } |
+    {
+        name: '1431';
+        children: BigUnion[];
+    } |
+    {
+        name: '1432';
+        children: BigUnion[];
+    } |
+    {
+        name: '1433';
+        children: BigUnion[];
+    } |
+    {
+        name: '1434';
+        children: BigUnion[];
+    } |
+    {
+        name: '1435';
+        children: BigUnion[];
+    } |
+    {
+        name: '1436';
+        children: BigUnion[];
+    } |
+    {
+        name: '1437';
+        children: BigUnion[];
+    } |
+    {
+        name: '1438';
+        children: BigUnion[];
+    } |
+    {
+        name: '1439';
+        children: BigUnion[];
+    } |
+    {
+        name: '1440';
+        children: BigUnion[];
+    } |
+    {
+        name: '1441';
+        children: BigUnion[];
+    } |
+    {
+        name: '1442';
+        children: BigUnion[];
+    } |
+    {
+        name: '1443';
+        children: BigUnion[];
+    } |
+    {
+        name: '1444';
+        children: BigUnion[];
+    } |
+    {
+        name: '1445';
+        children: BigUnion[];
+    } |
+    {
+        name: '1446';
+        children: BigUnion[];
+    } |
+    {
+        name: '1447';
+        children: BigUnion[];
+    } |
+    {
+        name: '1448';
+        children: BigUnion[];
+    } |
+    {
+        name: '1449';
+        children: BigUnion[];
+    } |
+    {
+        name: '1450';
+        children: BigUnion[];
+    } |
+    {
+        name: '1451';
+        children: BigUnion[];
+    } |
+    {
+        name: '1452';
+        children: BigUnion[];
+    } |
+    {
+        name: '1453';
+        children: BigUnion[];
+    } |
+    {
+        name: '1454';
+        children: BigUnion[];
+    } |
+    {
+        name: '1455';
+        children: BigUnion[];
+    } |
+    {
+        name: '1456';
+        children: BigUnion[];
+    } |
+    {
+        name: '1457';
+        children: BigUnion[];
+    } |
+    {
+        name: '1458';
+        children: BigUnion[];
+    } |
+    {
+        name: '1459';
+        children: BigUnion[];
+    } |
+    {
+        name: '1460';
+        children: BigUnion[];
+    } |
+    {
+        name: '1461';
+        children: BigUnion[];
+    } |
+    {
+        name: '1462';
+        children: BigUnion[];
+    } |
+    {
+        name: '1463';
+        children: BigUnion[];
+    } |
+    {
+        name: '1464';
+        children: BigUnion[];
+    } |
+    {
+        name: '1465';
+        children: BigUnion[];
+    } |
+    {
+        name: '1466';
+        children: BigUnion[];
+    } |
+    {
+        name: '1467';
+        children: BigUnion[];
+    } |
+    {
+        name: '1468';
+        children: BigUnion[];
+    } |
+    {
+        name: '1469';
+        children: BigUnion[];
+    } |
+    {
+        name: '1470';
+        children: BigUnion[];
+    } |
+    {
+        name: '1471';
+        children: BigUnion[];
+    } |
+    {
+        name: '1472';
+        children: BigUnion[];
+    } |
+    {
+        name: '1473';
+        children: BigUnion[];
+    } |
+    {
+        name: '1474';
+        children: BigUnion[];
+    } |
+    {
+        name: '1475';
+        children: BigUnion[];
+    } |
+    {
+        name: '1476';
+        children: BigUnion[];
+    } |
+    {
+        name: '1477';
+        children: BigUnion[];
+    } |
+    {
+        name: '1478';
+        children: BigUnion[];
+    } |
+    {
+        name: '1479';
+        children: BigUnion[];
+    } |
+    {
+        name: '1480';
+        children: BigUnion[];
+    } |
+    {
+        name: '1481';
+        children: BigUnion[];
+    } |
+    {
+        name: '1482';
+        children: BigUnion[];
+    } |
+    {
+        name: '1483';
+        children: BigUnion[];
+    } |
+    {
+        name: '1484';
+        children: BigUnion[];
+    } |
+    {
+        name: '1485';
+        children: BigUnion[];
+    } |
+    {
+        name: '1486';
+        children: BigUnion[];
+    } |
+    {
+        name: '1487';
+        children: BigUnion[];
+    } |
+    {
+        name: '1488';
+        children: BigUnion[];
+    } |
+    {
+        name: '1489';
+        children: BigUnion[];
+    } |
+    {
+        name: '1490';
+        children: BigUnion[];
+    } |
+    {
+        name: '1491';
+        children: BigUnion[];
+    } |
+    {
+        name: '1492';
+        children: BigUnion[];
+    } |
+    {
+        name: '1493';
+        children: BigUnion[];
+    } |
+    {
+        name: '1494';
+        children: BigUnion[];
+    } |
+    {
+        name: '1495';
+        children: BigUnion[];
+    } |
+    {
+        name: '1496';
+        children: BigUnion[];
+    } |
+    {
+        name: '1497';
+        children: BigUnion[];
+    } |
+    {
+        name: '1498';
+        children: BigUnion[];
+    } |
+    {
+        name: '1499';
+        children: BigUnion[];
+    } |
+    {
+        name: '1500';
+        children: BigUnion[];
+    } |
+    {
+        name: '1501';
+        children: BigUnion[];
+    } |
+    {
+        name: '1502';
+        children: BigUnion[];
+    } |
+    {
+        name: '1503';
+        children: BigUnion[];
+    } |
+    {
+        name: '1504';
+        children: BigUnion[];
+    } |
+    {
+        name: '1505';
+        children: BigUnion[];
+    } |
+    {
+        name: '1506';
+        children: BigUnion[];
+    } |
+    {
+        name: '1507';
+        children: BigUnion[];
+    } |
+    {
+        name: '1508';
+        children: BigUnion[];
+    } |
+    {
+        name: '1509';
+        children: BigUnion[];
+    } |
+    {
+        name: '1510';
+        children: BigUnion[];
+    } |
+    {
+        name: '1511';
+        children: BigUnion[];
+    } |
+    {
+        name: '1512';
+        children: BigUnion[];
+    } |
+    {
+        name: '1513';
+        children: BigUnion[];
+    } |
+    {
+        name: '1514';
+        children: BigUnion[];
+    } |
+    {
+        name: '1515';
+        children: BigUnion[];
+    } |
+    {
+        name: '1516';
+        children: BigUnion[];
+    } |
+    {
+        name: '1517';
+        children: BigUnion[];
+    } |
+    {
+        name: '1518';
+        children: BigUnion[];
+    } |
+    {
+        name: '1519';
+        children: BigUnion[];
+    } |
+    {
+        name: '1520';
+        children: BigUnion[];
+    } |
+    {
+        name: '1521';
+        children: BigUnion[];
+    } |
+    {
+        name: '1522';
+        children: BigUnion[];
+    } |
+    {
+        name: '1523';
+        children: BigUnion[];
+    } |
+    {
+        name: '1524';
+        children: BigUnion[];
+    } |
+    {
+        name: '1525';
+        children: BigUnion[];
+    } |
+    {
+        name: '1526';
+        children: BigUnion[];
+    } |
+    {
+        name: '1527';
+        children: BigUnion[];
+    } |
+    {
+        name: '1528';
+        children: BigUnion[];
+    } |
+    {
+        name: '1529';
+        children: BigUnion[];
+    } |
+    {
+        name: '1530';
+        children: BigUnion[];
+    } |
+    {
+        name: '1531';
+        children: BigUnion[];
+    } |
+    {
+        name: '1532';
+        children: BigUnion[];
+    } |
+    {
+        name: '1533';
+        children: BigUnion[];
+    } |
+    {
+        name: '1534';
+        children: BigUnion[];
+    } |
+    {
+        name: '1535';
+        children: BigUnion[];
+    } |
+    {
+        name: '1536';
+        children: BigUnion[];
+    } |
+    {
+        name: '1537';
+        children: BigUnion[];
+    } |
+    {
+        name: '1538';
+        children: BigUnion[];
+    } |
+    {
+        name: '1539';
+        children: BigUnion[];
+    } |
+    {
+        name: '1540';
+        children: BigUnion[];
+    } |
+    {
+        name: '1541';
+        children: BigUnion[];
+    } |
+    {
+        name: '1542';
+        children: BigUnion[];
+    } |
+    {
+        name: '1543';
+        children: BigUnion[];
+    } |
+    {
+        name: '1544';
+        children: BigUnion[];
+    } |
+    {
+        name: '1545';
+        children: BigUnion[];
+    } |
+    {
+        name: '1546';
+        children: BigUnion[];
+    } |
+    {
+        name: '1547';
+        children: BigUnion[];
+    } |
+    {
+        name: '1548';
+        children: BigUnion[];
+    } |
+    {
+        name: '1549';
+        children: BigUnion[];
+    } |
+    {
+        name: '1550';
+        children: BigUnion[];
+    } |
+    {
+        name: '1551';
+        children: BigUnion[];
+    } |
+    {
+        name: '1552';
+        children: BigUnion[];
+    } |
+    {
+        name: '1553';
+        children: BigUnion[];
+    } |
+    {
+        name: '1554';
+        children: BigUnion[];
+    } |
+    {
+        name: '1555';
+        children: BigUnion[];
+    } |
+    {
+        name: '1556';
+        children: BigUnion[];
+    } |
+    {
+        name: '1557';
+        children: BigUnion[];
+    } |
+    {
+        name: '1558';
+        children: BigUnion[];
+    } |
+    {
+        name: '1559';
+        children: BigUnion[];
+    } |
+    {
+        name: '1560';
+        children: BigUnion[];
+    } |
+    {
+        name: '1561';
+        children: BigUnion[];
+    } |
+    {
+        name: '1562';
+        children: BigUnion[];
+    } |
+    {
+        name: '1563';
+        children: BigUnion[];
+    } |
+    {
+        name: '1564';
+        children: BigUnion[];
+    } |
+    {
+        name: '1565';
+        children: BigUnion[];
+    } |
+    {
+        name: '1566';
+        children: BigUnion[];
+    } |
+    {
+        name: '1567';
+        children: BigUnion[];
+    } |
+    {
+        name: '1568';
+        children: BigUnion[];
+    } |
+    {
+        name: '1569';
+        children: BigUnion[];
+    } |
+    {
+        name: '1570';
+        children: BigUnion[];
+    } |
+    {
+        name: '1571';
+        children: BigUnion[];
+    } |
+    {
+        name: '1572';
+        children: BigUnion[];
+    } |
+    {
+        name: '1573';
+        children: BigUnion[];
+    } |
+    {
+        name: '1574';
+        children: BigUnion[];
+    } |
+    {
+        name: '1575';
+        children: BigUnion[];
+    } |
+    {
+        name: '1576';
+        children: BigUnion[];
+    } |
+    {
+        name: '1577';
+        children: BigUnion[];
+    } |
+    {
+        name: '1578';
+        children: BigUnion[];
+    } |
+    {
+        name: '1579';
+        children: BigUnion[];
+    } |
+    {
+        name: '1580';
+        children: BigUnion[];
+    } |
+    {
+        name: '1581';
+        children: BigUnion[];
+    } |
+    {
+        name: '1582';
+        children: BigUnion[];
+    } |
+    {
+        name: '1583';
+        children: BigUnion[];
+    } |
+    {
+        name: '1584';
+        children: BigUnion[];
+    } |
+    {
+        name: '1585';
+        children: BigUnion[];
+    } |
+    {
+        name: '1586';
+        children: BigUnion[];
+    } |
+    {
+        name: '1587';
+        children: BigUnion[];
+    } |
+    {
+        name: '1588';
+        children: BigUnion[];
+    } |
+    {
+        name: '1589';
+        children: BigUnion[];
+    } |
+    {
+        name: '1590';
+        children: BigUnion[];
+    } |
+    {
+        name: '1591';
+        children: BigUnion[];
+    } |
+    {
+        name: '1592';
+        children: BigUnion[];
+    } |
+    {
+        name: '1593';
+        children: BigUnion[];
+    } |
+    {
+        name: '1594';
+        children: BigUnion[];
+    } |
+    {
+        name: '1595';
+        children: BigUnion[];
+    } |
+    {
+        name: '1596';
+        children: BigUnion[];
+    } |
+    {
+        name: '1597';
+        children: BigUnion[];
+    } |
+    {
+        name: '1598';
+        children: BigUnion[];
+    } |
+    {
+        name: '1599';
+        children: BigUnion[];
+    } |
+    {
+        name: '1600';
+        children: BigUnion[];
+    } |
+    {
+        name: '1601';
+        children: BigUnion[];
+    } |
+    {
+        name: '1602';
+        children: BigUnion[];
+    } |
+    {
+        name: '1603';
+        children: BigUnion[];
+    } |
+    {
+        name: '1604';
+        children: BigUnion[];
+    } |
+    {
+        name: '1605';
+        children: BigUnion[];
+    } |
+    {
+        name: '1606';
+        children: BigUnion[];
+    } |
+    {
+        name: '1607';
+        children: BigUnion[];
+    } |
+    {
+        name: '1608';
+        children: BigUnion[];
+    } |
+    {
+        name: '1609';
+        children: BigUnion[];
+    } |
+    {
+        name: '1610';
+        children: BigUnion[];
+    } |
+    {
+        name: '1611';
+        children: BigUnion[];
+    } |
+    {
+        name: '1612';
+        children: BigUnion[];
+    } |
+    {
+        name: '1613';
+        children: BigUnion[];
+    } |
+    {
+        name: '1614';
+        children: BigUnion[];
+    } |
+    {
+        name: '1615';
+        children: BigUnion[];
+    } |
+    {
+        name: '1616';
+        children: BigUnion[];
+    } |
+    {
+        name: '1617';
+        children: BigUnion[];
+    } |
+    {
+        name: '1618';
+        children: BigUnion[];
+    } |
+    {
+        name: '1619';
+        children: BigUnion[];
+    } |
+    {
+        name: '1620';
+        children: BigUnion[];
+    } |
+    {
+        name: '1621';
+        children: BigUnion[];
+    } |
+    {
+        name: '1622';
+        children: BigUnion[];
+    } |
+    {
+        name: '1623';
+        children: BigUnion[];
+    } |
+    {
+        name: '1624';
+        children: BigUnion[];
+    } |
+    {
+        name: '1625';
+        children: BigUnion[];
+    } |
+    {
+        name: '1626';
+        children: BigUnion[];
+    } |
+    {
+        name: '1627';
+        children: BigUnion[];
+    } |
+    {
+        name: '1628';
+        children: BigUnion[];
+    } |
+    {
+        name: '1629';
+        children: BigUnion[];
+    } |
+    {
+        name: '1630';
+        children: BigUnion[];
+    } |
+    {
+        name: '1631';
+        children: BigUnion[];
+    } |
+    {
+        name: '1632';
+        children: BigUnion[];
+    } |
+    {
+        name: '1633';
+        children: BigUnion[];
+    } |
+    {
+        name: '1634';
+        children: BigUnion[];
+    } |
+    {
+        name: '1635';
+        children: BigUnion[];
+    } |
+    {
+        name: '1636';
+        children: BigUnion[];
+    } |
+    {
+        name: '1637';
+        children: BigUnion[];
+    } |
+    {
+        name: '1638';
+        children: BigUnion[];
+    } |
+    {
+        name: '1639';
+        children: BigUnion[];
+    } |
+    {
+        name: '1640';
+        children: BigUnion[];
+    } |
+    {
+        name: '1641';
+        children: BigUnion[];
+    } |
+    {
+        name: '1642';
+        children: BigUnion[];
+    } |
+    {
+        name: '1643';
+        children: BigUnion[];
+    } |
+    {
+        name: '1644';
+        children: BigUnion[];
+    } |
+    {
+        name: '1645';
+        children: BigUnion[];
+    } |
+    {
+        name: '1646';
+        children: BigUnion[];
+    } |
+    {
+        name: '1647';
+        children: BigUnion[];
+    } |
+    {
+        name: '1648';
+        children: BigUnion[];
+    } |
+    {
+        name: '1649';
+        children: BigUnion[];
+    } |
+    {
+        name: '1650';
+        children: BigUnion[];
+    } |
+    {
+        name: '1651';
+        children: BigUnion[];
+    } |
+    {
+        name: '1652';
+        children: BigUnion[];
+    } |
+    {
+        name: '1653';
+        children: BigUnion[];
+    } |
+    {
+        name: '1654';
+        children: BigUnion[];
+    } |
+    {
+        name: '1655';
+        children: BigUnion[];
+    } |
+    {
+        name: '1656';
+        children: BigUnion[];
+    } |
+    {
+        name: '1657';
+        children: BigUnion[];
+    } |
+    {
+        name: '1658';
+        children: BigUnion[];
+    } |
+    {
+        name: '1659';
+        children: BigUnion[];
+    } |
+    {
+        name: '1660';
+        children: BigUnion[];
+    } |
+    {
+        name: '1661';
+        children: BigUnion[];
+    } |
+    {
+        name: '1662';
+        children: BigUnion[];
+    } |
+    {
+        name: '1663';
+        children: BigUnion[];
+    } |
+    {
+        name: '1664';
+        children: BigUnion[];
+    } |
+    {
+        name: '1665';
+        children: BigUnion[];
+    } |
+    {
+        name: '1666';
+        children: BigUnion[];
+    } |
+    {
+        name: '1667';
+        children: BigUnion[];
+    } |
+    {
+        name: '1668';
+        children: BigUnion[];
+    } |
+    {
+        name: '1669';
+        children: BigUnion[];
+    } |
+    {
+        name: '1670';
+        children: BigUnion[];
+    } |
+    {
+        name: '1671';
+        children: BigUnion[];
+    } |
+    {
+        name: '1672';
+        children: BigUnion[];
+    } |
+    {
+        name: '1673';
+        children: BigUnion[];
+    } |
+    {
+        name: '1674';
+        children: BigUnion[];
+    } |
+    {
+        name: '1675';
+        children: BigUnion[];
+    } |
+    {
+        name: '1676';
+        children: BigUnion[];
+    } |
+    {
+        name: '1677';
+        children: BigUnion[];
+    } |
+    {
+        name: '1678';
+        children: BigUnion[];
+    } |
+    {
+        name: '1679';
+        children: BigUnion[];
+    } |
+    {
+        name: '1680';
+        children: BigUnion[];
+    } |
+    {
+        name: '1681';
+        children: BigUnion[];
+    } |
+    {
+        name: '1682';
+        children: BigUnion[];
+    } |
+    {
+        name: '1683';
+        children: BigUnion[];
+    } |
+    {
+        name: '1684';
+        children: BigUnion[];
+    } |
+    {
+        name: '1685';
+        children: BigUnion[];
+    } |
+    {
+        name: '1686';
+        children: BigUnion[];
+    } |
+    {
+        name: '1687';
+        children: BigUnion[];
+    } |
+    {
+        name: '1688';
+        children: BigUnion[];
+    } |
+    {
+        name: '1689';
+        children: BigUnion[];
+    } |
+    {
+        name: '1690';
+        children: BigUnion[];
+    } |
+    {
+        name: '1691';
+        children: BigUnion[];
+    } |
+    {
+        name: '1692';
+        children: BigUnion[];
+    } |
+    {
+        name: '1693';
+        children: BigUnion[];
+    } |
+    {
+        name: '1694';
+        children: BigUnion[];
+    } |
+    {
+        name: '1695';
+        children: BigUnion[];
+    } |
+    {
+        name: '1696';
+        children: BigUnion[];
+    } |
+    {
+        name: '1697';
+        children: BigUnion[];
+    } |
+    {
+        name: '1698';
+        children: BigUnion[];
+    } |
+    {
+        name: '1699';
+        children: BigUnion[];
+    } |
+    {
+        name: '1700';
+        children: BigUnion[];
+    } |
+    {
+        name: '1701';
+        children: BigUnion[];
+    } |
+    {
+        name: '1702';
+        children: BigUnion[];
+    } |
+    {
+        name: '1703';
+        children: BigUnion[];
+    } |
+    {
+        name: '1704';
+        children: BigUnion[];
+    } |
+    {
+        name: '1705';
+        children: BigUnion[];
+    } |
+    {
+        name: '1706';
+        children: BigUnion[];
+    } |
+    {
+        name: '1707';
+        children: BigUnion[];
+    } |
+    {
+        name: '1708';
+        children: BigUnion[];
+    } |
+    {
+        name: '1709';
+        children: BigUnion[];
+    } |
+    {
+        name: '1710';
+        children: BigUnion[];
+    } |
+    {
+        name: '1711';
+        children: BigUnion[];
+    } |
+    {
+        name: '1712';
+        children: BigUnion[];
+    } |
+    {
+        name: '1713';
+        children: BigUnion[];
+    } |
+    {
+        name: '1714';
+        children: BigUnion[];
+    } |
+    {
+        name: '1715';
+        children: BigUnion[];
+    } |
+    {
+        name: '1716';
+        children: BigUnion[];
+    } |
+    {
+        name: '1717';
+        children: BigUnion[];
+    } |
+    {
+        name: '1718';
+        children: BigUnion[];
+    } |
+    {
+        name: '1719';
+        children: BigUnion[];
+    } |
+    {
+        name: '1720';
+        children: BigUnion[];
+    } |
+    {
+        name: '1721';
+        children: BigUnion[];
+    } |
+    {
+        name: '1722';
+        children: BigUnion[];
+    } |
+    {
+        name: '1723';
+        children: BigUnion[];
+    } |
+    {
+        name: '1724';
+        children: BigUnion[];
+    } |
+    {
+        name: '1725';
+        children: BigUnion[];
+    } |
+    {
+        name: '1726';
+        children: BigUnion[];
+    } |
+    {
+        name: '1727';
+        children: BigUnion[];
+    } |
+    {
+        name: '1728';
+        children: BigUnion[];
+    } |
+    {
+        name: '1729';
+        children: BigUnion[];
+    } |
+    {
+        name: '1730';
+        children: BigUnion[];
+    } |
+    {
+        name: '1731';
+        children: BigUnion[];
+    } |
+    {
+        name: '1732';
+        children: BigUnion[];
+    } |
+    {
+        name: '1733';
+        children: BigUnion[];
+    } |
+    {
+        name: '1734';
+        children: BigUnion[];
+    } |
+    {
+        name: '1735';
+        children: BigUnion[];
+    } |
+    {
+        name: '1736';
+        children: BigUnion[];
+    } |
+    {
+        name: '1737';
+        children: BigUnion[];
+    } |
+    {
+        name: '1738';
+        children: BigUnion[];
+    } |
+    {
+        name: '1739';
+        children: BigUnion[];
+    } |
+    {
+        name: '1740';
+        children: BigUnion[];
+    } |
+    {
+        name: '1741';
+        children: BigUnion[];
+    } |
+    {
+        name: '1742';
+        children: BigUnion[];
+    } |
+    {
+        name: '1743';
+        children: BigUnion[];
+    } |
+    {
+        name: '1744';
+        children: BigUnion[];
+    } |
+    {
+        name: '1745';
+        children: BigUnion[];
+    } |
+    {
+        name: '1746';
+        children: BigUnion[];
+    } |
+    {
+        name: '1747';
+        children: BigUnion[];
+    } |
+    {
+        name: '1748';
+        children: BigUnion[];
+    } |
+    {
+        name: '1749';
+        children: BigUnion[];
+    } |
+    {
+        name: '1750';
+        children: BigUnion[];
+    } |
+    {
+        name: '1751';
+        children: BigUnion[];
+    } |
+    {
+        name: '1752';
+        children: BigUnion[];
+    } |
+    {
+        name: '1753';
+        children: BigUnion[];
+    } |
+    {
+        name: '1754';
+        children: BigUnion[];
+    } |
+    {
+        name: '1755';
+        children: BigUnion[];
+    } |
+    {
+        name: '1756';
+        children: BigUnion[];
+    } |
+    {
+        name: '1757';
+        children: BigUnion[];
+    } |
+    {
+        name: '1758';
+        children: BigUnion[];
+    } |
+    {
+        name: '1759';
+        children: BigUnion[];
+    } |
+    {
+        name: '1760';
+        children: BigUnion[];
+    } |
+    {
+        name: '1761';
+        children: BigUnion[];
+    } |
+    {
+        name: '1762';
+        children: BigUnion[];
+    } |
+    {
+        name: '1763';
+        children: BigUnion[];
+    } |
+    {
+        name: '1764';
+        children: BigUnion[];
+    } |
+    {
+        name: '1765';
+        children: BigUnion[];
+    } |
+    {
+        name: '1766';
+        children: BigUnion[];
+    } |
+    {
+        name: '1767';
+        children: BigUnion[];
+    } |
+    {
+        name: '1768';
+        children: BigUnion[];
+    } |
+    {
+        name: '1769';
+        children: BigUnion[];
+    } |
+    {
+        name: '1770';
+        children: BigUnion[];
+    } |
+    {
+        name: '1771';
+        children: BigUnion[];
+    } |
+    {
+        name: '1772';
+        children: BigUnion[];
+    } |
+    {
+        name: '1773';
+        children: BigUnion[];
+    } |
+    {
+        name: '1774';
+        children: BigUnion[];
+    } |
+    {
+        name: '1775';
+        children: BigUnion[];
+    } |
+    {
+        name: '1776';
+        children: BigUnion[];
+    } |
+    {
+        name: '1777';
+        children: BigUnion[];
+    } |
+    {
+        name: '1778';
+        children: BigUnion[];
+    } |
+    {
+        name: '1779';
+        children: BigUnion[];
+    } |
+    {
+        name: '1780';
+        children: BigUnion[];
+    } |
+    {
+        name: '1781';
+        children: BigUnion[];
+    } |
+    {
+        name: '1782';
+        children: BigUnion[];
+    } |
+    {
+        name: '1783';
+        children: BigUnion[];
+    } |
+    {
+        name: '1784';
+        children: BigUnion[];
+    } |
+    {
+        name: '1785';
+        children: BigUnion[];
+    } |
+    {
+        name: '1786';
+        children: BigUnion[];
+    } |
+    {
+        name: '1787';
+        children: BigUnion[];
+    } |
+    {
+        name: '1788';
+        children: BigUnion[];
+    } |
+    {
+        name: '1789';
+        children: BigUnion[];
+    } |
+    {
+        name: '1790';
+        children: BigUnion[];
+    } |
+    {
+        name: '1791';
+        children: BigUnion[];
+    } |
+    {
+        name: '1792';
+        children: BigUnion[];
+    } |
+    {
+        name: '1793';
+        children: BigUnion[];
+    } |
+    {
+        name: '1794';
+        children: BigUnion[];
+    } |
+    {
+        name: '1795';
+        children: BigUnion[];
+    } |
+    {
+        name: '1796';
+        children: BigUnion[];
+    } |
+    {
+        name: '1797';
+        children: BigUnion[];
+    } |
+    {
+        name: '1798';
+        children: BigUnion[];
+    } |
+    {
+        name: '1799';
+        children: BigUnion[];
+    } |
+    {
+        name: '1800';
+        children: BigUnion[];
+    } |
+    {
+        name: '1801';
+        children: BigUnion[];
+    } |
+    {
+        name: '1802';
+        children: BigUnion[];
+    } |
+    {
+        name: '1803';
+        children: BigUnion[];
+    } |
+    {
+        name: '1804';
+        children: BigUnion[];
+    } |
+    {
+        name: '1805';
+        children: BigUnion[];
+    } |
+    {
+        name: '1806';
+        children: BigUnion[];
+    } |
+    {
+        name: '1807';
+        children: BigUnion[];
+    } |
+    {
+        name: '1808';
+        children: BigUnion[];
+    } |
+    {
+        name: '1809';
+        children: BigUnion[];
+    } |
+    {
+        name: '1810';
+        children: BigUnion[];
+    } |
+    {
+        name: '1811';
+        children: BigUnion[];
+    } |
+    {
+        name: '1812';
+        children: BigUnion[];
+    } |
+    {
+        name: '1813';
+        children: BigUnion[];
+    } |
+    {
+        name: '1814';
+        children: BigUnion[];
+    } |
+    {
+        name: '1815';
+        children: BigUnion[];
+    } |
+    {
+        name: '1816';
+        children: BigUnion[];
+    } |
+    {
+        name: '1817';
+        children: BigUnion[];
+    } |
+    {
+        name: '1818';
+        children: BigUnion[];
+    } |
+    {
+        name: '1819';
+        children: BigUnion[];
+    } |
+    {
+        name: '1820';
+        children: BigUnion[];
+    } |
+    {
+        name: '1821';
+        children: BigUnion[];
+    } |
+    {
+        name: '1822';
+        children: BigUnion[];
+    } |
+    {
+        name: '1823';
+        children: BigUnion[];
+    } |
+    {
+        name: '1824';
+        children: BigUnion[];
+    } |
+    {
+        name: '1825';
+        children: BigUnion[];
+    } |
+    {
+        name: '1826';
+        children: BigUnion[];
+    } |
+    {
+        name: '1827';
+        children: BigUnion[];
+    } |
+    {
+        name: '1828';
+        children: BigUnion[];
+    } |
+    {
+        name: '1829';
+        children: BigUnion[];
+    } |
+    {
+        name: '1830';
+        children: BigUnion[];
+    } |
+    {
+        name: '1831';
+        children: BigUnion[];
+    } |
+    {
+        name: '1832';
+        children: BigUnion[];
+    } |
+    {
+        name: '1833';
+        children: BigUnion[];
+    } |
+    {
+        name: '1834';
+        children: BigUnion[];
+    } |
+    {
+        name: '1835';
+        children: BigUnion[];
+    } |
+    {
+        name: '1836';
+        children: BigUnion[];
+    } |
+    {
+        name: '1837';
+        children: BigUnion[];
+    } |
+    {
+        name: '1838';
+        children: BigUnion[];
+    } |
+    {
+        name: '1839';
+        children: BigUnion[];
+    } |
+    {
+        name: '1840';
+        children: BigUnion[];
+    } |
+    {
+        name: '1841';
+        children: BigUnion[];
+    } |
+    {
+        name: '1842';
+        children: BigUnion[];
+    } |
+    {
+        name: '1843';
+        children: BigUnion[];
+    } |
+    {
+        name: '1844';
+        children: BigUnion[];
+    } |
+    {
+        name: '1845';
+        children: BigUnion[];
+    } |
+    {
+        name: '1846';
+        children: BigUnion[];
+    } |
+    {
+        name: '1847';
+        children: BigUnion[];
+    } |
+    {
+        name: '1848';
+        children: BigUnion[];
+    } |
+    {
+        name: '1849';
+        children: BigUnion[];
+    } |
+    {
+        name: '1850';
+        children: BigUnion[];
+    } |
+    {
+        name: '1851';
+        children: BigUnion[];
+    } |
+    {
+        name: '1852';
+        children: BigUnion[];
+    } |
+    {
+        name: '1853';
+        children: BigUnion[];
+    } |
+    {
+        name: '1854';
+        children: BigUnion[];
+    } |
+    {
+        name: '1855';
+        children: BigUnion[];
+    } |
+    {
+        name: '1856';
+        children: BigUnion[];
+    } |
+    {
+        name: '1857';
+        children: BigUnion[];
+    } |
+    {
+        name: '1858';
+        children: BigUnion[];
+    } |
+    {
+        name: '1859';
+        children: BigUnion[];
+    } |
+    {
+        name: '1860';
+        children: BigUnion[];
+    } |
+    {
+        name: '1861';
+        children: BigUnion[];
+    } |
+    {
+        name: '1862';
+        children: BigUnion[];
+    } |
+    {
+        name: '1863';
+        children: BigUnion[];
+    } |
+    {
+        name: '1864';
+        children: BigUnion[];
+    } |
+    {
+        name: '1865';
+        children: BigUnion[];
+    } |
+    {
+        name: '1866';
+        children: BigUnion[];
+    } |
+    {
+        name: '1867';
+        children: BigUnion[];
+    } |
+    {
+        name: '1868';
+        children: BigUnion[];
+    } |
+    {
+        name: '1869';
+        children: BigUnion[];
+    } |
+    {
+        name: '1870';
+        children: BigUnion[];
+    } |
+    {
+        name: '1871';
+        children: BigUnion[];
+    } |
+    {
+        name: '1872';
+        children: BigUnion[];
+    } |
+    {
+        name: '1873';
+        children: BigUnion[];
+    } |
+    {
+        name: '1874';
+        children: BigUnion[];
+    } |
+    {
+        name: '1875';
+        children: BigUnion[];
+    } |
+    {
+        name: '1876';
+        children: BigUnion[];
+    } |
+    {
+        name: '1877';
+        children: BigUnion[];
+    } |
+    {
+        name: '1878';
+        children: BigUnion[];
+    } |
+    {
+        name: '1879';
+        children: BigUnion[];
+    } |
+    {
+        name: '1880';
+        children: BigUnion[];
+    } |
+    {
+        name: '1881';
+        children: BigUnion[];
+    } |
+    {
+        name: '1882';
+        children: BigUnion[];
+    } |
+    {
+        name: '1883';
+        children: BigUnion[];
+    } |
+    {
+        name: '1884';
+        children: BigUnion[];
+    } |
+    {
+        name: '1885';
+        children: BigUnion[];
+    } |
+    {
+        name: '1886';
+        children: BigUnion[];
+    } |
+    {
+        name: '1887';
+        children: BigUnion[];
+    } |
+    {
+        name: '1888';
+        children: BigUnion[];
+    } |
+    {
+        name: '1889';
+        children: BigUnion[];
+    } |
+    {
+        name: '1890';
+        children: BigUnion[];
+    } |
+    {
+        name: '1891';
+        children: BigUnion[];
+    } |
+    {
+        name: '1892';
+        children: BigUnion[];
+    } |
+    {
+        name: '1893';
+        children: BigUnion[];
+    } |
+    {
+        name: '1894';
+        children: BigUnion[];
+    } |
+    {
+        name: '1895';
+        children: BigUnion[];
+    } |
+    {
+        name: '1896';
+        children: BigUnion[];
+    } |
+    {
+        name: '1897';
+        children: BigUnion[];
+    } |
+    {
+        name: '1898';
+        children: BigUnion[];
+    } |
+    {
+        name: '1899';
+        children: BigUnion[];
+    } |
+    {
+        name: '1900';
+        children: BigUnion[];
+    } |
+    {
+        name: '1901';
+        children: BigUnion[];
+    } |
+    {
+        name: '1902';
+        children: BigUnion[];
+    } |
+    {
+        name: '1903';
+        children: BigUnion[];
+    } |
+    {
+        name: '1904';
+        children: BigUnion[];
+    } |
+    {
+        name: '1905';
+        children: BigUnion[];
+    } |
+    {
+        name: '1906';
+        children: BigUnion[];
+    } |
+    {
+        name: '1907';
+        children: BigUnion[];
+    } |
+    {
+        name: '1908';
+        children: BigUnion[];
+    } |
+    {
+        name: '1909';
+        children: BigUnion[];
+    } |
+    {
+        name: '1910';
+        children: BigUnion[];
+    } |
+    {
+        name: '1911';
+        children: BigUnion[];
+    } |
+    {
+        name: '1912';
+        children: BigUnion[];
+    } |
+    {
+        name: '1913';
+        children: BigUnion[];
+    } |
+    {
+        name: '1914';
+        children: BigUnion[];
+    } |
+    {
+        name: '1915';
+        children: BigUnion[];
+    } |
+    {
+        name: '1916';
+        children: BigUnion[];
+    } |
+    {
+        name: '1917';
+        children: BigUnion[];
+    } |
+    {
+        name: '1918';
+        children: BigUnion[];
+    } |
+    {
+        name: '1919';
+        children: BigUnion[];
+    } |
+    {
+        name: '1920';
+        children: BigUnion[];
+    } |
+    {
+        name: '1921';
+        children: BigUnion[];
+    } |
+    {
+        name: '1922';
+        children: BigUnion[];
+    } |
+    {
+        name: '1923';
+        children: BigUnion[];
+    } |
+    {
+        name: '1924';
+        children: BigUnion[];
+    } |
+    {
+        name: '1925';
+        children: BigUnion[];
+    } |
+    {
+        name: '1926';
+        children: BigUnion[];
+    } |
+    {
+        name: '1927';
+        children: BigUnion[];
+    } |
+    {
+        name: '1928';
+        children: BigUnion[];
+    } |
+    {
+        name: '1929';
+        children: BigUnion[];
+    } |
+    {
+        name: '1930';
+        children: BigUnion[];
+    } |
+    {
+        name: '1931';
+        children: BigUnion[];
+    } |
+    {
+        name: '1932';
+        children: BigUnion[];
+    } |
+    {
+        name: '1933';
+        children: BigUnion[];
+    } |
+    {
+        name: '1934';
+        children: BigUnion[];
+    } |
+    {
+        name: '1935';
+        children: BigUnion[];
+    } |
+    {
+        name: '1936';
+        children: BigUnion[];
+    } |
+    {
+        name: '1937';
+        children: BigUnion[];
+    } |
+    {
+        name: '1938';
+        children: BigUnion[];
+    } |
+    {
+        name: '1939';
+        children: BigUnion[];
+    } |
+    {
+        name: '1940';
+        children: BigUnion[];
+    } |
+    {
+        name: '1941';
+        children: BigUnion[];
+    } |
+    {
+        name: '1942';
+        children: BigUnion[];
+    } |
+    {
+        name: '1943';
+        children: BigUnion[];
+    } |
+    {
+        name: '1944';
+        children: BigUnion[];
+    } |
+    {
+        name: '1945';
+        children: BigUnion[];
+    } |
+    {
+        name: '1946';
+        children: BigUnion[];
+    } |
+    {
+        name: '1947';
+        children: BigUnion[];
+    } |
+    {
+        name: '1948';
+        children: BigUnion[];
+    } |
+    {
+        name: '1949';
+        children: BigUnion[];
+    } |
+    {
+        name: '1950';
+        children: BigUnion[];
+    } |
+    {
+        name: '1951';
+        children: BigUnion[];
+    } |
+    {
+        name: '1952';
+        children: BigUnion[];
+    } |
+    {
+        name: '1953';
+        children: BigUnion[];
+    } |
+    {
+        name: '1954';
+        children: BigUnion[];
+    } |
+    {
+        name: '1955';
+        children: BigUnion[];
+    } |
+    {
+        name: '1956';
+        children: BigUnion[];
+    } |
+    {
+        name: '1957';
+        children: BigUnion[];
+    } |
+    {
+        name: '1958';
+        children: BigUnion[];
+    } |
+    {
+        name: '1959';
+        children: BigUnion[];
+    } |
+    {
+        name: '1960';
+        children: BigUnion[];
+    } |
+    {
+        name: '1961';
+        children: BigUnion[];
+    } |
+    {
+        name: '1962';
+        children: BigUnion[];
+    } |
+    {
+        name: '1963';
+        children: BigUnion[];
+    } |
+    {
+        name: '1964';
+        children: BigUnion[];
+    } |
+    {
+        name: '1965';
+        children: BigUnion[];
+    } |
+    {
+        name: '1966';
+        children: BigUnion[];
+    } |
+    {
+        name: '1967';
+        children: BigUnion[];
+    } |
+    {
+        name: '1968';
+        children: BigUnion[];
+    } |
+    {
+        name: '1969';
+        children: BigUnion[];
+    } |
+    {
+        name: '1970';
+        children: BigUnion[];
+    } |
+    {
+        name: '1971';
+        children: BigUnion[];
+    } |
+    {
+        name: '1972';
+        children: BigUnion[];
+    } |
+    {
+        name: '1973';
+        children: BigUnion[];
+    } |
+    {
+        name: '1974';
+        children: BigUnion[];
+    } |
+    {
+        name: '1975';
+        children: BigUnion[];
+    } |
+    {
+        name: '1976';
+        children: BigUnion[];
+    } |
+    {
+        name: '1977';
+        children: BigUnion[];
+    } |
+    {
+        name: '1978';
+        children: BigUnion[];
+    } |
+    {
+        name: '1979';
+        children: BigUnion[];
+    } |
+    {
+        name: '1980';
+        children: BigUnion[];
+    } |
+    {
+        name: '1981';
+        children: BigUnion[];
+    } |
+    {
+        name: '1982';
+        children: BigUnion[];
+    } |
+    {
+        name: '1983';
+        children: BigUnion[];
+    } |
+    {
+        name: '1984';
+        children: BigUnion[];
+    } |
+    {
+        name: '1985';
+        children: BigUnion[];
+    } |
+    {
+        name: '1986';
+        children: BigUnion[];
+    } |
+    {
+        name: '1987';
+        children: BigUnion[];
+    } |
+    {
+        name: '1988';
+        children: BigUnion[];
+    } |
+    {
+        name: '1989';
+        children: BigUnion[];
+    } |
+    {
+        name: '1990';
+        children: BigUnion[];
+    } |
+    {
+        name: '1991';
+        children: BigUnion[];
+    } |
+    {
+        name: '1992';
+        children: BigUnion[];
+    } |
+    {
+        name: '1993';
+        children: BigUnion[];
+    } |
+    {
+        name: '1994';
+        children: BigUnion[];
+    } |
+    {
+        name: '1995';
+        children: BigUnion[];
+    } |
+    {
+        name: '1996';
+        children: BigUnion[];
+    } |
+    {
+        name: '1997';
+        children: BigUnion[];
+    } |
+    {
+        name: '1998';
+        children: BigUnion[];
+    } |
+    {
+        name: '1999';
+        children: BigUnion[];
+    };
+
+type DiscriminateUnion<T, K extends keyof T, V extends T[K]> = T extends Record<K, V> ? T : never;
+
+type WithName<T extends BigUnion['name']> = DiscriminateUnion<BigUnion, 'name', T>;
+
+type ChildrenOf<T extends BigUnion> = T['children'][number];
+
+export function makeThing<T extends BigUnion['name']>(
+    name: T,
+    children: ChildrenOf<WithName<T>>[] = [],
+) { }
+
+//// [conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.js]
+"use strict";
+exports.__esModule = true;
+exports.makeThing = void 0;
+function makeThing(name, children) {
+    if (children === void 0) { children = []; }
+}
+exports.makeThing = makeThing;

--- a/tests/baselines/reference/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.symbols
+++ b/tests/baselines/reference/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.symbols
@@ -1,0 +1,18048 @@
+=== tests/cases/compiler/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts ===
+type BigUnion =
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+    {
+        name: '0';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2, 18))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6, 18))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '2';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 9, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 10, 18))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '3';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 13, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 14, 18))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '4';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 17, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 18, 18))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '5';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 21, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 22, 18))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '6';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 25, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 26, 18))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '7';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 29, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 30, 18))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '8';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 33, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 34, 18))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '9';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 37, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 38, 18))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '10';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 41, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 42, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '11';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 45, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 46, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '12';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 49, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 50, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '13';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 53, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 54, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '14';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 57, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 58, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '15';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 61, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 62, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '16';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 65, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 66, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '17';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 69, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 70, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '18';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 73, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 74, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '19';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 77, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 78, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '20';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 81, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 82, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '21';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 85, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 86, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '22';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 89, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 90, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '23';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 93, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 94, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '24';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 97, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 98, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '25';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 101, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 102, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '26';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 105, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 106, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '27';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 109, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 110, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '28';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 113, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 114, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '29';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 117, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 118, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '30';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 121, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 122, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '31';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 125, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 126, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '32';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 129, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 130, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '33';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 133, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 134, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '34';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 137, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 138, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '35';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 141, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 142, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '36';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 145, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 146, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '37';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 149, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 150, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '38';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 153, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 154, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '39';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 157, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 158, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '40';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 161, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 162, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '41';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 165, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 166, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '42';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 169, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 170, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '43';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 173, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 174, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '44';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 177, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 178, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '45';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 181, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 182, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '46';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 185, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 186, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '47';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 189, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 190, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '48';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 193, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 194, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '49';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 197, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 198, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '50';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 201, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 202, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '51';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 205, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 206, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '52';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 209, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 210, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '53';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 213, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 214, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '54';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 217, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 218, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '55';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 221, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 222, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '56';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 225, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 226, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '57';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 229, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 230, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '58';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 233, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 234, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '59';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 237, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 238, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '60';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 241, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 242, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '61';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 245, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 246, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '62';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 249, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 250, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '63';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 253, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 254, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '64';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 257, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 258, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '65';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 261, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 262, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '66';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 265, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 266, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '67';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 269, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 270, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '68';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 273, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 274, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '69';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 277, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 278, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '70';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 281, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 282, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '71';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 285, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 286, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '72';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 289, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 290, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '73';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 293, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 294, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '74';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 297, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 298, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '75';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 301, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 302, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '76';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 305, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 306, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '77';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 309, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 310, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '78';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 313, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 314, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '79';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 317, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 318, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '80';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 321, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 322, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '81';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 325, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 326, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '82';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 329, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 330, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '83';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 333, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 334, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '84';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 337, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 338, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '85';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 341, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 342, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '86';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 345, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 346, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '87';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 349, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 350, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '88';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 353, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 354, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '89';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 357, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 358, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '90';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 361, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 362, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '91';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 365, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 366, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '92';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 369, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 370, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '93';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 373, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 374, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '94';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 377, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 378, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '95';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 381, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 382, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '96';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 385, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 386, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '97';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 389, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 390, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '98';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 393, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 394, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '99';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 397, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 398, 19))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '100';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 401, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 402, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '101';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 405, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 406, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '102';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 409, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 410, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '103';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 413, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 414, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '104';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 417, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 418, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '105';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 421, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 422, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '106';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 425, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 426, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '107';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 429, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 430, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '108';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 433, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 434, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '109';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 437, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 438, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '110';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 441, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 442, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '111';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 445, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 446, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '112';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 449, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 450, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '113';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 453, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 454, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '114';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 457, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 458, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '115';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 461, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 462, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '116';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 465, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 466, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '117';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 469, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 470, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '118';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 473, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 474, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '119';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 477, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 478, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '120';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 481, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 482, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '121';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 485, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 486, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '122';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 489, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 490, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '123';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 493, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 494, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '124';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 497, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 498, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '125';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 501, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 502, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '126';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 505, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 506, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '127';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 509, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 510, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '128';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 513, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 514, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '129';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 517, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 518, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '130';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 521, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 522, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '131';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 525, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 526, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '132';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 529, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 530, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '133';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 533, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 534, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '134';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 537, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 538, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '135';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 541, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 542, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '136';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 545, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 546, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '137';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 549, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 550, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '138';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 553, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 554, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '139';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 557, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 558, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '140';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 561, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 562, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '141';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 565, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 566, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '142';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 569, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 570, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '143';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 573, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 574, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '144';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 577, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 578, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '145';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 581, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 582, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '146';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 585, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 586, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '147';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 589, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 590, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '148';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 593, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 594, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '149';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 597, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 598, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '150';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 601, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 602, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '151';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 605, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 606, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '152';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 609, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 610, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '153';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 613, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 614, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '154';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 617, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 618, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '155';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 621, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 622, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '156';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 625, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 626, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '157';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 629, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 630, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '158';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 633, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 634, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '159';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 637, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 638, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '160';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 641, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 642, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '161';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 645, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 646, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '162';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 649, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 650, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '163';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 653, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 654, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '164';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 657, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 658, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '165';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 661, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 662, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '166';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 665, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 666, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '167';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 669, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 670, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '168';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 673, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 674, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '169';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 677, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 678, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '170';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 681, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 682, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '171';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 685, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 686, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '172';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 689, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 690, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '173';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 693, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 694, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '174';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 697, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 698, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '175';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 701, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 702, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '176';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 705, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 706, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '177';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 709, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 710, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '178';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 713, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 714, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '179';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 717, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 718, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '180';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 721, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 722, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '181';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 725, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 726, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '182';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 729, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 730, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '183';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 733, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 734, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '184';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 737, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 738, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '185';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 741, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 742, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '186';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 745, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 746, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '187';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 749, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 750, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '188';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 753, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 754, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '189';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 757, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 758, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '190';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 761, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 762, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '191';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 765, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 766, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '192';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 769, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 770, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '193';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 773, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 774, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '194';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 777, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 778, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '195';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 781, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 782, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '196';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 785, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 786, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '197';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 789, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 790, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '198';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 793, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 794, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '199';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 797, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 798, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '200';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 801, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 802, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '201';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 805, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 806, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '202';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 809, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 810, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '203';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 813, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 814, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '204';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 817, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 818, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '205';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 821, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 822, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '206';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 825, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 826, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '207';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 829, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 830, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '208';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 833, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 834, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '209';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 837, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 838, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '210';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 841, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 842, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '211';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 845, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 846, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '212';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 849, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 850, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '213';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 853, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 854, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '214';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 857, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 858, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '215';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 861, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 862, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '216';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 865, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 866, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '217';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 869, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 870, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '218';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 873, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 874, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '219';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 877, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 878, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '220';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 881, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 882, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '221';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 885, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 886, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '222';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 889, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 890, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '223';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 893, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 894, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '224';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 897, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 898, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '225';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 901, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 902, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '226';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 905, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 906, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '227';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 909, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 910, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '228';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 913, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 914, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '229';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 917, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 918, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '230';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 921, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 922, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '231';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 925, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 926, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '232';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 929, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 930, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '233';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 933, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 934, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '234';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 937, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 938, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '235';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 941, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 942, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '236';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 945, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 946, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '237';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 949, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 950, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '238';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 953, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 954, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '239';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 957, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 958, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '240';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 961, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 962, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '241';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 965, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 966, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '242';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 969, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 970, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '243';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 973, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 974, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '244';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 977, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 978, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '245';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 981, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 982, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '246';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 985, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 986, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '247';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 989, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 990, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '248';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 993, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 994, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '249';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 997, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 998, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '250';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1001, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1002, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '251';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1005, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1006, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '252';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1009, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1010, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '253';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1013, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1014, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '254';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1017, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1018, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '255';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1021, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1022, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '256';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1025, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1026, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '257';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1029, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1030, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '258';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1033, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1034, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '259';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1037, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1038, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '260';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1041, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1042, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '261';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1045, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1046, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '262';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1049, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1050, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '263';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1053, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1054, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '264';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1057, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1058, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '265';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1061, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1062, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '266';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1065, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1066, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '267';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1069, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1070, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '268';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1073, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1074, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '269';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1077, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1078, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '270';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1081, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1082, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '271';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1085, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1086, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '272';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1089, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1090, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '273';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1093, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1094, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '274';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1097, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1098, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '275';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1101, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1102, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '276';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1105, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1106, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '277';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1109, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1110, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '278';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1113, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1114, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '279';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1117, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1118, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '280';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1121, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1122, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '281';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1125, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1126, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '282';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1129, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1130, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '283';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1133, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1134, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '284';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1137, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1138, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '285';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1141, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1142, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '286';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1145, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1146, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '287';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1149, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1150, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '288';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1153, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1154, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '289';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1157, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1158, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '290';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1161, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1162, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '291';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1165, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1166, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '292';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1169, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1170, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '293';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1173, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1174, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '294';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1177, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1178, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '295';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1181, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1182, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '296';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1185, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1186, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '297';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1189, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1190, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '298';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1193, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1194, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '299';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1197, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1198, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '300';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1201, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1202, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '301';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1205, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1206, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '302';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1209, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1210, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '303';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1213, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1214, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '304';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1217, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1218, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '305';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1221, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1222, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '306';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1225, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1226, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '307';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1229, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1230, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '308';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1233, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1234, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '309';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1237, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1238, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '310';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1241, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1242, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '311';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1245, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1246, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '312';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1249, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1250, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '313';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1253, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1254, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '314';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1257, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1258, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '315';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1261, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1262, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '316';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1265, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1266, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '317';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1269, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1270, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '318';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1273, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1274, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '319';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1277, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1278, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '320';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1281, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1282, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '321';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1285, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1286, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '322';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1289, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1290, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '323';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1293, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1294, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '324';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1297, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1298, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '325';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1301, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1302, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '326';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1305, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1306, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '327';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1309, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1310, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '328';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1313, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1314, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '329';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1317, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1318, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '330';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1321, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1322, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '331';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1325, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1326, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '332';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1329, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1330, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '333';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1333, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1334, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '334';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1337, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1338, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '335';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1341, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1342, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '336';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1345, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1346, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '337';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1349, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1350, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '338';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1353, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1354, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '339';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1357, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1358, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '340';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1361, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1362, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '341';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1365, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1366, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '342';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1369, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1370, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '343';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1373, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1374, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '344';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1377, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1378, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '345';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1381, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1382, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '346';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1385, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1386, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '347';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1389, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1390, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '348';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1393, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1394, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '349';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1397, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1398, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '350';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1401, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1402, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '351';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1405, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1406, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '352';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1409, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1410, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '353';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1413, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1414, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '354';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1417, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1418, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '355';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1421, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1422, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '356';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1425, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1426, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '357';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1429, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1430, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '358';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1433, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1434, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '359';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1437, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1438, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '360';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1441, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1442, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '361';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1445, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1446, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '362';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1449, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1450, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '363';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1453, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1454, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '364';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1457, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1458, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '365';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1461, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1462, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '366';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1465, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1466, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '367';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1469, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1470, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '368';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1473, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1474, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '369';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1477, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1478, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '370';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1481, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1482, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '371';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1485, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1486, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '372';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1489, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1490, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '373';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1493, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1494, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '374';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1497, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1498, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '375';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1501, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1502, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '376';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1505, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1506, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '377';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1509, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1510, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '378';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1513, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1514, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '379';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1517, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1518, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '380';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1521, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1522, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '381';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1525, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1526, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '382';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1529, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1530, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '383';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1533, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1534, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '384';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1537, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1538, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '385';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1541, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1542, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '386';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1545, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1546, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '387';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1549, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1550, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '388';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1553, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1554, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '389';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1557, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1558, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '390';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1561, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1562, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '391';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1565, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1566, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '392';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1569, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1570, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '393';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1573, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1574, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '394';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1577, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1578, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '395';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1581, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1582, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '396';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1585, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1586, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '397';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1589, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1590, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '398';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1593, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1594, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '399';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1597, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1598, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '400';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1601, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1602, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '401';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1605, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1606, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '402';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1609, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1610, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '403';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1613, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1614, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '404';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1617, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1618, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '405';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1621, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1622, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '406';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1625, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1626, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '407';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1629, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1630, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '408';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1633, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1634, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '409';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1637, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1638, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '410';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1641, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1642, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '411';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1645, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1646, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '412';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1649, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1650, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '413';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1653, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1654, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '414';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1657, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1658, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '415';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1661, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1662, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '416';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1665, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1666, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '417';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1669, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1670, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '418';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1673, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1674, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '419';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1677, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1678, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '420';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1681, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1682, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '421';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1685, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1686, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '422';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1689, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1690, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '423';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1693, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1694, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '424';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1697, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1698, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '425';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1701, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1702, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '426';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1705, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1706, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '427';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1709, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1710, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '428';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1713, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1714, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '429';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1717, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1718, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '430';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1721, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1722, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '431';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1725, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1726, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '432';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1729, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1730, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '433';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1733, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1734, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '434';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1737, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1738, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '435';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1741, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1742, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '436';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1745, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1746, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '437';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1749, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1750, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '438';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1753, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1754, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '439';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1757, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1758, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '440';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1761, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1762, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '441';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1765, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1766, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '442';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1769, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1770, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '443';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1773, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1774, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '444';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1777, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1778, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '445';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1781, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1782, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '446';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1785, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1786, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '447';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1789, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1790, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '448';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1793, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1794, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '449';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1797, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1798, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '450';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1801, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1802, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '451';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1805, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1806, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '452';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1809, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1810, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '453';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1813, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1814, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '454';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1817, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1818, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '455';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1821, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1822, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '456';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1825, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1826, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '457';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1829, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1830, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '458';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1833, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1834, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '459';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1837, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1838, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '460';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1841, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1842, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '461';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1845, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1846, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '462';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1849, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1850, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '463';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1853, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1854, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '464';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1857, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1858, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '465';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1861, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1862, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '466';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1865, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1866, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '467';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1869, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1870, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '468';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1873, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1874, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '469';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1877, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1878, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '470';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1881, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1882, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '471';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1885, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1886, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '472';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1889, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1890, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '473';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1893, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1894, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '474';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1897, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1898, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '475';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1901, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1902, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '476';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1905, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1906, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '477';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1909, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1910, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '478';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1913, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1914, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '479';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1917, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1918, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '480';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1921, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1922, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '481';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1925, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1926, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '482';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1929, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1930, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '483';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1933, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1934, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '484';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1937, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1938, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '485';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1941, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1942, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '486';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1945, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1946, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '487';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1949, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1950, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '488';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1953, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1954, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '489';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1957, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1958, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '490';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1961, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1962, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '491';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1965, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1966, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '492';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1969, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1970, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '493';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1973, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1974, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '494';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1977, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1978, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '495';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1981, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1982, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '496';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1985, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1986, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '497';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1989, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1990, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '498';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1993, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1994, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '499';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1997, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 1998, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '500';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2001, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2002, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '501';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2005, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2006, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '502';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2009, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2010, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '503';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2013, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2014, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '504';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2017, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2018, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '505';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2021, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2022, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '506';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2025, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2026, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '507';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2029, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2030, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '508';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2033, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2034, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '509';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2037, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2038, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '510';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2041, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2042, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '511';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2045, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2046, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '512';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2049, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2050, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '513';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2053, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2054, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '514';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2057, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2058, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '515';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2061, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2062, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '516';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2065, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2066, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '517';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2069, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2070, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '518';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2073, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2074, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '519';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2077, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2078, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '520';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2081, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2082, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '521';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2085, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2086, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '522';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2089, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2090, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '523';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2093, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2094, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '524';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2097, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2098, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '525';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2101, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2102, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '526';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2105, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2106, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '527';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2109, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2110, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '528';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2113, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2114, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '529';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2117, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2118, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '530';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2121, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2122, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '531';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2125, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2126, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '532';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2129, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2130, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '533';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2133, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2134, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '534';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2137, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2138, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '535';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2141, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2142, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '536';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2145, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2146, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '537';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2149, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2150, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '538';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2153, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2154, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '539';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2157, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2158, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '540';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2161, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2162, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '541';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2165, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2166, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '542';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2169, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2170, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '543';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2173, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2174, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '544';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2177, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2178, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '545';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2181, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2182, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '546';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2185, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2186, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '547';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2189, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2190, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '548';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2193, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2194, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '549';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2197, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2198, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '550';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2201, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2202, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '551';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2205, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2206, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '552';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2209, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2210, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '553';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2213, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2214, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '554';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2217, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2218, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '555';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2221, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2222, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '556';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2225, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2226, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '557';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2229, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2230, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '558';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2233, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2234, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '559';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2237, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2238, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '560';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2241, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2242, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '561';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2245, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2246, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '562';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2249, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2250, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '563';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2253, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2254, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '564';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2257, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2258, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '565';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2261, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2262, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '566';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2265, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2266, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '567';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2269, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2270, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '568';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2273, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2274, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '569';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2277, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2278, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '570';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2281, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2282, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '571';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2285, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2286, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '572';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2289, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2290, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '573';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2293, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2294, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '574';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2297, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2298, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '575';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2301, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2302, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '576';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2305, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2306, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '577';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2309, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2310, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '578';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2313, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2314, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '579';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2317, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2318, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '580';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2321, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2322, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '581';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2325, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2326, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '582';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2329, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2330, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '583';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2333, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2334, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '584';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2337, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2338, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '585';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2341, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2342, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '586';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2345, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2346, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '587';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2349, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2350, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '588';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2353, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2354, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '589';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2357, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2358, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '590';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2361, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2362, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '591';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2365, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2366, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '592';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2369, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2370, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '593';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2373, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2374, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '594';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2377, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2378, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '595';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2381, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2382, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '596';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2385, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2386, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '597';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2389, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2390, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '598';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2393, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2394, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '599';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2397, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2398, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '600';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2401, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2402, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '601';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2405, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2406, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '602';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2409, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2410, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '603';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2413, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2414, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '604';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2417, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2418, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '605';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2421, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2422, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '606';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2425, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2426, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '607';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2429, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2430, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '608';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2433, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2434, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '609';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2437, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2438, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '610';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2441, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2442, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '611';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2445, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2446, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '612';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2449, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2450, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '613';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2453, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2454, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '614';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2457, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2458, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '615';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2461, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2462, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '616';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2465, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2466, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '617';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2469, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2470, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '618';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2473, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2474, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '619';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2477, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2478, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '620';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2481, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2482, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '621';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2485, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2486, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '622';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2489, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2490, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '623';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2493, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2494, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '624';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2497, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2498, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '625';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2501, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2502, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '626';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2505, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2506, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '627';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2509, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2510, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '628';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2513, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2514, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '629';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2517, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2518, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '630';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2521, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2522, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '631';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2525, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2526, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '632';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2529, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2530, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '633';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2533, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2534, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '634';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2537, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2538, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '635';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2541, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2542, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '636';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2545, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2546, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '637';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2549, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2550, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '638';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2553, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2554, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '639';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2557, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2558, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '640';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2561, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2562, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '641';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2565, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2566, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '642';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2569, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2570, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '643';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2573, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2574, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '644';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2577, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2578, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '645';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2581, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2582, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '646';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2585, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2586, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '647';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2589, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2590, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '648';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2593, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2594, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '649';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2597, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2598, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '650';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2601, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2602, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '651';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2605, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2606, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '652';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2609, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2610, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '653';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2613, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2614, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '654';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2617, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2618, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '655';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2621, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2622, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '656';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2625, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2626, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '657';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2629, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2630, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '658';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2633, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2634, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '659';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2637, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2638, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '660';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2641, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2642, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '661';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2645, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2646, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '662';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2649, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2650, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '663';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2653, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2654, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '664';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2657, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2658, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '665';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2661, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2662, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '666';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2665, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2666, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '667';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2669, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2670, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '668';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2673, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2674, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '669';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2677, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2678, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '670';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2681, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2682, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '671';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2685, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2686, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '672';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2689, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2690, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '673';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2693, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2694, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '674';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2697, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2698, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '675';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2701, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2702, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '676';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2705, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2706, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '677';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2709, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2710, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '678';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2713, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2714, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '679';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2717, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2718, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '680';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2721, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2722, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '681';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2725, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2726, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '682';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2729, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2730, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '683';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2733, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2734, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '684';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2737, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2738, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '685';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2741, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2742, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '686';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2745, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2746, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '687';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2749, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2750, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '688';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2753, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2754, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '689';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2757, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2758, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '690';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2761, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2762, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '691';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2765, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2766, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '692';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2769, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2770, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '693';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2773, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2774, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '694';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2777, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2778, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '695';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2781, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2782, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '696';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2785, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2786, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '697';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2789, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2790, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '698';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2793, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2794, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '699';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2797, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2798, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '700';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2801, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2802, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '701';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2805, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2806, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '702';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2809, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2810, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '703';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2813, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2814, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '704';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2817, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2818, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '705';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2821, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2822, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '706';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2825, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2826, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '707';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2829, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2830, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '708';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2833, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2834, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '709';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2837, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2838, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '710';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2841, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2842, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '711';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2845, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2846, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '712';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2849, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2850, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '713';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2853, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2854, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '714';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2857, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2858, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '715';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2861, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2862, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '716';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2865, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2866, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '717';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2869, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2870, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '718';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2873, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2874, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '719';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2877, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2878, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '720';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2881, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2882, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '721';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2885, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2886, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '722';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2889, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2890, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '723';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2893, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2894, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '724';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2897, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2898, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '725';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2901, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2902, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '726';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2905, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2906, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '727';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2909, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2910, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '728';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2913, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2914, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '729';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2917, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2918, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '730';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2921, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2922, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '731';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2925, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2926, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '732';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2929, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2930, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '733';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2933, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2934, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '734';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2937, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2938, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '735';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2941, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2942, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '736';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2945, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2946, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '737';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2949, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2950, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '738';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2953, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2954, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '739';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2957, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2958, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '740';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2961, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2962, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '741';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2965, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2966, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '742';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2969, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2970, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '743';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2973, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2974, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '744';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2977, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2978, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '745';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2981, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2982, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '746';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2985, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2986, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '747';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2989, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2990, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '748';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2993, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2994, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '749';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2997, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 2998, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '750';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3001, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3002, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '751';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3005, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3006, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '752';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3009, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3010, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '753';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3013, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3014, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '754';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3017, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3018, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '755';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3021, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3022, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '756';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3025, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3026, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '757';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3029, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3030, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '758';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3033, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3034, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '759';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3037, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3038, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '760';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3041, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3042, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '761';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3045, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3046, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '762';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3049, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3050, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '763';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3053, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3054, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '764';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3057, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3058, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '765';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3061, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3062, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '766';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3065, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3066, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '767';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3069, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3070, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '768';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3073, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3074, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '769';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3077, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3078, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '770';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3081, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3082, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '771';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3085, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3086, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '772';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3089, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3090, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '773';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3093, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3094, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '774';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3097, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3098, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '775';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3101, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3102, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '776';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3105, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3106, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '777';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3109, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3110, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '778';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3113, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3114, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '779';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3117, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3118, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '780';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3121, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3122, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '781';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3125, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3126, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '782';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3129, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3130, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '783';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3133, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3134, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '784';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3137, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3138, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '785';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3141, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3142, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '786';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3145, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3146, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '787';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3149, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3150, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '788';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3153, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3154, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '789';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3157, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3158, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '790';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3161, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3162, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '791';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3165, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3166, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '792';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3169, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3170, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '793';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3173, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3174, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '794';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3177, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3178, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '795';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3181, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3182, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '796';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3185, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3186, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '797';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3189, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3190, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '798';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3193, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3194, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '799';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3197, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3198, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '800';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3201, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3202, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '801';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3205, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3206, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '802';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3209, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3210, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '803';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3213, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3214, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '804';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3217, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3218, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '805';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3221, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3222, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '806';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3225, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3226, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '807';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3229, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3230, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '808';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3233, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3234, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '809';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3237, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3238, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '810';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3241, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3242, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '811';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3245, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3246, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '812';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3249, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3250, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '813';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3253, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3254, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '814';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3257, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3258, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '815';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3261, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3262, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '816';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3265, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3266, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '817';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3269, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3270, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '818';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3273, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3274, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '819';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3277, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3278, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '820';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3281, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3282, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '821';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3285, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3286, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '822';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3289, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3290, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '823';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3293, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3294, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '824';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3297, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3298, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '825';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3301, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3302, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '826';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3305, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3306, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '827';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3309, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3310, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '828';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3313, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3314, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '829';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3317, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3318, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '830';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3321, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3322, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '831';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3325, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3326, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '832';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3329, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3330, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '833';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3333, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3334, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '834';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3337, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3338, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '835';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3341, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3342, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '836';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3345, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3346, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '837';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3349, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3350, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '838';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3353, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3354, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '839';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3357, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3358, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '840';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3361, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3362, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '841';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3365, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3366, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '842';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3369, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3370, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '843';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3373, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3374, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '844';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3377, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3378, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '845';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3381, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3382, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '846';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3385, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3386, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '847';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3389, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3390, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '848';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3393, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3394, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '849';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3397, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3398, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '850';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3401, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3402, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '851';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3405, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3406, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '852';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3409, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3410, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '853';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3413, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3414, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '854';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3417, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3418, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '855';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3421, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3422, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '856';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3425, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3426, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '857';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3429, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3430, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '858';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3433, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3434, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '859';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3437, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3438, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '860';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3441, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3442, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '861';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3445, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3446, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '862';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3449, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3450, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '863';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3453, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3454, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '864';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3457, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3458, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '865';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3461, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3462, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '866';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3465, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3466, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '867';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3469, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3470, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '868';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3473, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3474, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '869';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3477, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3478, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '870';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3481, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3482, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '871';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3485, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3486, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '872';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3489, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3490, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '873';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3493, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3494, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '874';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3497, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3498, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '875';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3501, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3502, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '876';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3505, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3506, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '877';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3509, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3510, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '878';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3513, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3514, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '879';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3517, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3518, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '880';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3521, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3522, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '881';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3525, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3526, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '882';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3529, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3530, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '883';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3533, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3534, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '884';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3537, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3538, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '885';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3541, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3542, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '886';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3545, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3546, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '887';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3549, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3550, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '888';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3553, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3554, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '889';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3557, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3558, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '890';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3561, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3562, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '891';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3565, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3566, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '892';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3569, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3570, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '893';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3573, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3574, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '894';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3577, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3578, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '895';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3581, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3582, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '896';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3585, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3586, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '897';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3589, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3590, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '898';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3593, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3594, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '899';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3597, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3598, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '900';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3601, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3602, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '901';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3605, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3606, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '902';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3609, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3610, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '903';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3613, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3614, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '904';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3617, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3618, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '905';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3621, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3622, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '906';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3625, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3626, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '907';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3629, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3630, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '908';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3633, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3634, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '909';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3637, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3638, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '910';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3641, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3642, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '911';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3645, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3646, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '912';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3649, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3650, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '913';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3653, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3654, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '914';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3657, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3658, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '915';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3661, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3662, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '916';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3665, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3666, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '917';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3669, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3670, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '918';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3673, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3674, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '919';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3677, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3678, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '920';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3681, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3682, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '921';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3685, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3686, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '922';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3689, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3690, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '923';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3693, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3694, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '924';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3697, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3698, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '925';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3701, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3702, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '926';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3705, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3706, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '927';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3709, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3710, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '928';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3713, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3714, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '929';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3717, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3718, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '930';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3721, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3722, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '931';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3725, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3726, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '932';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3729, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3730, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '933';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3733, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3734, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '934';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3737, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3738, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '935';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3741, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3742, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '936';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3745, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3746, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '937';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3749, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3750, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '938';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3753, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3754, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '939';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3757, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3758, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '940';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3761, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3762, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '941';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3765, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3766, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '942';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3769, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3770, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '943';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3773, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3774, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '944';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3777, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3778, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '945';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3781, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3782, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '946';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3785, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3786, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '947';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3789, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3790, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '948';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3793, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3794, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '949';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3797, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3798, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '950';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3801, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3802, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '951';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3805, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3806, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '952';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3809, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3810, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '953';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3813, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3814, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '954';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3817, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3818, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '955';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3821, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3822, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '956';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3825, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3826, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '957';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3829, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3830, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '958';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3833, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3834, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '959';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3837, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3838, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '960';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3841, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3842, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '961';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3845, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3846, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '962';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3849, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3850, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '963';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3853, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3854, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '964';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3857, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3858, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '965';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3861, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3862, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '966';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3865, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3866, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '967';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3869, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3870, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '968';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3873, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3874, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '969';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3877, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3878, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '970';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3881, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3882, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '971';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3885, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3886, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '972';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3889, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3890, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '973';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3893, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3894, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '974';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3897, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3898, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '975';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3901, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3902, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '976';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3905, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3906, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '977';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3909, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3910, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '978';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3913, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3914, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '979';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3917, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3918, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '980';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3921, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3922, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '981';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3925, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3926, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '982';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3929, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3930, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '983';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3933, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3934, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '984';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3937, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3938, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '985';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3941, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3942, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '986';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3945, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3946, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '987';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3949, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3950, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '988';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3953, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3954, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '989';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3957, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3958, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '990';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3961, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3962, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '991';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3965, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3966, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '992';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3969, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3970, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '993';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3973, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3974, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '994';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3977, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3978, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '995';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3981, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3982, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '996';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3985, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3986, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '997';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3989, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3990, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '998';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3993, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3994, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '999';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3997, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 3998, 20))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1000';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4001, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4002, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1001';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4005, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4006, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1002';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4009, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4010, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1003';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4013, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4014, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1004';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4017, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4018, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1005';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4021, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4022, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1006';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4025, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4026, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1007';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4029, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4030, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1008';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4033, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4034, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1009';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4037, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4038, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1010';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4041, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4042, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1011';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4045, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4046, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1012';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4049, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4050, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1013';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4053, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4054, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1014';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4057, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4058, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1015';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4061, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4062, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1016';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4065, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4066, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1017';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4069, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4070, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1018';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4073, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4074, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1019';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4077, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4078, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1020';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4081, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4082, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1021';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4085, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4086, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1022';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4089, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4090, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1023';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4093, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4094, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1024';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4097, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4098, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1025';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4101, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4102, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1026';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4105, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4106, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1027';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4109, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4110, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1028';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4113, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4114, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1029';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4117, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4118, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1030';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4121, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4122, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1031';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4125, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4126, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1032';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4129, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4130, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1033';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4133, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4134, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1034';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4137, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4138, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1035';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4141, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4142, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1036';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4145, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4146, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1037';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4149, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4150, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1038';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4153, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4154, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1039';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4157, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4158, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1040';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4161, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4162, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1041';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4165, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4166, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1042';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4169, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4170, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1043';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4173, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4174, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1044';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4177, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4178, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1045';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4181, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4182, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1046';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4185, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4186, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1047';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4189, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4190, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1048';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4193, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4194, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1049';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4197, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4198, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1050';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4201, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4202, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1051';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4205, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4206, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1052';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4209, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4210, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1053';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4213, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4214, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1054';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4217, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4218, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1055';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4221, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4222, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1056';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4225, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4226, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1057';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4229, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4230, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1058';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4233, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4234, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1059';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4237, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4238, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1060';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4241, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4242, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1061';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4245, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4246, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1062';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4249, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4250, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1063';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4253, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4254, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1064';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4257, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4258, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1065';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4261, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4262, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1066';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4265, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4266, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1067';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4269, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4270, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1068';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4273, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4274, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1069';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4277, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4278, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1070';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4281, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4282, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1071';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4285, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4286, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1072';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4289, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4290, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1073';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4293, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4294, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1074';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4297, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4298, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1075';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4301, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4302, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1076';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4305, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4306, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1077';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4309, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4310, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1078';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4313, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4314, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1079';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4317, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4318, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1080';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4321, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4322, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1081';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4325, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4326, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1082';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4329, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4330, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1083';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4333, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4334, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1084';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4337, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4338, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1085';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4341, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4342, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1086';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4345, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4346, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1087';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4349, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4350, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1088';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4353, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4354, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1089';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4357, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4358, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1090';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4361, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4362, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1091';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4365, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4366, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1092';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4369, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4370, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1093';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4373, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4374, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1094';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4377, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4378, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1095';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4381, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4382, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1096';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4385, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4386, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1097';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4389, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4390, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1098';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4393, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4394, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1099';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4397, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4398, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1100';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4401, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4402, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1101';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4405, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4406, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1102';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4409, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4410, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1103';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4413, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4414, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1104';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4417, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4418, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1105';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4421, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4422, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1106';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4425, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4426, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1107';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4429, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4430, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1108';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4433, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4434, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1109';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4437, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4438, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1110';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4441, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4442, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1111';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4445, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4446, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1112';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4449, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4450, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1113';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4453, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4454, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1114';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4457, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4458, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1115';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4461, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4462, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1116';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4465, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4466, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1117';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4469, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4470, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1118';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4473, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4474, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1119';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4477, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4478, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1120';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4481, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4482, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1121';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4485, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4486, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1122';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4489, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4490, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1123';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4493, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4494, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1124';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4497, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4498, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1125';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4501, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4502, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1126';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4505, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4506, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1127';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4509, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4510, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1128';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4513, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4514, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1129';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4517, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4518, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1130';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4521, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4522, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1131';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4525, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4526, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1132';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4529, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4530, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1133';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4533, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4534, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1134';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4537, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4538, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1135';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4541, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4542, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1136';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4545, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4546, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1137';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4549, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4550, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1138';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4553, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4554, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1139';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4557, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4558, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1140';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4561, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4562, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1141';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4565, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4566, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1142';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4569, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4570, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1143';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4573, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4574, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1144';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4577, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4578, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1145';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4581, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4582, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1146';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4585, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4586, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1147';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4589, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4590, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1148';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4593, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4594, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1149';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4597, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4598, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1150';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4601, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4602, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1151';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4605, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4606, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1152';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4609, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4610, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1153';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4613, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4614, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1154';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4617, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4618, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1155';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4621, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4622, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1156';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4625, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4626, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1157';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4629, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4630, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1158';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4633, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4634, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1159';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4637, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4638, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1160';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4641, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4642, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1161';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4645, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4646, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1162';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4649, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4650, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1163';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4653, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4654, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1164';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4657, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4658, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1165';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4661, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4662, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1166';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4665, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4666, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1167';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4669, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4670, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1168';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4673, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4674, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1169';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4677, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4678, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1170';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4681, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4682, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1171';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4685, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4686, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1172';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4689, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4690, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1173';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4693, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4694, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1174';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4697, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4698, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1175';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4701, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4702, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1176';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4705, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4706, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1177';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4709, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4710, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1178';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4713, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4714, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1179';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4717, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4718, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1180';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4721, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4722, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1181';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4725, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4726, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1182';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4729, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4730, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1183';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4733, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4734, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1184';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4737, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4738, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1185';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4741, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4742, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1186';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4745, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4746, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1187';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4749, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4750, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1188';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4753, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4754, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1189';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4757, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4758, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1190';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4761, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4762, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1191';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4765, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4766, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1192';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4769, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4770, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1193';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4773, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4774, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1194';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4777, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4778, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1195';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4781, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4782, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1196';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4785, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4786, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1197';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4789, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4790, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1198';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4793, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4794, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1199';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4797, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4798, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1200';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4801, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4802, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1201';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4805, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4806, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1202';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4809, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4810, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1203';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4813, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4814, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1204';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4817, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4818, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1205';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4821, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4822, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1206';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4825, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4826, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1207';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4829, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4830, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1208';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4833, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4834, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1209';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4837, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4838, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1210';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4841, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4842, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1211';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4845, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4846, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1212';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4849, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4850, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1213';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4853, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4854, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1214';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4857, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4858, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1215';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4861, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4862, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1216';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4865, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4866, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1217';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4869, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4870, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1218';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4873, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4874, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1219';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4877, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4878, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1220';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4881, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4882, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1221';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4885, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4886, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1222';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4889, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4890, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1223';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4893, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4894, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1224';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4897, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4898, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1225';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4901, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4902, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1226';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4905, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4906, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1227';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4909, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4910, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1228';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4913, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4914, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1229';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4917, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4918, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1230';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4921, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4922, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1231';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4925, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4926, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1232';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4929, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4930, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1233';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4933, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4934, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1234';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4937, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4938, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1235';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4941, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4942, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1236';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4945, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4946, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1237';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4949, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4950, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1238';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4953, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4954, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1239';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4957, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4958, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1240';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4961, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4962, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1241';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4965, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4966, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1242';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4969, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4970, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1243';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4973, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4974, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1244';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4977, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4978, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1245';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4981, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4982, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1246';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4985, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4986, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1247';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4989, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4990, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1248';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4993, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4994, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1249';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4997, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 4998, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1250';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5001, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5002, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1251';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5005, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5006, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1252';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5009, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5010, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1253';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5013, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5014, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1254';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5017, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5018, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1255';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5021, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5022, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1256';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5025, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5026, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1257';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5029, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5030, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1258';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5033, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5034, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1259';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5037, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5038, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1260';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5041, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5042, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1261';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5045, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5046, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1262';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5049, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5050, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1263';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5053, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5054, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1264';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5057, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5058, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1265';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5061, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5062, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1266';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5065, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5066, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1267';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5069, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5070, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1268';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5073, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5074, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1269';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5077, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5078, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1270';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5081, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5082, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1271';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5085, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5086, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1272';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5089, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5090, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1273';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5093, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5094, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1274';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5097, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5098, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1275';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5101, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5102, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1276';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5105, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5106, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1277';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5109, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5110, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1278';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5113, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5114, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1279';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5117, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5118, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1280';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5121, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5122, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1281';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5125, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5126, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1282';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5129, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5130, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1283';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5133, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5134, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1284';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5137, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5138, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1285';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5141, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5142, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1286';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5145, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5146, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1287';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5149, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5150, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1288';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5153, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5154, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1289';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5157, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5158, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1290';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5161, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5162, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1291';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5165, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5166, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1292';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5169, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5170, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1293';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5173, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5174, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1294';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5177, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5178, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1295';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5181, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5182, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1296';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5185, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5186, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1297';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5189, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5190, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1298';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5193, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5194, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1299';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5197, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5198, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1300';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5201, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5202, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1301';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5205, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5206, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1302';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5209, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5210, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1303';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5213, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5214, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1304';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5217, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5218, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1305';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5221, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5222, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1306';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5225, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5226, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1307';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5229, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5230, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1308';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5233, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5234, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1309';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5237, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5238, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1310';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5241, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5242, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1311';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5245, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5246, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1312';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5249, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5250, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1313';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5253, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5254, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1314';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5257, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5258, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1315';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5261, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5262, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1316';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5265, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5266, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1317';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5269, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5270, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1318';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5273, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5274, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1319';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5277, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5278, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1320';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5281, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5282, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1321';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5285, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5286, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1322';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5289, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5290, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1323';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5293, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5294, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1324';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5297, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5298, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1325';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5301, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5302, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1326';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5305, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5306, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1327';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5309, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5310, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1328';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5313, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5314, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1329';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5317, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5318, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1330';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5321, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5322, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1331';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5325, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5326, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1332';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5329, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5330, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1333';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5333, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5334, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1334';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5337, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5338, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1335';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5341, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5342, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1336';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5345, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5346, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1337';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5349, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5350, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1338';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5353, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5354, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1339';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5357, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5358, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1340';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5361, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5362, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1341';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5365, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5366, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1342';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5369, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5370, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1343';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5373, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5374, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1344';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5377, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5378, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1345';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5381, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5382, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1346';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5385, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5386, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1347';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5389, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5390, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1348';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5393, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5394, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1349';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5397, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5398, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1350';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5401, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5402, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1351';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5405, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5406, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1352';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5409, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5410, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1353';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5413, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5414, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1354';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5417, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5418, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1355';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5421, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5422, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1356';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5425, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5426, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1357';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5429, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5430, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1358';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5433, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5434, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1359';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5437, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5438, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1360';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5441, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5442, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1361';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5445, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5446, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1362';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5449, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5450, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1363';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5453, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5454, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1364';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5457, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5458, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1365';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5461, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5462, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1366';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5465, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5466, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1367';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5469, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5470, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1368';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5473, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5474, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1369';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5477, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5478, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1370';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5481, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5482, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1371';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5485, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5486, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1372';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5489, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5490, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1373';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5493, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5494, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1374';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5497, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5498, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1375';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5501, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5502, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1376';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5505, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5506, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1377';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5509, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5510, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1378';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5513, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5514, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1379';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5517, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5518, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1380';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5521, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5522, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1381';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5525, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5526, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1382';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5529, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5530, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1383';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5533, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5534, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1384';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5537, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5538, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1385';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5541, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5542, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1386';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5545, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5546, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1387';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5549, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5550, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1388';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5553, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5554, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1389';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5557, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5558, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1390';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5561, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5562, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1391';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5565, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5566, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1392';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5569, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5570, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1393';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5573, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5574, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1394';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5577, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5578, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1395';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5581, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5582, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1396';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5585, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5586, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1397';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5589, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5590, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1398';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5593, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5594, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1399';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5597, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5598, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1400';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5601, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5602, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1401';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5605, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5606, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1402';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5609, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5610, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1403';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5613, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5614, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1404';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5617, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5618, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1405';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5621, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5622, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1406';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5625, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5626, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1407';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5629, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5630, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1408';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5633, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5634, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1409';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5637, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5638, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1410';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5641, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5642, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1411';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5645, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5646, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1412';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5649, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5650, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1413';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5653, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5654, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1414';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5657, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5658, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1415';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5661, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5662, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1416';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5665, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5666, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1417';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5669, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5670, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1418';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5673, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5674, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1419';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5677, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5678, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1420';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5681, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5682, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1421';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5685, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5686, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1422';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5689, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5690, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1423';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5693, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5694, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1424';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5697, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5698, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1425';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5701, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5702, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1426';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5705, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5706, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1427';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5709, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5710, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1428';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5713, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5714, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1429';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5717, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5718, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1430';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5721, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5722, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1431';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5725, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5726, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1432';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5729, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5730, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1433';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5733, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5734, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1434';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5737, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5738, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1435';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5741, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5742, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1436';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5745, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5746, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1437';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5749, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5750, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1438';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5753, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5754, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1439';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5757, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5758, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1440';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5761, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5762, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1441';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5765, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5766, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1442';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5769, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5770, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1443';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5773, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5774, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1444';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5777, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5778, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1445';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5781, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5782, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1446';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5785, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5786, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1447';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5789, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5790, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1448';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5793, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5794, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1449';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5797, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5798, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1450';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5801, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5802, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1451';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5805, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5806, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1452';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5809, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5810, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1453';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5813, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5814, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1454';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5817, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5818, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1455';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5821, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5822, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1456';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5825, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5826, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1457';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5829, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5830, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1458';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5833, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5834, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1459';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5837, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5838, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1460';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5841, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5842, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1461';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5845, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5846, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1462';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5849, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5850, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1463';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5853, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5854, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1464';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5857, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5858, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1465';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5861, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5862, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1466';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5865, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5866, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1467';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5869, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5870, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1468';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5873, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5874, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1469';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5877, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5878, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1470';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5881, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5882, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1471';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5885, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5886, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1472';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5889, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5890, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1473';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5893, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5894, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1474';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5897, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5898, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1475';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5901, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5902, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1476';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5905, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5906, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1477';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5909, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5910, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1478';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5913, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5914, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1479';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5917, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5918, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1480';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5921, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5922, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1481';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5925, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5926, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1482';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5929, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5930, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1483';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5933, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5934, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1484';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5937, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5938, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1485';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5941, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5942, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1486';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5945, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5946, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1487';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5949, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5950, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1488';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5953, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5954, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1489';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5957, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5958, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1490';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5961, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5962, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1491';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5965, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5966, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1492';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5969, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5970, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1493';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5973, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5974, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1494';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5977, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5978, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1495';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5981, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5982, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1496';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5985, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5986, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1497';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5989, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5990, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1498';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5993, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5994, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1499';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5997, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 5998, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1500';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6001, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6002, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1501';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6005, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6006, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1502';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6009, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6010, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1503';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6013, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6014, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1504';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6017, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6018, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1505';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6021, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6022, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1506';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6025, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6026, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1507';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6029, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6030, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1508';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6033, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6034, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1509';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6037, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6038, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1510';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6041, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6042, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1511';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6045, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6046, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1512';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6049, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6050, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1513';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6053, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6054, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1514';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6057, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6058, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1515';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6061, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6062, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1516';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6065, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6066, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1517';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6069, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6070, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1518';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6073, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6074, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1519';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6077, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6078, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1520';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6081, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6082, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1521';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6085, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6086, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1522';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6089, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6090, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1523';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6093, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6094, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1524';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6097, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6098, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1525';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6101, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6102, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1526';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6105, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6106, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1527';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6109, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6110, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1528';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6113, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6114, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1529';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6117, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6118, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1530';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6121, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6122, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1531';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6125, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6126, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1532';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6129, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6130, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1533';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6133, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6134, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1534';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6137, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6138, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1535';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6141, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6142, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1536';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6145, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6146, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1537';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6149, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6150, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1538';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6153, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6154, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1539';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6157, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6158, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1540';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6161, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6162, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1541';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6165, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6166, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1542';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6169, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6170, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1543';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6173, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6174, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1544';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6177, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6178, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1545';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6181, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6182, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1546';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6185, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6186, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1547';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6189, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6190, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1548';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6193, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6194, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1549';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6197, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6198, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1550';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6201, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6202, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1551';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6205, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6206, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1552';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6209, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6210, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1553';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6213, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6214, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1554';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6217, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6218, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1555';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6221, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6222, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1556';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6225, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6226, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1557';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6229, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6230, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1558';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6233, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6234, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1559';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6237, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6238, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1560';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6241, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6242, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1561';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6245, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6246, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1562';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6249, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6250, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1563';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6253, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6254, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1564';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6257, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6258, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1565';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6261, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6262, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1566';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6265, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6266, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1567';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6269, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6270, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1568';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6273, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6274, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1569';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6277, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6278, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1570';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6281, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6282, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1571';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6285, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6286, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1572';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6289, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6290, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1573';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6293, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6294, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1574';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6297, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6298, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1575';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6301, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6302, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1576';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6305, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6306, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1577';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6309, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6310, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1578';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6313, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6314, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1579';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6317, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6318, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1580';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6321, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6322, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1581';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6325, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6326, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1582';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6329, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6330, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1583';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6333, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6334, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1584';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6337, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6338, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1585';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6341, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6342, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1586';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6345, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6346, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1587';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6349, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6350, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1588';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6353, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6354, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1589';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6357, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6358, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1590';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6361, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6362, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1591';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6365, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6366, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1592';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6369, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6370, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1593';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6373, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6374, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1594';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6377, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6378, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1595';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6381, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6382, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1596';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6385, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6386, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1597';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6389, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6390, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1598';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6393, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6394, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1599';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6397, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6398, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1600';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6401, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6402, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1601';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6405, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6406, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1602';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6409, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6410, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1603';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6413, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6414, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1604';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6417, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6418, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1605';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6421, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6422, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1606';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6425, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6426, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1607';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6429, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6430, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1608';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6433, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6434, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1609';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6437, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6438, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1610';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6441, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6442, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1611';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6445, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6446, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1612';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6449, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6450, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1613';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6453, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6454, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1614';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6457, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6458, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1615';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6461, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6462, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1616';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6465, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6466, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1617';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6469, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6470, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1618';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6473, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6474, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1619';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6477, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6478, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1620';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6481, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6482, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1621';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6485, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6486, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1622';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6489, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6490, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1623';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6493, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6494, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1624';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6497, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6498, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1625';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6501, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6502, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1626';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6505, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6506, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1627';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6509, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6510, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1628';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6513, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6514, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1629';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6517, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6518, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1630';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6521, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6522, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1631';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6525, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6526, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1632';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6529, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6530, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1633';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6533, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6534, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1634';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6537, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6538, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1635';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6541, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6542, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1636';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6545, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6546, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1637';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6549, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6550, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1638';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6553, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6554, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1639';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6557, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6558, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1640';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6561, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6562, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1641';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6565, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6566, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1642';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6569, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6570, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1643';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6573, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6574, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1644';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6577, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6578, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1645';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6581, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6582, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1646';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6585, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6586, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1647';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6589, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6590, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1648';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6593, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6594, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1649';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6597, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6598, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1650';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6601, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6602, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1651';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6605, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6606, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1652';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6609, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6610, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1653';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6613, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6614, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1654';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6617, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6618, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1655';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6621, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6622, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1656';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6625, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6626, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1657';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6629, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6630, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1658';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6633, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6634, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1659';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6637, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6638, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1660';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6641, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6642, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1661';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6645, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6646, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1662';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6649, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6650, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1663';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6653, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6654, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1664';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6657, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6658, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1665';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6661, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6662, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1666';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6665, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6666, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1667';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6669, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6670, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1668';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6673, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6674, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1669';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6677, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6678, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1670';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6681, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6682, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1671';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6685, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6686, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1672';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6689, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6690, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1673';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6693, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6694, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1674';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6697, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6698, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1675';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6701, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6702, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1676';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6705, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6706, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1677';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6709, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6710, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1678';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6713, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6714, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1679';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6717, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6718, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1680';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6721, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6722, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1681';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6725, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6726, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1682';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6729, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6730, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1683';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6733, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6734, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1684';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6737, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6738, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1685';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6741, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6742, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1686';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6745, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6746, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1687';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6749, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6750, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1688';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6753, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6754, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1689';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6757, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6758, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1690';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6761, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6762, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1691';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6765, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6766, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1692';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6769, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6770, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1693';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6773, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6774, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1694';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6777, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6778, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1695';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6781, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6782, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1696';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6785, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6786, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1697';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6789, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6790, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1698';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6793, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6794, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1699';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6797, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6798, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1700';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6801, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6802, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1701';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6805, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6806, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1702';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6809, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6810, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1703';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6813, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6814, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1704';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6817, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6818, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1705';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6821, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6822, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1706';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6825, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6826, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1707';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6829, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6830, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1708';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6833, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6834, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1709';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6837, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6838, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1710';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6841, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6842, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1711';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6845, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6846, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1712';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6849, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6850, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1713';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6853, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6854, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1714';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6857, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6858, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1715';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6861, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6862, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1716';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6865, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6866, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1717';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6869, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6870, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1718';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6873, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6874, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1719';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6877, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6878, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1720';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6881, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6882, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1721';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6885, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6886, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1722';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6889, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6890, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1723';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6893, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6894, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1724';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6897, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6898, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1725';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6901, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6902, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1726';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6905, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6906, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1727';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6909, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6910, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1728';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6913, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6914, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1729';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6917, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6918, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1730';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6921, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6922, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1731';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6925, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6926, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1732';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6929, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6930, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1733';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6933, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6934, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1734';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6937, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6938, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1735';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6941, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6942, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1736';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6945, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6946, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1737';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6949, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6950, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1738';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6953, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6954, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1739';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6957, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6958, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1740';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6961, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6962, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1741';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6965, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6966, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1742';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6969, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6970, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1743';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6973, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6974, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1744';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6977, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6978, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1745';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6981, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6982, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1746';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6985, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6986, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1747';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6989, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6990, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1748';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6993, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6994, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1749';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6997, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 6998, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1750';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7001, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7002, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1751';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7005, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7006, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1752';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7009, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7010, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1753';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7013, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7014, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1754';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7017, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7018, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1755';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7021, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7022, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1756';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7025, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7026, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1757';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7029, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7030, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1758';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7033, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7034, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1759';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7037, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7038, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1760';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7041, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7042, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1761';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7045, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7046, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1762';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7049, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7050, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1763';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7053, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7054, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1764';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7057, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7058, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1765';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7061, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7062, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1766';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7065, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7066, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1767';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7069, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7070, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1768';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7073, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7074, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1769';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7077, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7078, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1770';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7081, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7082, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1771';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7085, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7086, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1772';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7089, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7090, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1773';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7093, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7094, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1774';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7097, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7098, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1775';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7101, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7102, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1776';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7105, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7106, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1777';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7109, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7110, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1778';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7113, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7114, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1779';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7117, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7118, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1780';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7121, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7122, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1781';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7125, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7126, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1782';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7129, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7130, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1783';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7133, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7134, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1784';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7137, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7138, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1785';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7141, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7142, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1786';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7145, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7146, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1787';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7149, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7150, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1788';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7153, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7154, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1789';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7157, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7158, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1790';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7161, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7162, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1791';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7165, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7166, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1792';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7169, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7170, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1793';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7173, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7174, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1794';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7177, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7178, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1795';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7181, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7182, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1796';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7185, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7186, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1797';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7189, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7190, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1798';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7193, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7194, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1799';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7197, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7198, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1800';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7201, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7202, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1801';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7205, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7206, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1802';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7209, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7210, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1803';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7213, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7214, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1804';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7217, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7218, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1805';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7221, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7222, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1806';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7225, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7226, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1807';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7229, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7230, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1808';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7233, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7234, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1809';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7237, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7238, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1810';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7241, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7242, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1811';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7245, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7246, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1812';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7249, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7250, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1813';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7253, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7254, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1814';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7257, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7258, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1815';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7261, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7262, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1816';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7265, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7266, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1817';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7269, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7270, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1818';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7273, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7274, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1819';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7277, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7278, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1820';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7281, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7282, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1821';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7285, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7286, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1822';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7289, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7290, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1823';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7293, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7294, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1824';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7297, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7298, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1825';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7301, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7302, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1826';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7305, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7306, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1827';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7309, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7310, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1828';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7313, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7314, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1829';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7317, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7318, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1830';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7321, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7322, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1831';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7325, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7326, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1832';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7329, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7330, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1833';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7333, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7334, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1834';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7337, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7338, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1835';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7341, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7342, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1836';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7345, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7346, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1837';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7349, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7350, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1838';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7353, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7354, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1839';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7357, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7358, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1840';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7361, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7362, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1841';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7365, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7366, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1842';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7369, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7370, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1843';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7373, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7374, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1844';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7377, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7378, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1845';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7381, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7382, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1846';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7385, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7386, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1847';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7389, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7390, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1848';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7393, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7394, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1849';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7397, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7398, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1850';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7401, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7402, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1851';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7405, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7406, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1852';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7409, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7410, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1853';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7413, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7414, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1854';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7417, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7418, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1855';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7421, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7422, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1856';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7425, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7426, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1857';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7429, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7430, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1858';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7433, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7434, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1859';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7437, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7438, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1860';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7441, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7442, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1861';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7445, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7446, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1862';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7449, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7450, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1863';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7453, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7454, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1864';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7457, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7458, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1865';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7461, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7462, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1866';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7465, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7466, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1867';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7469, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7470, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1868';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7473, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7474, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1869';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7477, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7478, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1870';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7481, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7482, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1871';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7485, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7486, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1872';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7489, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7490, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1873';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7493, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7494, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1874';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7497, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7498, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1875';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7501, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7502, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1876';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7505, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7506, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1877';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7509, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7510, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1878';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7513, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7514, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1879';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7517, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7518, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1880';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7521, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7522, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1881';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7525, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7526, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1882';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7529, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7530, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1883';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7533, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7534, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1884';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7537, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7538, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1885';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7541, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7542, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1886';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7545, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7546, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1887';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7549, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7550, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1888';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7553, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7554, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1889';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7557, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7558, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1890';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7561, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7562, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1891';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7565, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7566, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1892';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7569, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7570, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1893';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7573, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7574, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1894';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7577, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7578, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1895';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7581, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7582, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1896';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7585, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7586, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1897';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7589, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7590, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1898';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7593, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7594, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1899';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7597, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7598, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1900';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7601, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7602, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1901';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7605, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7606, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1902';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7609, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7610, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1903';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7613, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7614, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1904';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7617, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7618, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1905';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7621, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7622, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1906';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7625, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7626, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1907';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7629, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7630, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1908';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7633, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7634, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1909';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7637, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7638, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1910';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7641, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7642, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1911';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7645, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7646, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1912';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7649, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7650, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1913';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7653, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7654, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1914';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7657, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7658, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1915';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7661, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7662, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1916';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7665, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7666, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1917';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7669, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7670, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1918';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7673, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7674, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1919';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7677, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7678, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1920';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7681, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7682, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1921';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7685, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7686, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1922';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7689, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7690, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1923';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7693, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7694, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1924';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7697, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7698, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1925';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7701, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7702, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1926';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7705, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7706, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1927';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7709, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7710, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1928';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7713, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7714, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1929';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7717, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7718, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1930';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7721, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7722, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1931';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7725, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7726, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1932';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7729, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7730, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1933';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7733, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7734, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1934';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7737, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7738, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1935';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7741, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7742, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1936';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7745, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7746, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1937';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7749, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7750, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1938';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7753, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7754, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1939';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7757, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7758, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1940';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7761, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7762, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1941';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7765, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7766, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1942';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7769, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7770, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1943';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7773, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7774, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1944';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7777, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7778, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1945';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7781, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7782, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1946';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7785, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7786, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1947';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7789, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7790, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1948';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7793, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7794, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1949';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7797, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7798, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1950';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7801, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7802, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1951';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7805, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7806, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1952';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7809, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7810, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1953';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7813, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7814, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1954';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7817, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7818, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1955';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7821, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7822, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1956';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7825, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7826, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1957';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7829, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7830, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1958';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7833, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7834, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1959';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7837, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7838, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1960';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7841, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7842, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1961';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7845, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7846, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1962';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7849, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7850, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1963';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7853, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7854, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1964';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7857, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7858, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1965';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7861, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7862, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1966';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7865, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7866, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1967';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7869, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7870, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1968';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7873, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7874, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1969';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7877, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7878, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1970';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7881, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7882, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1971';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7885, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7886, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1972';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7889, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7890, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1973';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7893, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7894, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1974';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7897, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7898, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1975';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7901, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7902, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1976';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7905, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7906, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1977';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7909, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7910, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1978';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7913, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7914, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1979';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7917, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7918, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1980';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7921, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7922, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1981';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7925, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7926, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1982';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7929, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7930, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1983';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7933, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7934, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1984';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7937, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7938, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1985';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7941, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7942, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1986';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7945, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7946, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1987';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7949, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7950, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1988';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7953, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7954, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1989';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7957, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7958, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1990';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7961, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7962, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1991';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7965, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7966, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1992';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7969, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7970, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1993';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7973, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7974, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1994';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7977, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7978, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1995';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7981, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7982, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1996';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7985, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7986, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1997';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7989, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7990, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1998';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7993, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7994, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    } |
+    {
+        name: '1999';
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7997, 5))
+
+        children: BigUnion[];
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 7998, 21))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    };
+
+type DiscriminateUnion<T, K extends keyof T, V extends T[K]> = T extends Record<K, V> ? T : never;
+>DiscriminateUnion : Symbol(DiscriminateUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8000, 6))
+>T : Symbol(T, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8002, 23))
+>K : Symbol(K, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8002, 25))
+>T : Symbol(T, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8002, 23))
+>V : Symbol(V, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8002, 44))
+>T : Symbol(T, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8002, 23))
+>K : Symbol(K, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8002, 25))
+>T : Symbol(T, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8002, 23))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>K : Symbol(K, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8002, 25))
+>V : Symbol(V, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8002, 44))
+>T : Symbol(T, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8002, 23))
+
+type WithName<T extends BigUnion['name']> = DiscriminateUnion<BigUnion, 'name', T>;
+>WithName : Symbol(WithName, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8002, 98))
+>T : Symbol(T, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8004, 14))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+>DiscriminateUnion : Symbol(DiscriminateUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8000, 6))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+>T : Symbol(T, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8004, 14))
+
+type ChildrenOf<T extends BigUnion> = T['children'][number];
+>ChildrenOf : Symbol(ChildrenOf, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8004, 83))
+>T : Symbol(T, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8006, 16))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+>T : Symbol(T, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8006, 16))
+
+export function makeThing<T extends BigUnion['name']>(
+>makeThing : Symbol(makeThing, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8006, 60))
+>T : Symbol(T, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8008, 26))
+>BigUnion : Symbol(BigUnion, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 0, 0))
+
+    name: T,
+>name : Symbol(name, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8008, 54))
+>T : Symbol(T, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8008, 26))
+
+    children: ChildrenOf<WithName<T>>[] = [],
+>children : Symbol(children, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8009, 12))
+>ChildrenOf : Symbol(ChildrenOf, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8004, 83))
+>WithName : Symbol(WithName, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8002, 98))
+>T : Symbol(T, Decl(conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts, 8008, 26))
+
+) { }

--- a/tests/baselines/reference/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.types
+++ b/tests/baselines/reference/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.types
@@ -1,0 +1,16024 @@
+=== tests/cases/compiler/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts ===
+type BigUnion =
+>BigUnion : BigUnion
+    {
+        name: '0';
+>name : "0"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1';
+>name : "1"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '2';
+>name : "2"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '3';
+>name : "3"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '4';
+>name : "4"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '5';
+>name : "5"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '6';
+>name : "6"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '7';
+>name : "7"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '8';
+>name : "8"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '9';
+>name : "9"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '10';
+>name : "10"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '11';
+>name : "11"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '12';
+>name : "12"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '13';
+>name : "13"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '14';
+>name : "14"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '15';
+>name : "15"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '16';
+>name : "16"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '17';
+>name : "17"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '18';
+>name : "18"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '19';
+>name : "19"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '20';
+>name : "20"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '21';
+>name : "21"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '22';
+>name : "22"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '23';
+>name : "23"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '24';
+>name : "24"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '25';
+>name : "25"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '26';
+>name : "26"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '27';
+>name : "27"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '28';
+>name : "28"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '29';
+>name : "29"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '30';
+>name : "30"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '31';
+>name : "31"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '32';
+>name : "32"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '33';
+>name : "33"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '34';
+>name : "34"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '35';
+>name : "35"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '36';
+>name : "36"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '37';
+>name : "37"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '38';
+>name : "38"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '39';
+>name : "39"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '40';
+>name : "40"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '41';
+>name : "41"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '42';
+>name : "42"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '43';
+>name : "43"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '44';
+>name : "44"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '45';
+>name : "45"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '46';
+>name : "46"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '47';
+>name : "47"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '48';
+>name : "48"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '49';
+>name : "49"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '50';
+>name : "50"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '51';
+>name : "51"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '52';
+>name : "52"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '53';
+>name : "53"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '54';
+>name : "54"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '55';
+>name : "55"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '56';
+>name : "56"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '57';
+>name : "57"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '58';
+>name : "58"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '59';
+>name : "59"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '60';
+>name : "60"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '61';
+>name : "61"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '62';
+>name : "62"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '63';
+>name : "63"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '64';
+>name : "64"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '65';
+>name : "65"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '66';
+>name : "66"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '67';
+>name : "67"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '68';
+>name : "68"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '69';
+>name : "69"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '70';
+>name : "70"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '71';
+>name : "71"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '72';
+>name : "72"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '73';
+>name : "73"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '74';
+>name : "74"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '75';
+>name : "75"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '76';
+>name : "76"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '77';
+>name : "77"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '78';
+>name : "78"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '79';
+>name : "79"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '80';
+>name : "80"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '81';
+>name : "81"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '82';
+>name : "82"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '83';
+>name : "83"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '84';
+>name : "84"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '85';
+>name : "85"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '86';
+>name : "86"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '87';
+>name : "87"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '88';
+>name : "88"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '89';
+>name : "89"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '90';
+>name : "90"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '91';
+>name : "91"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '92';
+>name : "92"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '93';
+>name : "93"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '94';
+>name : "94"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '95';
+>name : "95"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '96';
+>name : "96"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '97';
+>name : "97"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '98';
+>name : "98"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '99';
+>name : "99"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '100';
+>name : "100"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '101';
+>name : "101"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '102';
+>name : "102"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '103';
+>name : "103"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '104';
+>name : "104"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '105';
+>name : "105"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '106';
+>name : "106"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '107';
+>name : "107"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '108';
+>name : "108"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '109';
+>name : "109"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '110';
+>name : "110"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '111';
+>name : "111"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '112';
+>name : "112"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '113';
+>name : "113"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '114';
+>name : "114"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '115';
+>name : "115"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '116';
+>name : "116"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '117';
+>name : "117"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '118';
+>name : "118"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '119';
+>name : "119"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '120';
+>name : "120"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '121';
+>name : "121"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '122';
+>name : "122"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '123';
+>name : "123"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '124';
+>name : "124"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '125';
+>name : "125"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '126';
+>name : "126"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '127';
+>name : "127"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '128';
+>name : "128"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '129';
+>name : "129"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '130';
+>name : "130"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '131';
+>name : "131"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '132';
+>name : "132"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '133';
+>name : "133"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '134';
+>name : "134"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '135';
+>name : "135"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '136';
+>name : "136"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '137';
+>name : "137"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '138';
+>name : "138"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '139';
+>name : "139"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '140';
+>name : "140"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '141';
+>name : "141"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '142';
+>name : "142"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '143';
+>name : "143"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '144';
+>name : "144"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '145';
+>name : "145"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '146';
+>name : "146"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '147';
+>name : "147"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '148';
+>name : "148"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '149';
+>name : "149"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '150';
+>name : "150"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '151';
+>name : "151"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '152';
+>name : "152"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '153';
+>name : "153"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '154';
+>name : "154"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '155';
+>name : "155"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '156';
+>name : "156"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '157';
+>name : "157"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '158';
+>name : "158"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '159';
+>name : "159"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '160';
+>name : "160"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '161';
+>name : "161"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '162';
+>name : "162"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '163';
+>name : "163"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '164';
+>name : "164"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '165';
+>name : "165"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '166';
+>name : "166"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '167';
+>name : "167"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '168';
+>name : "168"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '169';
+>name : "169"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '170';
+>name : "170"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '171';
+>name : "171"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '172';
+>name : "172"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '173';
+>name : "173"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '174';
+>name : "174"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '175';
+>name : "175"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '176';
+>name : "176"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '177';
+>name : "177"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '178';
+>name : "178"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '179';
+>name : "179"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '180';
+>name : "180"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '181';
+>name : "181"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '182';
+>name : "182"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '183';
+>name : "183"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '184';
+>name : "184"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '185';
+>name : "185"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '186';
+>name : "186"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '187';
+>name : "187"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '188';
+>name : "188"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '189';
+>name : "189"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '190';
+>name : "190"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '191';
+>name : "191"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '192';
+>name : "192"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '193';
+>name : "193"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '194';
+>name : "194"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '195';
+>name : "195"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '196';
+>name : "196"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '197';
+>name : "197"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '198';
+>name : "198"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '199';
+>name : "199"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '200';
+>name : "200"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '201';
+>name : "201"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '202';
+>name : "202"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '203';
+>name : "203"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '204';
+>name : "204"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '205';
+>name : "205"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '206';
+>name : "206"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '207';
+>name : "207"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '208';
+>name : "208"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '209';
+>name : "209"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '210';
+>name : "210"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '211';
+>name : "211"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '212';
+>name : "212"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '213';
+>name : "213"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '214';
+>name : "214"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '215';
+>name : "215"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '216';
+>name : "216"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '217';
+>name : "217"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '218';
+>name : "218"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '219';
+>name : "219"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '220';
+>name : "220"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '221';
+>name : "221"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '222';
+>name : "222"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '223';
+>name : "223"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '224';
+>name : "224"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '225';
+>name : "225"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '226';
+>name : "226"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '227';
+>name : "227"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '228';
+>name : "228"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '229';
+>name : "229"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '230';
+>name : "230"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '231';
+>name : "231"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '232';
+>name : "232"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '233';
+>name : "233"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '234';
+>name : "234"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '235';
+>name : "235"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '236';
+>name : "236"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '237';
+>name : "237"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '238';
+>name : "238"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '239';
+>name : "239"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '240';
+>name : "240"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '241';
+>name : "241"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '242';
+>name : "242"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '243';
+>name : "243"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '244';
+>name : "244"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '245';
+>name : "245"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '246';
+>name : "246"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '247';
+>name : "247"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '248';
+>name : "248"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '249';
+>name : "249"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '250';
+>name : "250"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '251';
+>name : "251"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '252';
+>name : "252"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '253';
+>name : "253"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '254';
+>name : "254"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '255';
+>name : "255"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '256';
+>name : "256"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '257';
+>name : "257"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '258';
+>name : "258"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '259';
+>name : "259"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '260';
+>name : "260"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '261';
+>name : "261"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '262';
+>name : "262"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '263';
+>name : "263"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '264';
+>name : "264"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '265';
+>name : "265"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '266';
+>name : "266"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '267';
+>name : "267"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '268';
+>name : "268"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '269';
+>name : "269"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '270';
+>name : "270"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '271';
+>name : "271"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '272';
+>name : "272"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '273';
+>name : "273"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '274';
+>name : "274"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '275';
+>name : "275"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '276';
+>name : "276"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '277';
+>name : "277"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '278';
+>name : "278"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '279';
+>name : "279"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '280';
+>name : "280"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '281';
+>name : "281"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '282';
+>name : "282"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '283';
+>name : "283"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '284';
+>name : "284"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '285';
+>name : "285"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '286';
+>name : "286"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '287';
+>name : "287"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '288';
+>name : "288"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '289';
+>name : "289"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '290';
+>name : "290"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '291';
+>name : "291"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '292';
+>name : "292"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '293';
+>name : "293"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '294';
+>name : "294"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '295';
+>name : "295"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '296';
+>name : "296"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '297';
+>name : "297"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '298';
+>name : "298"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '299';
+>name : "299"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '300';
+>name : "300"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '301';
+>name : "301"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '302';
+>name : "302"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '303';
+>name : "303"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '304';
+>name : "304"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '305';
+>name : "305"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '306';
+>name : "306"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '307';
+>name : "307"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '308';
+>name : "308"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '309';
+>name : "309"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '310';
+>name : "310"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '311';
+>name : "311"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '312';
+>name : "312"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '313';
+>name : "313"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '314';
+>name : "314"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '315';
+>name : "315"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '316';
+>name : "316"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '317';
+>name : "317"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '318';
+>name : "318"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '319';
+>name : "319"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '320';
+>name : "320"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '321';
+>name : "321"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '322';
+>name : "322"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '323';
+>name : "323"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '324';
+>name : "324"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '325';
+>name : "325"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '326';
+>name : "326"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '327';
+>name : "327"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '328';
+>name : "328"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '329';
+>name : "329"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '330';
+>name : "330"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '331';
+>name : "331"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '332';
+>name : "332"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '333';
+>name : "333"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '334';
+>name : "334"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '335';
+>name : "335"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '336';
+>name : "336"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '337';
+>name : "337"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '338';
+>name : "338"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '339';
+>name : "339"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '340';
+>name : "340"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '341';
+>name : "341"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '342';
+>name : "342"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '343';
+>name : "343"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '344';
+>name : "344"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '345';
+>name : "345"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '346';
+>name : "346"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '347';
+>name : "347"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '348';
+>name : "348"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '349';
+>name : "349"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '350';
+>name : "350"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '351';
+>name : "351"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '352';
+>name : "352"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '353';
+>name : "353"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '354';
+>name : "354"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '355';
+>name : "355"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '356';
+>name : "356"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '357';
+>name : "357"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '358';
+>name : "358"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '359';
+>name : "359"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '360';
+>name : "360"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '361';
+>name : "361"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '362';
+>name : "362"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '363';
+>name : "363"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '364';
+>name : "364"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '365';
+>name : "365"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '366';
+>name : "366"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '367';
+>name : "367"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '368';
+>name : "368"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '369';
+>name : "369"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '370';
+>name : "370"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '371';
+>name : "371"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '372';
+>name : "372"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '373';
+>name : "373"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '374';
+>name : "374"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '375';
+>name : "375"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '376';
+>name : "376"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '377';
+>name : "377"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '378';
+>name : "378"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '379';
+>name : "379"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '380';
+>name : "380"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '381';
+>name : "381"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '382';
+>name : "382"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '383';
+>name : "383"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '384';
+>name : "384"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '385';
+>name : "385"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '386';
+>name : "386"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '387';
+>name : "387"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '388';
+>name : "388"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '389';
+>name : "389"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '390';
+>name : "390"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '391';
+>name : "391"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '392';
+>name : "392"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '393';
+>name : "393"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '394';
+>name : "394"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '395';
+>name : "395"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '396';
+>name : "396"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '397';
+>name : "397"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '398';
+>name : "398"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '399';
+>name : "399"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '400';
+>name : "400"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '401';
+>name : "401"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '402';
+>name : "402"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '403';
+>name : "403"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '404';
+>name : "404"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '405';
+>name : "405"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '406';
+>name : "406"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '407';
+>name : "407"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '408';
+>name : "408"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '409';
+>name : "409"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '410';
+>name : "410"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '411';
+>name : "411"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '412';
+>name : "412"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '413';
+>name : "413"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '414';
+>name : "414"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '415';
+>name : "415"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '416';
+>name : "416"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '417';
+>name : "417"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '418';
+>name : "418"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '419';
+>name : "419"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '420';
+>name : "420"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '421';
+>name : "421"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '422';
+>name : "422"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '423';
+>name : "423"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '424';
+>name : "424"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '425';
+>name : "425"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '426';
+>name : "426"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '427';
+>name : "427"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '428';
+>name : "428"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '429';
+>name : "429"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '430';
+>name : "430"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '431';
+>name : "431"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '432';
+>name : "432"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '433';
+>name : "433"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '434';
+>name : "434"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '435';
+>name : "435"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '436';
+>name : "436"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '437';
+>name : "437"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '438';
+>name : "438"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '439';
+>name : "439"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '440';
+>name : "440"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '441';
+>name : "441"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '442';
+>name : "442"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '443';
+>name : "443"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '444';
+>name : "444"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '445';
+>name : "445"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '446';
+>name : "446"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '447';
+>name : "447"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '448';
+>name : "448"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '449';
+>name : "449"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '450';
+>name : "450"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '451';
+>name : "451"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '452';
+>name : "452"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '453';
+>name : "453"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '454';
+>name : "454"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '455';
+>name : "455"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '456';
+>name : "456"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '457';
+>name : "457"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '458';
+>name : "458"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '459';
+>name : "459"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '460';
+>name : "460"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '461';
+>name : "461"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '462';
+>name : "462"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '463';
+>name : "463"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '464';
+>name : "464"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '465';
+>name : "465"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '466';
+>name : "466"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '467';
+>name : "467"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '468';
+>name : "468"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '469';
+>name : "469"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '470';
+>name : "470"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '471';
+>name : "471"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '472';
+>name : "472"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '473';
+>name : "473"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '474';
+>name : "474"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '475';
+>name : "475"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '476';
+>name : "476"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '477';
+>name : "477"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '478';
+>name : "478"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '479';
+>name : "479"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '480';
+>name : "480"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '481';
+>name : "481"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '482';
+>name : "482"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '483';
+>name : "483"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '484';
+>name : "484"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '485';
+>name : "485"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '486';
+>name : "486"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '487';
+>name : "487"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '488';
+>name : "488"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '489';
+>name : "489"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '490';
+>name : "490"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '491';
+>name : "491"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '492';
+>name : "492"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '493';
+>name : "493"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '494';
+>name : "494"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '495';
+>name : "495"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '496';
+>name : "496"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '497';
+>name : "497"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '498';
+>name : "498"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '499';
+>name : "499"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '500';
+>name : "500"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '501';
+>name : "501"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '502';
+>name : "502"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '503';
+>name : "503"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '504';
+>name : "504"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '505';
+>name : "505"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '506';
+>name : "506"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '507';
+>name : "507"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '508';
+>name : "508"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '509';
+>name : "509"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '510';
+>name : "510"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '511';
+>name : "511"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '512';
+>name : "512"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '513';
+>name : "513"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '514';
+>name : "514"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '515';
+>name : "515"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '516';
+>name : "516"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '517';
+>name : "517"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '518';
+>name : "518"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '519';
+>name : "519"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '520';
+>name : "520"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '521';
+>name : "521"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '522';
+>name : "522"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '523';
+>name : "523"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '524';
+>name : "524"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '525';
+>name : "525"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '526';
+>name : "526"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '527';
+>name : "527"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '528';
+>name : "528"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '529';
+>name : "529"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '530';
+>name : "530"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '531';
+>name : "531"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '532';
+>name : "532"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '533';
+>name : "533"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '534';
+>name : "534"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '535';
+>name : "535"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '536';
+>name : "536"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '537';
+>name : "537"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '538';
+>name : "538"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '539';
+>name : "539"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '540';
+>name : "540"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '541';
+>name : "541"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '542';
+>name : "542"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '543';
+>name : "543"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '544';
+>name : "544"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '545';
+>name : "545"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '546';
+>name : "546"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '547';
+>name : "547"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '548';
+>name : "548"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '549';
+>name : "549"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '550';
+>name : "550"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '551';
+>name : "551"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '552';
+>name : "552"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '553';
+>name : "553"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '554';
+>name : "554"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '555';
+>name : "555"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '556';
+>name : "556"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '557';
+>name : "557"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '558';
+>name : "558"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '559';
+>name : "559"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '560';
+>name : "560"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '561';
+>name : "561"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '562';
+>name : "562"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '563';
+>name : "563"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '564';
+>name : "564"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '565';
+>name : "565"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '566';
+>name : "566"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '567';
+>name : "567"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '568';
+>name : "568"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '569';
+>name : "569"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '570';
+>name : "570"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '571';
+>name : "571"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '572';
+>name : "572"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '573';
+>name : "573"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '574';
+>name : "574"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '575';
+>name : "575"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '576';
+>name : "576"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '577';
+>name : "577"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '578';
+>name : "578"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '579';
+>name : "579"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '580';
+>name : "580"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '581';
+>name : "581"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '582';
+>name : "582"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '583';
+>name : "583"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '584';
+>name : "584"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '585';
+>name : "585"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '586';
+>name : "586"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '587';
+>name : "587"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '588';
+>name : "588"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '589';
+>name : "589"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '590';
+>name : "590"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '591';
+>name : "591"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '592';
+>name : "592"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '593';
+>name : "593"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '594';
+>name : "594"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '595';
+>name : "595"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '596';
+>name : "596"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '597';
+>name : "597"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '598';
+>name : "598"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '599';
+>name : "599"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '600';
+>name : "600"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '601';
+>name : "601"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '602';
+>name : "602"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '603';
+>name : "603"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '604';
+>name : "604"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '605';
+>name : "605"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '606';
+>name : "606"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '607';
+>name : "607"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '608';
+>name : "608"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '609';
+>name : "609"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '610';
+>name : "610"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '611';
+>name : "611"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '612';
+>name : "612"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '613';
+>name : "613"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '614';
+>name : "614"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '615';
+>name : "615"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '616';
+>name : "616"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '617';
+>name : "617"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '618';
+>name : "618"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '619';
+>name : "619"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '620';
+>name : "620"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '621';
+>name : "621"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '622';
+>name : "622"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '623';
+>name : "623"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '624';
+>name : "624"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '625';
+>name : "625"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '626';
+>name : "626"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '627';
+>name : "627"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '628';
+>name : "628"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '629';
+>name : "629"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '630';
+>name : "630"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '631';
+>name : "631"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '632';
+>name : "632"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '633';
+>name : "633"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '634';
+>name : "634"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '635';
+>name : "635"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '636';
+>name : "636"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '637';
+>name : "637"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '638';
+>name : "638"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '639';
+>name : "639"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '640';
+>name : "640"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '641';
+>name : "641"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '642';
+>name : "642"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '643';
+>name : "643"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '644';
+>name : "644"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '645';
+>name : "645"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '646';
+>name : "646"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '647';
+>name : "647"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '648';
+>name : "648"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '649';
+>name : "649"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '650';
+>name : "650"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '651';
+>name : "651"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '652';
+>name : "652"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '653';
+>name : "653"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '654';
+>name : "654"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '655';
+>name : "655"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '656';
+>name : "656"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '657';
+>name : "657"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '658';
+>name : "658"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '659';
+>name : "659"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '660';
+>name : "660"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '661';
+>name : "661"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '662';
+>name : "662"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '663';
+>name : "663"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '664';
+>name : "664"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '665';
+>name : "665"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '666';
+>name : "666"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '667';
+>name : "667"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '668';
+>name : "668"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '669';
+>name : "669"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '670';
+>name : "670"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '671';
+>name : "671"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '672';
+>name : "672"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '673';
+>name : "673"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '674';
+>name : "674"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '675';
+>name : "675"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '676';
+>name : "676"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '677';
+>name : "677"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '678';
+>name : "678"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '679';
+>name : "679"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '680';
+>name : "680"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '681';
+>name : "681"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '682';
+>name : "682"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '683';
+>name : "683"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '684';
+>name : "684"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '685';
+>name : "685"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '686';
+>name : "686"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '687';
+>name : "687"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '688';
+>name : "688"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '689';
+>name : "689"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '690';
+>name : "690"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '691';
+>name : "691"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '692';
+>name : "692"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '693';
+>name : "693"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '694';
+>name : "694"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '695';
+>name : "695"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '696';
+>name : "696"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '697';
+>name : "697"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '698';
+>name : "698"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '699';
+>name : "699"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '700';
+>name : "700"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '701';
+>name : "701"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '702';
+>name : "702"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '703';
+>name : "703"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '704';
+>name : "704"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '705';
+>name : "705"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '706';
+>name : "706"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '707';
+>name : "707"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '708';
+>name : "708"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '709';
+>name : "709"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '710';
+>name : "710"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '711';
+>name : "711"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '712';
+>name : "712"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '713';
+>name : "713"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '714';
+>name : "714"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '715';
+>name : "715"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '716';
+>name : "716"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '717';
+>name : "717"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '718';
+>name : "718"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '719';
+>name : "719"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '720';
+>name : "720"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '721';
+>name : "721"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '722';
+>name : "722"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '723';
+>name : "723"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '724';
+>name : "724"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '725';
+>name : "725"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '726';
+>name : "726"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '727';
+>name : "727"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '728';
+>name : "728"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '729';
+>name : "729"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '730';
+>name : "730"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '731';
+>name : "731"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '732';
+>name : "732"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '733';
+>name : "733"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '734';
+>name : "734"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '735';
+>name : "735"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '736';
+>name : "736"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '737';
+>name : "737"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '738';
+>name : "738"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '739';
+>name : "739"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '740';
+>name : "740"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '741';
+>name : "741"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '742';
+>name : "742"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '743';
+>name : "743"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '744';
+>name : "744"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '745';
+>name : "745"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '746';
+>name : "746"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '747';
+>name : "747"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '748';
+>name : "748"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '749';
+>name : "749"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '750';
+>name : "750"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '751';
+>name : "751"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '752';
+>name : "752"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '753';
+>name : "753"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '754';
+>name : "754"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '755';
+>name : "755"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '756';
+>name : "756"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '757';
+>name : "757"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '758';
+>name : "758"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '759';
+>name : "759"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '760';
+>name : "760"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '761';
+>name : "761"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '762';
+>name : "762"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '763';
+>name : "763"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '764';
+>name : "764"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '765';
+>name : "765"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '766';
+>name : "766"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '767';
+>name : "767"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '768';
+>name : "768"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '769';
+>name : "769"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '770';
+>name : "770"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '771';
+>name : "771"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '772';
+>name : "772"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '773';
+>name : "773"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '774';
+>name : "774"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '775';
+>name : "775"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '776';
+>name : "776"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '777';
+>name : "777"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '778';
+>name : "778"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '779';
+>name : "779"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '780';
+>name : "780"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '781';
+>name : "781"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '782';
+>name : "782"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '783';
+>name : "783"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '784';
+>name : "784"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '785';
+>name : "785"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '786';
+>name : "786"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '787';
+>name : "787"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '788';
+>name : "788"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '789';
+>name : "789"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '790';
+>name : "790"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '791';
+>name : "791"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '792';
+>name : "792"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '793';
+>name : "793"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '794';
+>name : "794"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '795';
+>name : "795"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '796';
+>name : "796"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '797';
+>name : "797"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '798';
+>name : "798"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '799';
+>name : "799"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '800';
+>name : "800"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '801';
+>name : "801"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '802';
+>name : "802"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '803';
+>name : "803"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '804';
+>name : "804"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '805';
+>name : "805"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '806';
+>name : "806"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '807';
+>name : "807"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '808';
+>name : "808"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '809';
+>name : "809"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '810';
+>name : "810"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '811';
+>name : "811"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '812';
+>name : "812"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '813';
+>name : "813"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '814';
+>name : "814"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '815';
+>name : "815"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '816';
+>name : "816"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '817';
+>name : "817"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '818';
+>name : "818"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '819';
+>name : "819"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '820';
+>name : "820"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '821';
+>name : "821"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '822';
+>name : "822"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '823';
+>name : "823"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '824';
+>name : "824"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '825';
+>name : "825"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '826';
+>name : "826"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '827';
+>name : "827"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '828';
+>name : "828"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '829';
+>name : "829"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '830';
+>name : "830"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '831';
+>name : "831"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '832';
+>name : "832"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '833';
+>name : "833"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '834';
+>name : "834"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '835';
+>name : "835"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '836';
+>name : "836"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '837';
+>name : "837"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '838';
+>name : "838"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '839';
+>name : "839"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '840';
+>name : "840"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '841';
+>name : "841"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '842';
+>name : "842"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '843';
+>name : "843"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '844';
+>name : "844"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '845';
+>name : "845"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '846';
+>name : "846"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '847';
+>name : "847"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '848';
+>name : "848"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '849';
+>name : "849"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '850';
+>name : "850"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '851';
+>name : "851"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '852';
+>name : "852"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '853';
+>name : "853"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '854';
+>name : "854"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '855';
+>name : "855"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '856';
+>name : "856"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '857';
+>name : "857"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '858';
+>name : "858"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '859';
+>name : "859"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '860';
+>name : "860"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '861';
+>name : "861"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '862';
+>name : "862"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '863';
+>name : "863"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '864';
+>name : "864"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '865';
+>name : "865"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '866';
+>name : "866"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '867';
+>name : "867"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '868';
+>name : "868"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '869';
+>name : "869"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '870';
+>name : "870"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '871';
+>name : "871"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '872';
+>name : "872"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '873';
+>name : "873"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '874';
+>name : "874"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '875';
+>name : "875"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '876';
+>name : "876"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '877';
+>name : "877"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '878';
+>name : "878"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '879';
+>name : "879"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '880';
+>name : "880"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '881';
+>name : "881"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '882';
+>name : "882"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '883';
+>name : "883"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '884';
+>name : "884"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '885';
+>name : "885"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '886';
+>name : "886"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '887';
+>name : "887"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '888';
+>name : "888"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '889';
+>name : "889"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '890';
+>name : "890"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '891';
+>name : "891"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '892';
+>name : "892"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '893';
+>name : "893"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '894';
+>name : "894"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '895';
+>name : "895"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '896';
+>name : "896"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '897';
+>name : "897"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '898';
+>name : "898"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '899';
+>name : "899"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '900';
+>name : "900"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '901';
+>name : "901"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '902';
+>name : "902"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '903';
+>name : "903"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '904';
+>name : "904"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '905';
+>name : "905"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '906';
+>name : "906"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '907';
+>name : "907"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '908';
+>name : "908"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '909';
+>name : "909"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '910';
+>name : "910"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '911';
+>name : "911"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '912';
+>name : "912"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '913';
+>name : "913"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '914';
+>name : "914"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '915';
+>name : "915"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '916';
+>name : "916"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '917';
+>name : "917"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '918';
+>name : "918"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '919';
+>name : "919"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '920';
+>name : "920"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '921';
+>name : "921"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '922';
+>name : "922"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '923';
+>name : "923"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '924';
+>name : "924"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '925';
+>name : "925"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '926';
+>name : "926"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '927';
+>name : "927"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '928';
+>name : "928"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '929';
+>name : "929"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '930';
+>name : "930"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '931';
+>name : "931"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '932';
+>name : "932"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '933';
+>name : "933"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '934';
+>name : "934"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '935';
+>name : "935"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '936';
+>name : "936"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '937';
+>name : "937"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '938';
+>name : "938"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '939';
+>name : "939"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '940';
+>name : "940"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '941';
+>name : "941"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '942';
+>name : "942"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '943';
+>name : "943"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '944';
+>name : "944"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '945';
+>name : "945"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '946';
+>name : "946"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '947';
+>name : "947"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '948';
+>name : "948"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '949';
+>name : "949"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '950';
+>name : "950"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '951';
+>name : "951"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '952';
+>name : "952"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '953';
+>name : "953"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '954';
+>name : "954"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '955';
+>name : "955"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '956';
+>name : "956"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '957';
+>name : "957"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '958';
+>name : "958"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '959';
+>name : "959"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '960';
+>name : "960"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '961';
+>name : "961"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '962';
+>name : "962"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '963';
+>name : "963"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '964';
+>name : "964"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '965';
+>name : "965"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '966';
+>name : "966"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '967';
+>name : "967"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '968';
+>name : "968"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '969';
+>name : "969"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '970';
+>name : "970"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '971';
+>name : "971"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '972';
+>name : "972"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '973';
+>name : "973"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '974';
+>name : "974"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '975';
+>name : "975"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '976';
+>name : "976"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '977';
+>name : "977"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '978';
+>name : "978"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '979';
+>name : "979"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '980';
+>name : "980"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '981';
+>name : "981"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '982';
+>name : "982"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '983';
+>name : "983"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '984';
+>name : "984"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '985';
+>name : "985"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '986';
+>name : "986"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '987';
+>name : "987"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '988';
+>name : "988"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '989';
+>name : "989"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '990';
+>name : "990"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '991';
+>name : "991"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '992';
+>name : "992"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '993';
+>name : "993"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '994';
+>name : "994"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '995';
+>name : "995"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '996';
+>name : "996"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '997';
+>name : "997"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '998';
+>name : "998"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '999';
+>name : "999"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1000';
+>name : "1000"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1001';
+>name : "1001"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1002';
+>name : "1002"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1003';
+>name : "1003"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1004';
+>name : "1004"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1005';
+>name : "1005"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1006';
+>name : "1006"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1007';
+>name : "1007"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1008';
+>name : "1008"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1009';
+>name : "1009"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1010';
+>name : "1010"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1011';
+>name : "1011"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1012';
+>name : "1012"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1013';
+>name : "1013"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1014';
+>name : "1014"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1015';
+>name : "1015"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1016';
+>name : "1016"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1017';
+>name : "1017"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1018';
+>name : "1018"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1019';
+>name : "1019"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1020';
+>name : "1020"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1021';
+>name : "1021"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1022';
+>name : "1022"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1023';
+>name : "1023"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1024';
+>name : "1024"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1025';
+>name : "1025"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1026';
+>name : "1026"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1027';
+>name : "1027"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1028';
+>name : "1028"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1029';
+>name : "1029"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1030';
+>name : "1030"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1031';
+>name : "1031"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1032';
+>name : "1032"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1033';
+>name : "1033"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1034';
+>name : "1034"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1035';
+>name : "1035"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1036';
+>name : "1036"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1037';
+>name : "1037"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1038';
+>name : "1038"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1039';
+>name : "1039"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1040';
+>name : "1040"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1041';
+>name : "1041"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1042';
+>name : "1042"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1043';
+>name : "1043"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1044';
+>name : "1044"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1045';
+>name : "1045"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1046';
+>name : "1046"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1047';
+>name : "1047"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1048';
+>name : "1048"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1049';
+>name : "1049"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1050';
+>name : "1050"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1051';
+>name : "1051"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1052';
+>name : "1052"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1053';
+>name : "1053"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1054';
+>name : "1054"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1055';
+>name : "1055"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1056';
+>name : "1056"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1057';
+>name : "1057"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1058';
+>name : "1058"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1059';
+>name : "1059"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1060';
+>name : "1060"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1061';
+>name : "1061"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1062';
+>name : "1062"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1063';
+>name : "1063"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1064';
+>name : "1064"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1065';
+>name : "1065"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1066';
+>name : "1066"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1067';
+>name : "1067"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1068';
+>name : "1068"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1069';
+>name : "1069"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1070';
+>name : "1070"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1071';
+>name : "1071"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1072';
+>name : "1072"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1073';
+>name : "1073"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1074';
+>name : "1074"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1075';
+>name : "1075"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1076';
+>name : "1076"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1077';
+>name : "1077"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1078';
+>name : "1078"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1079';
+>name : "1079"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1080';
+>name : "1080"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1081';
+>name : "1081"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1082';
+>name : "1082"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1083';
+>name : "1083"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1084';
+>name : "1084"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1085';
+>name : "1085"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1086';
+>name : "1086"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1087';
+>name : "1087"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1088';
+>name : "1088"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1089';
+>name : "1089"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1090';
+>name : "1090"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1091';
+>name : "1091"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1092';
+>name : "1092"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1093';
+>name : "1093"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1094';
+>name : "1094"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1095';
+>name : "1095"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1096';
+>name : "1096"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1097';
+>name : "1097"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1098';
+>name : "1098"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1099';
+>name : "1099"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1100';
+>name : "1100"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1101';
+>name : "1101"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1102';
+>name : "1102"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1103';
+>name : "1103"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1104';
+>name : "1104"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1105';
+>name : "1105"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1106';
+>name : "1106"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1107';
+>name : "1107"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1108';
+>name : "1108"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1109';
+>name : "1109"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1110';
+>name : "1110"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1111';
+>name : "1111"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1112';
+>name : "1112"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1113';
+>name : "1113"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1114';
+>name : "1114"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1115';
+>name : "1115"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1116';
+>name : "1116"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1117';
+>name : "1117"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1118';
+>name : "1118"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1119';
+>name : "1119"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1120';
+>name : "1120"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1121';
+>name : "1121"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1122';
+>name : "1122"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1123';
+>name : "1123"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1124';
+>name : "1124"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1125';
+>name : "1125"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1126';
+>name : "1126"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1127';
+>name : "1127"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1128';
+>name : "1128"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1129';
+>name : "1129"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1130';
+>name : "1130"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1131';
+>name : "1131"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1132';
+>name : "1132"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1133';
+>name : "1133"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1134';
+>name : "1134"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1135';
+>name : "1135"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1136';
+>name : "1136"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1137';
+>name : "1137"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1138';
+>name : "1138"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1139';
+>name : "1139"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1140';
+>name : "1140"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1141';
+>name : "1141"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1142';
+>name : "1142"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1143';
+>name : "1143"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1144';
+>name : "1144"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1145';
+>name : "1145"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1146';
+>name : "1146"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1147';
+>name : "1147"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1148';
+>name : "1148"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1149';
+>name : "1149"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1150';
+>name : "1150"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1151';
+>name : "1151"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1152';
+>name : "1152"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1153';
+>name : "1153"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1154';
+>name : "1154"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1155';
+>name : "1155"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1156';
+>name : "1156"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1157';
+>name : "1157"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1158';
+>name : "1158"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1159';
+>name : "1159"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1160';
+>name : "1160"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1161';
+>name : "1161"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1162';
+>name : "1162"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1163';
+>name : "1163"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1164';
+>name : "1164"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1165';
+>name : "1165"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1166';
+>name : "1166"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1167';
+>name : "1167"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1168';
+>name : "1168"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1169';
+>name : "1169"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1170';
+>name : "1170"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1171';
+>name : "1171"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1172';
+>name : "1172"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1173';
+>name : "1173"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1174';
+>name : "1174"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1175';
+>name : "1175"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1176';
+>name : "1176"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1177';
+>name : "1177"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1178';
+>name : "1178"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1179';
+>name : "1179"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1180';
+>name : "1180"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1181';
+>name : "1181"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1182';
+>name : "1182"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1183';
+>name : "1183"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1184';
+>name : "1184"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1185';
+>name : "1185"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1186';
+>name : "1186"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1187';
+>name : "1187"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1188';
+>name : "1188"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1189';
+>name : "1189"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1190';
+>name : "1190"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1191';
+>name : "1191"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1192';
+>name : "1192"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1193';
+>name : "1193"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1194';
+>name : "1194"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1195';
+>name : "1195"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1196';
+>name : "1196"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1197';
+>name : "1197"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1198';
+>name : "1198"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1199';
+>name : "1199"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1200';
+>name : "1200"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1201';
+>name : "1201"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1202';
+>name : "1202"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1203';
+>name : "1203"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1204';
+>name : "1204"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1205';
+>name : "1205"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1206';
+>name : "1206"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1207';
+>name : "1207"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1208';
+>name : "1208"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1209';
+>name : "1209"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1210';
+>name : "1210"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1211';
+>name : "1211"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1212';
+>name : "1212"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1213';
+>name : "1213"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1214';
+>name : "1214"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1215';
+>name : "1215"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1216';
+>name : "1216"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1217';
+>name : "1217"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1218';
+>name : "1218"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1219';
+>name : "1219"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1220';
+>name : "1220"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1221';
+>name : "1221"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1222';
+>name : "1222"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1223';
+>name : "1223"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1224';
+>name : "1224"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1225';
+>name : "1225"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1226';
+>name : "1226"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1227';
+>name : "1227"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1228';
+>name : "1228"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1229';
+>name : "1229"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1230';
+>name : "1230"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1231';
+>name : "1231"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1232';
+>name : "1232"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1233';
+>name : "1233"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1234';
+>name : "1234"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1235';
+>name : "1235"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1236';
+>name : "1236"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1237';
+>name : "1237"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1238';
+>name : "1238"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1239';
+>name : "1239"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1240';
+>name : "1240"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1241';
+>name : "1241"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1242';
+>name : "1242"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1243';
+>name : "1243"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1244';
+>name : "1244"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1245';
+>name : "1245"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1246';
+>name : "1246"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1247';
+>name : "1247"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1248';
+>name : "1248"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1249';
+>name : "1249"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1250';
+>name : "1250"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1251';
+>name : "1251"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1252';
+>name : "1252"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1253';
+>name : "1253"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1254';
+>name : "1254"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1255';
+>name : "1255"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1256';
+>name : "1256"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1257';
+>name : "1257"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1258';
+>name : "1258"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1259';
+>name : "1259"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1260';
+>name : "1260"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1261';
+>name : "1261"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1262';
+>name : "1262"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1263';
+>name : "1263"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1264';
+>name : "1264"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1265';
+>name : "1265"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1266';
+>name : "1266"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1267';
+>name : "1267"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1268';
+>name : "1268"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1269';
+>name : "1269"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1270';
+>name : "1270"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1271';
+>name : "1271"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1272';
+>name : "1272"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1273';
+>name : "1273"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1274';
+>name : "1274"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1275';
+>name : "1275"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1276';
+>name : "1276"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1277';
+>name : "1277"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1278';
+>name : "1278"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1279';
+>name : "1279"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1280';
+>name : "1280"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1281';
+>name : "1281"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1282';
+>name : "1282"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1283';
+>name : "1283"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1284';
+>name : "1284"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1285';
+>name : "1285"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1286';
+>name : "1286"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1287';
+>name : "1287"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1288';
+>name : "1288"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1289';
+>name : "1289"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1290';
+>name : "1290"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1291';
+>name : "1291"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1292';
+>name : "1292"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1293';
+>name : "1293"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1294';
+>name : "1294"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1295';
+>name : "1295"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1296';
+>name : "1296"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1297';
+>name : "1297"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1298';
+>name : "1298"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1299';
+>name : "1299"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1300';
+>name : "1300"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1301';
+>name : "1301"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1302';
+>name : "1302"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1303';
+>name : "1303"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1304';
+>name : "1304"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1305';
+>name : "1305"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1306';
+>name : "1306"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1307';
+>name : "1307"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1308';
+>name : "1308"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1309';
+>name : "1309"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1310';
+>name : "1310"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1311';
+>name : "1311"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1312';
+>name : "1312"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1313';
+>name : "1313"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1314';
+>name : "1314"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1315';
+>name : "1315"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1316';
+>name : "1316"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1317';
+>name : "1317"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1318';
+>name : "1318"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1319';
+>name : "1319"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1320';
+>name : "1320"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1321';
+>name : "1321"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1322';
+>name : "1322"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1323';
+>name : "1323"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1324';
+>name : "1324"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1325';
+>name : "1325"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1326';
+>name : "1326"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1327';
+>name : "1327"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1328';
+>name : "1328"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1329';
+>name : "1329"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1330';
+>name : "1330"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1331';
+>name : "1331"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1332';
+>name : "1332"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1333';
+>name : "1333"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1334';
+>name : "1334"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1335';
+>name : "1335"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1336';
+>name : "1336"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1337';
+>name : "1337"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1338';
+>name : "1338"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1339';
+>name : "1339"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1340';
+>name : "1340"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1341';
+>name : "1341"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1342';
+>name : "1342"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1343';
+>name : "1343"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1344';
+>name : "1344"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1345';
+>name : "1345"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1346';
+>name : "1346"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1347';
+>name : "1347"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1348';
+>name : "1348"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1349';
+>name : "1349"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1350';
+>name : "1350"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1351';
+>name : "1351"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1352';
+>name : "1352"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1353';
+>name : "1353"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1354';
+>name : "1354"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1355';
+>name : "1355"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1356';
+>name : "1356"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1357';
+>name : "1357"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1358';
+>name : "1358"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1359';
+>name : "1359"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1360';
+>name : "1360"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1361';
+>name : "1361"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1362';
+>name : "1362"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1363';
+>name : "1363"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1364';
+>name : "1364"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1365';
+>name : "1365"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1366';
+>name : "1366"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1367';
+>name : "1367"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1368';
+>name : "1368"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1369';
+>name : "1369"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1370';
+>name : "1370"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1371';
+>name : "1371"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1372';
+>name : "1372"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1373';
+>name : "1373"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1374';
+>name : "1374"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1375';
+>name : "1375"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1376';
+>name : "1376"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1377';
+>name : "1377"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1378';
+>name : "1378"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1379';
+>name : "1379"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1380';
+>name : "1380"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1381';
+>name : "1381"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1382';
+>name : "1382"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1383';
+>name : "1383"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1384';
+>name : "1384"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1385';
+>name : "1385"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1386';
+>name : "1386"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1387';
+>name : "1387"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1388';
+>name : "1388"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1389';
+>name : "1389"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1390';
+>name : "1390"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1391';
+>name : "1391"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1392';
+>name : "1392"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1393';
+>name : "1393"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1394';
+>name : "1394"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1395';
+>name : "1395"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1396';
+>name : "1396"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1397';
+>name : "1397"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1398';
+>name : "1398"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1399';
+>name : "1399"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1400';
+>name : "1400"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1401';
+>name : "1401"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1402';
+>name : "1402"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1403';
+>name : "1403"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1404';
+>name : "1404"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1405';
+>name : "1405"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1406';
+>name : "1406"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1407';
+>name : "1407"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1408';
+>name : "1408"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1409';
+>name : "1409"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1410';
+>name : "1410"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1411';
+>name : "1411"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1412';
+>name : "1412"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1413';
+>name : "1413"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1414';
+>name : "1414"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1415';
+>name : "1415"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1416';
+>name : "1416"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1417';
+>name : "1417"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1418';
+>name : "1418"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1419';
+>name : "1419"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1420';
+>name : "1420"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1421';
+>name : "1421"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1422';
+>name : "1422"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1423';
+>name : "1423"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1424';
+>name : "1424"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1425';
+>name : "1425"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1426';
+>name : "1426"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1427';
+>name : "1427"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1428';
+>name : "1428"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1429';
+>name : "1429"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1430';
+>name : "1430"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1431';
+>name : "1431"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1432';
+>name : "1432"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1433';
+>name : "1433"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1434';
+>name : "1434"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1435';
+>name : "1435"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1436';
+>name : "1436"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1437';
+>name : "1437"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1438';
+>name : "1438"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1439';
+>name : "1439"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1440';
+>name : "1440"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1441';
+>name : "1441"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1442';
+>name : "1442"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1443';
+>name : "1443"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1444';
+>name : "1444"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1445';
+>name : "1445"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1446';
+>name : "1446"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1447';
+>name : "1447"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1448';
+>name : "1448"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1449';
+>name : "1449"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1450';
+>name : "1450"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1451';
+>name : "1451"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1452';
+>name : "1452"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1453';
+>name : "1453"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1454';
+>name : "1454"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1455';
+>name : "1455"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1456';
+>name : "1456"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1457';
+>name : "1457"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1458';
+>name : "1458"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1459';
+>name : "1459"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1460';
+>name : "1460"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1461';
+>name : "1461"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1462';
+>name : "1462"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1463';
+>name : "1463"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1464';
+>name : "1464"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1465';
+>name : "1465"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1466';
+>name : "1466"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1467';
+>name : "1467"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1468';
+>name : "1468"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1469';
+>name : "1469"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1470';
+>name : "1470"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1471';
+>name : "1471"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1472';
+>name : "1472"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1473';
+>name : "1473"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1474';
+>name : "1474"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1475';
+>name : "1475"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1476';
+>name : "1476"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1477';
+>name : "1477"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1478';
+>name : "1478"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1479';
+>name : "1479"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1480';
+>name : "1480"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1481';
+>name : "1481"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1482';
+>name : "1482"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1483';
+>name : "1483"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1484';
+>name : "1484"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1485';
+>name : "1485"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1486';
+>name : "1486"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1487';
+>name : "1487"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1488';
+>name : "1488"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1489';
+>name : "1489"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1490';
+>name : "1490"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1491';
+>name : "1491"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1492';
+>name : "1492"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1493';
+>name : "1493"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1494';
+>name : "1494"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1495';
+>name : "1495"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1496';
+>name : "1496"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1497';
+>name : "1497"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1498';
+>name : "1498"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1499';
+>name : "1499"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1500';
+>name : "1500"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1501';
+>name : "1501"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1502';
+>name : "1502"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1503';
+>name : "1503"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1504';
+>name : "1504"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1505';
+>name : "1505"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1506';
+>name : "1506"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1507';
+>name : "1507"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1508';
+>name : "1508"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1509';
+>name : "1509"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1510';
+>name : "1510"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1511';
+>name : "1511"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1512';
+>name : "1512"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1513';
+>name : "1513"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1514';
+>name : "1514"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1515';
+>name : "1515"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1516';
+>name : "1516"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1517';
+>name : "1517"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1518';
+>name : "1518"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1519';
+>name : "1519"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1520';
+>name : "1520"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1521';
+>name : "1521"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1522';
+>name : "1522"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1523';
+>name : "1523"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1524';
+>name : "1524"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1525';
+>name : "1525"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1526';
+>name : "1526"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1527';
+>name : "1527"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1528';
+>name : "1528"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1529';
+>name : "1529"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1530';
+>name : "1530"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1531';
+>name : "1531"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1532';
+>name : "1532"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1533';
+>name : "1533"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1534';
+>name : "1534"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1535';
+>name : "1535"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1536';
+>name : "1536"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1537';
+>name : "1537"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1538';
+>name : "1538"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1539';
+>name : "1539"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1540';
+>name : "1540"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1541';
+>name : "1541"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1542';
+>name : "1542"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1543';
+>name : "1543"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1544';
+>name : "1544"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1545';
+>name : "1545"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1546';
+>name : "1546"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1547';
+>name : "1547"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1548';
+>name : "1548"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1549';
+>name : "1549"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1550';
+>name : "1550"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1551';
+>name : "1551"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1552';
+>name : "1552"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1553';
+>name : "1553"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1554';
+>name : "1554"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1555';
+>name : "1555"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1556';
+>name : "1556"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1557';
+>name : "1557"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1558';
+>name : "1558"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1559';
+>name : "1559"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1560';
+>name : "1560"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1561';
+>name : "1561"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1562';
+>name : "1562"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1563';
+>name : "1563"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1564';
+>name : "1564"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1565';
+>name : "1565"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1566';
+>name : "1566"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1567';
+>name : "1567"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1568';
+>name : "1568"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1569';
+>name : "1569"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1570';
+>name : "1570"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1571';
+>name : "1571"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1572';
+>name : "1572"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1573';
+>name : "1573"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1574';
+>name : "1574"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1575';
+>name : "1575"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1576';
+>name : "1576"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1577';
+>name : "1577"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1578';
+>name : "1578"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1579';
+>name : "1579"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1580';
+>name : "1580"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1581';
+>name : "1581"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1582';
+>name : "1582"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1583';
+>name : "1583"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1584';
+>name : "1584"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1585';
+>name : "1585"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1586';
+>name : "1586"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1587';
+>name : "1587"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1588';
+>name : "1588"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1589';
+>name : "1589"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1590';
+>name : "1590"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1591';
+>name : "1591"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1592';
+>name : "1592"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1593';
+>name : "1593"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1594';
+>name : "1594"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1595';
+>name : "1595"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1596';
+>name : "1596"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1597';
+>name : "1597"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1598';
+>name : "1598"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1599';
+>name : "1599"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1600';
+>name : "1600"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1601';
+>name : "1601"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1602';
+>name : "1602"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1603';
+>name : "1603"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1604';
+>name : "1604"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1605';
+>name : "1605"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1606';
+>name : "1606"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1607';
+>name : "1607"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1608';
+>name : "1608"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1609';
+>name : "1609"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1610';
+>name : "1610"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1611';
+>name : "1611"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1612';
+>name : "1612"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1613';
+>name : "1613"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1614';
+>name : "1614"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1615';
+>name : "1615"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1616';
+>name : "1616"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1617';
+>name : "1617"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1618';
+>name : "1618"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1619';
+>name : "1619"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1620';
+>name : "1620"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1621';
+>name : "1621"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1622';
+>name : "1622"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1623';
+>name : "1623"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1624';
+>name : "1624"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1625';
+>name : "1625"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1626';
+>name : "1626"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1627';
+>name : "1627"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1628';
+>name : "1628"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1629';
+>name : "1629"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1630';
+>name : "1630"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1631';
+>name : "1631"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1632';
+>name : "1632"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1633';
+>name : "1633"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1634';
+>name : "1634"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1635';
+>name : "1635"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1636';
+>name : "1636"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1637';
+>name : "1637"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1638';
+>name : "1638"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1639';
+>name : "1639"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1640';
+>name : "1640"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1641';
+>name : "1641"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1642';
+>name : "1642"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1643';
+>name : "1643"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1644';
+>name : "1644"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1645';
+>name : "1645"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1646';
+>name : "1646"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1647';
+>name : "1647"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1648';
+>name : "1648"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1649';
+>name : "1649"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1650';
+>name : "1650"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1651';
+>name : "1651"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1652';
+>name : "1652"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1653';
+>name : "1653"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1654';
+>name : "1654"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1655';
+>name : "1655"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1656';
+>name : "1656"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1657';
+>name : "1657"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1658';
+>name : "1658"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1659';
+>name : "1659"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1660';
+>name : "1660"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1661';
+>name : "1661"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1662';
+>name : "1662"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1663';
+>name : "1663"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1664';
+>name : "1664"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1665';
+>name : "1665"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1666';
+>name : "1666"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1667';
+>name : "1667"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1668';
+>name : "1668"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1669';
+>name : "1669"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1670';
+>name : "1670"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1671';
+>name : "1671"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1672';
+>name : "1672"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1673';
+>name : "1673"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1674';
+>name : "1674"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1675';
+>name : "1675"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1676';
+>name : "1676"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1677';
+>name : "1677"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1678';
+>name : "1678"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1679';
+>name : "1679"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1680';
+>name : "1680"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1681';
+>name : "1681"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1682';
+>name : "1682"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1683';
+>name : "1683"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1684';
+>name : "1684"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1685';
+>name : "1685"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1686';
+>name : "1686"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1687';
+>name : "1687"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1688';
+>name : "1688"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1689';
+>name : "1689"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1690';
+>name : "1690"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1691';
+>name : "1691"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1692';
+>name : "1692"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1693';
+>name : "1693"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1694';
+>name : "1694"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1695';
+>name : "1695"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1696';
+>name : "1696"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1697';
+>name : "1697"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1698';
+>name : "1698"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1699';
+>name : "1699"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1700';
+>name : "1700"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1701';
+>name : "1701"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1702';
+>name : "1702"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1703';
+>name : "1703"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1704';
+>name : "1704"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1705';
+>name : "1705"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1706';
+>name : "1706"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1707';
+>name : "1707"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1708';
+>name : "1708"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1709';
+>name : "1709"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1710';
+>name : "1710"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1711';
+>name : "1711"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1712';
+>name : "1712"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1713';
+>name : "1713"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1714';
+>name : "1714"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1715';
+>name : "1715"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1716';
+>name : "1716"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1717';
+>name : "1717"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1718';
+>name : "1718"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1719';
+>name : "1719"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1720';
+>name : "1720"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1721';
+>name : "1721"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1722';
+>name : "1722"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1723';
+>name : "1723"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1724';
+>name : "1724"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1725';
+>name : "1725"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1726';
+>name : "1726"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1727';
+>name : "1727"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1728';
+>name : "1728"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1729';
+>name : "1729"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1730';
+>name : "1730"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1731';
+>name : "1731"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1732';
+>name : "1732"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1733';
+>name : "1733"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1734';
+>name : "1734"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1735';
+>name : "1735"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1736';
+>name : "1736"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1737';
+>name : "1737"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1738';
+>name : "1738"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1739';
+>name : "1739"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1740';
+>name : "1740"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1741';
+>name : "1741"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1742';
+>name : "1742"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1743';
+>name : "1743"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1744';
+>name : "1744"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1745';
+>name : "1745"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1746';
+>name : "1746"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1747';
+>name : "1747"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1748';
+>name : "1748"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1749';
+>name : "1749"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1750';
+>name : "1750"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1751';
+>name : "1751"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1752';
+>name : "1752"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1753';
+>name : "1753"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1754';
+>name : "1754"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1755';
+>name : "1755"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1756';
+>name : "1756"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1757';
+>name : "1757"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1758';
+>name : "1758"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1759';
+>name : "1759"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1760';
+>name : "1760"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1761';
+>name : "1761"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1762';
+>name : "1762"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1763';
+>name : "1763"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1764';
+>name : "1764"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1765';
+>name : "1765"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1766';
+>name : "1766"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1767';
+>name : "1767"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1768';
+>name : "1768"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1769';
+>name : "1769"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1770';
+>name : "1770"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1771';
+>name : "1771"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1772';
+>name : "1772"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1773';
+>name : "1773"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1774';
+>name : "1774"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1775';
+>name : "1775"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1776';
+>name : "1776"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1777';
+>name : "1777"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1778';
+>name : "1778"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1779';
+>name : "1779"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1780';
+>name : "1780"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1781';
+>name : "1781"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1782';
+>name : "1782"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1783';
+>name : "1783"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1784';
+>name : "1784"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1785';
+>name : "1785"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1786';
+>name : "1786"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1787';
+>name : "1787"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1788';
+>name : "1788"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1789';
+>name : "1789"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1790';
+>name : "1790"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1791';
+>name : "1791"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1792';
+>name : "1792"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1793';
+>name : "1793"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1794';
+>name : "1794"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1795';
+>name : "1795"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1796';
+>name : "1796"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1797';
+>name : "1797"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1798';
+>name : "1798"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1799';
+>name : "1799"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1800';
+>name : "1800"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1801';
+>name : "1801"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1802';
+>name : "1802"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1803';
+>name : "1803"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1804';
+>name : "1804"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1805';
+>name : "1805"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1806';
+>name : "1806"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1807';
+>name : "1807"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1808';
+>name : "1808"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1809';
+>name : "1809"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1810';
+>name : "1810"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1811';
+>name : "1811"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1812';
+>name : "1812"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1813';
+>name : "1813"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1814';
+>name : "1814"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1815';
+>name : "1815"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1816';
+>name : "1816"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1817';
+>name : "1817"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1818';
+>name : "1818"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1819';
+>name : "1819"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1820';
+>name : "1820"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1821';
+>name : "1821"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1822';
+>name : "1822"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1823';
+>name : "1823"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1824';
+>name : "1824"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1825';
+>name : "1825"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1826';
+>name : "1826"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1827';
+>name : "1827"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1828';
+>name : "1828"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1829';
+>name : "1829"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1830';
+>name : "1830"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1831';
+>name : "1831"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1832';
+>name : "1832"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1833';
+>name : "1833"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1834';
+>name : "1834"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1835';
+>name : "1835"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1836';
+>name : "1836"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1837';
+>name : "1837"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1838';
+>name : "1838"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1839';
+>name : "1839"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1840';
+>name : "1840"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1841';
+>name : "1841"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1842';
+>name : "1842"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1843';
+>name : "1843"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1844';
+>name : "1844"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1845';
+>name : "1845"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1846';
+>name : "1846"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1847';
+>name : "1847"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1848';
+>name : "1848"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1849';
+>name : "1849"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1850';
+>name : "1850"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1851';
+>name : "1851"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1852';
+>name : "1852"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1853';
+>name : "1853"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1854';
+>name : "1854"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1855';
+>name : "1855"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1856';
+>name : "1856"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1857';
+>name : "1857"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1858';
+>name : "1858"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1859';
+>name : "1859"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1860';
+>name : "1860"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1861';
+>name : "1861"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1862';
+>name : "1862"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1863';
+>name : "1863"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1864';
+>name : "1864"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1865';
+>name : "1865"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1866';
+>name : "1866"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1867';
+>name : "1867"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1868';
+>name : "1868"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1869';
+>name : "1869"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1870';
+>name : "1870"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1871';
+>name : "1871"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1872';
+>name : "1872"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1873';
+>name : "1873"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1874';
+>name : "1874"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1875';
+>name : "1875"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1876';
+>name : "1876"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1877';
+>name : "1877"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1878';
+>name : "1878"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1879';
+>name : "1879"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1880';
+>name : "1880"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1881';
+>name : "1881"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1882';
+>name : "1882"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1883';
+>name : "1883"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1884';
+>name : "1884"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1885';
+>name : "1885"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1886';
+>name : "1886"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1887';
+>name : "1887"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1888';
+>name : "1888"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1889';
+>name : "1889"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1890';
+>name : "1890"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1891';
+>name : "1891"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1892';
+>name : "1892"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1893';
+>name : "1893"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1894';
+>name : "1894"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1895';
+>name : "1895"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1896';
+>name : "1896"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1897';
+>name : "1897"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1898';
+>name : "1898"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1899';
+>name : "1899"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1900';
+>name : "1900"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1901';
+>name : "1901"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1902';
+>name : "1902"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1903';
+>name : "1903"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1904';
+>name : "1904"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1905';
+>name : "1905"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1906';
+>name : "1906"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1907';
+>name : "1907"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1908';
+>name : "1908"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1909';
+>name : "1909"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1910';
+>name : "1910"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1911';
+>name : "1911"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1912';
+>name : "1912"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1913';
+>name : "1913"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1914';
+>name : "1914"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1915';
+>name : "1915"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1916';
+>name : "1916"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1917';
+>name : "1917"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1918';
+>name : "1918"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1919';
+>name : "1919"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1920';
+>name : "1920"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1921';
+>name : "1921"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1922';
+>name : "1922"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1923';
+>name : "1923"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1924';
+>name : "1924"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1925';
+>name : "1925"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1926';
+>name : "1926"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1927';
+>name : "1927"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1928';
+>name : "1928"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1929';
+>name : "1929"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1930';
+>name : "1930"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1931';
+>name : "1931"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1932';
+>name : "1932"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1933';
+>name : "1933"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1934';
+>name : "1934"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1935';
+>name : "1935"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1936';
+>name : "1936"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1937';
+>name : "1937"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1938';
+>name : "1938"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1939';
+>name : "1939"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1940';
+>name : "1940"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1941';
+>name : "1941"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1942';
+>name : "1942"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1943';
+>name : "1943"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1944';
+>name : "1944"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1945';
+>name : "1945"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1946';
+>name : "1946"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1947';
+>name : "1947"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1948';
+>name : "1948"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1949';
+>name : "1949"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1950';
+>name : "1950"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1951';
+>name : "1951"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1952';
+>name : "1952"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1953';
+>name : "1953"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1954';
+>name : "1954"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1955';
+>name : "1955"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1956';
+>name : "1956"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1957';
+>name : "1957"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1958';
+>name : "1958"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1959';
+>name : "1959"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1960';
+>name : "1960"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1961';
+>name : "1961"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1962';
+>name : "1962"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1963';
+>name : "1963"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1964';
+>name : "1964"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1965';
+>name : "1965"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1966';
+>name : "1966"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1967';
+>name : "1967"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1968';
+>name : "1968"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1969';
+>name : "1969"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1970';
+>name : "1970"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1971';
+>name : "1971"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1972';
+>name : "1972"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1973';
+>name : "1973"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1974';
+>name : "1974"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1975';
+>name : "1975"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1976';
+>name : "1976"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1977';
+>name : "1977"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1978';
+>name : "1978"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1979';
+>name : "1979"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1980';
+>name : "1980"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1981';
+>name : "1981"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1982';
+>name : "1982"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1983';
+>name : "1983"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1984';
+>name : "1984"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1985';
+>name : "1985"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1986';
+>name : "1986"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1987';
+>name : "1987"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1988';
+>name : "1988"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1989';
+>name : "1989"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1990';
+>name : "1990"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1991';
+>name : "1991"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1992';
+>name : "1992"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1993';
+>name : "1993"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1994';
+>name : "1994"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1995';
+>name : "1995"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1996';
+>name : "1996"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1997';
+>name : "1997"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1998';
+>name : "1998"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    } |
+    {
+        name: '1999';
+>name : "1999"
+
+        children: BigUnion[];
+>children : BigUnion[]
+
+    };
+
+type DiscriminateUnion<T, K extends keyof T, V extends T[K]> = T extends Record<K, V> ? T : never;
+>DiscriminateUnion : DiscriminateUnion<T, K, V>
+
+type WithName<T extends BigUnion['name']> = DiscriminateUnion<BigUnion, 'name', T>;
+>WithName : DiscriminateUnion<{ name: "0"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "2"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "3"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "4"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "5"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "6"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "7"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "8"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "9"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "10"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "11"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "12"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "13"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "14"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "15"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "16"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "17"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "18"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "19"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "20"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "21"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "22"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "23"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "24"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "25"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "26"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "27"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "28"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "29"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "30"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "31"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "32"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "33"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "34"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "35"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "36"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "37"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "38"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "39"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "40"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "41"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "42"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "43"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "44"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "45"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "46"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "47"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "48"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "49"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "50"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "51"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "52"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "53"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "54"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "55"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "56"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "57"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "58"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "59"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "60"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "61"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "62"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "63"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "64"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "65"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "66"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "67"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "68"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "69"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "70"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "71"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "72"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "73"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "74"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "75"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "76"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "77"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "78"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "79"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "80"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "81"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "82"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "83"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "84"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "85"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "86"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "87"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "88"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "89"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "90"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "91"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "92"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "93"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "94"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "95"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "96"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "97"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "98"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "99"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "100"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "101"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "102"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "103"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "104"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "105"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "106"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "107"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "108"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "109"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "110"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "111"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "112"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "113"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "114"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "115"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "116"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "117"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "118"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "119"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "120"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "121"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "122"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "123"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "124"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "125"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "126"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "127"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "128"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "129"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "130"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "131"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "132"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "133"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "134"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "135"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "136"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "137"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "138"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "139"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "140"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "141"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "142"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "143"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "144"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "145"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "146"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "147"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "148"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "149"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "150"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "151"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "152"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "153"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "154"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "155"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "156"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "157"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "158"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "159"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "160"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "161"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "162"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "163"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "164"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "165"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "166"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "167"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "168"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "169"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "170"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "171"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "172"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "173"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "174"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "175"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "176"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "177"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "178"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "179"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "180"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "181"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "182"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "183"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "184"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "185"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "186"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "187"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "188"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "189"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "190"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "191"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "192"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "193"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "194"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "195"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "196"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "197"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "198"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "199"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "200"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "201"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "202"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "203"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "204"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "205"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "206"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "207"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "208"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "209"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "210"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "211"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "212"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "213"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "214"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "215"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "216"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "217"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "218"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "219"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "220"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "221"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "222"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "223"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "224"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "225"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "226"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "227"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "228"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "229"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "230"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "231"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "232"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "233"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "234"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "235"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "236"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "237"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "238"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "239"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "240"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "241"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "242"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "243"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "244"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "245"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "246"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "247"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "248"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "249"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "250"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "251"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "252"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "253"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "254"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "255"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "256"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "257"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "258"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "259"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "260"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "261"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "262"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "263"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "264"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "265"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "266"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "267"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "268"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "269"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "270"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "271"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "272"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "273"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "274"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "275"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "276"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "277"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "278"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "279"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "280"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "281"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "282"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "283"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "284"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "285"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "286"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "287"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "288"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "289"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "290"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "291"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "292"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "293"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "294"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "295"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "296"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "297"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "298"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "299"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "300"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "301"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "302"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "303"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "304"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "305"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "306"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "307"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "308"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "309"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "310"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "311"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "312"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "313"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "314"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "315"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "316"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "317"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "318"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "319"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "320"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "321"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "322"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "323"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "324"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "325"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "326"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "327"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "328"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "329"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "330"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "331"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "332"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "333"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "334"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "335"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "336"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "337"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "338"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "339"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "340"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "341"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "342"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "343"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "344"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "345"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "346"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "347"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "348"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "349"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "350"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "351"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "352"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "353"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "354"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "355"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "356"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "357"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "358"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "359"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "360"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "361"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "362"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "363"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "364"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "365"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "366"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "367"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "368"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "369"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "370"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "371"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "372"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "373"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "374"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "375"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "376"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "377"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "378"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "379"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "380"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "381"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "382"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "383"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "384"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "385"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "386"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "387"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "388"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "389"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "390"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "391"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "392"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "393"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "394"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "395"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "396"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "397"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "398"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "399"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "400"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "401"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "402"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "403"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "404"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "405"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "406"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "407"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "408"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "409"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "410"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "411"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "412"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "413"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "414"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "415"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "416"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "417"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "418"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "419"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "420"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "421"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "422"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "423"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "424"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "425"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "426"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "427"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "428"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "429"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "430"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "431"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "432"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "433"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "434"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "435"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "436"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "437"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "438"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "439"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "440"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "441"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "442"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "443"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "444"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "445"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "446"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "447"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "448"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "449"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "450"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "451"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "452"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "453"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "454"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "455"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "456"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "457"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "458"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "459"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "460"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "461"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "462"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "463"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "464"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "465"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "466"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "467"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "468"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "469"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "470"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "471"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "472"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "473"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "474"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "475"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "476"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "477"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "478"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "479"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "480"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "481"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "482"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "483"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "484"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "485"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "486"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "487"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "488"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "489"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "490"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "491"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "492"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "493"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "494"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "495"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "496"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "497"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "498"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "499"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "500"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "501"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "502"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "503"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "504"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "505"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "506"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "507"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "508"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "509"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "510"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "511"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "512"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "513"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "514"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "515"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "516"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "517"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "518"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "519"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "520"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "521"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "522"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "523"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "524"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "525"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "526"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "527"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "528"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "529"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "530"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "531"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "532"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "533"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "534"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "535"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "536"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "537"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "538"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "539"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "540"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "541"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "542"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "543"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "544"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "545"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "546"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "547"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "548"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "549"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "550"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "551"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "552"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "553"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "554"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "555"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "556"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "557"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "558"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "559"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "560"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "561"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "562"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "563"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "564"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "565"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "566"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "567"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "568"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "569"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "570"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "571"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "572"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "573"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "574"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "575"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "576"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "577"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "578"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "579"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "580"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "581"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "582"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "583"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "584"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "585"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "586"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "587"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "588"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "589"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "590"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "591"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "592"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "593"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "594"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "595"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "596"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "597"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "598"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "599"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "600"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "601"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "602"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "603"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "604"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "605"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "606"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "607"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "608"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "609"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "610"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "611"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "612"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "613"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "614"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "615"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "616"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "617"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "618"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "619"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "620"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "621"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "622"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "623"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "624"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "625"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "626"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "627"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "628"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "629"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "630"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "631"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "632"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "633"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "634"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "635"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "636"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "637"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "638"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "639"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "640"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "641"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "642"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "643"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "644"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "645"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "646"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "647"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "648"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "649"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "650"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "651"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "652"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "653"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "654"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "655"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "656"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "657"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "658"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "659"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "660"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "661"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "662"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "663"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "664"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "665"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "666"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "667"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "668"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "669"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "670"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "671"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "672"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "673"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "674"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "675"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "676"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "677"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "678"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "679"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "680"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "681"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "682"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "683"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "684"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "685"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "686"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "687"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "688"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "689"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "690"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "691"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "692"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "693"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "694"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "695"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "696"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "697"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "698"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "699"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "700"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "701"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "702"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "703"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "704"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "705"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "706"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "707"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "708"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "709"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "710"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "711"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "712"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "713"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "714"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "715"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "716"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "717"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "718"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "719"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "720"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "721"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "722"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "723"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "724"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "725"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "726"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "727"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "728"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "729"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "730"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "731"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "732"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "733"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "734"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "735"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "736"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "737"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "738"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "739"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "740"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "741"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "742"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "743"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "744"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "745"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "746"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "747"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "748"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "749"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "750"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "751"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "752"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "753"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "754"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "755"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "756"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "757"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "758"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "759"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "760"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "761"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "762"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "763"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "764"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "765"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "766"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "767"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "768"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "769"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "770"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "771"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "772"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "773"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "774"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "775"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "776"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "777"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "778"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "779"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "780"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "781"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "782"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "783"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "784"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "785"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "786"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "787"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "788"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "789"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "790"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "791"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "792"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "793"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "794"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "795"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "796"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "797"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "798"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "799"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "800"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "801"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "802"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "803"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "804"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "805"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "806"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "807"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "808"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "809"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "810"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "811"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "812"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "813"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "814"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "815"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "816"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "817"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "818"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "819"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "820"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "821"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "822"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "823"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "824"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "825"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "826"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "827"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "828"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "829"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "830"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "831"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "832"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "833"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "834"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "835"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "836"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "837"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "838"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "839"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "840"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "841"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "842"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "843"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "844"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "845"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "846"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "847"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "848"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "849"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "850"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "851"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "852"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "853"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "854"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "855"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "856"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "857"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "858"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "859"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "860"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "861"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "862"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "863"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "864"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "865"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "866"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "867"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "868"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "869"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "870"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "871"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "872"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "873"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "874"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "875"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "876"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "877"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "878"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "879"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "880"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "881"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "882"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "883"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "884"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "885"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "886"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "887"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "888"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "889"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "890"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "891"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "892"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "893"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "894"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "895"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "896"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "897"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "898"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "899"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "900"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "901"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "902"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "903"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "904"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "905"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "906"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "907"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "908"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "909"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "910"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "911"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "912"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "913"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "914"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "915"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "916"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "917"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "918"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "919"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "920"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "921"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "922"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "923"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "924"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "925"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "926"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "927"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "928"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "929"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "930"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "931"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "932"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "933"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "934"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "935"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "936"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "937"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "938"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "939"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "940"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "941"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "942"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "943"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "944"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "945"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "946"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "947"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "948"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "949"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "950"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "951"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "952"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "953"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "954"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "955"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "956"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "957"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "958"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "959"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "960"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "961"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "962"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "963"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "964"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "965"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "966"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "967"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "968"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "969"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "970"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "971"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "972"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "973"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "974"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "975"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "976"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "977"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "978"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "979"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "980"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "981"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "982"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "983"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "984"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "985"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "986"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "987"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "988"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "989"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "990"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "991"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "992"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "993"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "994"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "995"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "996"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "997"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "998"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "999"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1000"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1001"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1002"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1003"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1004"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1005"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1006"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1007"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1008"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1009"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1010"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1011"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1012"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1013"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1014"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1015"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1016"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1017"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1018"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1019"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1020"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1021"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1022"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1023"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1024"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1025"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1026"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1027"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1028"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1029"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1030"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1031"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1032"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1033"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1034"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1035"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1036"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1037"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1038"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1039"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1040"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1041"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1042"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1043"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1044"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1045"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1046"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1047"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1048"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1049"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1050"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1051"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1052"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1053"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1054"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1055"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1056"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1057"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1058"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1059"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1060"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1061"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1062"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1063"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1064"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1065"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1066"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1067"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1068"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1069"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1070"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1071"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1072"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1073"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1074"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1075"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1076"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1077"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1078"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1079"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1080"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1081"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1082"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1083"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1084"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1085"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1086"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1087"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1088"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1089"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1090"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1091"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1092"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1093"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1094"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1095"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1096"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1097"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1098"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1099"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1100"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1101"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1102"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1103"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1104"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1105"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1106"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1107"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1108"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1109"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1110"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1111"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1112"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1113"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1114"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1115"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1116"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1117"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1118"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1119"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1120"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1121"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1122"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1123"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1124"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1125"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1126"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1127"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1128"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1129"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1130"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1131"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1132"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1133"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1134"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1135"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1136"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1137"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1138"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1139"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1140"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1141"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1142"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1143"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1144"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1145"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1146"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1147"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1148"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1149"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1150"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1151"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1152"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1153"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1154"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1155"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1156"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1157"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1158"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1159"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1160"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1161"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1162"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1163"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1164"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1165"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1166"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1167"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1168"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1169"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1170"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1171"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1172"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1173"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1174"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1175"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1176"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1177"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1178"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1179"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1180"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1181"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1182"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1183"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1184"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1185"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1186"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1187"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1188"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1189"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1190"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1191"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1192"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1193"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1194"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1195"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1196"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1197"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1198"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1199"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1200"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1201"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1202"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1203"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1204"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1205"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1206"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1207"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1208"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1209"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1210"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1211"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1212"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1213"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1214"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1215"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1216"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1217"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1218"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1219"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1220"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1221"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1222"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1223"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1224"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1225"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1226"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1227"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1228"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1229"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1230"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1231"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1232"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1233"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1234"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1235"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1236"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1237"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1238"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1239"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1240"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1241"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1242"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1243"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1244"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1245"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1246"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1247"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1248"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1249"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1250"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1251"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1252"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1253"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1254"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1255"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1256"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1257"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1258"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1259"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1260"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1261"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1262"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1263"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1264"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1265"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1266"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1267"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1268"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1269"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1270"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1271"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1272"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1273"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1274"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1275"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1276"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1277"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1278"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1279"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1280"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1281"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1282"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1283"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1284"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1285"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1286"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1287"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1288"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1289"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1290"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1291"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1292"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1293"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1294"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1295"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1296"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1297"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1298"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1299"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1300"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1301"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1302"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1303"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1304"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1305"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1306"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1307"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1308"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1309"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1310"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1311"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1312"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1313"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1314"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1315"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1316"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1317"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1318"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1319"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1320"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1321"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1322"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1323"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1324"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1325"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1326"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1327"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1328"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1329"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1330"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1331"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1332"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1333"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1334"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1335"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1336"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1337"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1338"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1339"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1340"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1341"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1342"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1343"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1344"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1345"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1346"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1347"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1348"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1349"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1350"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1351"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1352"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1353"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1354"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1355"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1356"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1357"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1358"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1359"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1360"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1361"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1362"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1363"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1364"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1365"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1366"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1367"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1368"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1369"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1370"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1371"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1372"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1373"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1374"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1375"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1376"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1377"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1378"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1379"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1380"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1381"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1382"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1383"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1384"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1385"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1386"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1387"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1388"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1389"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1390"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1391"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1392"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1393"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1394"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1395"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1396"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1397"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1398"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1399"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1400"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1401"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1402"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1403"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1404"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1405"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1406"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1407"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1408"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1409"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1410"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1411"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1412"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1413"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1414"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1415"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1416"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1417"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1418"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1419"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1420"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1421"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1422"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1423"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1424"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1425"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1426"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1427"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1428"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1429"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1430"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1431"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1432"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1433"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1434"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1435"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1436"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1437"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1438"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1439"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1440"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1441"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1442"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1443"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1444"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1445"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1446"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1447"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1448"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1449"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1450"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1451"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1452"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1453"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1454"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1455"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1456"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1457"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1458"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1459"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1460"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1461"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1462"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1463"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1464"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1465"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1466"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1467"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1468"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1469"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1470"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1471"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1472"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1473"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1474"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1475"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1476"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1477"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1478"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1479"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1480"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1481"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1482"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1483"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1484"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1485"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1486"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1487"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1488"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1489"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1490"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1491"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1492"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1493"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1494"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1495"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1496"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1497"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1498"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1499"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1500"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1501"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1502"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1503"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1504"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1505"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1506"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1507"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1508"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1509"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1510"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1511"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1512"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1513"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1514"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1515"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1516"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1517"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1518"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1519"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1520"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1521"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1522"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1523"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1524"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1525"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1526"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1527"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1528"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1529"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1530"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1531"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1532"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1533"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1534"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1535"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1536"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1537"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1538"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1539"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1540"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1541"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1542"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1543"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1544"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1545"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1546"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1547"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1548"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1549"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1550"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1551"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1552"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1553"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1554"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1555"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1556"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1557"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1558"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1559"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1560"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1561"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1562"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1563"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1564"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1565"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1566"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1567"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1568"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1569"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1570"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1571"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1572"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1573"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1574"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1575"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1576"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1577"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1578"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1579"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1580"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1581"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1582"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1583"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1584"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1585"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1586"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1587"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1588"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1589"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1590"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1591"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1592"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1593"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1594"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1595"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1596"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1597"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1598"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1599"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1600"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1601"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1602"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1603"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1604"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1605"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1606"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1607"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1608"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1609"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1610"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1611"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1612"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1613"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1614"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1615"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1616"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1617"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1618"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1619"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1620"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1621"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1622"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1623"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1624"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1625"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1626"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1627"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1628"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1629"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1630"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1631"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1632"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1633"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1634"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1635"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1636"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1637"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1638"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1639"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1640"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1641"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1642"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1643"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1644"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1645"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1646"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1647"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1648"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1649"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1650"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1651"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1652"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1653"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1654"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1655"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1656"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1657"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1658"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1659"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1660"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1661"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1662"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1663"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1664"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1665"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1666"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1667"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1668"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1669"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1670"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1671"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1672"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1673"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1674"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1675"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1676"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1677"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1678"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1679"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1680"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1681"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1682"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1683"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1684"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1685"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1686"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1687"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1688"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1689"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1690"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1691"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1692"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1693"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1694"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1695"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1696"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1697"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1698"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1699"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1700"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1701"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1702"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1703"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1704"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1705"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1706"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1707"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1708"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1709"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1710"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1711"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1712"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1713"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1714"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1715"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1716"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1717"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1718"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1719"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1720"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1721"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1722"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1723"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1724"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1725"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1726"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1727"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1728"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1729"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1730"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1731"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1732"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1733"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1734"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1735"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1736"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1737"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1738"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1739"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1740"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1741"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1742"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1743"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1744"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1745"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1746"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1747"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1748"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1749"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1750"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1751"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1752"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1753"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1754"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1755"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1756"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1757"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1758"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1759"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1760"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1761"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1762"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1763"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1764"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1765"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1766"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1767"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1768"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1769"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1770"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1771"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1772"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1773"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1774"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1775"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1776"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1777"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1778"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1779"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1780"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1781"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1782"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1783"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1784"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1785"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1786"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1787"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1788"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1789"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1790"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1791"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1792"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1793"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1794"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1795"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1796"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1797"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1798"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1799"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1800"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1801"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1802"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1803"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1804"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1805"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1806"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1807"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1808"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1809"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1810"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1811"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1812"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1813"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1814"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1815"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1816"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1817"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1818"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1819"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1820"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1821"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1822"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1823"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1824"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1825"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1826"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1827"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1828"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1829"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1830"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1831"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1832"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1833"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1834"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1835"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1836"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1837"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1838"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1839"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1840"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1841"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1842"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1843"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1844"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1845"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1846"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1847"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1848"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1849"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1850"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1851"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1852"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1853"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1854"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1855"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1856"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1857"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1858"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1859"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1860"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1861"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1862"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1863"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1864"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1865"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1866"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1867"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1868"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1869"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1870"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1871"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1872"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1873"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1874"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1875"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1876"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1877"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1878"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1879"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1880"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1881"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1882"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1883"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1884"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1885"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1886"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1887"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1888"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1889"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1890"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1891"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1892"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1893"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1894"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1895"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1896"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1897"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1898"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1899"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1900"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1901"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1902"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1903"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1904"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1905"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1906"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1907"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1908"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1909"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1910"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1911"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1912"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1913"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1914"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1915"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1916"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1917"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1918"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1919"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1920"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1921"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1922"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1923"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1924"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1925"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1926"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1927"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1928"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1929"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1930"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1931"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1932"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1933"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1934"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1935"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1936"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1937"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1938"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1939"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1940"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1941"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1942"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1943"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1944"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1945"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1946"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1947"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1948"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1949"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1950"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1951"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1952"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1953"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1954"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1955"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1956"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1957"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1958"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1959"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1960"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1961"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1962"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1963"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1964"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1965"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1966"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1967"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1968"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1969"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1970"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1971"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1972"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1973"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1974"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1975"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1976"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1977"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1978"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1979"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1980"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1981"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1982"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1983"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1984"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1985"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1986"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1987"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1988"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1989"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1990"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1991"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1992"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1993"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1994"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1995"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1996"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1997"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1998"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1999"; children: BigUnion[]; }, "name", T>
+
+type ChildrenOf<T extends BigUnion> = T['children'][number];
+>ChildrenOf : T["children"][number]
+
+export function makeThing<T extends BigUnion['name']>(
+>makeThing : <T extends "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12" | "13" | "14" | "15" | "16" | "17" | "18" | "19" | "20" | "21" | "22" | "23" | "24" | "25" | "26" | "27" | "28" | "29" | "30" | "31" | "32" | "33" | "34" | "35" | "36" | "37" | "38" | "39" | "40" | "41" | "42" | "43" | "44" | "45" | "46" | "47" | "48" | "49" | "50" | "51" | "52" | "53" | "54" | "55" | "56" | "57" | "58" | "59" | "60" | "61" | "62" | "63" | "64" | "65" | "66" | "67" | "68" | "69" | "70" | "71" | "72" | "73" | "74" | "75" | "76" | "77" | "78" | "79" | "80" | "81" | "82" | "83" | "84" | "85" | "86" | "87" | "88" | "89" | "90" | "91" | "92" | "93" | "94" | "95" | "96" | "97" | "98" | "99" | "100" | "101" | "102" | "103" | "104" | "105" | "106" | "107" | "108" | "109" | "110" | "111" | "112" | "113" | "114" | "115" | "116" | "117" | "118" | "119" | "120" | "121" | "122" | "123" | "124" | "125" | "126" | "127" | "128" | "129" | "130" | "131" | "132" | "133" | "134" | "135" | "136" | "137" | "138" | "139" | "140" | "141" | "142" | "143" | "144" | "145" | "146" | "147" | "148" | "149" | "150" | "151" | "152" | "153" | "154" | "155" | "156" | "157" | "158" | "159" | "160" | "161" | "162" | "163" | "164" | "165" | "166" | "167" | "168" | "169" | "170" | "171" | "172" | "173" | "174" | "175" | "176" | "177" | "178" | "179" | "180" | "181" | "182" | "183" | "184" | "185" | "186" | "187" | "188" | "189" | "190" | "191" | "192" | "193" | "194" | "195" | "196" | "197" | "198" | "199" | "200" | "201" | "202" | "203" | "204" | "205" | "206" | "207" | "208" | "209" | "210" | "211" | "212" | "213" | "214" | "215" | "216" | "217" | "218" | "219" | "220" | "221" | "222" | "223" | "224" | "225" | "226" | "227" | "228" | "229" | "230" | "231" | "232" | "233" | "234" | "235" | "236" | "237" | "238" | "239" | "240" | "241" | "242" | "243" | "244" | "245" | "246" | "247" | "248" | "249" | "250" | "251" | "252" | "253" | "254" | "255" | "256" | "257" | "258" | "259" | "260" | "261" | "262" | "263" | "264" | "265" | "266" | "267" | "268" | "269" | "270" | "271" | "272" | "273" | "274" | "275" | "276" | "277" | "278" | "279" | "280" | "281" | "282" | "283" | "284" | "285" | "286" | "287" | "288" | "289" | "290" | "291" | "292" | "293" | "294" | "295" | "296" | "297" | "298" | "299" | "300" | "301" | "302" | "303" | "304" | "305" | "306" | "307" | "308" | "309" | "310" | "311" | "312" | "313" | "314" | "315" | "316" | "317" | "318" | "319" | "320" | "321" | "322" | "323" | "324" | "325" | "326" | "327" | "328" | "329" | "330" | "331" | "332" | "333" | "334" | "335" | "336" | "337" | "338" | "339" | "340" | "341" | "342" | "343" | "344" | "345" | "346" | "347" | "348" | "349" | "350" | "351" | "352" | "353" | "354" | "355" | "356" | "357" | "358" | "359" | "360" | "361" | "362" | "363" | "364" | "365" | "366" | "367" | "368" | "369" | "370" | "371" | "372" | "373" | "374" | "375" | "376" | "377" | "378" | "379" | "380" | "381" | "382" | "383" | "384" | "385" | "386" | "387" | "388" | "389" | "390" | "391" | "392" | "393" | "394" | "395" | "396" | "397" | "398" | "399" | "400" | "401" | "402" | "403" | "404" | "405" | "406" | "407" | "408" | "409" | "410" | "411" | "412" | "413" | "414" | "415" | "416" | "417" | "418" | "419" | "420" | "421" | "422" | "423" | "424" | "425" | "426" | "427" | "428" | "429" | "430" | "431" | "432" | "433" | "434" | "435" | "436" | "437" | "438" | "439" | "440" | "441" | "442" | "443" | "444" | "445" | "446" | "447" | "448" | "449" | "450" | "451" | "452" | "453" | "454" | "455" | "456" | "457" | "458" | "459" | "460" | "461" | "462" | "463" | "464" | "465" | "466" | "467" | "468" | "469" | "470" | "471" | "472" | "473" | "474" | "475" | "476" | "477" | "478" | "479" | "480" | "481" | "482" | "483" | "484" | "485" | "486" | "487" | "488" | "489" | "490" | "491" | "492" | "493" | "494" | "495" | "496" | "497" | "498" | "499" | "500" | "501" | "502" | "503" | "504" | "505" | "506" | "507" | "508" | "509" | "510" | "511" | "512" | "513" | "514" | "515" | "516" | "517" | "518" | "519" | "520" | "521" | "522" | "523" | "524" | "525" | "526" | "527" | "528" | "529" | "530" | "531" | "532" | "533" | "534" | "535" | "536" | "537" | "538" | "539" | "540" | "541" | "542" | "543" | "544" | "545" | "546" | "547" | "548" | "549" | "550" | "551" | "552" | "553" | "554" | "555" | "556" | "557" | "558" | "559" | "560" | "561" | "562" | "563" | "564" | "565" | "566" | "567" | "568" | "569" | "570" | "571" | "572" | "573" | "574" | "575" | "576" | "577" | "578" | "579" | "580" | "581" | "582" | "583" | "584" | "585" | "586" | "587" | "588" | "589" | "590" | "591" | "592" | "593" | "594" | "595" | "596" | "597" | "598" | "599" | "600" | "601" | "602" | "603" | "604" | "605" | "606" | "607" | "608" | "609" | "610" | "611" | "612" | "613" | "614" | "615" | "616" | "617" | "618" | "619" | "620" | "621" | "622" | "623" | "624" | "625" | "626" | "627" | "628" | "629" | "630" | "631" | "632" | "633" | "634" | "635" | "636" | "637" | "638" | "639" | "640" | "641" | "642" | "643" | "644" | "645" | "646" | "647" | "648" | "649" | "650" | "651" | "652" | "653" | "654" | "655" | "656" | "657" | "658" | "659" | "660" | "661" | "662" | "663" | "664" | "665" | "666" | "667" | "668" | "669" | "670" | "671" | "672" | "673" | "674" | "675" | "676" | "677" | "678" | "679" | "680" | "681" | "682" | "683" | "684" | "685" | "686" | "687" | "688" | "689" | "690" | "691" | "692" | "693" | "694" | "695" | "696" | "697" | "698" | "699" | "700" | "701" | "702" | "703" | "704" | "705" | "706" | "707" | "708" | "709" | "710" | "711" | "712" | "713" | "714" | "715" | "716" | "717" | "718" | "719" | "720" | "721" | "722" | "723" | "724" | "725" | "726" | "727" | "728" | "729" | "730" | "731" | "732" | "733" | "734" | "735" | "736" | "737" | "738" | "739" | "740" | "741" | "742" | "743" | "744" | "745" | "746" | "747" | "748" | "749" | "750" | "751" | "752" | "753" | "754" | "755" | "756" | "757" | "758" | "759" | "760" | "761" | "762" | "763" | "764" | "765" | "766" | "767" | "768" | "769" | "770" | "771" | "772" | "773" | "774" | "775" | "776" | "777" | "778" | "779" | "780" | "781" | "782" | "783" | "784" | "785" | "786" | "787" | "788" | "789" | "790" | "791" | "792" | "793" | "794" | "795" | "796" | "797" | "798" | "799" | "800" | "801" | "802" | "803" | "804" | "805" | "806" | "807" | "808" | "809" | "810" | "811" | "812" | "813" | "814" | "815" | "816" | "817" | "818" | "819" | "820" | "821" | "822" | "823" | "824" | "825" | "826" | "827" | "828" | "829" | "830" | "831" | "832" | "833" | "834" | "835" | "836" | "837" | "838" | "839" | "840" | "841" | "842" | "843" | "844" | "845" | "846" | "847" | "848" | "849" | "850" | "851" | "852" | "853" | "854" | "855" | "856" | "857" | "858" | "859" | "860" | "861" | "862" | "863" | "864" | "865" | "866" | "867" | "868" | "869" | "870" | "871" | "872" | "873" | "874" | "875" | "876" | "877" | "878" | "879" | "880" | "881" | "882" | "883" | "884" | "885" | "886" | "887" | "888" | "889" | "890" | "891" | "892" | "893" | "894" | "895" | "896" | "897" | "898" | "899" | "900" | "901" | "902" | "903" | "904" | "905" | "906" | "907" | "908" | "909" | "910" | "911" | "912" | "913" | "914" | "915" | "916" | "917" | "918" | "919" | "920" | "921" | "922" | "923" | "924" | "925" | "926" | "927" | "928" | "929" | "930" | "931" | "932" | "933" | "934" | "935" | "936" | "937" | "938" | "939" | "940" | "941" | "942" | "943" | "944" | "945" | "946" | "947" | "948" | "949" | "950" | "951" | "952" | "953" | "954" | "955" | "956" | "957" | "958" | "959" | "960" | "961" | "962" | "963" | "964" | "965" | "966" | "967" | "968" | "969" | "970" | "971" | "972" | "973" | "974" | "975" | "976" | "977" | "978" | "979" | "980" | "981" | "982" | "983" | "984" | "985" | "986" | "987" | "988" | "989" | "990" | "991" | "992" | "993" | "994" | "995" | "996" | "997" | "998" | "999" | "1000" | "1001" | "1002" | "1003" | "1004" | "1005" | "1006" | "1007" | "1008" | "1009" | "1010" | "1011" | "1012" | "1013" | "1014" | "1015" | "1016" | "1017" | "1018" | "1019" | "1020" | "1021" | "1022" | "1023" | "1024" | "1025" | "1026" | "1027" | "1028" | "1029" | "1030" | "1031" | "1032" | "1033" | "1034" | "1035" | "1036" | "1037" | "1038" | "1039" | "1040" | "1041" | "1042" | "1043" | "1044" | "1045" | "1046" | "1047" | "1048" | "1049" | "1050" | "1051" | "1052" | "1053" | "1054" | "1055" | "1056" | "1057" | "1058" | "1059" | "1060" | "1061" | "1062" | "1063" | "1064" | "1065" | "1066" | "1067" | "1068" | "1069" | "1070" | "1071" | "1072" | "1073" | "1074" | "1075" | "1076" | "1077" | "1078" | "1079" | "1080" | "1081" | "1082" | "1083" | "1084" | "1085" | "1086" | "1087" | "1088" | "1089" | "1090" | "1091" | "1092" | "1093" | "1094" | "1095" | "1096" | "1097" | "1098" | "1099" | "1100" | "1101" | "1102" | "1103" | "1104" | "1105" | "1106" | "1107" | "1108" | "1109" | "1110" | "1111" | "1112" | "1113" | "1114" | "1115" | "1116" | "1117" | "1118" | "1119" | "1120" | "1121" | "1122" | "1123" | "1124" | "1125" | "1126" | "1127" | "1128" | "1129" | "1130" | "1131" | "1132" | "1133" | "1134" | "1135" | "1136" | "1137" | "1138" | "1139" | "1140" | "1141" | "1142" | "1143" | "1144" | "1145" | "1146" | "1147" | "1148" | "1149" | "1150" | "1151" | "1152" | "1153" | "1154" | "1155" | "1156" | "1157" | "1158" | "1159" | "1160" | "1161" | "1162" | "1163" | "1164" | "1165" | "1166" | "1167" | "1168" | "1169" | "1170" | "1171" | "1172" | "1173" | "1174" | "1175" | "1176" | "1177" | "1178" | "1179" | "1180" | "1181" | "1182" | "1183" | "1184" | "1185" | "1186" | "1187" | "1188" | "1189" | "1190" | "1191" | "1192" | "1193" | "1194" | "1195" | "1196" | "1197" | "1198" | "1199" | "1200" | "1201" | "1202" | "1203" | "1204" | "1205" | "1206" | "1207" | "1208" | "1209" | "1210" | "1211" | "1212" | "1213" | "1214" | "1215" | "1216" | "1217" | "1218" | "1219" | "1220" | "1221" | "1222" | "1223" | "1224" | "1225" | "1226" | "1227" | "1228" | "1229" | "1230" | "1231" | "1232" | "1233" | "1234" | "1235" | "1236" | "1237" | "1238" | "1239" | "1240" | "1241" | "1242" | "1243" | "1244" | "1245" | "1246" | "1247" | "1248" | "1249" | "1250" | "1251" | "1252" | "1253" | "1254" | "1255" | "1256" | "1257" | "1258" | "1259" | "1260" | "1261" | "1262" | "1263" | "1264" | "1265" | "1266" | "1267" | "1268" | "1269" | "1270" | "1271" | "1272" | "1273" | "1274" | "1275" | "1276" | "1277" | "1278" | "1279" | "1280" | "1281" | "1282" | "1283" | "1284" | "1285" | "1286" | "1287" | "1288" | "1289" | "1290" | "1291" | "1292" | "1293" | "1294" | "1295" | "1296" | "1297" | "1298" | "1299" | "1300" | "1301" | "1302" | "1303" | "1304" | "1305" | "1306" | "1307" | "1308" | "1309" | "1310" | "1311" | "1312" | "1313" | "1314" | "1315" | "1316" | "1317" | "1318" | "1319" | "1320" | "1321" | "1322" | "1323" | "1324" | "1325" | "1326" | "1327" | "1328" | "1329" | "1330" | "1331" | "1332" | "1333" | "1334" | "1335" | "1336" | "1337" | "1338" | "1339" | "1340" | "1341" | "1342" | "1343" | "1344" | "1345" | "1346" | "1347" | "1348" | "1349" | "1350" | "1351" | "1352" | "1353" | "1354" | "1355" | "1356" | "1357" | "1358" | "1359" | "1360" | "1361" | "1362" | "1363" | "1364" | "1365" | "1366" | "1367" | "1368" | "1369" | "1370" | "1371" | "1372" | "1373" | "1374" | "1375" | "1376" | "1377" | "1378" | "1379" | "1380" | "1381" | "1382" | "1383" | "1384" | "1385" | "1386" | "1387" | "1388" | "1389" | "1390" | "1391" | "1392" | "1393" | "1394" | "1395" | "1396" | "1397" | "1398" | "1399" | "1400" | "1401" | "1402" | "1403" | "1404" | "1405" | "1406" | "1407" | "1408" | "1409" | "1410" | "1411" | "1412" | "1413" | "1414" | "1415" | "1416" | "1417" | "1418" | "1419" | "1420" | "1421" | "1422" | "1423" | "1424" | "1425" | "1426" | "1427" | "1428" | "1429" | "1430" | "1431" | "1432" | "1433" | "1434" | "1435" | "1436" | "1437" | "1438" | "1439" | "1440" | "1441" | "1442" | "1443" | "1444" | "1445" | "1446" | "1447" | "1448" | "1449" | "1450" | "1451" | "1452" | "1453" | "1454" | "1455" | "1456" | "1457" | "1458" | "1459" | "1460" | "1461" | "1462" | "1463" | "1464" | "1465" | "1466" | "1467" | "1468" | "1469" | "1470" | "1471" | "1472" | "1473" | "1474" | "1475" | "1476" | "1477" | "1478" | "1479" | "1480" | "1481" | "1482" | "1483" | "1484" | "1485" | "1486" | "1487" | "1488" | "1489" | "1490" | "1491" | "1492" | "1493" | "1494" | "1495" | "1496" | "1497" | "1498" | "1499" | "1500" | "1501" | "1502" | "1503" | "1504" | "1505" | "1506" | "1507" | "1508" | "1509" | "1510" | "1511" | "1512" | "1513" | "1514" | "1515" | "1516" | "1517" | "1518" | "1519" | "1520" | "1521" | "1522" | "1523" | "1524" | "1525" | "1526" | "1527" | "1528" | "1529" | "1530" | "1531" | "1532" | "1533" | "1534" | "1535" | "1536" | "1537" | "1538" | "1539" | "1540" | "1541" | "1542" | "1543" | "1544" | "1545" | "1546" | "1547" | "1548" | "1549" | "1550" | "1551" | "1552" | "1553" | "1554" | "1555" | "1556" | "1557" | "1558" | "1559" | "1560" | "1561" | "1562" | "1563" | "1564" | "1565" | "1566" | "1567" | "1568" | "1569" | "1570" | "1571" | "1572" | "1573" | "1574" | "1575" | "1576" | "1577" | "1578" | "1579" | "1580" | "1581" | "1582" | "1583" | "1584" | "1585" | "1586" | "1587" | "1588" | "1589" | "1590" | "1591" | "1592" | "1593" | "1594" | "1595" | "1596" | "1597" | "1598" | "1599" | "1600" | "1601" | "1602" | "1603" | "1604" | "1605" | "1606" | "1607" | "1608" | "1609" | "1610" | "1611" | "1612" | "1613" | "1614" | "1615" | "1616" | "1617" | "1618" | "1619" | "1620" | "1621" | "1622" | "1623" | "1624" | "1625" | "1626" | "1627" | "1628" | "1629" | "1630" | "1631" | "1632" | "1633" | "1634" | "1635" | "1636" | "1637" | "1638" | "1639" | "1640" | "1641" | "1642" | "1643" | "1644" | "1645" | "1646" | "1647" | "1648" | "1649" | "1650" | "1651" | "1652" | "1653" | "1654" | "1655" | "1656" | "1657" | "1658" | "1659" | "1660" | "1661" | "1662" | "1663" | "1664" | "1665" | "1666" | "1667" | "1668" | "1669" | "1670" | "1671" | "1672" | "1673" | "1674" | "1675" | "1676" | "1677" | "1678" | "1679" | "1680" | "1681" | "1682" | "1683" | "1684" | "1685" | "1686" | "1687" | "1688" | "1689" | "1690" | "1691" | "1692" | "1693" | "1694" | "1695" | "1696" | "1697" | "1698" | "1699" | "1700" | "1701" | "1702" | "1703" | "1704" | "1705" | "1706" | "1707" | "1708" | "1709" | "1710" | "1711" | "1712" | "1713" | "1714" | "1715" | "1716" | "1717" | "1718" | "1719" | "1720" | "1721" | "1722" | "1723" | "1724" | "1725" | "1726" | "1727" | "1728" | "1729" | "1730" | "1731" | "1732" | "1733" | "1734" | "1735" | "1736" | "1737" | "1738" | "1739" | "1740" | "1741" | "1742" | "1743" | "1744" | "1745" | "1746" | "1747" | "1748" | "1749" | "1750" | "1751" | "1752" | "1753" | "1754" | "1755" | "1756" | "1757" | "1758" | "1759" | "1760" | "1761" | "1762" | "1763" | "1764" | "1765" | "1766" | "1767" | "1768" | "1769" | "1770" | "1771" | "1772" | "1773" | "1774" | "1775" | "1776" | "1777" | "1778" | "1779" | "1780" | "1781" | "1782" | "1783" | "1784" | "1785" | "1786" | "1787" | "1788" | "1789" | "1790" | "1791" | "1792" | "1793" | "1794" | "1795" | "1796" | "1797" | "1798" | "1799" | "1800" | "1801" | "1802" | "1803" | "1804" | "1805" | "1806" | "1807" | "1808" | "1809" | "1810" | "1811" | "1812" | "1813" | "1814" | "1815" | "1816" | "1817" | "1818" | "1819" | "1820" | "1821" | "1822" | "1823" | "1824" | "1825" | "1826" | "1827" | "1828" | "1829" | "1830" | "1831" | "1832" | "1833" | "1834" | "1835" | "1836" | "1837" | "1838" | "1839" | "1840" | "1841" | "1842" | "1843" | "1844" | "1845" | "1846" | "1847" | "1848" | "1849" | "1850" | "1851" | "1852" | "1853" | "1854" | "1855" | "1856" | "1857" | "1858" | "1859" | "1860" | "1861" | "1862" | "1863" | "1864" | "1865" | "1866" | "1867" | "1868" | "1869" | "1870" | "1871" | "1872" | "1873" | "1874" | "1875" | "1876" | "1877" | "1878" | "1879" | "1880" | "1881" | "1882" | "1883" | "1884" | "1885" | "1886" | "1887" | "1888" | "1889" | "1890" | "1891" | "1892" | "1893" | "1894" | "1895" | "1896" | "1897" | "1898" | "1899" | "1900" | "1901" | "1902" | "1903" | "1904" | "1905" | "1906" | "1907" | "1908" | "1909" | "1910" | "1911" | "1912" | "1913" | "1914" | "1915" | "1916" | "1917" | "1918" | "1919" | "1920" | "1921" | "1922" | "1923" | "1924" | "1925" | "1926" | "1927" | "1928" | "1929" | "1930" | "1931" | "1932" | "1933" | "1934" | "1935" | "1936" | "1937" | "1938" | "1939" | "1940" | "1941" | "1942" | "1943" | "1944" | "1945" | "1946" | "1947" | "1948" | "1949" | "1950" | "1951" | "1952" | "1953" | "1954" | "1955" | "1956" | "1957" | "1958" | "1959" | "1960" | "1961" | "1962" | "1963" | "1964" | "1965" | "1966" | "1967" | "1968" | "1969" | "1970" | "1971" | "1972" | "1973" | "1974" | "1975" | "1976" | "1977" | "1978" | "1979" | "1980" | "1981" | "1982" | "1983" | "1984" | "1985" | "1986" | "1987" | "1988" | "1989" | "1990" | "1991" | "1992" | "1993" | "1994" | "1995" | "1996" | "1997" | "1998" | "1999">(name: T, children?: ChildrenOf<WithName<T>>[]) => void
+
+    name: T,
+>name : T
+
+    children: ChildrenOf<WithName<T>>[] = [],
+>children : (DiscriminateUnion<{ name: "0"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "2"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "3"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "4"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "5"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "6"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "7"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "8"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "9"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "10"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "11"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "12"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "13"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "14"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "15"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "16"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "17"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "18"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "19"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "20"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "21"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "22"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "23"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "24"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "25"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "26"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "27"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "28"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "29"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "30"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "31"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "32"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "33"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "34"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "35"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "36"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "37"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "38"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "39"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "40"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "41"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "42"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "43"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "44"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "45"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "46"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "47"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "48"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "49"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "50"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "51"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "52"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "53"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "54"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "55"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "56"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "57"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "58"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "59"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "60"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "61"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "62"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "63"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "64"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "65"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "66"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "67"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "68"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "69"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "70"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "71"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "72"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "73"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "74"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "75"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "76"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "77"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "78"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "79"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "80"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "81"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "82"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "83"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "84"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "85"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "86"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "87"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "88"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "89"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "90"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "91"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "92"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "93"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "94"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "95"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "96"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "97"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "98"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "99"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "100"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "101"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "102"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "103"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "104"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "105"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "106"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "107"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "108"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "109"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "110"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "111"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "112"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "113"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "114"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "115"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "116"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "117"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "118"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "119"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "120"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "121"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "122"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "123"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "124"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "125"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "126"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "127"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "128"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "129"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "130"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "131"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "132"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "133"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "134"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "135"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "136"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "137"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "138"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "139"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "140"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "141"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "142"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "143"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "144"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "145"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "146"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "147"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "148"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "149"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "150"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "151"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "152"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "153"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "154"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "155"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "156"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "157"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "158"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "159"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "160"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "161"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "162"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "163"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "164"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "165"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "166"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "167"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "168"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "169"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "170"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "171"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "172"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "173"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "174"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "175"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "176"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "177"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "178"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "179"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "180"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "181"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "182"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "183"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "184"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "185"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "186"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "187"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "188"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "189"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "190"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "191"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "192"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "193"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "194"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "195"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "196"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "197"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "198"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "199"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "200"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "201"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "202"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "203"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "204"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "205"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "206"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "207"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "208"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "209"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "210"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "211"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "212"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "213"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "214"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "215"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "216"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "217"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "218"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "219"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "220"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "221"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "222"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "223"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "224"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "225"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "226"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "227"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "228"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "229"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "230"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "231"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "232"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "233"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "234"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "235"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "236"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "237"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "238"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "239"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "240"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "241"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "242"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "243"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "244"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "245"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "246"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "247"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "248"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "249"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "250"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "251"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "252"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "253"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "254"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "255"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "256"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "257"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "258"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "259"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "260"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "261"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "262"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "263"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "264"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "265"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "266"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "267"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "268"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "269"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "270"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "271"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "272"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "273"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "274"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "275"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "276"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "277"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "278"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "279"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "280"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "281"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "282"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "283"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "284"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "285"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "286"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "287"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "288"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "289"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "290"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "291"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "292"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "293"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "294"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "295"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "296"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "297"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "298"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "299"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "300"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "301"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "302"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "303"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "304"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "305"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "306"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "307"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "308"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "309"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "310"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "311"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "312"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "313"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "314"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "315"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "316"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "317"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "318"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "319"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "320"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "321"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "322"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "323"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "324"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "325"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "326"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "327"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "328"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "329"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "330"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "331"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "332"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "333"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "334"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "335"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "336"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "337"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "338"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "339"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "340"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "341"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "342"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "343"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "344"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "345"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "346"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "347"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "348"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "349"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "350"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "351"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "352"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "353"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "354"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "355"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "356"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "357"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "358"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "359"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "360"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "361"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "362"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "363"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "364"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "365"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "366"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "367"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "368"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "369"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "370"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "371"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "372"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "373"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "374"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "375"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "376"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "377"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "378"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "379"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "380"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "381"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "382"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "383"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "384"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "385"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "386"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "387"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "388"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "389"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "390"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "391"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "392"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "393"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "394"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "395"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "396"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "397"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "398"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "399"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "400"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "401"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "402"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "403"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "404"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "405"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "406"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "407"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "408"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "409"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "410"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "411"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "412"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "413"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "414"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "415"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "416"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "417"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "418"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "419"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "420"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "421"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "422"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "423"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "424"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "425"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "426"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "427"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "428"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "429"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "430"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "431"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "432"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "433"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "434"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "435"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "436"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "437"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "438"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "439"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "440"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "441"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "442"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "443"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "444"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "445"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "446"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "447"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "448"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "449"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "450"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "451"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "452"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "453"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "454"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "455"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "456"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "457"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "458"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "459"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "460"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "461"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "462"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "463"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "464"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "465"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "466"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "467"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "468"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "469"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "470"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "471"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "472"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "473"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "474"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "475"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "476"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "477"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "478"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "479"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "480"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "481"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "482"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "483"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "484"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "485"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "486"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "487"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "488"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "489"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "490"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "491"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "492"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "493"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "494"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "495"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "496"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "497"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "498"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "499"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "500"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "501"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "502"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "503"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "504"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "505"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "506"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "507"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "508"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "509"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "510"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "511"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "512"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "513"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "514"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "515"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "516"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "517"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "518"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "519"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "520"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "521"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "522"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "523"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "524"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "525"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "526"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "527"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "528"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "529"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "530"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "531"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "532"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "533"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "534"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "535"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "536"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "537"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "538"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "539"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "540"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "541"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "542"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "543"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "544"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "545"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "546"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "547"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "548"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "549"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "550"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "551"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "552"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "553"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "554"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "555"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "556"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "557"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "558"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "559"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "560"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "561"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "562"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "563"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "564"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "565"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "566"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "567"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "568"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "569"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "570"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "571"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "572"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "573"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "574"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "575"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "576"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "577"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "578"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "579"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "580"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "581"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "582"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "583"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "584"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "585"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "586"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "587"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "588"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "589"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "590"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "591"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "592"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "593"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "594"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "595"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "596"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "597"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "598"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "599"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "600"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "601"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "602"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "603"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "604"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "605"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "606"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "607"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "608"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "609"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "610"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "611"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "612"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "613"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "614"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "615"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "616"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "617"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "618"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "619"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "620"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "621"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "622"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "623"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "624"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "625"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "626"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "627"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "628"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "629"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "630"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "631"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "632"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "633"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "634"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "635"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "636"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "637"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "638"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "639"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "640"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "641"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "642"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "643"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "644"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "645"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "646"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "647"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "648"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "649"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "650"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "651"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "652"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "653"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "654"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "655"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "656"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "657"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "658"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "659"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "660"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "661"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "662"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "663"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "664"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "665"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "666"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "667"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "668"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "669"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "670"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "671"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "672"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "673"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "674"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "675"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "676"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "677"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "678"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "679"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "680"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "681"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "682"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "683"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "684"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "685"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "686"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "687"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "688"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "689"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "690"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "691"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "692"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "693"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "694"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "695"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "696"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "697"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "698"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "699"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "700"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "701"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "702"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "703"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "704"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "705"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "706"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "707"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "708"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "709"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "710"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "711"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "712"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "713"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "714"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "715"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "716"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "717"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "718"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "719"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "720"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "721"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "722"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "723"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "724"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "725"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "726"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "727"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "728"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "729"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "730"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "731"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "732"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "733"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "734"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "735"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "736"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "737"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "738"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "739"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "740"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "741"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "742"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "743"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "744"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "745"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "746"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "747"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "748"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "749"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "750"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "751"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "752"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "753"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "754"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "755"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "756"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "757"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "758"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "759"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "760"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "761"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "762"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "763"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "764"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "765"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "766"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "767"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "768"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "769"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "770"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "771"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "772"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "773"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "774"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "775"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "776"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "777"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "778"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "779"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "780"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "781"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "782"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "783"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "784"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "785"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "786"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "787"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "788"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "789"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "790"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "791"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "792"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "793"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "794"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "795"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "796"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "797"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "798"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "799"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "800"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "801"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "802"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "803"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "804"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "805"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "806"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "807"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "808"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "809"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "810"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "811"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "812"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "813"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "814"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "815"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "816"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "817"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "818"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "819"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "820"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "821"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "822"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "823"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "824"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "825"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "826"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "827"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "828"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "829"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "830"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "831"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "832"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "833"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "834"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "835"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "836"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "837"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "838"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "839"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "840"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "841"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "842"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "843"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "844"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "845"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "846"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "847"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "848"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "849"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "850"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "851"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "852"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "853"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "854"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "855"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "856"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "857"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "858"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "859"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "860"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "861"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "862"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "863"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "864"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "865"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "866"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "867"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "868"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "869"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "870"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "871"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "872"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "873"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "874"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "875"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "876"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "877"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "878"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "879"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "880"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "881"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "882"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "883"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "884"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "885"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "886"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "887"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "888"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "889"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "890"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "891"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "892"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "893"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "894"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "895"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "896"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "897"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "898"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "899"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "900"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "901"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "902"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "903"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "904"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "905"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "906"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "907"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "908"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "909"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "910"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "911"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "912"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "913"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "914"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "915"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "916"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "917"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "918"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "919"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "920"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "921"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "922"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "923"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "924"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "925"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "926"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "927"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "928"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "929"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "930"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "931"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "932"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "933"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "934"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "935"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "936"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "937"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "938"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "939"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "940"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "941"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "942"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "943"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "944"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "945"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "946"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "947"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "948"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "949"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "950"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "951"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "952"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "953"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "954"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "955"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "956"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "957"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "958"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "959"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "960"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "961"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "962"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "963"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "964"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "965"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "966"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "967"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "968"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "969"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "970"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "971"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "972"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "973"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "974"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "975"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "976"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "977"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "978"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "979"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "980"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "981"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "982"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "983"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "984"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "985"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "986"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "987"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "988"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "989"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "990"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "991"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "992"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "993"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "994"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "995"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "996"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "997"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "998"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "999"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1000"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1001"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1002"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1003"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1004"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1005"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1006"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1007"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1008"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1009"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1010"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1011"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1012"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1013"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1014"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1015"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1016"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1017"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1018"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1019"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1020"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1021"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1022"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1023"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1024"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1025"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1026"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1027"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1028"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1029"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1030"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1031"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1032"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1033"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1034"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1035"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1036"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1037"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1038"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1039"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1040"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1041"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1042"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1043"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1044"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1045"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1046"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1047"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1048"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1049"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1050"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1051"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1052"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1053"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1054"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1055"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1056"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1057"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1058"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1059"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1060"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1061"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1062"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1063"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1064"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1065"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1066"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1067"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1068"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1069"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1070"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1071"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1072"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1073"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1074"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1075"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1076"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1077"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1078"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1079"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1080"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1081"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1082"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1083"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1084"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1085"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1086"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1087"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1088"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1089"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1090"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1091"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1092"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1093"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1094"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1095"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1096"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1097"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1098"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1099"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1100"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1101"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1102"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1103"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1104"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1105"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1106"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1107"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1108"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1109"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1110"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1111"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1112"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1113"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1114"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1115"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1116"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1117"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1118"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1119"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1120"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1121"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1122"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1123"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1124"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1125"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1126"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1127"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1128"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1129"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1130"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1131"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1132"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1133"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1134"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1135"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1136"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1137"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1138"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1139"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1140"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1141"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1142"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1143"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1144"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1145"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1146"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1147"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1148"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1149"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1150"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1151"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1152"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1153"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1154"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1155"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1156"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1157"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1158"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1159"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1160"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1161"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1162"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1163"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1164"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1165"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1166"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1167"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1168"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1169"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1170"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1171"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1172"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1173"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1174"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1175"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1176"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1177"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1178"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1179"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1180"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1181"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1182"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1183"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1184"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1185"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1186"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1187"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1188"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1189"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1190"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1191"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1192"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1193"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1194"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1195"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1196"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1197"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1198"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1199"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1200"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1201"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1202"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1203"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1204"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1205"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1206"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1207"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1208"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1209"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1210"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1211"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1212"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1213"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1214"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1215"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1216"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1217"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1218"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1219"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1220"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1221"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1222"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1223"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1224"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1225"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1226"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1227"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1228"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1229"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1230"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1231"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1232"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1233"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1234"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1235"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1236"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1237"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1238"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1239"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1240"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1241"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1242"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1243"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1244"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1245"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1246"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1247"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1248"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1249"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1250"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1251"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1252"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1253"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1254"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1255"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1256"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1257"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1258"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1259"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1260"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1261"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1262"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1263"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1264"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1265"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1266"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1267"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1268"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1269"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1270"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1271"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1272"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1273"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1274"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1275"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1276"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1277"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1278"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1279"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1280"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1281"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1282"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1283"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1284"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1285"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1286"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1287"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1288"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1289"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1290"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1291"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1292"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1293"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1294"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1295"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1296"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1297"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1298"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1299"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1300"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1301"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1302"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1303"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1304"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1305"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1306"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1307"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1308"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1309"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1310"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1311"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1312"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1313"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1314"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1315"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1316"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1317"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1318"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1319"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1320"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1321"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1322"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1323"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1324"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1325"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1326"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1327"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1328"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1329"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1330"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1331"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1332"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1333"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1334"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1335"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1336"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1337"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1338"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1339"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1340"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1341"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1342"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1343"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1344"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1345"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1346"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1347"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1348"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1349"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1350"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1351"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1352"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1353"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1354"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1355"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1356"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1357"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1358"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1359"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1360"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1361"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1362"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1363"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1364"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1365"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1366"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1367"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1368"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1369"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1370"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1371"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1372"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1373"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1374"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1375"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1376"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1377"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1378"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1379"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1380"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1381"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1382"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1383"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1384"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1385"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1386"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1387"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1388"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1389"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1390"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1391"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1392"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1393"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1394"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1395"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1396"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1397"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1398"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1399"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1400"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1401"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1402"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1403"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1404"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1405"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1406"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1407"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1408"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1409"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1410"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1411"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1412"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1413"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1414"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1415"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1416"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1417"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1418"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1419"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1420"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1421"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1422"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1423"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1424"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1425"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1426"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1427"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1428"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1429"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1430"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1431"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1432"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1433"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1434"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1435"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1436"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1437"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1438"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1439"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1440"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1441"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1442"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1443"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1444"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1445"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1446"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1447"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1448"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1449"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1450"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1451"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1452"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1453"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1454"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1455"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1456"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1457"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1458"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1459"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1460"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1461"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1462"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1463"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1464"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1465"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1466"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1467"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1468"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1469"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1470"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1471"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1472"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1473"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1474"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1475"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1476"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1477"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1478"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1479"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1480"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1481"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1482"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1483"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1484"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1485"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1486"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1487"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1488"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1489"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1490"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1491"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1492"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1493"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1494"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1495"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1496"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1497"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1498"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1499"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1500"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1501"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1502"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1503"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1504"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1505"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1506"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1507"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1508"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1509"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1510"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1511"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1512"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1513"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1514"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1515"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1516"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1517"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1518"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1519"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1520"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1521"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1522"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1523"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1524"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1525"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1526"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1527"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1528"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1529"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1530"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1531"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1532"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1533"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1534"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1535"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1536"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1537"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1538"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1539"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1540"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1541"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1542"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1543"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1544"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1545"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1546"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1547"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1548"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1549"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1550"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1551"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1552"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1553"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1554"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1555"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1556"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1557"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1558"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1559"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1560"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1561"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1562"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1563"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1564"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1565"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1566"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1567"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1568"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1569"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1570"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1571"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1572"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1573"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1574"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1575"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1576"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1577"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1578"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1579"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1580"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1581"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1582"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1583"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1584"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1585"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1586"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1587"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1588"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1589"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1590"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1591"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1592"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1593"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1594"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1595"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1596"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1597"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1598"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1599"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1600"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1601"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1602"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1603"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1604"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1605"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1606"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1607"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1608"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1609"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1610"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1611"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1612"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1613"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1614"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1615"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1616"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1617"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1618"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1619"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1620"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1621"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1622"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1623"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1624"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1625"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1626"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1627"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1628"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1629"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1630"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1631"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1632"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1633"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1634"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1635"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1636"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1637"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1638"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1639"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1640"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1641"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1642"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1643"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1644"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1645"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1646"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1647"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1648"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1649"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1650"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1651"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1652"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1653"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1654"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1655"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1656"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1657"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1658"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1659"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1660"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1661"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1662"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1663"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1664"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1665"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1666"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1667"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1668"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1669"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1670"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1671"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1672"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1673"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1674"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1675"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1676"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1677"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1678"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1679"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1680"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1681"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1682"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1683"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1684"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1685"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1686"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1687"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1688"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1689"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1690"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1691"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1692"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1693"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1694"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1695"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1696"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1697"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1698"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1699"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1700"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1701"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1702"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1703"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1704"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1705"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1706"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1707"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1708"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1709"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1710"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1711"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1712"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1713"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1714"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1715"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1716"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1717"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1718"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1719"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1720"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1721"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1722"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1723"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1724"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1725"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1726"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1727"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1728"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1729"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1730"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1731"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1732"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1733"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1734"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1735"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1736"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1737"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1738"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1739"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1740"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1741"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1742"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1743"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1744"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1745"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1746"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1747"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1748"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1749"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1750"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1751"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1752"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1753"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1754"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1755"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1756"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1757"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1758"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1759"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1760"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1761"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1762"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1763"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1764"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1765"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1766"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1767"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1768"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1769"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1770"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1771"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1772"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1773"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1774"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1775"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1776"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1777"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1778"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1779"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1780"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1781"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1782"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1783"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1784"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1785"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1786"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1787"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1788"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1789"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1790"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1791"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1792"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1793"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1794"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1795"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1796"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1797"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1798"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1799"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1800"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1801"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1802"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1803"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1804"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1805"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1806"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1807"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1808"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1809"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1810"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1811"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1812"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1813"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1814"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1815"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1816"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1817"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1818"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1819"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1820"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1821"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1822"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1823"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1824"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1825"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1826"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1827"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1828"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1829"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1830"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1831"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1832"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1833"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1834"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1835"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1836"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1837"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1838"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1839"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1840"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1841"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1842"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1843"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1844"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1845"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1846"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1847"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1848"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1849"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1850"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1851"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1852"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1853"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1854"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1855"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1856"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1857"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1858"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1859"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1860"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1861"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1862"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1863"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1864"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1865"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1866"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1867"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1868"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1869"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1870"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1871"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1872"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1873"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1874"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1875"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1876"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1877"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1878"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1879"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1880"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1881"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1882"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1883"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1884"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1885"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1886"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1887"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1888"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1889"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1890"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1891"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1892"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1893"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1894"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1895"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1896"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1897"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1898"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1899"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1900"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1901"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1902"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1903"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1904"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1905"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1906"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1907"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1908"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1909"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1910"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1911"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1912"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1913"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1914"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1915"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1916"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1917"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1918"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1919"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1920"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1921"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1922"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1923"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1924"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1925"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1926"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1927"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1928"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1929"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1930"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1931"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1932"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1933"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1934"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1935"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1936"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1937"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1938"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1939"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1940"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1941"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1942"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1943"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1944"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1945"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1946"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1947"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1948"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1949"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1950"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1951"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1952"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1953"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1954"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1955"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1956"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1957"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1958"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1959"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1960"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1961"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1962"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1963"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1964"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1965"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1966"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1967"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1968"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1969"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1970"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1971"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1972"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1973"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1974"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1975"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1976"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1977"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1978"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1979"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1980"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1981"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1982"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1983"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1984"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1985"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1986"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1987"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1988"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1989"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1990"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1991"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1992"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1993"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1994"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1995"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1996"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1997"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1998"; children: BigUnion[]; }, "name", T> | DiscriminateUnion<{ name: "1999"; children: BigUnion[]; }, "name", T>)["children"][number][]
+>[] : undefined[]
+
+) { }

--- a/tests/cases/compiler/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts
+++ b/tests/cases/compiler/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts
@@ -1,0 +1,8012 @@
+type BigUnion =
+    {
+        name: '0';
+        children: BigUnion[];
+    } |
+    {
+        name: '1';
+        children: BigUnion[];
+    } |
+    {
+        name: '2';
+        children: BigUnion[];
+    } |
+    {
+        name: '3';
+        children: BigUnion[];
+    } |
+    {
+        name: '4';
+        children: BigUnion[];
+    } |
+    {
+        name: '5';
+        children: BigUnion[];
+    } |
+    {
+        name: '6';
+        children: BigUnion[];
+    } |
+    {
+        name: '7';
+        children: BigUnion[];
+    } |
+    {
+        name: '8';
+        children: BigUnion[];
+    } |
+    {
+        name: '9';
+        children: BigUnion[];
+    } |
+    {
+        name: '10';
+        children: BigUnion[];
+    } |
+    {
+        name: '11';
+        children: BigUnion[];
+    } |
+    {
+        name: '12';
+        children: BigUnion[];
+    } |
+    {
+        name: '13';
+        children: BigUnion[];
+    } |
+    {
+        name: '14';
+        children: BigUnion[];
+    } |
+    {
+        name: '15';
+        children: BigUnion[];
+    } |
+    {
+        name: '16';
+        children: BigUnion[];
+    } |
+    {
+        name: '17';
+        children: BigUnion[];
+    } |
+    {
+        name: '18';
+        children: BigUnion[];
+    } |
+    {
+        name: '19';
+        children: BigUnion[];
+    } |
+    {
+        name: '20';
+        children: BigUnion[];
+    } |
+    {
+        name: '21';
+        children: BigUnion[];
+    } |
+    {
+        name: '22';
+        children: BigUnion[];
+    } |
+    {
+        name: '23';
+        children: BigUnion[];
+    } |
+    {
+        name: '24';
+        children: BigUnion[];
+    } |
+    {
+        name: '25';
+        children: BigUnion[];
+    } |
+    {
+        name: '26';
+        children: BigUnion[];
+    } |
+    {
+        name: '27';
+        children: BigUnion[];
+    } |
+    {
+        name: '28';
+        children: BigUnion[];
+    } |
+    {
+        name: '29';
+        children: BigUnion[];
+    } |
+    {
+        name: '30';
+        children: BigUnion[];
+    } |
+    {
+        name: '31';
+        children: BigUnion[];
+    } |
+    {
+        name: '32';
+        children: BigUnion[];
+    } |
+    {
+        name: '33';
+        children: BigUnion[];
+    } |
+    {
+        name: '34';
+        children: BigUnion[];
+    } |
+    {
+        name: '35';
+        children: BigUnion[];
+    } |
+    {
+        name: '36';
+        children: BigUnion[];
+    } |
+    {
+        name: '37';
+        children: BigUnion[];
+    } |
+    {
+        name: '38';
+        children: BigUnion[];
+    } |
+    {
+        name: '39';
+        children: BigUnion[];
+    } |
+    {
+        name: '40';
+        children: BigUnion[];
+    } |
+    {
+        name: '41';
+        children: BigUnion[];
+    } |
+    {
+        name: '42';
+        children: BigUnion[];
+    } |
+    {
+        name: '43';
+        children: BigUnion[];
+    } |
+    {
+        name: '44';
+        children: BigUnion[];
+    } |
+    {
+        name: '45';
+        children: BigUnion[];
+    } |
+    {
+        name: '46';
+        children: BigUnion[];
+    } |
+    {
+        name: '47';
+        children: BigUnion[];
+    } |
+    {
+        name: '48';
+        children: BigUnion[];
+    } |
+    {
+        name: '49';
+        children: BigUnion[];
+    } |
+    {
+        name: '50';
+        children: BigUnion[];
+    } |
+    {
+        name: '51';
+        children: BigUnion[];
+    } |
+    {
+        name: '52';
+        children: BigUnion[];
+    } |
+    {
+        name: '53';
+        children: BigUnion[];
+    } |
+    {
+        name: '54';
+        children: BigUnion[];
+    } |
+    {
+        name: '55';
+        children: BigUnion[];
+    } |
+    {
+        name: '56';
+        children: BigUnion[];
+    } |
+    {
+        name: '57';
+        children: BigUnion[];
+    } |
+    {
+        name: '58';
+        children: BigUnion[];
+    } |
+    {
+        name: '59';
+        children: BigUnion[];
+    } |
+    {
+        name: '60';
+        children: BigUnion[];
+    } |
+    {
+        name: '61';
+        children: BigUnion[];
+    } |
+    {
+        name: '62';
+        children: BigUnion[];
+    } |
+    {
+        name: '63';
+        children: BigUnion[];
+    } |
+    {
+        name: '64';
+        children: BigUnion[];
+    } |
+    {
+        name: '65';
+        children: BigUnion[];
+    } |
+    {
+        name: '66';
+        children: BigUnion[];
+    } |
+    {
+        name: '67';
+        children: BigUnion[];
+    } |
+    {
+        name: '68';
+        children: BigUnion[];
+    } |
+    {
+        name: '69';
+        children: BigUnion[];
+    } |
+    {
+        name: '70';
+        children: BigUnion[];
+    } |
+    {
+        name: '71';
+        children: BigUnion[];
+    } |
+    {
+        name: '72';
+        children: BigUnion[];
+    } |
+    {
+        name: '73';
+        children: BigUnion[];
+    } |
+    {
+        name: '74';
+        children: BigUnion[];
+    } |
+    {
+        name: '75';
+        children: BigUnion[];
+    } |
+    {
+        name: '76';
+        children: BigUnion[];
+    } |
+    {
+        name: '77';
+        children: BigUnion[];
+    } |
+    {
+        name: '78';
+        children: BigUnion[];
+    } |
+    {
+        name: '79';
+        children: BigUnion[];
+    } |
+    {
+        name: '80';
+        children: BigUnion[];
+    } |
+    {
+        name: '81';
+        children: BigUnion[];
+    } |
+    {
+        name: '82';
+        children: BigUnion[];
+    } |
+    {
+        name: '83';
+        children: BigUnion[];
+    } |
+    {
+        name: '84';
+        children: BigUnion[];
+    } |
+    {
+        name: '85';
+        children: BigUnion[];
+    } |
+    {
+        name: '86';
+        children: BigUnion[];
+    } |
+    {
+        name: '87';
+        children: BigUnion[];
+    } |
+    {
+        name: '88';
+        children: BigUnion[];
+    } |
+    {
+        name: '89';
+        children: BigUnion[];
+    } |
+    {
+        name: '90';
+        children: BigUnion[];
+    } |
+    {
+        name: '91';
+        children: BigUnion[];
+    } |
+    {
+        name: '92';
+        children: BigUnion[];
+    } |
+    {
+        name: '93';
+        children: BigUnion[];
+    } |
+    {
+        name: '94';
+        children: BigUnion[];
+    } |
+    {
+        name: '95';
+        children: BigUnion[];
+    } |
+    {
+        name: '96';
+        children: BigUnion[];
+    } |
+    {
+        name: '97';
+        children: BigUnion[];
+    } |
+    {
+        name: '98';
+        children: BigUnion[];
+    } |
+    {
+        name: '99';
+        children: BigUnion[];
+    } |
+    {
+        name: '100';
+        children: BigUnion[];
+    } |
+    {
+        name: '101';
+        children: BigUnion[];
+    } |
+    {
+        name: '102';
+        children: BigUnion[];
+    } |
+    {
+        name: '103';
+        children: BigUnion[];
+    } |
+    {
+        name: '104';
+        children: BigUnion[];
+    } |
+    {
+        name: '105';
+        children: BigUnion[];
+    } |
+    {
+        name: '106';
+        children: BigUnion[];
+    } |
+    {
+        name: '107';
+        children: BigUnion[];
+    } |
+    {
+        name: '108';
+        children: BigUnion[];
+    } |
+    {
+        name: '109';
+        children: BigUnion[];
+    } |
+    {
+        name: '110';
+        children: BigUnion[];
+    } |
+    {
+        name: '111';
+        children: BigUnion[];
+    } |
+    {
+        name: '112';
+        children: BigUnion[];
+    } |
+    {
+        name: '113';
+        children: BigUnion[];
+    } |
+    {
+        name: '114';
+        children: BigUnion[];
+    } |
+    {
+        name: '115';
+        children: BigUnion[];
+    } |
+    {
+        name: '116';
+        children: BigUnion[];
+    } |
+    {
+        name: '117';
+        children: BigUnion[];
+    } |
+    {
+        name: '118';
+        children: BigUnion[];
+    } |
+    {
+        name: '119';
+        children: BigUnion[];
+    } |
+    {
+        name: '120';
+        children: BigUnion[];
+    } |
+    {
+        name: '121';
+        children: BigUnion[];
+    } |
+    {
+        name: '122';
+        children: BigUnion[];
+    } |
+    {
+        name: '123';
+        children: BigUnion[];
+    } |
+    {
+        name: '124';
+        children: BigUnion[];
+    } |
+    {
+        name: '125';
+        children: BigUnion[];
+    } |
+    {
+        name: '126';
+        children: BigUnion[];
+    } |
+    {
+        name: '127';
+        children: BigUnion[];
+    } |
+    {
+        name: '128';
+        children: BigUnion[];
+    } |
+    {
+        name: '129';
+        children: BigUnion[];
+    } |
+    {
+        name: '130';
+        children: BigUnion[];
+    } |
+    {
+        name: '131';
+        children: BigUnion[];
+    } |
+    {
+        name: '132';
+        children: BigUnion[];
+    } |
+    {
+        name: '133';
+        children: BigUnion[];
+    } |
+    {
+        name: '134';
+        children: BigUnion[];
+    } |
+    {
+        name: '135';
+        children: BigUnion[];
+    } |
+    {
+        name: '136';
+        children: BigUnion[];
+    } |
+    {
+        name: '137';
+        children: BigUnion[];
+    } |
+    {
+        name: '138';
+        children: BigUnion[];
+    } |
+    {
+        name: '139';
+        children: BigUnion[];
+    } |
+    {
+        name: '140';
+        children: BigUnion[];
+    } |
+    {
+        name: '141';
+        children: BigUnion[];
+    } |
+    {
+        name: '142';
+        children: BigUnion[];
+    } |
+    {
+        name: '143';
+        children: BigUnion[];
+    } |
+    {
+        name: '144';
+        children: BigUnion[];
+    } |
+    {
+        name: '145';
+        children: BigUnion[];
+    } |
+    {
+        name: '146';
+        children: BigUnion[];
+    } |
+    {
+        name: '147';
+        children: BigUnion[];
+    } |
+    {
+        name: '148';
+        children: BigUnion[];
+    } |
+    {
+        name: '149';
+        children: BigUnion[];
+    } |
+    {
+        name: '150';
+        children: BigUnion[];
+    } |
+    {
+        name: '151';
+        children: BigUnion[];
+    } |
+    {
+        name: '152';
+        children: BigUnion[];
+    } |
+    {
+        name: '153';
+        children: BigUnion[];
+    } |
+    {
+        name: '154';
+        children: BigUnion[];
+    } |
+    {
+        name: '155';
+        children: BigUnion[];
+    } |
+    {
+        name: '156';
+        children: BigUnion[];
+    } |
+    {
+        name: '157';
+        children: BigUnion[];
+    } |
+    {
+        name: '158';
+        children: BigUnion[];
+    } |
+    {
+        name: '159';
+        children: BigUnion[];
+    } |
+    {
+        name: '160';
+        children: BigUnion[];
+    } |
+    {
+        name: '161';
+        children: BigUnion[];
+    } |
+    {
+        name: '162';
+        children: BigUnion[];
+    } |
+    {
+        name: '163';
+        children: BigUnion[];
+    } |
+    {
+        name: '164';
+        children: BigUnion[];
+    } |
+    {
+        name: '165';
+        children: BigUnion[];
+    } |
+    {
+        name: '166';
+        children: BigUnion[];
+    } |
+    {
+        name: '167';
+        children: BigUnion[];
+    } |
+    {
+        name: '168';
+        children: BigUnion[];
+    } |
+    {
+        name: '169';
+        children: BigUnion[];
+    } |
+    {
+        name: '170';
+        children: BigUnion[];
+    } |
+    {
+        name: '171';
+        children: BigUnion[];
+    } |
+    {
+        name: '172';
+        children: BigUnion[];
+    } |
+    {
+        name: '173';
+        children: BigUnion[];
+    } |
+    {
+        name: '174';
+        children: BigUnion[];
+    } |
+    {
+        name: '175';
+        children: BigUnion[];
+    } |
+    {
+        name: '176';
+        children: BigUnion[];
+    } |
+    {
+        name: '177';
+        children: BigUnion[];
+    } |
+    {
+        name: '178';
+        children: BigUnion[];
+    } |
+    {
+        name: '179';
+        children: BigUnion[];
+    } |
+    {
+        name: '180';
+        children: BigUnion[];
+    } |
+    {
+        name: '181';
+        children: BigUnion[];
+    } |
+    {
+        name: '182';
+        children: BigUnion[];
+    } |
+    {
+        name: '183';
+        children: BigUnion[];
+    } |
+    {
+        name: '184';
+        children: BigUnion[];
+    } |
+    {
+        name: '185';
+        children: BigUnion[];
+    } |
+    {
+        name: '186';
+        children: BigUnion[];
+    } |
+    {
+        name: '187';
+        children: BigUnion[];
+    } |
+    {
+        name: '188';
+        children: BigUnion[];
+    } |
+    {
+        name: '189';
+        children: BigUnion[];
+    } |
+    {
+        name: '190';
+        children: BigUnion[];
+    } |
+    {
+        name: '191';
+        children: BigUnion[];
+    } |
+    {
+        name: '192';
+        children: BigUnion[];
+    } |
+    {
+        name: '193';
+        children: BigUnion[];
+    } |
+    {
+        name: '194';
+        children: BigUnion[];
+    } |
+    {
+        name: '195';
+        children: BigUnion[];
+    } |
+    {
+        name: '196';
+        children: BigUnion[];
+    } |
+    {
+        name: '197';
+        children: BigUnion[];
+    } |
+    {
+        name: '198';
+        children: BigUnion[];
+    } |
+    {
+        name: '199';
+        children: BigUnion[];
+    } |
+    {
+        name: '200';
+        children: BigUnion[];
+    } |
+    {
+        name: '201';
+        children: BigUnion[];
+    } |
+    {
+        name: '202';
+        children: BigUnion[];
+    } |
+    {
+        name: '203';
+        children: BigUnion[];
+    } |
+    {
+        name: '204';
+        children: BigUnion[];
+    } |
+    {
+        name: '205';
+        children: BigUnion[];
+    } |
+    {
+        name: '206';
+        children: BigUnion[];
+    } |
+    {
+        name: '207';
+        children: BigUnion[];
+    } |
+    {
+        name: '208';
+        children: BigUnion[];
+    } |
+    {
+        name: '209';
+        children: BigUnion[];
+    } |
+    {
+        name: '210';
+        children: BigUnion[];
+    } |
+    {
+        name: '211';
+        children: BigUnion[];
+    } |
+    {
+        name: '212';
+        children: BigUnion[];
+    } |
+    {
+        name: '213';
+        children: BigUnion[];
+    } |
+    {
+        name: '214';
+        children: BigUnion[];
+    } |
+    {
+        name: '215';
+        children: BigUnion[];
+    } |
+    {
+        name: '216';
+        children: BigUnion[];
+    } |
+    {
+        name: '217';
+        children: BigUnion[];
+    } |
+    {
+        name: '218';
+        children: BigUnion[];
+    } |
+    {
+        name: '219';
+        children: BigUnion[];
+    } |
+    {
+        name: '220';
+        children: BigUnion[];
+    } |
+    {
+        name: '221';
+        children: BigUnion[];
+    } |
+    {
+        name: '222';
+        children: BigUnion[];
+    } |
+    {
+        name: '223';
+        children: BigUnion[];
+    } |
+    {
+        name: '224';
+        children: BigUnion[];
+    } |
+    {
+        name: '225';
+        children: BigUnion[];
+    } |
+    {
+        name: '226';
+        children: BigUnion[];
+    } |
+    {
+        name: '227';
+        children: BigUnion[];
+    } |
+    {
+        name: '228';
+        children: BigUnion[];
+    } |
+    {
+        name: '229';
+        children: BigUnion[];
+    } |
+    {
+        name: '230';
+        children: BigUnion[];
+    } |
+    {
+        name: '231';
+        children: BigUnion[];
+    } |
+    {
+        name: '232';
+        children: BigUnion[];
+    } |
+    {
+        name: '233';
+        children: BigUnion[];
+    } |
+    {
+        name: '234';
+        children: BigUnion[];
+    } |
+    {
+        name: '235';
+        children: BigUnion[];
+    } |
+    {
+        name: '236';
+        children: BigUnion[];
+    } |
+    {
+        name: '237';
+        children: BigUnion[];
+    } |
+    {
+        name: '238';
+        children: BigUnion[];
+    } |
+    {
+        name: '239';
+        children: BigUnion[];
+    } |
+    {
+        name: '240';
+        children: BigUnion[];
+    } |
+    {
+        name: '241';
+        children: BigUnion[];
+    } |
+    {
+        name: '242';
+        children: BigUnion[];
+    } |
+    {
+        name: '243';
+        children: BigUnion[];
+    } |
+    {
+        name: '244';
+        children: BigUnion[];
+    } |
+    {
+        name: '245';
+        children: BigUnion[];
+    } |
+    {
+        name: '246';
+        children: BigUnion[];
+    } |
+    {
+        name: '247';
+        children: BigUnion[];
+    } |
+    {
+        name: '248';
+        children: BigUnion[];
+    } |
+    {
+        name: '249';
+        children: BigUnion[];
+    } |
+    {
+        name: '250';
+        children: BigUnion[];
+    } |
+    {
+        name: '251';
+        children: BigUnion[];
+    } |
+    {
+        name: '252';
+        children: BigUnion[];
+    } |
+    {
+        name: '253';
+        children: BigUnion[];
+    } |
+    {
+        name: '254';
+        children: BigUnion[];
+    } |
+    {
+        name: '255';
+        children: BigUnion[];
+    } |
+    {
+        name: '256';
+        children: BigUnion[];
+    } |
+    {
+        name: '257';
+        children: BigUnion[];
+    } |
+    {
+        name: '258';
+        children: BigUnion[];
+    } |
+    {
+        name: '259';
+        children: BigUnion[];
+    } |
+    {
+        name: '260';
+        children: BigUnion[];
+    } |
+    {
+        name: '261';
+        children: BigUnion[];
+    } |
+    {
+        name: '262';
+        children: BigUnion[];
+    } |
+    {
+        name: '263';
+        children: BigUnion[];
+    } |
+    {
+        name: '264';
+        children: BigUnion[];
+    } |
+    {
+        name: '265';
+        children: BigUnion[];
+    } |
+    {
+        name: '266';
+        children: BigUnion[];
+    } |
+    {
+        name: '267';
+        children: BigUnion[];
+    } |
+    {
+        name: '268';
+        children: BigUnion[];
+    } |
+    {
+        name: '269';
+        children: BigUnion[];
+    } |
+    {
+        name: '270';
+        children: BigUnion[];
+    } |
+    {
+        name: '271';
+        children: BigUnion[];
+    } |
+    {
+        name: '272';
+        children: BigUnion[];
+    } |
+    {
+        name: '273';
+        children: BigUnion[];
+    } |
+    {
+        name: '274';
+        children: BigUnion[];
+    } |
+    {
+        name: '275';
+        children: BigUnion[];
+    } |
+    {
+        name: '276';
+        children: BigUnion[];
+    } |
+    {
+        name: '277';
+        children: BigUnion[];
+    } |
+    {
+        name: '278';
+        children: BigUnion[];
+    } |
+    {
+        name: '279';
+        children: BigUnion[];
+    } |
+    {
+        name: '280';
+        children: BigUnion[];
+    } |
+    {
+        name: '281';
+        children: BigUnion[];
+    } |
+    {
+        name: '282';
+        children: BigUnion[];
+    } |
+    {
+        name: '283';
+        children: BigUnion[];
+    } |
+    {
+        name: '284';
+        children: BigUnion[];
+    } |
+    {
+        name: '285';
+        children: BigUnion[];
+    } |
+    {
+        name: '286';
+        children: BigUnion[];
+    } |
+    {
+        name: '287';
+        children: BigUnion[];
+    } |
+    {
+        name: '288';
+        children: BigUnion[];
+    } |
+    {
+        name: '289';
+        children: BigUnion[];
+    } |
+    {
+        name: '290';
+        children: BigUnion[];
+    } |
+    {
+        name: '291';
+        children: BigUnion[];
+    } |
+    {
+        name: '292';
+        children: BigUnion[];
+    } |
+    {
+        name: '293';
+        children: BigUnion[];
+    } |
+    {
+        name: '294';
+        children: BigUnion[];
+    } |
+    {
+        name: '295';
+        children: BigUnion[];
+    } |
+    {
+        name: '296';
+        children: BigUnion[];
+    } |
+    {
+        name: '297';
+        children: BigUnion[];
+    } |
+    {
+        name: '298';
+        children: BigUnion[];
+    } |
+    {
+        name: '299';
+        children: BigUnion[];
+    } |
+    {
+        name: '300';
+        children: BigUnion[];
+    } |
+    {
+        name: '301';
+        children: BigUnion[];
+    } |
+    {
+        name: '302';
+        children: BigUnion[];
+    } |
+    {
+        name: '303';
+        children: BigUnion[];
+    } |
+    {
+        name: '304';
+        children: BigUnion[];
+    } |
+    {
+        name: '305';
+        children: BigUnion[];
+    } |
+    {
+        name: '306';
+        children: BigUnion[];
+    } |
+    {
+        name: '307';
+        children: BigUnion[];
+    } |
+    {
+        name: '308';
+        children: BigUnion[];
+    } |
+    {
+        name: '309';
+        children: BigUnion[];
+    } |
+    {
+        name: '310';
+        children: BigUnion[];
+    } |
+    {
+        name: '311';
+        children: BigUnion[];
+    } |
+    {
+        name: '312';
+        children: BigUnion[];
+    } |
+    {
+        name: '313';
+        children: BigUnion[];
+    } |
+    {
+        name: '314';
+        children: BigUnion[];
+    } |
+    {
+        name: '315';
+        children: BigUnion[];
+    } |
+    {
+        name: '316';
+        children: BigUnion[];
+    } |
+    {
+        name: '317';
+        children: BigUnion[];
+    } |
+    {
+        name: '318';
+        children: BigUnion[];
+    } |
+    {
+        name: '319';
+        children: BigUnion[];
+    } |
+    {
+        name: '320';
+        children: BigUnion[];
+    } |
+    {
+        name: '321';
+        children: BigUnion[];
+    } |
+    {
+        name: '322';
+        children: BigUnion[];
+    } |
+    {
+        name: '323';
+        children: BigUnion[];
+    } |
+    {
+        name: '324';
+        children: BigUnion[];
+    } |
+    {
+        name: '325';
+        children: BigUnion[];
+    } |
+    {
+        name: '326';
+        children: BigUnion[];
+    } |
+    {
+        name: '327';
+        children: BigUnion[];
+    } |
+    {
+        name: '328';
+        children: BigUnion[];
+    } |
+    {
+        name: '329';
+        children: BigUnion[];
+    } |
+    {
+        name: '330';
+        children: BigUnion[];
+    } |
+    {
+        name: '331';
+        children: BigUnion[];
+    } |
+    {
+        name: '332';
+        children: BigUnion[];
+    } |
+    {
+        name: '333';
+        children: BigUnion[];
+    } |
+    {
+        name: '334';
+        children: BigUnion[];
+    } |
+    {
+        name: '335';
+        children: BigUnion[];
+    } |
+    {
+        name: '336';
+        children: BigUnion[];
+    } |
+    {
+        name: '337';
+        children: BigUnion[];
+    } |
+    {
+        name: '338';
+        children: BigUnion[];
+    } |
+    {
+        name: '339';
+        children: BigUnion[];
+    } |
+    {
+        name: '340';
+        children: BigUnion[];
+    } |
+    {
+        name: '341';
+        children: BigUnion[];
+    } |
+    {
+        name: '342';
+        children: BigUnion[];
+    } |
+    {
+        name: '343';
+        children: BigUnion[];
+    } |
+    {
+        name: '344';
+        children: BigUnion[];
+    } |
+    {
+        name: '345';
+        children: BigUnion[];
+    } |
+    {
+        name: '346';
+        children: BigUnion[];
+    } |
+    {
+        name: '347';
+        children: BigUnion[];
+    } |
+    {
+        name: '348';
+        children: BigUnion[];
+    } |
+    {
+        name: '349';
+        children: BigUnion[];
+    } |
+    {
+        name: '350';
+        children: BigUnion[];
+    } |
+    {
+        name: '351';
+        children: BigUnion[];
+    } |
+    {
+        name: '352';
+        children: BigUnion[];
+    } |
+    {
+        name: '353';
+        children: BigUnion[];
+    } |
+    {
+        name: '354';
+        children: BigUnion[];
+    } |
+    {
+        name: '355';
+        children: BigUnion[];
+    } |
+    {
+        name: '356';
+        children: BigUnion[];
+    } |
+    {
+        name: '357';
+        children: BigUnion[];
+    } |
+    {
+        name: '358';
+        children: BigUnion[];
+    } |
+    {
+        name: '359';
+        children: BigUnion[];
+    } |
+    {
+        name: '360';
+        children: BigUnion[];
+    } |
+    {
+        name: '361';
+        children: BigUnion[];
+    } |
+    {
+        name: '362';
+        children: BigUnion[];
+    } |
+    {
+        name: '363';
+        children: BigUnion[];
+    } |
+    {
+        name: '364';
+        children: BigUnion[];
+    } |
+    {
+        name: '365';
+        children: BigUnion[];
+    } |
+    {
+        name: '366';
+        children: BigUnion[];
+    } |
+    {
+        name: '367';
+        children: BigUnion[];
+    } |
+    {
+        name: '368';
+        children: BigUnion[];
+    } |
+    {
+        name: '369';
+        children: BigUnion[];
+    } |
+    {
+        name: '370';
+        children: BigUnion[];
+    } |
+    {
+        name: '371';
+        children: BigUnion[];
+    } |
+    {
+        name: '372';
+        children: BigUnion[];
+    } |
+    {
+        name: '373';
+        children: BigUnion[];
+    } |
+    {
+        name: '374';
+        children: BigUnion[];
+    } |
+    {
+        name: '375';
+        children: BigUnion[];
+    } |
+    {
+        name: '376';
+        children: BigUnion[];
+    } |
+    {
+        name: '377';
+        children: BigUnion[];
+    } |
+    {
+        name: '378';
+        children: BigUnion[];
+    } |
+    {
+        name: '379';
+        children: BigUnion[];
+    } |
+    {
+        name: '380';
+        children: BigUnion[];
+    } |
+    {
+        name: '381';
+        children: BigUnion[];
+    } |
+    {
+        name: '382';
+        children: BigUnion[];
+    } |
+    {
+        name: '383';
+        children: BigUnion[];
+    } |
+    {
+        name: '384';
+        children: BigUnion[];
+    } |
+    {
+        name: '385';
+        children: BigUnion[];
+    } |
+    {
+        name: '386';
+        children: BigUnion[];
+    } |
+    {
+        name: '387';
+        children: BigUnion[];
+    } |
+    {
+        name: '388';
+        children: BigUnion[];
+    } |
+    {
+        name: '389';
+        children: BigUnion[];
+    } |
+    {
+        name: '390';
+        children: BigUnion[];
+    } |
+    {
+        name: '391';
+        children: BigUnion[];
+    } |
+    {
+        name: '392';
+        children: BigUnion[];
+    } |
+    {
+        name: '393';
+        children: BigUnion[];
+    } |
+    {
+        name: '394';
+        children: BigUnion[];
+    } |
+    {
+        name: '395';
+        children: BigUnion[];
+    } |
+    {
+        name: '396';
+        children: BigUnion[];
+    } |
+    {
+        name: '397';
+        children: BigUnion[];
+    } |
+    {
+        name: '398';
+        children: BigUnion[];
+    } |
+    {
+        name: '399';
+        children: BigUnion[];
+    } |
+    {
+        name: '400';
+        children: BigUnion[];
+    } |
+    {
+        name: '401';
+        children: BigUnion[];
+    } |
+    {
+        name: '402';
+        children: BigUnion[];
+    } |
+    {
+        name: '403';
+        children: BigUnion[];
+    } |
+    {
+        name: '404';
+        children: BigUnion[];
+    } |
+    {
+        name: '405';
+        children: BigUnion[];
+    } |
+    {
+        name: '406';
+        children: BigUnion[];
+    } |
+    {
+        name: '407';
+        children: BigUnion[];
+    } |
+    {
+        name: '408';
+        children: BigUnion[];
+    } |
+    {
+        name: '409';
+        children: BigUnion[];
+    } |
+    {
+        name: '410';
+        children: BigUnion[];
+    } |
+    {
+        name: '411';
+        children: BigUnion[];
+    } |
+    {
+        name: '412';
+        children: BigUnion[];
+    } |
+    {
+        name: '413';
+        children: BigUnion[];
+    } |
+    {
+        name: '414';
+        children: BigUnion[];
+    } |
+    {
+        name: '415';
+        children: BigUnion[];
+    } |
+    {
+        name: '416';
+        children: BigUnion[];
+    } |
+    {
+        name: '417';
+        children: BigUnion[];
+    } |
+    {
+        name: '418';
+        children: BigUnion[];
+    } |
+    {
+        name: '419';
+        children: BigUnion[];
+    } |
+    {
+        name: '420';
+        children: BigUnion[];
+    } |
+    {
+        name: '421';
+        children: BigUnion[];
+    } |
+    {
+        name: '422';
+        children: BigUnion[];
+    } |
+    {
+        name: '423';
+        children: BigUnion[];
+    } |
+    {
+        name: '424';
+        children: BigUnion[];
+    } |
+    {
+        name: '425';
+        children: BigUnion[];
+    } |
+    {
+        name: '426';
+        children: BigUnion[];
+    } |
+    {
+        name: '427';
+        children: BigUnion[];
+    } |
+    {
+        name: '428';
+        children: BigUnion[];
+    } |
+    {
+        name: '429';
+        children: BigUnion[];
+    } |
+    {
+        name: '430';
+        children: BigUnion[];
+    } |
+    {
+        name: '431';
+        children: BigUnion[];
+    } |
+    {
+        name: '432';
+        children: BigUnion[];
+    } |
+    {
+        name: '433';
+        children: BigUnion[];
+    } |
+    {
+        name: '434';
+        children: BigUnion[];
+    } |
+    {
+        name: '435';
+        children: BigUnion[];
+    } |
+    {
+        name: '436';
+        children: BigUnion[];
+    } |
+    {
+        name: '437';
+        children: BigUnion[];
+    } |
+    {
+        name: '438';
+        children: BigUnion[];
+    } |
+    {
+        name: '439';
+        children: BigUnion[];
+    } |
+    {
+        name: '440';
+        children: BigUnion[];
+    } |
+    {
+        name: '441';
+        children: BigUnion[];
+    } |
+    {
+        name: '442';
+        children: BigUnion[];
+    } |
+    {
+        name: '443';
+        children: BigUnion[];
+    } |
+    {
+        name: '444';
+        children: BigUnion[];
+    } |
+    {
+        name: '445';
+        children: BigUnion[];
+    } |
+    {
+        name: '446';
+        children: BigUnion[];
+    } |
+    {
+        name: '447';
+        children: BigUnion[];
+    } |
+    {
+        name: '448';
+        children: BigUnion[];
+    } |
+    {
+        name: '449';
+        children: BigUnion[];
+    } |
+    {
+        name: '450';
+        children: BigUnion[];
+    } |
+    {
+        name: '451';
+        children: BigUnion[];
+    } |
+    {
+        name: '452';
+        children: BigUnion[];
+    } |
+    {
+        name: '453';
+        children: BigUnion[];
+    } |
+    {
+        name: '454';
+        children: BigUnion[];
+    } |
+    {
+        name: '455';
+        children: BigUnion[];
+    } |
+    {
+        name: '456';
+        children: BigUnion[];
+    } |
+    {
+        name: '457';
+        children: BigUnion[];
+    } |
+    {
+        name: '458';
+        children: BigUnion[];
+    } |
+    {
+        name: '459';
+        children: BigUnion[];
+    } |
+    {
+        name: '460';
+        children: BigUnion[];
+    } |
+    {
+        name: '461';
+        children: BigUnion[];
+    } |
+    {
+        name: '462';
+        children: BigUnion[];
+    } |
+    {
+        name: '463';
+        children: BigUnion[];
+    } |
+    {
+        name: '464';
+        children: BigUnion[];
+    } |
+    {
+        name: '465';
+        children: BigUnion[];
+    } |
+    {
+        name: '466';
+        children: BigUnion[];
+    } |
+    {
+        name: '467';
+        children: BigUnion[];
+    } |
+    {
+        name: '468';
+        children: BigUnion[];
+    } |
+    {
+        name: '469';
+        children: BigUnion[];
+    } |
+    {
+        name: '470';
+        children: BigUnion[];
+    } |
+    {
+        name: '471';
+        children: BigUnion[];
+    } |
+    {
+        name: '472';
+        children: BigUnion[];
+    } |
+    {
+        name: '473';
+        children: BigUnion[];
+    } |
+    {
+        name: '474';
+        children: BigUnion[];
+    } |
+    {
+        name: '475';
+        children: BigUnion[];
+    } |
+    {
+        name: '476';
+        children: BigUnion[];
+    } |
+    {
+        name: '477';
+        children: BigUnion[];
+    } |
+    {
+        name: '478';
+        children: BigUnion[];
+    } |
+    {
+        name: '479';
+        children: BigUnion[];
+    } |
+    {
+        name: '480';
+        children: BigUnion[];
+    } |
+    {
+        name: '481';
+        children: BigUnion[];
+    } |
+    {
+        name: '482';
+        children: BigUnion[];
+    } |
+    {
+        name: '483';
+        children: BigUnion[];
+    } |
+    {
+        name: '484';
+        children: BigUnion[];
+    } |
+    {
+        name: '485';
+        children: BigUnion[];
+    } |
+    {
+        name: '486';
+        children: BigUnion[];
+    } |
+    {
+        name: '487';
+        children: BigUnion[];
+    } |
+    {
+        name: '488';
+        children: BigUnion[];
+    } |
+    {
+        name: '489';
+        children: BigUnion[];
+    } |
+    {
+        name: '490';
+        children: BigUnion[];
+    } |
+    {
+        name: '491';
+        children: BigUnion[];
+    } |
+    {
+        name: '492';
+        children: BigUnion[];
+    } |
+    {
+        name: '493';
+        children: BigUnion[];
+    } |
+    {
+        name: '494';
+        children: BigUnion[];
+    } |
+    {
+        name: '495';
+        children: BigUnion[];
+    } |
+    {
+        name: '496';
+        children: BigUnion[];
+    } |
+    {
+        name: '497';
+        children: BigUnion[];
+    } |
+    {
+        name: '498';
+        children: BigUnion[];
+    } |
+    {
+        name: '499';
+        children: BigUnion[];
+    } |
+    {
+        name: '500';
+        children: BigUnion[];
+    } |
+    {
+        name: '501';
+        children: BigUnion[];
+    } |
+    {
+        name: '502';
+        children: BigUnion[];
+    } |
+    {
+        name: '503';
+        children: BigUnion[];
+    } |
+    {
+        name: '504';
+        children: BigUnion[];
+    } |
+    {
+        name: '505';
+        children: BigUnion[];
+    } |
+    {
+        name: '506';
+        children: BigUnion[];
+    } |
+    {
+        name: '507';
+        children: BigUnion[];
+    } |
+    {
+        name: '508';
+        children: BigUnion[];
+    } |
+    {
+        name: '509';
+        children: BigUnion[];
+    } |
+    {
+        name: '510';
+        children: BigUnion[];
+    } |
+    {
+        name: '511';
+        children: BigUnion[];
+    } |
+    {
+        name: '512';
+        children: BigUnion[];
+    } |
+    {
+        name: '513';
+        children: BigUnion[];
+    } |
+    {
+        name: '514';
+        children: BigUnion[];
+    } |
+    {
+        name: '515';
+        children: BigUnion[];
+    } |
+    {
+        name: '516';
+        children: BigUnion[];
+    } |
+    {
+        name: '517';
+        children: BigUnion[];
+    } |
+    {
+        name: '518';
+        children: BigUnion[];
+    } |
+    {
+        name: '519';
+        children: BigUnion[];
+    } |
+    {
+        name: '520';
+        children: BigUnion[];
+    } |
+    {
+        name: '521';
+        children: BigUnion[];
+    } |
+    {
+        name: '522';
+        children: BigUnion[];
+    } |
+    {
+        name: '523';
+        children: BigUnion[];
+    } |
+    {
+        name: '524';
+        children: BigUnion[];
+    } |
+    {
+        name: '525';
+        children: BigUnion[];
+    } |
+    {
+        name: '526';
+        children: BigUnion[];
+    } |
+    {
+        name: '527';
+        children: BigUnion[];
+    } |
+    {
+        name: '528';
+        children: BigUnion[];
+    } |
+    {
+        name: '529';
+        children: BigUnion[];
+    } |
+    {
+        name: '530';
+        children: BigUnion[];
+    } |
+    {
+        name: '531';
+        children: BigUnion[];
+    } |
+    {
+        name: '532';
+        children: BigUnion[];
+    } |
+    {
+        name: '533';
+        children: BigUnion[];
+    } |
+    {
+        name: '534';
+        children: BigUnion[];
+    } |
+    {
+        name: '535';
+        children: BigUnion[];
+    } |
+    {
+        name: '536';
+        children: BigUnion[];
+    } |
+    {
+        name: '537';
+        children: BigUnion[];
+    } |
+    {
+        name: '538';
+        children: BigUnion[];
+    } |
+    {
+        name: '539';
+        children: BigUnion[];
+    } |
+    {
+        name: '540';
+        children: BigUnion[];
+    } |
+    {
+        name: '541';
+        children: BigUnion[];
+    } |
+    {
+        name: '542';
+        children: BigUnion[];
+    } |
+    {
+        name: '543';
+        children: BigUnion[];
+    } |
+    {
+        name: '544';
+        children: BigUnion[];
+    } |
+    {
+        name: '545';
+        children: BigUnion[];
+    } |
+    {
+        name: '546';
+        children: BigUnion[];
+    } |
+    {
+        name: '547';
+        children: BigUnion[];
+    } |
+    {
+        name: '548';
+        children: BigUnion[];
+    } |
+    {
+        name: '549';
+        children: BigUnion[];
+    } |
+    {
+        name: '550';
+        children: BigUnion[];
+    } |
+    {
+        name: '551';
+        children: BigUnion[];
+    } |
+    {
+        name: '552';
+        children: BigUnion[];
+    } |
+    {
+        name: '553';
+        children: BigUnion[];
+    } |
+    {
+        name: '554';
+        children: BigUnion[];
+    } |
+    {
+        name: '555';
+        children: BigUnion[];
+    } |
+    {
+        name: '556';
+        children: BigUnion[];
+    } |
+    {
+        name: '557';
+        children: BigUnion[];
+    } |
+    {
+        name: '558';
+        children: BigUnion[];
+    } |
+    {
+        name: '559';
+        children: BigUnion[];
+    } |
+    {
+        name: '560';
+        children: BigUnion[];
+    } |
+    {
+        name: '561';
+        children: BigUnion[];
+    } |
+    {
+        name: '562';
+        children: BigUnion[];
+    } |
+    {
+        name: '563';
+        children: BigUnion[];
+    } |
+    {
+        name: '564';
+        children: BigUnion[];
+    } |
+    {
+        name: '565';
+        children: BigUnion[];
+    } |
+    {
+        name: '566';
+        children: BigUnion[];
+    } |
+    {
+        name: '567';
+        children: BigUnion[];
+    } |
+    {
+        name: '568';
+        children: BigUnion[];
+    } |
+    {
+        name: '569';
+        children: BigUnion[];
+    } |
+    {
+        name: '570';
+        children: BigUnion[];
+    } |
+    {
+        name: '571';
+        children: BigUnion[];
+    } |
+    {
+        name: '572';
+        children: BigUnion[];
+    } |
+    {
+        name: '573';
+        children: BigUnion[];
+    } |
+    {
+        name: '574';
+        children: BigUnion[];
+    } |
+    {
+        name: '575';
+        children: BigUnion[];
+    } |
+    {
+        name: '576';
+        children: BigUnion[];
+    } |
+    {
+        name: '577';
+        children: BigUnion[];
+    } |
+    {
+        name: '578';
+        children: BigUnion[];
+    } |
+    {
+        name: '579';
+        children: BigUnion[];
+    } |
+    {
+        name: '580';
+        children: BigUnion[];
+    } |
+    {
+        name: '581';
+        children: BigUnion[];
+    } |
+    {
+        name: '582';
+        children: BigUnion[];
+    } |
+    {
+        name: '583';
+        children: BigUnion[];
+    } |
+    {
+        name: '584';
+        children: BigUnion[];
+    } |
+    {
+        name: '585';
+        children: BigUnion[];
+    } |
+    {
+        name: '586';
+        children: BigUnion[];
+    } |
+    {
+        name: '587';
+        children: BigUnion[];
+    } |
+    {
+        name: '588';
+        children: BigUnion[];
+    } |
+    {
+        name: '589';
+        children: BigUnion[];
+    } |
+    {
+        name: '590';
+        children: BigUnion[];
+    } |
+    {
+        name: '591';
+        children: BigUnion[];
+    } |
+    {
+        name: '592';
+        children: BigUnion[];
+    } |
+    {
+        name: '593';
+        children: BigUnion[];
+    } |
+    {
+        name: '594';
+        children: BigUnion[];
+    } |
+    {
+        name: '595';
+        children: BigUnion[];
+    } |
+    {
+        name: '596';
+        children: BigUnion[];
+    } |
+    {
+        name: '597';
+        children: BigUnion[];
+    } |
+    {
+        name: '598';
+        children: BigUnion[];
+    } |
+    {
+        name: '599';
+        children: BigUnion[];
+    } |
+    {
+        name: '600';
+        children: BigUnion[];
+    } |
+    {
+        name: '601';
+        children: BigUnion[];
+    } |
+    {
+        name: '602';
+        children: BigUnion[];
+    } |
+    {
+        name: '603';
+        children: BigUnion[];
+    } |
+    {
+        name: '604';
+        children: BigUnion[];
+    } |
+    {
+        name: '605';
+        children: BigUnion[];
+    } |
+    {
+        name: '606';
+        children: BigUnion[];
+    } |
+    {
+        name: '607';
+        children: BigUnion[];
+    } |
+    {
+        name: '608';
+        children: BigUnion[];
+    } |
+    {
+        name: '609';
+        children: BigUnion[];
+    } |
+    {
+        name: '610';
+        children: BigUnion[];
+    } |
+    {
+        name: '611';
+        children: BigUnion[];
+    } |
+    {
+        name: '612';
+        children: BigUnion[];
+    } |
+    {
+        name: '613';
+        children: BigUnion[];
+    } |
+    {
+        name: '614';
+        children: BigUnion[];
+    } |
+    {
+        name: '615';
+        children: BigUnion[];
+    } |
+    {
+        name: '616';
+        children: BigUnion[];
+    } |
+    {
+        name: '617';
+        children: BigUnion[];
+    } |
+    {
+        name: '618';
+        children: BigUnion[];
+    } |
+    {
+        name: '619';
+        children: BigUnion[];
+    } |
+    {
+        name: '620';
+        children: BigUnion[];
+    } |
+    {
+        name: '621';
+        children: BigUnion[];
+    } |
+    {
+        name: '622';
+        children: BigUnion[];
+    } |
+    {
+        name: '623';
+        children: BigUnion[];
+    } |
+    {
+        name: '624';
+        children: BigUnion[];
+    } |
+    {
+        name: '625';
+        children: BigUnion[];
+    } |
+    {
+        name: '626';
+        children: BigUnion[];
+    } |
+    {
+        name: '627';
+        children: BigUnion[];
+    } |
+    {
+        name: '628';
+        children: BigUnion[];
+    } |
+    {
+        name: '629';
+        children: BigUnion[];
+    } |
+    {
+        name: '630';
+        children: BigUnion[];
+    } |
+    {
+        name: '631';
+        children: BigUnion[];
+    } |
+    {
+        name: '632';
+        children: BigUnion[];
+    } |
+    {
+        name: '633';
+        children: BigUnion[];
+    } |
+    {
+        name: '634';
+        children: BigUnion[];
+    } |
+    {
+        name: '635';
+        children: BigUnion[];
+    } |
+    {
+        name: '636';
+        children: BigUnion[];
+    } |
+    {
+        name: '637';
+        children: BigUnion[];
+    } |
+    {
+        name: '638';
+        children: BigUnion[];
+    } |
+    {
+        name: '639';
+        children: BigUnion[];
+    } |
+    {
+        name: '640';
+        children: BigUnion[];
+    } |
+    {
+        name: '641';
+        children: BigUnion[];
+    } |
+    {
+        name: '642';
+        children: BigUnion[];
+    } |
+    {
+        name: '643';
+        children: BigUnion[];
+    } |
+    {
+        name: '644';
+        children: BigUnion[];
+    } |
+    {
+        name: '645';
+        children: BigUnion[];
+    } |
+    {
+        name: '646';
+        children: BigUnion[];
+    } |
+    {
+        name: '647';
+        children: BigUnion[];
+    } |
+    {
+        name: '648';
+        children: BigUnion[];
+    } |
+    {
+        name: '649';
+        children: BigUnion[];
+    } |
+    {
+        name: '650';
+        children: BigUnion[];
+    } |
+    {
+        name: '651';
+        children: BigUnion[];
+    } |
+    {
+        name: '652';
+        children: BigUnion[];
+    } |
+    {
+        name: '653';
+        children: BigUnion[];
+    } |
+    {
+        name: '654';
+        children: BigUnion[];
+    } |
+    {
+        name: '655';
+        children: BigUnion[];
+    } |
+    {
+        name: '656';
+        children: BigUnion[];
+    } |
+    {
+        name: '657';
+        children: BigUnion[];
+    } |
+    {
+        name: '658';
+        children: BigUnion[];
+    } |
+    {
+        name: '659';
+        children: BigUnion[];
+    } |
+    {
+        name: '660';
+        children: BigUnion[];
+    } |
+    {
+        name: '661';
+        children: BigUnion[];
+    } |
+    {
+        name: '662';
+        children: BigUnion[];
+    } |
+    {
+        name: '663';
+        children: BigUnion[];
+    } |
+    {
+        name: '664';
+        children: BigUnion[];
+    } |
+    {
+        name: '665';
+        children: BigUnion[];
+    } |
+    {
+        name: '666';
+        children: BigUnion[];
+    } |
+    {
+        name: '667';
+        children: BigUnion[];
+    } |
+    {
+        name: '668';
+        children: BigUnion[];
+    } |
+    {
+        name: '669';
+        children: BigUnion[];
+    } |
+    {
+        name: '670';
+        children: BigUnion[];
+    } |
+    {
+        name: '671';
+        children: BigUnion[];
+    } |
+    {
+        name: '672';
+        children: BigUnion[];
+    } |
+    {
+        name: '673';
+        children: BigUnion[];
+    } |
+    {
+        name: '674';
+        children: BigUnion[];
+    } |
+    {
+        name: '675';
+        children: BigUnion[];
+    } |
+    {
+        name: '676';
+        children: BigUnion[];
+    } |
+    {
+        name: '677';
+        children: BigUnion[];
+    } |
+    {
+        name: '678';
+        children: BigUnion[];
+    } |
+    {
+        name: '679';
+        children: BigUnion[];
+    } |
+    {
+        name: '680';
+        children: BigUnion[];
+    } |
+    {
+        name: '681';
+        children: BigUnion[];
+    } |
+    {
+        name: '682';
+        children: BigUnion[];
+    } |
+    {
+        name: '683';
+        children: BigUnion[];
+    } |
+    {
+        name: '684';
+        children: BigUnion[];
+    } |
+    {
+        name: '685';
+        children: BigUnion[];
+    } |
+    {
+        name: '686';
+        children: BigUnion[];
+    } |
+    {
+        name: '687';
+        children: BigUnion[];
+    } |
+    {
+        name: '688';
+        children: BigUnion[];
+    } |
+    {
+        name: '689';
+        children: BigUnion[];
+    } |
+    {
+        name: '690';
+        children: BigUnion[];
+    } |
+    {
+        name: '691';
+        children: BigUnion[];
+    } |
+    {
+        name: '692';
+        children: BigUnion[];
+    } |
+    {
+        name: '693';
+        children: BigUnion[];
+    } |
+    {
+        name: '694';
+        children: BigUnion[];
+    } |
+    {
+        name: '695';
+        children: BigUnion[];
+    } |
+    {
+        name: '696';
+        children: BigUnion[];
+    } |
+    {
+        name: '697';
+        children: BigUnion[];
+    } |
+    {
+        name: '698';
+        children: BigUnion[];
+    } |
+    {
+        name: '699';
+        children: BigUnion[];
+    } |
+    {
+        name: '700';
+        children: BigUnion[];
+    } |
+    {
+        name: '701';
+        children: BigUnion[];
+    } |
+    {
+        name: '702';
+        children: BigUnion[];
+    } |
+    {
+        name: '703';
+        children: BigUnion[];
+    } |
+    {
+        name: '704';
+        children: BigUnion[];
+    } |
+    {
+        name: '705';
+        children: BigUnion[];
+    } |
+    {
+        name: '706';
+        children: BigUnion[];
+    } |
+    {
+        name: '707';
+        children: BigUnion[];
+    } |
+    {
+        name: '708';
+        children: BigUnion[];
+    } |
+    {
+        name: '709';
+        children: BigUnion[];
+    } |
+    {
+        name: '710';
+        children: BigUnion[];
+    } |
+    {
+        name: '711';
+        children: BigUnion[];
+    } |
+    {
+        name: '712';
+        children: BigUnion[];
+    } |
+    {
+        name: '713';
+        children: BigUnion[];
+    } |
+    {
+        name: '714';
+        children: BigUnion[];
+    } |
+    {
+        name: '715';
+        children: BigUnion[];
+    } |
+    {
+        name: '716';
+        children: BigUnion[];
+    } |
+    {
+        name: '717';
+        children: BigUnion[];
+    } |
+    {
+        name: '718';
+        children: BigUnion[];
+    } |
+    {
+        name: '719';
+        children: BigUnion[];
+    } |
+    {
+        name: '720';
+        children: BigUnion[];
+    } |
+    {
+        name: '721';
+        children: BigUnion[];
+    } |
+    {
+        name: '722';
+        children: BigUnion[];
+    } |
+    {
+        name: '723';
+        children: BigUnion[];
+    } |
+    {
+        name: '724';
+        children: BigUnion[];
+    } |
+    {
+        name: '725';
+        children: BigUnion[];
+    } |
+    {
+        name: '726';
+        children: BigUnion[];
+    } |
+    {
+        name: '727';
+        children: BigUnion[];
+    } |
+    {
+        name: '728';
+        children: BigUnion[];
+    } |
+    {
+        name: '729';
+        children: BigUnion[];
+    } |
+    {
+        name: '730';
+        children: BigUnion[];
+    } |
+    {
+        name: '731';
+        children: BigUnion[];
+    } |
+    {
+        name: '732';
+        children: BigUnion[];
+    } |
+    {
+        name: '733';
+        children: BigUnion[];
+    } |
+    {
+        name: '734';
+        children: BigUnion[];
+    } |
+    {
+        name: '735';
+        children: BigUnion[];
+    } |
+    {
+        name: '736';
+        children: BigUnion[];
+    } |
+    {
+        name: '737';
+        children: BigUnion[];
+    } |
+    {
+        name: '738';
+        children: BigUnion[];
+    } |
+    {
+        name: '739';
+        children: BigUnion[];
+    } |
+    {
+        name: '740';
+        children: BigUnion[];
+    } |
+    {
+        name: '741';
+        children: BigUnion[];
+    } |
+    {
+        name: '742';
+        children: BigUnion[];
+    } |
+    {
+        name: '743';
+        children: BigUnion[];
+    } |
+    {
+        name: '744';
+        children: BigUnion[];
+    } |
+    {
+        name: '745';
+        children: BigUnion[];
+    } |
+    {
+        name: '746';
+        children: BigUnion[];
+    } |
+    {
+        name: '747';
+        children: BigUnion[];
+    } |
+    {
+        name: '748';
+        children: BigUnion[];
+    } |
+    {
+        name: '749';
+        children: BigUnion[];
+    } |
+    {
+        name: '750';
+        children: BigUnion[];
+    } |
+    {
+        name: '751';
+        children: BigUnion[];
+    } |
+    {
+        name: '752';
+        children: BigUnion[];
+    } |
+    {
+        name: '753';
+        children: BigUnion[];
+    } |
+    {
+        name: '754';
+        children: BigUnion[];
+    } |
+    {
+        name: '755';
+        children: BigUnion[];
+    } |
+    {
+        name: '756';
+        children: BigUnion[];
+    } |
+    {
+        name: '757';
+        children: BigUnion[];
+    } |
+    {
+        name: '758';
+        children: BigUnion[];
+    } |
+    {
+        name: '759';
+        children: BigUnion[];
+    } |
+    {
+        name: '760';
+        children: BigUnion[];
+    } |
+    {
+        name: '761';
+        children: BigUnion[];
+    } |
+    {
+        name: '762';
+        children: BigUnion[];
+    } |
+    {
+        name: '763';
+        children: BigUnion[];
+    } |
+    {
+        name: '764';
+        children: BigUnion[];
+    } |
+    {
+        name: '765';
+        children: BigUnion[];
+    } |
+    {
+        name: '766';
+        children: BigUnion[];
+    } |
+    {
+        name: '767';
+        children: BigUnion[];
+    } |
+    {
+        name: '768';
+        children: BigUnion[];
+    } |
+    {
+        name: '769';
+        children: BigUnion[];
+    } |
+    {
+        name: '770';
+        children: BigUnion[];
+    } |
+    {
+        name: '771';
+        children: BigUnion[];
+    } |
+    {
+        name: '772';
+        children: BigUnion[];
+    } |
+    {
+        name: '773';
+        children: BigUnion[];
+    } |
+    {
+        name: '774';
+        children: BigUnion[];
+    } |
+    {
+        name: '775';
+        children: BigUnion[];
+    } |
+    {
+        name: '776';
+        children: BigUnion[];
+    } |
+    {
+        name: '777';
+        children: BigUnion[];
+    } |
+    {
+        name: '778';
+        children: BigUnion[];
+    } |
+    {
+        name: '779';
+        children: BigUnion[];
+    } |
+    {
+        name: '780';
+        children: BigUnion[];
+    } |
+    {
+        name: '781';
+        children: BigUnion[];
+    } |
+    {
+        name: '782';
+        children: BigUnion[];
+    } |
+    {
+        name: '783';
+        children: BigUnion[];
+    } |
+    {
+        name: '784';
+        children: BigUnion[];
+    } |
+    {
+        name: '785';
+        children: BigUnion[];
+    } |
+    {
+        name: '786';
+        children: BigUnion[];
+    } |
+    {
+        name: '787';
+        children: BigUnion[];
+    } |
+    {
+        name: '788';
+        children: BigUnion[];
+    } |
+    {
+        name: '789';
+        children: BigUnion[];
+    } |
+    {
+        name: '790';
+        children: BigUnion[];
+    } |
+    {
+        name: '791';
+        children: BigUnion[];
+    } |
+    {
+        name: '792';
+        children: BigUnion[];
+    } |
+    {
+        name: '793';
+        children: BigUnion[];
+    } |
+    {
+        name: '794';
+        children: BigUnion[];
+    } |
+    {
+        name: '795';
+        children: BigUnion[];
+    } |
+    {
+        name: '796';
+        children: BigUnion[];
+    } |
+    {
+        name: '797';
+        children: BigUnion[];
+    } |
+    {
+        name: '798';
+        children: BigUnion[];
+    } |
+    {
+        name: '799';
+        children: BigUnion[];
+    } |
+    {
+        name: '800';
+        children: BigUnion[];
+    } |
+    {
+        name: '801';
+        children: BigUnion[];
+    } |
+    {
+        name: '802';
+        children: BigUnion[];
+    } |
+    {
+        name: '803';
+        children: BigUnion[];
+    } |
+    {
+        name: '804';
+        children: BigUnion[];
+    } |
+    {
+        name: '805';
+        children: BigUnion[];
+    } |
+    {
+        name: '806';
+        children: BigUnion[];
+    } |
+    {
+        name: '807';
+        children: BigUnion[];
+    } |
+    {
+        name: '808';
+        children: BigUnion[];
+    } |
+    {
+        name: '809';
+        children: BigUnion[];
+    } |
+    {
+        name: '810';
+        children: BigUnion[];
+    } |
+    {
+        name: '811';
+        children: BigUnion[];
+    } |
+    {
+        name: '812';
+        children: BigUnion[];
+    } |
+    {
+        name: '813';
+        children: BigUnion[];
+    } |
+    {
+        name: '814';
+        children: BigUnion[];
+    } |
+    {
+        name: '815';
+        children: BigUnion[];
+    } |
+    {
+        name: '816';
+        children: BigUnion[];
+    } |
+    {
+        name: '817';
+        children: BigUnion[];
+    } |
+    {
+        name: '818';
+        children: BigUnion[];
+    } |
+    {
+        name: '819';
+        children: BigUnion[];
+    } |
+    {
+        name: '820';
+        children: BigUnion[];
+    } |
+    {
+        name: '821';
+        children: BigUnion[];
+    } |
+    {
+        name: '822';
+        children: BigUnion[];
+    } |
+    {
+        name: '823';
+        children: BigUnion[];
+    } |
+    {
+        name: '824';
+        children: BigUnion[];
+    } |
+    {
+        name: '825';
+        children: BigUnion[];
+    } |
+    {
+        name: '826';
+        children: BigUnion[];
+    } |
+    {
+        name: '827';
+        children: BigUnion[];
+    } |
+    {
+        name: '828';
+        children: BigUnion[];
+    } |
+    {
+        name: '829';
+        children: BigUnion[];
+    } |
+    {
+        name: '830';
+        children: BigUnion[];
+    } |
+    {
+        name: '831';
+        children: BigUnion[];
+    } |
+    {
+        name: '832';
+        children: BigUnion[];
+    } |
+    {
+        name: '833';
+        children: BigUnion[];
+    } |
+    {
+        name: '834';
+        children: BigUnion[];
+    } |
+    {
+        name: '835';
+        children: BigUnion[];
+    } |
+    {
+        name: '836';
+        children: BigUnion[];
+    } |
+    {
+        name: '837';
+        children: BigUnion[];
+    } |
+    {
+        name: '838';
+        children: BigUnion[];
+    } |
+    {
+        name: '839';
+        children: BigUnion[];
+    } |
+    {
+        name: '840';
+        children: BigUnion[];
+    } |
+    {
+        name: '841';
+        children: BigUnion[];
+    } |
+    {
+        name: '842';
+        children: BigUnion[];
+    } |
+    {
+        name: '843';
+        children: BigUnion[];
+    } |
+    {
+        name: '844';
+        children: BigUnion[];
+    } |
+    {
+        name: '845';
+        children: BigUnion[];
+    } |
+    {
+        name: '846';
+        children: BigUnion[];
+    } |
+    {
+        name: '847';
+        children: BigUnion[];
+    } |
+    {
+        name: '848';
+        children: BigUnion[];
+    } |
+    {
+        name: '849';
+        children: BigUnion[];
+    } |
+    {
+        name: '850';
+        children: BigUnion[];
+    } |
+    {
+        name: '851';
+        children: BigUnion[];
+    } |
+    {
+        name: '852';
+        children: BigUnion[];
+    } |
+    {
+        name: '853';
+        children: BigUnion[];
+    } |
+    {
+        name: '854';
+        children: BigUnion[];
+    } |
+    {
+        name: '855';
+        children: BigUnion[];
+    } |
+    {
+        name: '856';
+        children: BigUnion[];
+    } |
+    {
+        name: '857';
+        children: BigUnion[];
+    } |
+    {
+        name: '858';
+        children: BigUnion[];
+    } |
+    {
+        name: '859';
+        children: BigUnion[];
+    } |
+    {
+        name: '860';
+        children: BigUnion[];
+    } |
+    {
+        name: '861';
+        children: BigUnion[];
+    } |
+    {
+        name: '862';
+        children: BigUnion[];
+    } |
+    {
+        name: '863';
+        children: BigUnion[];
+    } |
+    {
+        name: '864';
+        children: BigUnion[];
+    } |
+    {
+        name: '865';
+        children: BigUnion[];
+    } |
+    {
+        name: '866';
+        children: BigUnion[];
+    } |
+    {
+        name: '867';
+        children: BigUnion[];
+    } |
+    {
+        name: '868';
+        children: BigUnion[];
+    } |
+    {
+        name: '869';
+        children: BigUnion[];
+    } |
+    {
+        name: '870';
+        children: BigUnion[];
+    } |
+    {
+        name: '871';
+        children: BigUnion[];
+    } |
+    {
+        name: '872';
+        children: BigUnion[];
+    } |
+    {
+        name: '873';
+        children: BigUnion[];
+    } |
+    {
+        name: '874';
+        children: BigUnion[];
+    } |
+    {
+        name: '875';
+        children: BigUnion[];
+    } |
+    {
+        name: '876';
+        children: BigUnion[];
+    } |
+    {
+        name: '877';
+        children: BigUnion[];
+    } |
+    {
+        name: '878';
+        children: BigUnion[];
+    } |
+    {
+        name: '879';
+        children: BigUnion[];
+    } |
+    {
+        name: '880';
+        children: BigUnion[];
+    } |
+    {
+        name: '881';
+        children: BigUnion[];
+    } |
+    {
+        name: '882';
+        children: BigUnion[];
+    } |
+    {
+        name: '883';
+        children: BigUnion[];
+    } |
+    {
+        name: '884';
+        children: BigUnion[];
+    } |
+    {
+        name: '885';
+        children: BigUnion[];
+    } |
+    {
+        name: '886';
+        children: BigUnion[];
+    } |
+    {
+        name: '887';
+        children: BigUnion[];
+    } |
+    {
+        name: '888';
+        children: BigUnion[];
+    } |
+    {
+        name: '889';
+        children: BigUnion[];
+    } |
+    {
+        name: '890';
+        children: BigUnion[];
+    } |
+    {
+        name: '891';
+        children: BigUnion[];
+    } |
+    {
+        name: '892';
+        children: BigUnion[];
+    } |
+    {
+        name: '893';
+        children: BigUnion[];
+    } |
+    {
+        name: '894';
+        children: BigUnion[];
+    } |
+    {
+        name: '895';
+        children: BigUnion[];
+    } |
+    {
+        name: '896';
+        children: BigUnion[];
+    } |
+    {
+        name: '897';
+        children: BigUnion[];
+    } |
+    {
+        name: '898';
+        children: BigUnion[];
+    } |
+    {
+        name: '899';
+        children: BigUnion[];
+    } |
+    {
+        name: '900';
+        children: BigUnion[];
+    } |
+    {
+        name: '901';
+        children: BigUnion[];
+    } |
+    {
+        name: '902';
+        children: BigUnion[];
+    } |
+    {
+        name: '903';
+        children: BigUnion[];
+    } |
+    {
+        name: '904';
+        children: BigUnion[];
+    } |
+    {
+        name: '905';
+        children: BigUnion[];
+    } |
+    {
+        name: '906';
+        children: BigUnion[];
+    } |
+    {
+        name: '907';
+        children: BigUnion[];
+    } |
+    {
+        name: '908';
+        children: BigUnion[];
+    } |
+    {
+        name: '909';
+        children: BigUnion[];
+    } |
+    {
+        name: '910';
+        children: BigUnion[];
+    } |
+    {
+        name: '911';
+        children: BigUnion[];
+    } |
+    {
+        name: '912';
+        children: BigUnion[];
+    } |
+    {
+        name: '913';
+        children: BigUnion[];
+    } |
+    {
+        name: '914';
+        children: BigUnion[];
+    } |
+    {
+        name: '915';
+        children: BigUnion[];
+    } |
+    {
+        name: '916';
+        children: BigUnion[];
+    } |
+    {
+        name: '917';
+        children: BigUnion[];
+    } |
+    {
+        name: '918';
+        children: BigUnion[];
+    } |
+    {
+        name: '919';
+        children: BigUnion[];
+    } |
+    {
+        name: '920';
+        children: BigUnion[];
+    } |
+    {
+        name: '921';
+        children: BigUnion[];
+    } |
+    {
+        name: '922';
+        children: BigUnion[];
+    } |
+    {
+        name: '923';
+        children: BigUnion[];
+    } |
+    {
+        name: '924';
+        children: BigUnion[];
+    } |
+    {
+        name: '925';
+        children: BigUnion[];
+    } |
+    {
+        name: '926';
+        children: BigUnion[];
+    } |
+    {
+        name: '927';
+        children: BigUnion[];
+    } |
+    {
+        name: '928';
+        children: BigUnion[];
+    } |
+    {
+        name: '929';
+        children: BigUnion[];
+    } |
+    {
+        name: '930';
+        children: BigUnion[];
+    } |
+    {
+        name: '931';
+        children: BigUnion[];
+    } |
+    {
+        name: '932';
+        children: BigUnion[];
+    } |
+    {
+        name: '933';
+        children: BigUnion[];
+    } |
+    {
+        name: '934';
+        children: BigUnion[];
+    } |
+    {
+        name: '935';
+        children: BigUnion[];
+    } |
+    {
+        name: '936';
+        children: BigUnion[];
+    } |
+    {
+        name: '937';
+        children: BigUnion[];
+    } |
+    {
+        name: '938';
+        children: BigUnion[];
+    } |
+    {
+        name: '939';
+        children: BigUnion[];
+    } |
+    {
+        name: '940';
+        children: BigUnion[];
+    } |
+    {
+        name: '941';
+        children: BigUnion[];
+    } |
+    {
+        name: '942';
+        children: BigUnion[];
+    } |
+    {
+        name: '943';
+        children: BigUnion[];
+    } |
+    {
+        name: '944';
+        children: BigUnion[];
+    } |
+    {
+        name: '945';
+        children: BigUnion[];
+    } |
+    {
+        name: '946';
+        children: BigUnion[];
+    } |
+    {
+        name: '947';
+        children: BigUnion[];
+    } |
+    {
+        name: '948';
+        children: BigUnion[];
+    } |
+    {
+        name: '949';
+        children: BigUnion[];
+    } |
+    {
+        name: '950';
+        children: BigUnion[];
+    } |
+    {
+        name: '951';
+        children: BigUnion[];
+    } |
+    {
+        name: '952';
+        children: BigUnion[];
+    } |
+    {
+        name: '953';
+        children: BigUnion[];
+    } |
+    {
+        name: '954';
+        children: BigUnion[];
+    } |
+    {
+        name: '955';
+        children: BigUnion[];
+    } |
+    {
+        name: '956';
+        children: BigUnion[];
+    } |
+    {
+        name: '957';
+        children: BigUnion[];
+    } |
+    {
+        name: '958';
+        children: BigUnion[];
+    } |
+    {
+        name: '959';
+        children: BigUnion[];
+    } |
+    {
+        name: '960';
+        children: BigUnion[];
+    } |
+    {
+        name: '961';
+        children: BigUnion[];
+    } |
+    {
+        name: '962';
+        children: BigUnion[];
+    } |
+    {
+        name: '963';
+        children: BigUnion[];
+    } |
+    {
+        name: '964';
+        children: BigUnion[];
+    } |
+    {
+        name: '965';
+        children: BigUnion[];
+    } |
+    {
+        name: '966';
+        children: BigUnion[];
+    } |
+    {
+        name: '967';
+        children: BigUnion[];
+    } |
+    {
+        name: '968';
+        children: BigUnion[];
+    } |
+    {
+        name: '969';
+        children: BigUnion[];
+    } |
+    {
+        name: '970';
+        children: BigUnion[];
+    } |
+    {
+        name: '971';
+        children: BigUnion[];
+    } |
+    {
+        name: '972';
+        children: BigUnion[];
+    } |
+    {
+        name: '973';
+        children: BigUnion[];
+    } |
+    {
+        name: '974';
+        children: BigUnion[];
+    } |
+    {
+        name: '975';
+        children: BigUnion[];
+    } |
+    {
+        name: '976';
+        children: BigUnion[];
+    } |
+    {
+        name: '977';
+        children: BigUnion[];
+    } |
+    {
+        name: '978';
+        children: BigUnion[];
+    } |
+    {
+        name: '979';
+        children: BigUnion[];
+    } |
+    {
+        name: '980';
+        children: BigUnion[];
+    } |
+    {
+        name: '981';
+        children: BigUnion[];
+    } |
+    {
+        name: '982';
+        children: BigUnion[];
+    } |
+    {
+        name: '983';
+        children: BigUnion[];
+    } |
+    {
+        name: '984';
+        children: BigUnion[];
+    } |
+    {
+        name: '985';
+        children: BigUnion[];
+    } |
+    {
+        name: '986';
+        children: BigUnion[];
+    } |
+    {
+        name: '987';
+        children: BigUnion[];
+    } |
+    {
+        name: '988';
+        children: BigUnion[];
+    } |
+    {
+        name: '989';
+        children: BigUnion[];
+    } |
+    {
+        name: '990';
+        children: BigUnion[];
+    } |
+    {
+        name: '991';
+        children: BigUnion[];
+    } |
+    {
+        name: '992';
+        children: BigUnion[];
+    } |
+    {
+        name: '993';
+        children: BigUnion[];
+    } |
+    {
+        name: '994';
+        children: BigUnion[];
+    } |
+    {
+        name: '995';
+        children: BigUnion[];
+    } |
+    {
+        name: '996';
+        children: BigUnion[];
+    } |
+    {
+        name: '997';
+        children: BigUnion[];
+    } |
+    {
+        name: '998';
+        children: BigUnion[];
+    } |
+    {
+        name: '999';
+        children: BigUnion[];
+    } |
+    {
+        name: '1000';
+        children: BigUnion[];
+    } |
+    {
+        name: '1001';
+        children: BigUnion[];
+    } |
+    {
+        name: '1002';
+        children: BigUnion[];
+    } |
+    {
+        name: '1003';
+        children: BigUnion[];
+    } |
+    {
+        name: '1004';
+        children: BigUnion[];
+    } |
+    {
+        name: '1005';
+        children: BigUnion[];
+    } |
+    {
+        name: '1006';
+        children: BigUnion[];
+    } |
+    {
+        name: '1007';
+        children: BigUnion[];
+    } |
+    {
+        name: '1008';
+        children: BigUnion[];
+    } |
+    {
+        name: '1009';
+        children: BigUnion[];
+    } |
+    {
+        name: '1010';
+        children: BigUnion[];
+    } |
+    {
+        name: '1011';
+        children: BigUnion[];
+    } |
+    {
+        name: '1012';
+        children: BigUnion[];
+    } |
+    {
+        name: '1013';
+        children: BigUnion[];
+    } |
+    {
+        name: '1014';
+        children: BigUnion[];
+    } |
+    {
+        name: '1015';
+        children: BigUnion[];
+    } |
+    {
+        name: '1016';
+        children: BigUnion[];
+    } |
+    {
+        name: '1017';
+        children: BigUnion[];
+    } |
+    {
+        name: '1018';
+        children: BigUnion[];
+    } |
+    {
+        name: '1019';
+        children: BigUnion[];
+    } |
+    {
+        name: '1020';
+        children: BigUnion[];
+    } |
+    {
+        name: '1021';
+        children: BigUnion[];
+    } |
+    {
+        name: '1022';
+        children: BigUnion[];
+    } |
+    {
+        name: '1023';
+        children: BigUnion[];
+    } |
+    {
+        name: '1024';
+        children: BigUnion[];
+    } |
+    {
+        name: '1025';
+        children: BigUnion[];
+    } |
+    {
+        name: '1026';
+        children: BigUnion[];
+    } |
+    {
+        name: '1027';
+        children: BigUnion[];
+    } |
+    {
+        name: '1028';
+        children: BigUnion[];
+    } |
+    {
+        name: '1029';
+        children: BigUnion[];
+    } |
+    {
+        name: '1030';
+        children: BigUnion[];
+    } |
+    {
+        name: '1031';
+        children: BigUnion[];
+    } |
+    {
+        name: '1032';
+        children: BigUnion[];
+    } |
+    {
+        name: '1033';
+        children: BigUnion[];
+    } |
+    {
+        name: '1034';
+        children: BigUnion[];
+    } |
+    {
+        name: '1035';
+        children: BigUnion[];
+    } |
+    {
+        name: '1036';
+        children: BigUnion[];
+    } |
+    {
+        name: '1037';
+        children: BigUnion[];
+    } |
+    {
+        name: '1038';
+        children: BigUnion[];
+    } |
+    {
+        name: '1039';
+        children: BigUnion[];
+    } |
+    {
+        name: '1040';
+        children: BigUnion[];
+    } |
+    {
+        name: '1041';
+        children: BigUnion[];
+    } |
+    {
+        name: '1042';
+        children: BigUnion[];
+    } |
+    {
+        name: '1043';
+        children: BigUnion[];
+    } |
+    {
+        name: '1044';
+        children: BigUnion[];
+    } |
+    {
+        name: '1045';
+        children: BigUnion[];
+    } |
+    {
+        name: '1046';
+        children: BigUnion[];
+    } |
+    {
+        name: '1047';
+        children: BigUnion[];
+    } |
+    {
+        name: '1048';
+        children: BigUnion[];
+    } |
+    {
+        name: '1049';
+        children: BigUnion[];
+    } |
+    {
+        name: '1050';
+        children: BigUnion[];
+    } |
+    {
+        name: '1051';
+        children: BigUnion[];
+    } |
+    {
+        name: '1052';
+        children: BigUnion[];
+    } |
+    {
+        name: '1053';
+        children: BigUnion[];
+    } |
+    {
+        name: '1054';
+        children: BigUnion[];
+    } |
+    {
+        name: '1055';
+        children: BigUnion[];
+    } |
+    {
+        name: '1056';
+        children: BigUnion[];
+    } |
+    {
+        name: '1057';
+        children: BigUnion[];
+    } |
+    {
+        name: '1058';
+        children: BigUnion[];
+    } |
+    {
+        name: '1059';
+        children: BigUnion[];
+    } |
+    {
+        name: '1060';
+        children: BigUnion[];
+    } |
+    {
+        name: '1061';
+        children: BigUnion[];
+    } |
+    {
+        name: '1062';
+        children: BigUnion[];
+    } |
+    {
+        name: '1063';
+        children: BigUnion[];
+    } |
+    {
+        name: '1064';
+        children: BigUnion[];
+    } |
+    {
+        name: '1065';
+        children: BigUnion[];
+    } |
+    {
+        name: '1066';
+        children: BigUnion[];
+    } |
+    {
+        name: '1067';
+        children: BigUnion[];
+    } |
+    {
+        name: '1068';
+        children: BigUnion[];
+    } |
+    {
+        name: '1069';
+        children: BigUnion[];
+    } |
+    {
+        name: '1070';
+        children: BigUnion[];
+    } |
+    {
+        name: '1071';
+        children: BigUnion[];
+    } |
+    {
+        name: '1072';
+        children: BigUnion[];
+    } |
+    {
+        name: '1073';
+        children: BigUnion[];
+    } |
+    {
+        name: '1074';
+        children: BigUnion[];
+    } |
+    {
+        name: '1075';
+        children: BigUnion[];
+    } |
+    {
+        name: '1076';
+        children: BigUnion[];
+    } |
+    {
+        name: '1077';
+        children: BigUnion[];
+    } |
+    {
+        name: '1078';
+        children: BigUnion[];
+    } |
+    {
+        name: '1079';
+        children: BigUnion[];
+    } |
+    {
+        name: '1080';
+        children: BigUnion[];
+    } |
+    {
+        name: '1081';
+        children: BigUnion[];
+    } |
+    {
+        name: '1082';
+        children: BigUnion[];
+    } |
+    {
+        name: '1083';
+        children: BigUnion[];
+    } |
+    {
+        name: '1084';
+        children: BigUnion[];
+    } |
+    {
+        name: '1085';
+        children: BigUnion[];
+    } |
+    {
+        name: '1086';
+        children: BigUnion[];
+    } |
+    {
+        name: '1087';
+        children: BigUnion[];
+    } |
+    {
+        name: '1088';
+        children: BigUnion[];
+    } |
+    {
+        name: '1089';
+        children: BigUnion[];
+    } |
+    {
+        name: '1090';
+        children: BigUnion[];
+    } |
+    {
+        name: '1091';
+        children: BigUnion[];
+    } |
+    {
+        name: '1092';
+        children: BigUnion[];
+    } |
+    {
+        name: '1093';
+        children: BigUnion[];
+    } |
+    {
+        name: '1094';
+        children: BigUnion[];
+    } |
+    {
+        name: '1095';
+        children: BigUnion[];
+    } |
+    {
+        name: '1096';
+        children: BigUnion[];
+    } |
+    {
+        name: '1097';
+        children: BigUnion[];
+    } |
+    {
+        name: '1098';
+        children: BigUnion[];
+    } |
+    {
+        name: '1099';
+        children: BigUnion[];
+    } |
+    {
+        name: '1100';
+        children: BigUnion[];
+    } |
+    {
+        name: '1101';
+        children: BigUnion[];
+    } |
+    {
+        name: '1102';
+        children: BigUnion[];
+    } |
+    {
+        name: '1103';
+        children: BigUnion[];
+    } |
+    {
+        name: '1104';
+        children: BigUnion[];
+    } |
+    {
+        name: '1105';
+        children: BigUnion[];
+    } |
+    {
+        name: '1106';
+        children: BigUnion[];
+    } |
+    {
+        name: '1107';
+        children: BigUnion[];
+    } |
+    {
+        name: '1108';
+        children: BigUnion[];
+    } |
+    {
+        name: '1109';
+        children: BigUnion[];
+    } |
+    {
+        name: '1110';
+        children: BigUnion[];
+    } |
+    {
+        name: '1111';
+        children: BigUnion[];
+    } |
+    {
+        name: '1112';
+        children: BigUnion[];
+    } |
+    {
+        name: '1113';
+        children: BigUnion[];
+    } |
+    {
+        name: '1114';
+        children: BigUnion[];
+    } |
+    {
+        name: '1115';
+        children: BigUnion[];
+    } |
+    {
+        name: '1116';
+        children: BigUnion[];
+    } |
+    {
+        name: '1117';
+        children: BigUnion[];
+    } |
+    {
+        name: '1118';
+        children: BigUnion[];
+    } |
+    {
+        name: '1119';
+        children: BigUnion[];
+    } |
+    {
+        name: '1120';
+        children: BigUnion[];
+    } |
+    {
+        name: '1121';
+        children: BigUnion[];
+    } |
+    {
+        name: '1122';
+        children: BigUnion[];
+    } |
+    {
+        name: '1123';
+        children: BigUnion[];
+    } |
+    {
+        name: '1124';
+        children: BigUnion[];
+    } |
+    {
+        name: '1125';
+        children: BigUnion[];
+    } |
+    {
+        name: '1126';
+        children: BigUnion[];
+    } |
+    {
+        name: '1127';
+        children: BigUnion[];
+    } |
+    {
+        name: '1128';
+        children: BigUnion[];
+    } |
+    {
+        name: '1129';
+        children: BigUnion[];
+    } |
+    {
+        name: '1130';
+        children: BigUnion[];
+    } |
+    {
+        name: '1131';
+        children: BigUnion[];
+    } |
+    {
+        name: '1132';
+        children: BigUnion[];
+    } |
+    {
+        name: '1133';
+        children: BigUnion[];
+    } |
+    {
+        name: '1134';
+        children: BigUnion[];
+    } |
+    {
+        name: '1135';
+        children: BigUnion[];
+    } |
+    {
+        name: '1136';
+        children: BigUnion[];
+    } |
+    {
+        name: '1137';
+        children: BigUnion[];
+    } |
+    {
+        name: '1138';
+        children: BigUnion[];
+    } |
+    {
+        name: '1139';
+        children: BigUnion[];
+    } |
+    {
+        name: '1140';
+        children: BigUnion[];
+    } |
+    {
+        name: '1141';
+        children: BigUnion[];
+    } |
+    {
+        name: '1142';
+        children: BigUnion[];
+    } |
+    {
+        name: '1143';
+        children: BigUnion[];
+    } |
+    {
+        name: '1144';
+        children: BigUnion[];
+    } |
+    {
+        name: '1145';
+        children: BigUnion[];
+    } |
+    {
+        name: '1146';
+        children: BigUnion[];
+    } |
+    {
+        name: '1147';
+        children: BigUnion[];
+    } |
+    {
+        name: '1148';
+        children: BigUnion[];
+    } |
+    {
+        name: '1149';
+        children: BigUnion[];
+    } |
+    {
+        name: '1150';
+        children: BigUnion[];
+    } |
+    {
+        name: '1151';
+        children: BigUnion[];
+    } |
+    {
+        name: '1152';
+        children: BigUnion[];
+    } |
+    {
+        name: '1153';
+        children: BigUnion[];
+    } |
+    {
+        name: '1154';
+        children: BigUnion[];
+    } |
+    {
+        name: '1155';
+        children: BigUnion[];
+    } |
+    {
+        name: '1156';
+        children: BigUnion[];
+    } |
+    {
+        name: '1157';
+        children: BigUnion[];
+    } |
+    {
+        name: '1158';
+        children: BigUnion[];
+    } |
+    {
+        name: '1159';
+        children: BigUnion[];
+    } |
+    {
+        name: '1160';
+        children: BigUnion[];
+    } |
+    {
+        name: '1161';
+        children: BigUnion[];
+    } |
+    {
+        name: '1162';
+        children: BigUnion[];
+    } |
+    {
+        name: '1163';
+        children: BigUnion[];
+    } |
+    {
+        name: '1164';
+        children: BigUnion[];
+    } |
+    {
+        name: '1165';
+        children: BigUnion[];
+    } |
+    {
+        name: '1166';
+        children: BigUnion[];
+    } |
+    {
+        name: '1167';
+        children: BigUnion[];
+    } |
+    {
+        name: '1168';
+        children: BigUnion[];
+    } |
+    {
+        name: '1169';
+        children: BigUnion[];
+    } |
+    {
+        name: '1170';
+        children: BigUnion[];
+    } |
+    {
+        name: '1171';
+        children: BigUnion[];
+    } |
+    {
+        name: '1172';
+        children: BigUnion[];
+    } |
+    {
+        name: '1173';
+        children: BigUnion[];
+    } |
+    {
+        name: '1174';
+        children: BigUnion[];
+    } |
+    {
+        name: '1175';
+        children: BigUnion[];
+    } |
+    {
+        name: '1176';
+        children: BigUnion[];
+    } |
+    {
+        name: '1177';
+        children: BigUnion[];
+    } |
+    {
+        name: '1178';
+        children: BigUnion[];
+    } |
+    {
+        name: '1179';
+        children: BigUnion[];
+    } |
+    {
+        name: '1180';
+        children: BigUnion[];
+    } |
+    {
+        name: '1181';
+        children: BigUnion[];
+    } |
+    {
+        name: '1182';
+        children: BigUnion[];
+    } |
+    {
+        name: '1183';
+        children: BigUnion[];
+    } |
+    {
+        name: '1184';
+        children: BigUnion[];
+    } |
+    {
+        name: '1185';
+        children: BigUnion[];
+    } |
+    {
+        name: '1186';
+        children: BigUnion[];
+    } |
+    {
+        name: '1187';
+        children: BigUnion[];
+    } |
+    {
+        name: '1188';
+        children: BigUnion[];
+    } |
+    {
+        name: '1189';
+        children: BigUnion[];
+    } |
+    {
+        name: '1190';
+        children: BigUnion[];
+    } |
+    {
+        name: '1191';
+        children: BigUnion[];
+    } |
+    {
+        name: '1192';
+        children: BigUnion[];
+    } |
+    {
+        name: '1193';
+        children: BigUnion[];
+    } |
+    {
+        name: '1194';
+        children: BigUnion[];
+    } |
+    {
+        name: '1195';
+        children: BigUnion[];
+    } |
+    {
+        name: '1196';
+        children: BigUnion[];
+    } |
+    {
+        name: '1197';
+        children: BigUnion[];
+    } |
+    {
+        name: '1198';
+        children: BigUnion[];
+    } |
+    {
+        name: '1199';
+        children: BigUnion[];
+    } |
+    {
+        name: '1200';
+        children: BigUnion[];
+    } |
+    {
+        name: '1201';
+        children: BigUnion[];
+    } |
+    {
+        name: '1202';
+        children: BigUnion[];
+    } |
+    {
+        name: '1203';
+        children: BigUnion[];
+    } |
+    {
+        name: '1204';
+        children: BigUnion[];
+    } |
+    {
+        name: '1205';
+        children: BigUnion[];
+    } |
+    {
+        name: '1206';
+        children: BigUnion[];
+    } |
+    {
+        name: '1207';
+        children: BigUnion[];
+    } |
+    {
+        name: '1208';
+        children: BigUnion[];
+    } |
+    {
+        name: '1209';
+        children: BigUnion[];
+    } |
+    {
+        name: '1210';
+        children: BigUnion[];
+    } |
+    {
+        name: '1211';
+        children: BigUnion[];
+    } |
+    {
+        name: '1212';
+        children: BigUnion[];
+    } |
+    {
+        name: '1213';
+        children: BigUnion[];
+    } |
+    {
+        name: '1214';
+        children: BigUnion[];
+    } |
+    {
+        name: '1215';
+        children: BigUnion[];
+    } |
+    {
+        name: '1216';
+        children: BigUnion[];
+    } |
+    {
+        name: '1217';
+        children: BigUnion[];
+    } |
+    {
+        name: '1218';
+        children: BigUnion[];
+    } |
+    {
+        name: '1219';
+        children: BigUnion[];
+    } |
+    {
+        name: '1220';
+        children: BigUnion[];
+    } |
+    {
+        name: '1221';
+        children: BigUnion[];
+    } |
+    {
+        name: '1222';
+        children: BigUnion[];
+    } |
+    {
+        name: '1223';
+        children: BigUnion[];
+    } |
+    {
+        name: '1224';
+        children: BigUnion[];
+    } |
+    {
+        name: '1225';
+        children: BigUnion[];
+    } |
+    {
+        name: '1226';
+        children: BigUnion[];
+    } |
+    {
+        name: '1227';
+        children: BigUnion[];
+    } |
+    {
+        name: '1228';
+        children: BigUnion[];
+    } |
+    {
+        name: '1229';
+        children: BigUnion[];
+    } |
+    {
+        name: '1230';
+        children: BigUnion[];
+    } |
+    {
+        name: '1231';
+        children: BigUnion[];
+    } |
+    {
+        name: '1232';
+        children: BigUnion[];
+    } |
+    {
+        name: '1233';
+        children: BigUnion[];
+    } |
+    {
+        name: '1234';
+        children: BigUnion[];
+    } |
+    {
+        name: '1235';
+        children: BigUnion[];
+    } |
+    {
+        name: '1236';
+        children: BigUnion[];
+    } |
+    {
+        name: '1237';
+        children: BigUnion[];
+    } |
+    {
+        name: '1238';
+        children: BigUnion[];
+    } |
+    {
+        name: '1239';
+        children: BigUnion[];
+    } |
+    {
+        name: '1240';
+        children: BigUnion[];
+    } |
+    {
+        name: '1241';
+        children: BigUnion[];
+    } |
+    {
+        name: '1242';
+        children: BigUnion[];
+    } |
+    {
+        name: '1243';
+        children: BigUnion[];
+    } |
+    {
+        name: '1244';
+        children: BigUnion[];
+    } |
+    {
+        name: '1245';
+        children: BigUnion[];
+    } |
+    {
+        name: '1246';
+        children: BigUnion[];
+    } |
+    {
+        name: '1247';
+        children: BigUnion[];
+    } |
+    {
+        name: '1248';
+        children: BigUnion[];
+    } |
+    {
+        name: '1249';
+        children: BigUnion[];
+    } |
+    {
+        name: '1250';
+        children: BigUnion[];
+    } |
+    {
+        name: '1251';
+        children: BigUnion[];
+    } |
+    {
+        name: '1252';
+        children: BigUnion[];
+    } |
+    {
+        name: '1253';
+        children: BigUnion[];
+    } |
+    {
+        name: '1254';
+        children: BigUnion[];
+    } |
+    {
+        name: '1255';
+        children: BigUnion[];
+    } |
+    {
+        name: '1256';
+        children: BigUnion[];
+    } |
+    {
+        name: '1257';
+        children: BigUnion[];
+    } |
+    {
+        name: '1258';
+        children: BigUnion[];
+    } |
+    {
+        name: '1259';
+        children: BigUnion[];
+    } |
+    {
+        name: '1260';
+        children: BigUnion[];
+    } |
+    {
+        name: '1261';
+        children: BigUnion[];
+    } |
+    {
+        name: '1262';
+        children: BigUnion[];
+    } |
+    {
+        name: '1263';
+        children: BigUnion[];
+    } |
+    {
+        name: '1264';
+        children: BigUnion[];
+    } |
+    {
+        name: '1265';
+        children: BigUnion[];
+    } |
+    {
+        name: '1266';
+        children: BigUnion[];
+    } |
+    {
+        name: '1267';
+        children: BigUnion[];
+    } |
+    {
+        name: '1268';
+        children: BigUnion[];
+    } |
+    {
+        name: '1269';
+        children: BigUnion[];
+    } |
+    {
+        name: '1270';
+        children: BigUnion[];
+    } |
+    {
+        name: '1271';
+        children: BigUnion[];
+    } |
+    {
+        name: '1272';
+        children: BigUnion[];
+    } |
+    {
+        name: '1273';
+        children: BigUnion[];
+    } |
+    {
+        name: '1274';
+        children: BigUnion[];
+    } |
+    {
+        name: '1275';
+        children: BigUnion[];
+    } |
+    {
+        name: '1276';
+        children: BigUnion[];
+    } |
+    {
+        name: '1277';
+        children: BigUnion[];
+    } |
+    {
+        name: '1278';
+        children: BigUnion[];
+    } |
+    {
+        name: '1279';
+        children: BigUnion[];
+    } |
+    {
+        name: '1280';
+        children: BigUnion[];
+    } |
+    {
+        name: '1281';
+        children: BigUnion[];
+    } |
+    {
+        name: '1282';
+        children: BigUnion[];
+    } |
+    {
+        name: '1283';
+        children: BigUnion[];
+    } |
+    {
+        name: '1284';
+        children: BigUnion[];
+    } |
+    {
+        name: '1285';
+        children: BigUnion[];
+    } |
+    {
+        name: '1286';
+        children: BigUnion[];
+    } |
+    {
+        name: '1287';
+        children: BigUnion[];
+    } |
+    {
+        name: '1288';
+        children: BigUnion[];
+    } |
+    {
+        name: '1289';
+        children: BigUnion[];
+    } |
+    {
+        name: '1290';
+        children: BigUnion[];
+    } |
+    {
+        name: '1291';
+        children: BigUnion[];
+    } |
+    {
+        name: '1292';
+        children: BigUnion[];
+    } |
+    {
+        name: '1293';
+        children: BigUnion[];
+    } |
+    {
+        name: '1294';
+        children: BigUnion[];
+    } |
+    {
+        name: '1295';
+        children: BigUnion[];
+    } |
+    {
+        name: '1296';
+        children: BigUnion[];
+    } |
+    {
+        name: '1297';
+        children: BigUnion[];
+    } |
+    {
+        name: '1298';
+        children: BigUnion[];
+    } |
+    {
+        name: '1299';
+        children: BigUnion[];
+    } |
+    {
+        name: '1300';
+        children: BigUnion[];
+    } |
+    {
+        name: '1301';
+        children: BigUnion[];
+    } |
+    {
+        name: '1302';
+        children: BigUnion[];
+    } |
+    {
+        name: '1303';
+        children: BigUnion[];
+    } |
+    {
+        name: '1304';
+        children: BigUnion[];
+    } |
+    {
+        name: '1305';
+        children: BigUnion[];
+    } |
+    {
+        name: '1306';
+        children: BigUnion[];
+    } |
+    {
+        name: '1307';
+        children: BigUnion[];
+    } |
+    {
+        name: '1308';
+        children: BigUnion[];
+    } |
+    {
+        name: '1309';
+        children: BigUnion[];
+    } |
+    {
+        name: '1310';
+        children: BigUnion[];
+    } |
+    {
+        name: '1311';
+        children: BigUnion[];
+    } |
+    {
+        name: '1312';
+        children: BigUnion[];
+    } |
+    {
+        name: '1313';
+        children: BigUnion[];
+    } |
+    {
+        name: '1314';
+        children: BigUnion[];
+    } |
+    {
+        name: '1315';
+        children: BigUnion[];
+    } |
+    {
+        name: '1316';
+        children: BigUnion[];
+    } |
+    {
+        name: '1317';
+        children: BigUnion[];
+    } |
+    {
+        name: '1318';
+        children: BigUnion[];
+    } |
+    {
+        name: '1319';
+        children: BigUnion[];
+    } |
+    {
+        name: '1320';
+        children: BigUnion[];
+    } |
+    {
+        name: '1321';
+        children: BigUnion[];
+    } |
+    {
+        name: '1322';
+        children: BigUnion[];
+    } |
+    {
+        name: '1323';
+        children: BigUnion[];
+    } |
+    {
+        name: '1324';
+        children: BigUnion[];
+    } |
+    {
+        name: '1325';
+        children: BigUnion[];
+    } |
+    {
+        name: '1326';
+        children: BigUnion[];
+    } |
+    {
+        name: '1327';
+        children: BigUnion[];
+    } |
+    {
+        name: '1328';
+        children: BigUnion[];
+    } |
+    {
+        name: '1329';
+        children: BigUnion[];
+    } |
+    {
+        name: '1330';
+        children: BigUnion[];
+    } |
+    {
+        name: '1331';
+        children: BigUnion[];
+    } |
+    {
+        name: '1332';
+        children: BigUnion[];
+    } |
+    {
+        name: '1333';
+        children: BigUnion[];
+    } |
+    {
+        name: '1334';
+        children: BigUnion[];
+    } |
+    {
+        name: '1335';
+        children: BigUnion[];
+    } |
+    {
+        name: '1336';
+        children: BigUnion[];
+    } |
+    {
+        name: '1337';
+        children: BigUnion[];
+    } |
+    {
+        name: '1338';
+        children: BigUnion[];
+    } |
+    {
+        name: '1339';
+        children: BigUnion[];
+    } |
+    {
+        name: '1340';
+        children: BigUnion[];
+    } |
+    {
+        name: '1341';
+        children: BigUnion[];
+    } |
+    {
+        name: '1342';
+        children: BigUnion[];
+    } |
+    {
+        name: '1343';
+        children: BigUnion[];
+    } |
+    {
+        name: '1344';
+        children: BigUnion[];
+    } |
+    {
+        name: '1345';
+        children: BigUnion[];
+    } |
+    {
+        name: '1346';
+        children: BigUnion[];
+    } |
+    {
+        name: '1347';
+        children: BigUnion[];
+    } |
+    {
+        name: '1348';
+        children: BigUnion[];
+    } |
+    {
+        name: '1349';
+        children: BigUnion[];
+    } |
+    {
+        name: '1350';
+        children: BigUnion[];
+    } |
+    {
+        name: '1351';
+        children: BigUnion[];
+    } |
+    {
+        name: '1352';
+        children: BigUnion[];
+    } |
+    {
+        name: '1353';
+        children: BigUnion[];
+    } |
+    {
+        name: '1354';
+        children: BigUnion[];
+    } |
+    {
+        name: '1355';
+        children: BigUnion[];
+    } |
+    {
+        name: '1356';
+        children: BigUnion[];
+    } |
+    {
+        name: '1357';
+        children: BigUnion[];
+    } |
+    {
+        name: '1358';
+        children: BigUnion[];
+    } |
+    {
+        name: '1359';
+        children: BigUnion[];
+    } |
+    {
+        name: '1360';
+        children: BigUnion[];
+    } |
+    {
+        name: '1361';
+        children: BigUnion[];
+    } |
+    {
+        name: '1362';
+        children: BigUnion[];
+    } |
+    {
+        name: '1363';
+        children: BigUnion[];
+    } |
+    {
+        name: '1364';
+        children: BigUnion[];
+    } |
+    {
+        name: '1365';
+        children: BigUnion[];
+    } |
+    {
+        name: '1366';
+        children: BigUnion[];
+    } |
+    {
+        name: '1367';
+        children: BigUnion[];
+    } |
+    {
+        name: '1368';
+        children: BigUnion[];
+    } |
+    {
+        name: '1369';
+        children: BigUnion[];
+    } |
+    {
+        name: '1370';
+        children: BigUnion[];
+    } |
+    {
+        name: '1371';
+        children: BigUnion[];
+    } |
+    {
+        name: '1372';
+        children: BigUnion[];
+    } |
+    {
+        name: '1373';
+        children: BigUnion[];
+    } |
+    {
+        name: '1374';
+        children: BigUnion[];
+    } |
+    {
+        name: '1375';
+        children: BigUnion[];
+    } |
+    {
+        name: '1376';
+        children: BigUnion[];
+    } |
+    {
+        name: '1377';
+        children: BigUnion[];
+    } |
+    {
+        name: '1378';
+        children: BigUnion[];
+    } |
+    {
+        name: '1379';
+        children: BigUnion[];
+    } |
+    {
+        name: '1380';
+        children: BigUnion[];
+    } |
+    {
+        name: '1381';
+        children: BigUnion[];
+    } |
+    {
+        name: '1382';
+        children: BigUnion[];
+    } |
+    {
+        name: '1383';
+        children: BigUnion[];
+    } |
+    {
+        name: '1384';
+        children: BigUnion[];
+    } |
+    {
+        name: '1385';
+        children: BigUnion[];
+    } |
+    {
+        name: '1386';
+        children: BigUnion[];
+    } |
+    {
+        name: '1387';
+        children: BigUnion[];
+    } |
+    {
+        name: '1388';
+        children: BigUnion[];
+    } |
+    {
+        name: '1389';
+        children: BigUnion[];
+    } |
+    {
+        name: '1390';
+        children: BigUnion[];
+    } |
+    {
+        name: '1391';
+        children: BigUnion[];
+    } |
+    {
+        name: '1392';
+        children: BigUnion[];
+    } |
+    {
+        name: '1393';
+        children: BigUnion[];
+    } |
+    {
+        name: '1394';
+        children: BigUnion[];
+    } |
+    {
+        name: '1395';
+        children: BigUnion[];
+    } |
+    {
+        name: '1396';
+        children: BigUnion[];
+    } |
+    {
+        name: '1397';
+        children: BigUnion[];
+    } |
+    {
+        name: '1398';
+        children: BigUnion[];
+    } |
+    {
+        name: '1399';
+        children: BigUnion[];
+    } |
+    {
+        name: '1400';
+        children: BigUnion[];
+    } |
+    {
+        name: '1401';
+        children: BigUnion[];
+    } |
+    {
+        name: '1402';
+        children: BigUnion[];
+    } |
+    {
+        name: '1403';
+        children: BigUnion[];
+    } |
+    {
+        name: '1404';
+        children: BigUnion[];
+    } |
+    {
+        name: '1405';
+        children: BigUnion[];
+    } |
+    {
+        name: '1406';
+        children: BigUnion[];
+    } |
+    {
+        name: '1407';
+        children: BigUnion[];
+    } |
+    {
+        name: '1408';
+        children: BigUnion[];
+    } |
+    {
+        name: '1409';
+        children: BigUnion[];
+    } |
+    {
+        name: '1410';
+        children: BigUnion[];
+    } |
+    {
+        name: '1411';
+        children: BigUnion[];
+    } |
+    {
+        name: '1412';
+        children: BigUnion[];
+    } |
+    {
+        name: '1413';
+        children: BigUnion[];
+    } |
+    {
+        name: '1414';
+        children: BigUnion[];
+    } |
+    {
+        name: '1415';
+        children: BigUnion[];
+    } |
+    {
+        name: '1416';
+        children: BigUnion[];
+    } |
+    {
+        name: '1417';
+        children: BigUnion[];
+    } |
+    {
+        name: '1418';
+        children: BigUnion[];
+    } |
+    {
+        name: '1419';
+        children: BigUnion[];
+    } |
+    {
+        name: '1420';
+        children: BigUnion[];
+    } |
+    {
+        name: '1421';
+        children: BigUnion[];
+    } |
+    {
+        name: '1422';
+        children: BigUnion[];
+    } |
+    {
+        name: '1423';
+        children: BigUnion[];
+    } |
+    {
+        name: '1424';
+        children: BigUnion[];
+    } |
+    {
+        name: '1425';
+        children: BigUnion[];
+    } |
+    {
+        name: '1426';
+        children: BigUnion[];
+    } |
+    {
+        name: '1427';
+        children: BigUnion[];
+    } |
+    {
+        name: '1428';
+        children: BigUnion[];
+    } |
+    {
+        name: '1429';
+        children: BigUnion[];
+    } |
+    {
+        name: '1430';
+        children: BigUnion[];
+    } |
+    {
+        name: '1431';
+        children: BigUnion[];
+    } |
+    {
+        name: '1432';
+        children: BigUnion[];
+    } |
+    {
+        name: '1433';
+        children: BigUnion[];
+    } |
+    {
+        name: '1434';
+        children: BigUnion[];
+    } |
+    {
+        name: '1435';
+        children: BigUnion[];
+    } |
+    {
+        name: '1436';
+        children: BigUnion[];
+    } |
+    {
+        name: '1437';
+        children: BigUnion[];
+    } |
+    {
+        name: '1438';
+        children: BigUnion[];
+    } |
+    {
+        name: '1439';
+        children: BigUnion[];
+    } |
+    {
+        name: '1440';
+        children: BigUnion[];
+    } |
+    {
+        name: '1441';
+        children: BigUnion[];
+    } |
+    {
+        name: '1442';
+        children: BigUnion[];
+    } |
+    {
+        name: '1443';
+        children: BigUnion[];
+    } |
+    {
+        name: '1444';
+        children: BigUnion[];
+    } |
+    {
+        name: '1445';
+        children: BigUnion[];
+    } |
+    {
+        name: '1446';
+        children: BigUnion[];
+    } |
+    {
+        name: '1447';
+        children: BigUnion[];
+    } |
+    {
+        name: '1448';
+        children: BigUnion[];
+    } |
+    {
+        name: '1449';
+        children: BigUnion[];
+    } |
+    {
+        name: '1450';
+        children: BigUnion[];
+    } |
+    {
+        name: '1451';
+        children: BigUnion[];
+    } |
+    {
+        name: '1452';
+        children: BigUnion[];
+    } |
+    {
+        name: '1453';
+        children: BigUnion[];
+    } |
+    {
+        name: '1454';
+        children: BigUnion[];
+    } |
+    {
+        name: '1455';
+        children: BigUnion[];
+    } |
+    {
+        name: '1456';
+        children: BigUnion[];
+    } |
+    {
+        name: '1457';
+        children: BigUnion[];
+    } |
+    {
+        name: '1458';
+        children: BigUnion[];
+    } |
+    {
+        name: '1459';
+        children: BigUnion[];
+    } |
+    {
+        name: '1460';
+        children: BigUnion[];
+    } |
+    {
+        name: '1461';
+        children: BigUnion[];
+    } |
+    {
+        name: '1462';
+        children: BigUnion[];
+    } |
+    {
+        name: '1463';
+        children: BigUnion[];
+    } |
+    {
+        name: '1464';
+        children: BigUnion[];
+    } |
+    {
+        name: '1465';
+        children: BigUnion[];
+    } |
+    {
+        name: '1466';
+        children: BigUnion[];
+    } |
+    {
+        name: '1467';
+        children: BigUnion[];
+    } |
+    {
+        name: '1468';
+        children: BigUnion[];
+    } |
+    {
+        name: '1469';
+        children: BigUnion[];
+    } |
+    {
+        name: '1470';
+        children: BigUnion[];
+    } |
+    {
+        name: '1471';
+        children: BigUnion[];
+    } |
+    {
+        name: '1472';
+        children: BigUnion[];
+    } |
+    {
+        name: '1473';
+        children: BigUnion[];
+    } |
+    {
+        name: '1474';
+        children: BigUnion[];
+    } |
+    {
+        name: '1475';
+        children: BigUnion[];
+    } |
+    {
+        name: '1476';
+        children: BigUnion[];
+    } |
+    {
+        name: '1477';
+        children: BigUnion[];
+    } |
+    {
+        name: '1478';
+        children: BigUnion[];
+    } |
+    {
+        name: '1479';
+        children: BigUnion[];
+    } |
+    {
+        name: '1480';
+        children: BigUnion[];
+    } |
+    {
+        name: '1481';
+        children: BigUnion[];
+    } |
+    {
+        name: '1482';
+        children: BigUnion[];
+    } |
+    {
+        name: '1483';
+        children: BigUnion[];
+    } |
+    {
+        name: '1484';
+        children: BigUnion[];
+    } |
+    {
+        name: '1485';
+        children: BigUnion[];
+    } |
+    {
+        name: '1486';
+        children: BigUnion[];
+    } |
+    {
+        name: '1487';
+        children: BigUnion[];
+    } |
+    {
+        name: '1488';
+        children: BigUnion[];
+    } |
+    {
+        name: '1489';
+        children: BigUnion[];
+    } |
+    {
+        name: '1490';
+        children: BigUnion[];
+    } |
+    {
+        name: '1491';
+        children: BigUnion[];
+    } |
+    {
+        name: '1492';
+        children: BigUnion[];
+    } |
+    {
+        name: '1493';
+        children: BigUnion[];
+    } |
+    {
+        name: '1494';
+        children: BigUnion[];
+    } |
+    {
+        name: '1495';
+        children: BigUnion[];
+    } |
+    {
+        name: '1496';
+        children: BigUnion[];
+    } |
+    {
+        name: '1497';
+        children: BigUnion[];
+    } |
+    {
+        name: '1498';
+        children: BigUnion[];
+    } |
+    {
+        name: '1499';
+        children: BigUnion[];
+    } |
+    {
+        name: '1500';
+        children: BigUnion[];
+    } |
+    {
+        name: '1501';
+        children: BigUnion[];
+    } |
+    {
+        name: '1502';
+        children: BigUnion[];
+    } |
+    {
+        name: '1503';
+        children: BigUnion[];
+    } |
+    {
+        name: '1504';
+        children: BigUnion[];
+    } |
+    {
+        name: '1505';
+        children: BigUnion[];
+    } |
+    {
+        name: '1506';
+        children: BigUnion[];
+    } |
+    {
+        name: '1507';
+        children: BigUnion[];
+    } |
+    {
+        name: '1508';
+        children: BigUnion[];
+    } |
+    {
+        name: '1509';
+        children: BigUnion[];
+    } |
+    {
+        name: '1510';
+        children: BigUnion[];
+    } |
+    {
+        name: '1511';
+        children: BigUnion[];
+    } |
+    {
+        name: '1512';
+        children: BigUnion[];
+    } |
+    {
+        name: '1513';
+        children: BigUnion[];
+    } |
+    {
+        name: '1514';
+        children: BigUnion[];
+    } |
+    {
+        name: '1515';
+        children: BigUnion[];
+    } |
+    {
+        name: '1516';
+        children: BigUnion[];
+    } |
+    {
+        name: '1517';
+        children: BigUnion[];
+    } |
+    {
+        name: '1518';
+        children: BigUnion[];
+    } |
+    {
+        name: '1519';
+        children: BigUnion[];
+    } |
+    {
+        name: '1520';
+        children: BigUnion[];
+    } |
+    {
+        name: '1521';
+        children: BigUnion[];
+    } |
+    {
+        name: '1522';
+        children: BigUnion[];
+    } |
+    {
+        name: '1523';
+        children: BigUnion[];
+    } |
+    {
+        name: '1524';
+        children: BigUnion[];
+    } |
+    {
+        name: '1525';
+        children: BigUnion[];
+    } |
+    {
+        name: '1526';
+        children: BigUnion[];
+    } |
+    {
+        name: '1527';
+        children: BigUnion[];
+    } |
+    {
+        name: '1528';
+        children: BigUnion[];
+    } |
+    {
+        name: '1529';
+        children: BigUnion[];
+    } |
+    {
+        name: '1530';
+        children: BigUnion[];
+    } |
+    {
+        name: '1531';
+        children: BigUnion[];
+    } |
+    {
+        name: '1532';
+        children: BigUnion[];
+    } |
+    {
+        name: '1533';
+        children: BigUnion[];
+    } |
+    {
+        name: '1534';
+        children: BigUnion[];
+    } |
+    {
+        name: '1535';
+        children: BigUnion[];
+    } |
+    {
+        name: '1536';
+        children: BigUnion[];
+    } |
+    {
+        name: '1537';
+        children: BigUnion[];
+    } |
+    {
+        name: '1538';
+        children: BigUnion[];
+    } |
+    {
+        name: '1539';
+        children: BigUnion[];
+    } |
+    {
+        name: '1540';
+        children: BigUnion[];
+    } |
+    {
+        name: '1541';
+        children: BigUnion[];
+    } |
+    {
+        name: '1542';
+        children: BigUnion[];
+    } |
+    {
+        name: '1543';
+        children: BigUnion[];
+    } |
+    {
+        name: '1544';
+        children: BigUnion[];
+    } |
+    {
+        name: '1545';
+        children: BigUnion[];
+    } |
+    {
+        name: '1546';
+        children: BigUnion[];
+    } |
+    {
+        name: '1547';
+        children: BigUnion[];
+    } |
+    {
+        name: '1548';
+        children: BigUnion[];
+    } |
+    {
+        name: '1549';
+        children: BigUnion[];
+    } |
+    {
+        name: '1550';
+        children: BigUnion[];
+    } |
+    {
+        name: '1551';
+        children: BigUnion[];
+    } |
+    {
+        name: '1552';
+        children: BigUnion[];
+    } |
+    {
+        name: '1553';
+        children: BigUnion[];
+    } |
+    {
+        name: '1554';
+        children: BigUnion[];
+    } |
+    {
+        name: '1555';
+        children: BigUnion[];
+    } |
+    {
+        name: '1556';
+        children: BigUnion[];
+    } |
+    {
+        name: '1557';
+        children: BigUnion[];
+    } |
+    {
+        name: '1558';
+        children: BigUnion[];
+    } |
+    {
+        name: '1559';
+        children: BigUnion[];
+    } |
+    {
+        name: '1560';
+        children: BigUnion[];
+    } |
+    {
+        name: '1561';
+        children: BigUnion[];
+    } |
+    {
+        name: '1562';
+        children: BigUnion[];
+    } |
+    {
+        name: '1563';
+        children: BigUnion[];
+    } |
+    {
+        name: '1564';
+        children: BigUnion[];
+    } |
+    {
+        name: '1565';
+        children: BigUnion[];
+    } |
+    {
+        name: '1566';
+        children: BigUnion[];
+    } |
+    {
+        name: '1567';
+        children: BigUnion[];
+    } |
+    {
+        name: '1568';
+        children: BigUnion[];
+    } |
+    {
+        name: '1569';
+        children: BigUnion[];
+    } |
+    {
+        name: '1570';
+        children: BigUnion[];
+    } |
+    {
+        name: '1571';
+        children: BigUnion[];
+    } |
+    {
+        name: '1572';
+        children: BigUnion[];
+    } |
+    {
+        name: '1573';
+        children: BigUnion[];
+    } |
+    {
+        name: '1574';
+        children: BigUnion[];
+    } |
+    {
+        name: '1575';
+        children: BigUnion[];
+    } |
+    {
+        name: '1576';
+        children: BigUnion[];
+    } |
+    {
+        name: '1577';
+        children: BigUnion[];
+    } |
+    {
+        name: '1578';
+        children: BigUnion[];
+    } |
+    {
+        name: '1579';
+        children: BigUnion[];
+    } |
+    {
+        name: '1580';
+        children: BigUnion[];
+    } |
+    {
+        name: '1581';
+        children: BigUnion[];
+    } |
+    {
+        name: '1582';
+        children: BigUnion[];
+    } |
+    {
+        name: '1583';
+        children: BigUnion[];
+    } |
+    {
+        name: '1584';
+        children: BigUnion[];
+    } |
+    {
+        name: '1585';
+        children: BigUnion[];
+    } |
+    {
+        name: '1586';
+        children: BigUnion[];
+    } |
+    {
+        name: '1587';
+        children: BigUnion[];
+    } |
+    {
+        name: '1588';
+        children: BigUnion[];
+    } |
+    {
+        name: '1589';
+        children: BigUnion[];
+    } |
+    {
+        name: '1590';
+        children: BigUnion[];
+    } |
+    {
+        name: '1591';
+        children: BigUnion[];
+    } |
+    {
+        name: '1592';
+        children: BigUnion[];
+    } |
+    {
+        name: '1593';
+        children: BigUnion[];
+    } |
+    {
+        name: '1594';
+        children: BigUnion[];
+    } |
+    {
+        name: '1595';
+        children: BigUnion[];
+    } |
+    {
+        name: '1596';
+        children: BigUnion[];
+    } |
+    {
+        name: '1597';
+        children: BigUnion[];
+    } |
+    {
+        name: '1598';
+        children: BigUnion[];
+    } |
+    {
+        name: '1599';
+        children: BigUnion[];
+    } |
+    {
+        name: '1600';
+        children: BigUnion[];
+    } |
+    {
+        name: '1601';
+        children: BigUnion[];
+    } |
+    {
+        name: '1602';
+        children: BigUnion[];
+    } |
+    {
+        name: '1603';
+        children: BigUnion[];
+    } |
+    {
+        name: '1604';
+        children: BigUnion[];
+    } |
+    {
+        name: '1605';
+        children: BigUnion[];
+    } |
+    {
+        name: '1606';
+        children: BigUnion[];
+    } |
+    {
+        name: '1607';
+        children: BigUnion[];
+    } |
+    {
+        name: '1608';
+        children: BigUnion[];
+    } |
+    {
+        name: '1609';
+        children: BigUnion[];
+    } |
+    {
+        name: '1610';
+        children: BigUnion[];
+    } |
+    {
+        name: '1611';
+        children: BigUnion[];
+    } |
+    {
+        name: '1612';
+        children: BigUnion[];
+    } |
+    {
+        name: '1613';
+        children: BigUnion[];
+    } |
+    {
+        name: '1614';
+        children: BigUnion[];
+    } |
+    {
+        name: '1615';
+        children: BigUnion[];
+    } |
+    {
+        name: '1616';
+        children: BigUnion[];
+    } |
+    {
+        name: '1617';
+        children: BigUnion[];
+    } |
+    {
+        name: '1618';
+        children: BigUnion[];
+    } |
+    {
+        name: '1619';
+        children: BigUnion[];
+    } |
+    {
+        name: '1620';
+        children: BigUnion[];
+    } |
+    {
+        name: '1621';
+        children: BigUnion[];
+    } |
+    {
+        name: '1622';
+        children: BigUnion[];
+    } |
+    {
+        name: '1623';
+        children: BigUnion[];
+    } |
+    {
+        name: '1624';
+        children: BigUnion[];
+    } |
+    {
+        name: '1625';
+        children: BigUnion[];
+    } |
+    {
+        name: '1626';
+        children: BigUnion[];
+    } |
+    {
+        name: '1627';
+        children: BigUnion[];
+    } |
+    {
+        name: '1628';
+        children: BigUnion[];
+    } |
+    {
+        name: '1629';
+        children: BigUnion[];
+    } |
+    {
+        name: '1630';
+        children: BigUnion[];
+    } |
+    {
+        name: '1631';
+        children: BigUnion[];
+    } |
+    {
+        name: '1632';
+        children: BigUnion[];
+    } |
+    {
+        name: '1633';
+        children: BigUnion[];
+    } |
+    {
+        name: '1634';
+        children: BigUnion[];
+    } |
+    {
+        name: '1635';
+        children: BigUnion[];
+    } |
+    {
+        name: '1636';
+        children: BigUnion[];
+    } |
+    {
+        name: '1637';
+        children: BigUnion[];
+    } |
+    {
+        name: '1638';
+        children: BigUnion[];
+    } |
+    {
+        name: '1639';
+        children: BigUnion[];
+    } |
+    {
+        name: '1640';
+        children: BigUnion[];
+    } |
+    {
+        name: '1641';
+        children: BigUnion[];
+    } |
+    {
+        name: '1642';
+        children: BigUnion[];
+    } |
+    {
+        name: '1643';
+        children: BigUnion[];
+    } |
+    {
+        name: '1644';
+        children: BigUnion[];
+    } |
+    {
+        name: '1645';
+        children: BigUnion[];
+    } |
+    {
+        name: '1646';
+        children: BigUnion[];
+    } |
+    {
+        name: '1647';
+        children: BigUnion[];
+    } |
+    {
+        name: '1648';
+        children: BigUnion[];
+    } |
+    {
+        name: '1649';
+        children: BigUnion[];
+    } |
+    {
+        name: '1650';
+        children: BigUnion[];
+    } |
+    {
+        name: '1651';
+        children: BigUnion[];
+    } |
+    {
+        name: '1652';
+        children: BigUnion[];
+    } |
+    {
+        name: '1653';
+        children: BigUnion[];
+    } |
+    {
+        name: '1654';
+        children: BigUnion[];
+    } |
+    {
+        name: '1655';
+        children: BigUnion[];
+    } |
+    {
+        name: '1656';
+        children: BigUnion[];
+    } |
+    {
+        name: '1657';
+        children: BigUnion[];
+    } |
+    {
+        name: '1658';
+        children: BigUnion[];
+    } |
+    {
+        name: '1659';
+        children: BigUnion[];
+    } |
+    {
+        name: '1660';
+        children: BigUnion[];
+    } |
+    {
+        name: '1661';
+        children: BigUnion[];
+    } |
+    {
+        name: '1662';
+        children: BigUnion[];
+    } |
+    {
+        name: '1663';
+        children: BigUnion[];
+    } |
+    {
+        name: '1664';
+        children: BigUnion[];
+    } |
+    {
+        name: '1665';
+        children: BigUnion[];
+    } |
+    {
+        name: '1666';
+        children: BigUnion[];
+    } |
+    {
+        name: '1667';
+        children: BigUnion[];
+    } |
+    {
+        name: '1668';
+        children: BigUnion[];
+    } |
+    {
+        name: '1669';
+        children: BigUnion[];
+    } |
+    {
+        name: '1670';
+        children: BigUnion[];
+    } |
+    {
+        name: '1671';
+        children: BigUnion[];
+    } |
+    {
+        name: '1672';
+        children: BigUnion[];
+    } |
+    {
+        name: '1673';
+        children: BigUnion[];
+    } |
+    {
+        name: '1674';
+        children: BigUnion[];
+    } |
+    {
+        name: '1675';
+        children: BigUnion[];
+    } |
+    {
+        name: '1676';
+        children: BigUnion[];
+    } |
+    {
+        name: '1677';
+        children: BigUnion[];
+    } |
+    {
+        name: '1678';
+        children: BigUnion[];
+    } |
+    {
+        name: '1679';
+        children: BigUnion[];
+    } |
+    {
+        name: '1680';
+        children: BigUnion[];
+    } |
+    {
+        name: '1681';
+        children: BigUnion[];
+    } |
+    {
+        name: '1682';
+        children: BigUnion[];
+    } |
+    {
+        name: '1683';
+        children: BigUnion[];
+    } |
+    {
+        name: '1684';
+        children: BigUnion[];
+    } |
+    {
+        name: '1685';
+        children: BigUnion[];
+    } |
+    {
+        name: '1686';
+        children: BigUnion[];
+    } |
+    {
+        name: '1687';
+        children: BigUnion[];
+    } |
+    {
+        name: '1688';
+        children: BigUnion[];
+    } |
+    {
+        name: '1689';
+        children: BigUnion[];
+    } |
+    {
+        name: '1690';
+        children: BigUnion[];
+    } |
+    {
+        name: '1691';
+        children: BigUnion[];
+    } |
+    {
+        name: '1692';
+        children: BigUnion[];
+    } |
+    {
+        name: '1693';
+        children: BigUnion[];
+    } |
+    {
+        name: '1694';
+        children: BigUnion[];
+    } |
+    {
+        name: '1695';
+        children: BigUnion[];
+    } |
+    {
+        name: '1696';
+        children: BigUnion[];
+    } |
+    {
+        name: '1697';
+        children: BigUnion[];
+    } |
+    {
+        name: '1698';
+        children: BigUnion[];
+    } |
+    {
+        name: '1699';
+        children: BigUnion[];
+    } |
+    {
+        name: '1700';
+        children: BigUnion[];
+    } |
+    {
+        name: '1701';
+        children: BigUnion[];
+    } |
+    {
+        name: '1702';
+        children: BigUnion[];
+    } |
+    {
+        name: '1703';
+        children: BigUnion[];
+    } |
+    {
+        name: '1704';
+        children: BigUnion[];
+    } |
+    {
+        name: '1705';
+        children: BigUnion[];
+    } |
+    {
+        name: '1706';
+        children: BigUnion[];
+    } |
+    {
+        name: '1707';
+        children: BigUnion[];
+    } |
+    {
+        name: '1708';
+        children: BigUnion[];
+    } |
+    {
+        name: '1709';
+        children: BigUnion[];
+    } |
+    {
+        name: '1710';
+        children: BigUnion[];
+    } |
+    {
+        name: '1711';
+        children: BigUnion[];
+    } |
+    {
+        name: '1712';
+        children: BigUnion[];
+    } |
+    {
+        name: '1713';
+        children: BigUnion[];
+    } |
+    {
+        name: '1714';
+        children: BigUnion[];
+    } |
+    {
+        name: '1715';
+        children: BigUnion[];
+    } |
+    {
+        name: '1716';
+        children: BigUnion[];
+    } |
+    {
+        name: '1717';
+        children: BigUnion[];
+    } |
+    {
+        name: '1718';
+        children: BigUnion[];
+    } |
+    {
+        name: '1719';
+        children: BigUnion[];
+    } |
+    {
+        name: '1720';
+        children: BigUnion[];
+    } |
+    {
+        name: '1721';
+        children: BigUnion[];
+    } |
+    {
+        name: '1722';
+        children: BigUnion[];
+    } |
+    {
+        name: '1723';
+        children: BigUnion[];
+    } |
+    {
+        name: '1724';
+        children: BigUnion[];
+    } |
+    {
+        name: '1725';
+        children: BigUnion[];
+    } |
+    {
+        name: '1726';
+        children: BigUnion[];
+    } |
+    {
+        name: '1727';
+        children: BigUnion[];
+    } |
+    {
+        name: '1728';
+        children: BigUnion[];
+    } |
+    {
+        name: '1729';
+        children: BigUnion[];
+    } |
+    {
+        name: '1730';
+        children: BigUnion[];
+    } |
+    {
+        name: '1731';
+        children: BigUnion[];
+    } |
+    {
+        name: '1732';
+        children: BigUnion[];
+    } |
+    {
+        name: '1733';
+        children: BigUnion[];
+    } |
+    {
+        name: '1734';
+        children: BigUnion[];
+    } |
+    {
+        name: '1735';
+        children: BigUnion[];
+    } |
+    {
+        name: '1736';
+        children: BigUnion[];
+    } |
+    {
+        name: '1737';
+        children: BigUnion[];
+    } |
+    {
+        name: '1738';
+        children: BigUnion[];
+    } |
+    {
+        name: '1739';
+        children: BigUnion[];
+    } |
+    {
+        name: '1740';
+        children: BigUnion[];
+    } |
+    {
+        name: '1741';
+        children: BigUnion[];
+    } |
+    {
+        name: '1742';
+        children: BigUnion[];
+    } |
+    {
+        name: '1743';
+        children: BigUnion[];
+    } |
+    {
+        name: '1744';
+        children: BigUnion[];
+    } |
+    {
+        name: '1745';
+        children: BigUnion[];
+    } |
+    {
+        name: '1746';
+        children: BigUnion[];
+    } |
+    {
+        name: '1747';
+        children: BigUnion[];
+    } |
+    {
+        name: '1748';
+        children: BigUnion[];
+    } |
+    {
+        name: '1749';
+        children: BigUnion[];
+    } |
+    {
+        name: '1750';
+        children: BigUnion[];
+    } |
+    {
+        name: '1751';
+        children: BigUnion[];
+    } |
+    {
+        name: '1752';
+        children: BigUnion[];
+    } |
+    {
+        name: '1753';
+        children: BigUnion[];
+    } |
+    {
+        name: '1754';
+        children: BigUnion[];
+    } |
+    {
+        name: '1755';
+        children: BigUnion[];
+    } |
+    {
+        name: '1756';
+        children: BigUnion[];
+    } |
+    {
+        name: '1757';
+        children: BigUnion[];
+    } |
+    {
+        name: '1758';
+        children: BigUnion[];
+    } |
+    {
+        name: '1759';
+        children: BigUnion[];
+    } |
+    {
+        name: '1760';
+        children: BigUnion[];
+    } |
+    {
+        name: '1761';
+        children: BigUnion[];
+    } |
+    {
+        name: '1762';
+        children: BigUnion[];
+    } |
+    {
+        name: '1763';
+        children: BigUnion[];
+    } |
+    {
+        name: '1764';
+        children: BigUnion[];
+    } |
+    {
+        name: '1765';
+        children: BigUnion[];
+    } |
+    {
+        name: '1766';
+        children: BigUnion[];
+    } |
+    {
+        name: '1767';
+        children: BigUnion[];
+    } |
+    {
+        name: '1768';
+        children: BigUnion[];
+    } |
+    {
+        name: '1769';
+        children: BigUnion[];
+    } |
+    {
+        name: '1770';
+        children: BigUnion[];
+    } |
+    {
+        name: '1771';
+        children: BigUnion[];
+    } |
+    {
+        name: '1772';
+        children: BigUnion[];
+    } |
+    {
+        name: '1773';
+        children: BigUnion[];
+    } |
+    {
+        name: '1774';
+        children: BigUnion[];
+    } |
+    {
+        name: '1775';
+        children: BigUnion[];
+    } |
+    {
+        name: '1776';
+        children: BigUnion[];
+    } |
+    {
+        name: '1777';
+        children: BigUnion[];
+    } |
+    {
+        name: '1778';
+        children: BigUnion[];
+    } |
+    {
+        name: '1779';
+        children: BigUnion[];
+    } |
+    {
+        name: '1780';
+        children: BigUnion[];
+    } |
+    {
+        name: '1781';
+        children: BigUnion[];
+    } |
+    {
+        name: '1782';
+        children: BigUnion[];
+    } |
+    {
+        name: '1783';
+        children: BigUnion[];
+    } |
+    {
+        name: '1784';
+        children: BigUnion[];
+    } |
+    {
+        name: '1785';
+        children: BigUnion[];
+    } |
+    {
+        name: '1786';
+        children: BigUnion[];
+    } |
+    {
+        name: '1787';
+        children: BigUnion[];
+    } |
+    {
+        name: '1788';
+        children: BigUnion[];
+    } |
+    {
+        name: '1789';
+        children: BigUnion[];
+    } |
+    {
+        name: '1790';
+        children: BigUnion[];
+    } |
+    {
+        name: '1791';
+        children: BigUnion[];
+    } |
+    {
+        name: '1792';
+        children: BigUnion[];
+    } |
+    {
+        name: '1793';
+        children: BigUnion[];
+    } |
+    {
+        name: '1794';
+        children: BigUnion[];
+    } |
+    {
+        name: '1795';
+        children: BigUnion[];
+    } |
+    {
+        name: '1796';
+        children: BigUnion[];
+    } |
+    {
+        name: '1797';
+        children: BigUnion[];
+    } |
+    {
+        name: '1798';
+        children: BigUnion[];
+    } |
+    {
+        name: '1799';
+        children: BigUnion[];
+    } |
+    {
+        name: '1800';
+        children: BigUnion[];
+    } |
+    {
+        name: '1801';
+        children: BigUnion[];
+    } |
+    {
+        name: '1802';
+        children: BigUnion[];
+    } |
+    {
+        name: '1803';
+        children: BigUnion[];
+    } |
+    {
+        name: '1804';
+        children: BigUnion[];
+    } |
+    {
+        name: '1805';
+        children: BigUnion[];
+    } |
+    {
+        name: '1806';
+        children: BigUnion[];
+    } |
+    {
+        name: '1807';
+        children: BigUnion[];
+    } |
+    {
+        name: '1808';
+        children: BigUnion[];
+    } |
+    {
+        name: '1809';
+        children: BigUnion[];
+    } |
+    {
+        name: '1810';
+        children: BigUnion[];
+    } |
+    {
+        name: '1811';
+        children: BigUnion[];
+    } |
+    {
+        name: '1812';
+        children: BigUnion[];
+    } |
+    {
+        name: '1813';
+        children: BigUnion[];
+    } |
+    {
+        name: '1814';
+        children: BigUnion[];
+    } |
+    {
+        name: '1815';
+        children: BigUnion[];
+    } |
+    {
+        name: '1816';
+        children: BigUnion[];
+    } |
+    {
+        name: '1817';
+        children: BigUnion[];
+    } |
+    {
+        name: '1818';
+        children: BigUnion[];
+    } |
+    {
+        name: '1819';
+        children: BigUnion[];
+    } |
+    {
+        name: '1820';
+        children: BigUnion[];
+    } |
+    {
+        name: '1821';
+        children: BigUnion[];
+    } |
+    {
+        name: '1822';
+        children: BigUnion[];
+    } |
+    {
+        name: '1823';
+        children: BigUnion[];
+    } |
+    {
+        name: '1824';
+        children: BigUnion[];
+    } |
+    {
+        name: '1825';
+        children: BigUnion[];
+    } |
+    {
+        name: '1826';
+        children: BigUnion[];
+    } |
+    {
+        name: '1827';
+        children: BigUnion[];
+    } |
+    {
+        name: '1828';
+        children: BigUnion[];
+    } |
+    {
+        name: '1829';
+        children: BigUnion[];
+    } |
+    {
+        name: '1830';
+        children: BigUnion[];
+    } |
+    {
+        name: '1831';
+        children: BigUnion[];
+    } |
+    {
+        name: '1832';
+        children: BigUnion[];
+    } |
+    {
+        name: '1833';
+        children: BigUnion[];
+    } |
+    {
+        name: '1834';
+        children: BigUnion[];
+    } |
+    {
+        name: '1835';
+        children: BigUnion[];
+    } |
+    {
+        name: '1836';
+        children: BigUnion[];
+    } |
+    {
+        name: '1837';
+        children: BigUnion[];
+    } |
+    {
+        name: '1838';
+        children: BigUnion[];
+    } |
+    {
+        name: '1839';
+        children: BigUnion[];
+    } |
+    {
+        name: '1840';
+        children: BigUnion[];
+    } |
+    {
+        name: '1841';
+        children: BigUnion[];
+    } |
+    {
+        name: '1842';
+        children: BigUnion[];
+    } |
+    {
+        name: '1843';
+        children: BigUnion[];
+    } |
+    {
+        name: '1844';
+        children: BigUnion[];
+    } |
+    {
+        name: '1845';
+        children: BigUnion[];
+    } |
+    {
+        name: '1846';
+        children: BigUnion[];
+    } |
+    {
+        name: '1847';
+        children: BigUnion[];
+    } |
+    {
+        name: '1848';
+        children: BigUnion[];
+    } |
+    {
+        name: '1849';
+        children: BigUnion[];
+    } |
+    {
+        name: '1850';
+        children: BigUnion[];
+    } |
+    {
+        name: '1851';
+        children: BigUnion[];
+    } |
+    {
+        name: '1852';
+        children: BigUnion[];
+    } |
+    {
+        name: '1853';
+        children: BigUnion[];
+    } |
+    {
+        name: '1854';
+        children: BigUnion[];
+    } |
+    {
+        name: '1855';
+        children: BigUnion[];
+    } |
+    {
+        name: '1856';
+        children: BigUnion[];
+    } |
+    {
+        name: '1857';
+        children: BigUnion[];
+    } |
+    {
+        name: '1858';
+        children: BigUnion[];
+    } |
+    {
+        name: '1859';
+        children: BigUnion[];
+    } |
+    {
+        name: '1860';
+        children: BigUnion[];
+    } |
+    {
+        name: '1861';
+        children: BigUnion[];
+    } |
+    {
+        name: '1862';
+        children: BigUnion[];
+    } |
+    {
+        name: '1863';
+        children: BigUnion[];
+    } |
+    {
+        name: '1864';
+        children: BigUnion[];
+    } |
+    {
+        name: '1865';
+        children: BigUnion[];
+    } |
+    {
+        name: '1866';
+        children: BigUnion[];
+    } |
+    {
+        name: '1867';
+        children: BigUnion[];
+    } |
+    {
+        name: '1868';
+        children: BigUnion[];
+    } |
+    {
+        name: '1869';
+        children: BigUnion[];
+    } |
+    {
+        name: '1870';
+        children: BigUnion[];
+    } |
+    {
+        name: '1871';
+        children: BigUnion[];
+    } |
+    {
+        name: '1872';
+        children: BigUnion[];
+    } |
+    {
+        name: '1873';
+        children: BigUnion[];
+    } |
+    {
+        name: '1874';
+        children: BigUnion[];
+    } |
+    {
+        name: '1875';
+        children: BigUnion[];
+    } |
+    {
+        name: '1876';
+        children: BigUnion[];
+    } |
+    {
+        name: '1877';
+        children: BigUnion[];
+    } |
+    {
+        name: '1878';
+        children: BigUnion[];
+    } |
+    {
+        name: '1879';
+        children: BigUnion[];
+    } |
+    {
+        name: '1880';
+        children: BigUnion[];
+    } |
+    {
+        name: '1881';
+        children: BigUnion[];
+    } |
+    {
+        name: '1882';
+        children: BigUnion[];
+    } |
+    {
+        name: '1883';
+        children: BigUnion[];
+    } |
+    {
+        name: '1884';
+        children: BigUnion[];
+    } |
+    {
+        name: '1885';
+        children: BigUnion[];
+    } |
+    {
+        name: '1886';
+        children: BigUnion[];
+    } |
+    {
+        name: '1887';
+        children: BigUnion[];
+    } |
+    {
+        name: '1888';
+        children: BigUnion[];
+    } |
+    {
+        name: '1889';
+        children: BigUnion[];
+    } |
+    {
+        name: '1890';
+        children: BigUnion[];
+    } |
+    {
+        name: '1891';
+        children: BigUnion[];
+    } |
+    {
+        name: '1892';
+        children: BigUnion[];
+    } |
+    {
+        name: '1893';
+        children: BigUnion[];
+    } |
+    {
+        name: '1894';
+        children: BigUnion[];
+    } |
+    {
+        name: '1895';
+        children: BigUnion[];
+    } |
+    {
+        name: '1896';
+        children: BigUnion[];
+    } |
+    {
+        name: '1897';
+        children: BigUnion[];
+    } |
+    {
+        name: '1898';
+        children: BigUnion[];
+    } |
+    {
+        name: '1899';
+        children: BigUnion[];
+    } |
+    {
+        name: '1900';
+        children: BigUnion[];
+    } |
+    {
+        name: '1901';
+        children: BigUnion[];
+    } |
+    {
+        name: '1902';
+        children: BigUnion[];
+    } |
+    {
+        name: '1903';
+        children: BigUnion[];
+    } |
+    {
+        name: '1904';
+        children: BigUnion[];
+    } |
+    {
+        name: '1905';
+        children: BigUnion[];
+    } |
+    {
+        name: '1906';
+        children: BigUnion[];
+    } |
+    {
+        name: '1907';
+        children: BigUnion[];
+    } |
+    {
+        name: '1908';
+        children: BigUnion[];
+    } |
+    {
+        name: '1909';
+        children: BigUnion[];
+    } |
+    {
+        name: '1910';
+        children: BigUnion[];
+    } |
+    {
+        name: '1911';
+        children: BigUnion[];
+    } |
+    {
+        name: '1912';
+        children: BigUnion[];
+    } |
+    {
+        name: '1913';
+        children: BigUnion[];
+    } |
+    {
+        name: '1914';
+        children: BigUnion[];
+    } |
+    {
+        name: '1915';
+        children: BigUnion[];
+    } |
+    {
+        name: '1916';
+        children: BigUnion[];
+    } |
+    {
+        name: '1917';
+        children: BigUnion[];
+    } |
+    {
+        name: '1918';
+        children: BigUnion[];
+    } |
+    {
+        name: '1919';
+        children: BigUnion[];
+    } |
+    {
+        name: '1920';
+        children: BigUnion[];
+    } |
+    {
+        name: '1921';
+        children: BigUnion[];
+    } |
+    {
+        name: '1922';
+        children: BigUnion[];
+    } |
+    {
+        name: '1923';
+        children: BigUnion[];
+    } |
+    {
+        name: '1924';
+        children: BigUnion[];
+    } |
+    {
+        name: '1925';
+        children: BigUnion[];
+    } |
+    {
+        name: '1926';
+        children: BigUnion[];
+    } |
+    {
+        name: '1927';
+        children: BigUnion[];
+    } |
+    {
+        name: '1928';
+        children: BigUnion[];
+    } |
+    {
+        name: '1929';
+        children: BigUnion[];
+    } |
+    {
+        name: '1930';
+        children: BigUnion[];
+    } |
+    {
+        name: '1931';
+        children: BigUnion[];
+    } |
+    {
+        name: '1932';
+        children: BigUnion[];
+    } |
+    {
+        name: '1933';
+        children: BigUnion[];
+    } |
+    {
+        name: '1934';
+        children: BigUnion[];
+    } |
+    {
+        name: '1935';
+        children: BigUnion[];
+    } |
+    {
+        name: '1936';
+        children: BigUnion[];
+    } |
+    {
+        name: '1937';
+        children: BigUnion[];
+    } |
+    {
+        name: '1938';
+        children: BigUnion[];
+    } |
+    {
+        name: '1939';
+        children: BigUnion[];
+    } |
+    {
+        name: '1940';
+        children: BigUnion[];
+    } |
+    {
+        name: '1941';
+        children: BigUnion[];
+    } |
+    {
+        name: '1942';
+        children: BigUnion[];
+    } |
+    {
+        name: '1943';
+        children: BigUnion[];
+    } |
+    {
+        name: '1944';
+        children: BigUnion[];
+    } |
+    {
+        name: '1945';
+        children: BigUnion[];
+    } |
+    {
+        name: '1946';
+        children: BigUnion[];
+    } |
+    {
+        name: '1947';
+        children: BigUnion[];
+    } |
+    {
+        name: '1948';
+        children: BigUnion[];
+    } |
+    {
+        name: '1949';
+        children: BigUnion[];
+    } |
+    {
+        name: '1950';
+        children: BigUnion[];
+    } |
+    {
+        name: '1951';
+        children: BigUnion[];
+    } |
+    {
+        name: '1952';
+        children: BigUnion[];
+    } |
+    {
+        name: '1953';
+        children: BigUnion[];
+    } |
+    {
+        name: '1954';
+        children: BigUnion[];
+    } |
+    {
+        name: '1955';
+        children: BigUnion[];
+    } |
+    {
+        name: '1956';
+        children: BigUnion[];
+    } |
+    {
+        name: '1957';
+        children: BigUnion[];
+    } |
+    {
+        name: '1958';
+        children: BigUnion[];
+    } |
+    {
+        name: '1959';
+        children: BigUnion[];
+    } |
+    {
+        name: '1960';
+        children: BigUnion[];
+    } |
+    {
+        name: '1961';
+        children: BigUnion[];
+    } |
+    {
+        name: '1962';
+        children: BigUnion[];
+    } |
+    {
+        name: '1963';
+        children: BigUnion[];
+    } |
+    {
+        name: '1964';
+        children: BigUnion[];
+    } |
+    {
+        name: '1965';
+        children: BigUnion[];
+    } |
+    {
+        name: '1966';
+        children: BigUnion[];
+    } |
+    {
+        name: '1967';
+        children: BigUnion[];
+    } |
+    {
+        name: '1968';
+        children: BigUnion[];
+    } |
+    {
+        name: '1969';
+        children: BigUnion[];
+    } |
+    {
+        name: '1970';
+        children: BigUnion[];
+    } |
+    {
+        name: '1971';
+        children: BigUnion[];
+    } |
+    {
+        name: '1972';
+        children: BigUnion[];
+    } |
+    {
+        name: '1973';
+        children: BigUnion[];
+    } |
+    {
+        name: '1974';
+        children: BigUnion[];
+    } |
+    {
+        name: '1975';
+        children: BigUnion[];
+    } |
+    {
+        name: '1976';
+        children: BigUnion[];
+    } |
+    {
+        name: '1977';
+        children: BigUnion[];
+    } |
+    {
+        name: '1978';
+        children: BigUnion[];
+    } |
+    {
+        name: '1979';
+        children: BigUnion[];
+    } |
+    {
+        name: '1980';
+        children: BigUnion[];
+    } |
+    {
+        name: '1981';
+        children: BigUnion[];
+    } |
+    {
+        name: '1982';
+        children: BigUnion[];
+    } |
+    {
+        name: '1983';
+        children: BigUnion[];
+    } |
+    {
+        name: '1984';
+        children: BigUnion[];
+    } |
+    {
+        name: '1985';
+        children: BigUnion[];
+    } |
+    {
+        name: '1986';
+        children: BigUnion[];
+    } |
+    {
+        name: '1987';
+        children: BigUnion[];
+    } |
+    {
+        name: '1988';
+        children: BigUnion[];
+    } |
+    {
+        name: '1989';
+        children: BigUnion[];
+    } |
+    {
+        name: '1990';
+        children: BigUnion[];
+    } |
+    {
+        name: '1991';
+        children: BigUnion[];
+    } |
+    {
+        name: '1992';
+        children: BigUnion[];
+    } |
+    {
+        name: '1993';
+        children: BigUnion[];
+    } |
+    {
+        name: '1994';
+        children: BigUnion[];
+    } |
+    {
+        name: '1995';
+        children: BigUnion[];
+    } |
+    {
+        name: '1996';
+        children: BigUnion[];
+    } |
+    {
+        name: '1997';
+        children: BigUnion[];
+    } |
+    {
+        name: '1998';
+        children: BigUnion[];
+    } |
+    {
+        name: '1999';
+        children: BigUnion[];
+    };
+
+type DiscriminateUnion<T, K extends keyof T, V extends T[K]> = T extends Record<K, V> ? T : never;
+
+type WithName<T extends BigUnion['name']> = DiscriminateUnion<BigUnion, 'name', T>;
+
+type ChildrenOf<T extends BigUnion> = T['children'][number];
+
+export function makeThing<T extends BigUnion['name']>(
+    name: T,
+    children: ChildrenOf<WithName<T>>[] = [],
+) { }


### PR DESCRIPTION
Fixes #37744

I doubled the example size for good measure. This simple change takes the test run down from 11 minutes to 30 seconds. That 30 seconds could likely still stand to be improved, but this fixes the obvious complexity issue.