### PR TITLE
fix(37456): Incomplete type cleanup with `jsx` set to `preserve` / add tests for JsxOpeningElement nodes

### DIFF
--- a/tests/baselines/reference/tsxTypeArgumentsJsxPreserveOutput.js
+++ b/tests/baselines/reference/tsxTypeArgumentsJsxPreserveOutput.js
@@ -9,6 +9,7 @@ function Foo<T>() {
 }
 
 <>
+    {/* JsxSelfClosingElement */}
     <Foo<unknown> />
     <Foo<string> />
     <Foo<boolean> />
@@ -19,7 +20,20 @@ function Foo<T>() {
     <Foo<undefined> />
     <Foo<TypeProps> />
     <Foo<InterfaceProps> />
+
+    {/* JsxOpeningElement */}
+    <Foo<unknown>></Foo>
+    <Foo<string>></Foo>
+    <Foo<boolean>></Foo>
+    <Foo<object>></Foo>
+    <Foo<null>></Foo>
+    <Foo<any>></Foo>
+    <Foo<never>></Foo>
+    <Foo<undefined>></Foo>
+    <Foo<TypeProps>></Foo>
+    <Foo<InterfaceProps>></Foo>
 </>
+
 
 //// [foo.jsx]
 "use strict";
@@ -29,6 +43,7 @@ function Foo() {
     return null;
 }
 <>
+    
     <Foo />
     <Foo />
     <Foo />
@@ -39,4 +54,16 @@ function Foo() {
     <Foo />
     <Foo />
     <Foo />
+
+    
+    <Foo></Foo>
+    <Foo></Foo>
+    <Foo></Foo>
+    <Foo></Foo>
+    <Foo></Foo>
+    <Foo></Foo>
+    <Foo></Foo>
+    <Foo></Foo>
+    <Foo></Foo>
+    <Foo></Foo>
 </>;

--- a/tests/baselines/reference/tsxTypeArgumentsJsxPreserveOutput.symbols
+++ b/tests/baselines/reference/tsxTypeArgumentsJsxPreserveOutput.symbols
@@ -18,6 +18,7 @@ function Foo<T>() {
 }
 
 <>
+    {/* JsxSelfClosingElement */}
     <Foo<unknown> />
 >Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
 
@@ -50,4 +51,48 @@ function Foo<T>() {
 >Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
 >InterfaceProps : Symbol(InterfaceProps, Decl(foo.tsx, 2, 36))
 
+    {/* JsxOpeningElement */}
+    <Foo<unknown>></Foo>
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+
+    <Foo<string>></Foo>
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+
+    <Foo<boolean>></Foo>
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+
+    <Foo<object>></Foo>
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+
+    <Foo<null>></Foo>
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+
+    <Foo<any>></Foo>
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+
+    <Foo<never>></Foo>
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+
+    <Foo<undefined>></Foo>
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+
+    <Foo<TypeProps>></Foo>
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+>TypeProps : Symbol(TypeProps, Decl(foo.tsx, 0, 32))
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+
+    <Foo<InterfaceProps>></Foo>
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+>InterfaceProps : Symbol(InterfaceProps, Decl(foo.tsx, 2, 36))
+>Foo : Symbol(Foo, Decl(foo.tsx, 3, 43))
+
 </>
+

--- a/tests/baselines/reference/tsxTypeArgumentsJsxPreserveOutput.types
+++ b/tests/baselines/reference/tsxTypeArgumentsJsxPreserveOutput.types
@@ -17,8 +17,9 @@ function Foo<T>() {
 }
 
 <>
-><>    <Foo<unknown> />    <Foo<string> />    <Foo<boolean> />    <Foo<object> />    <Foo<null> />    <Foo<any> />    <Foo<never> />    <Foo<undefined> />    <Foo<TypeProps> />    <Foo<InterfaceProps> /></> : JSX.Element
+><>    {/* JsxSelfClosingElement */}    <Foo<unknown> />    <Foo<string> />    <Foo<boolean> />    <Foo<object> />    <Foo<null> />    <Foo<any> />    <Foo<never> />    <Foo<undefined> />    <Foo<TypeProps> />    <Foo<InterfaceProps> />    {/* JsxOpeningElement */}    <Foo<unknown>></Foo>    <Foo<string>></Foo>    <Foo<boolean>></Foo>    <Foo<object>></Foo>    <Foo<null>></Foo>    <Foo<any>></Foo>    <Foo<never>></Foo>    <Foo<undefined>></Foo>    <Foo<TypeProps>></Foo>    <Foo<InterfaceProps>></Foo></> : JSX.Element
 
+    {/* JsxSelfClosingElement */}
     <Foo<unknown> />
 ><Foo<unknown> /> : JSX.Element
 >Foo : <T>() => any
@@ -60,4 +61,57 @@ function Foo<T>() {
 ><Foo<InterfaceProps> /> : JSX.Element
 >Foo : <T>() => any
 
+    {/* JsxOpeningElement */}
+    <Foo<unknown>></Foo>
+><Foo<unknown>></Foo> : JSX.Element
+>Foo : <T>() => any
+>Foo : <T>() => any
+
+    <Foo<string>></Foo>
+><Foo<string>></Foo> : JSX.Element
+>Foo : <T>() => any
+>Foo : <T>() => any
+
+    <Foo<boolean>></Foo>
+><Foo<boolean>></Foo> : JSX.Element
+>Foo : <T>() => any
+>Foo : <T>() => any
+
+    <Foo<object>></Foo>
+><Foo<object>></Foo> : JSX.Element
+>Foo : <T>() => any
+>Foo : <T>() => any
+
+    <Foo<null>></Foo>
+><Foo<null>></Foo> : JSX.Element
+>Foo : <T>() => any
+>null : null
+>Foo : <T>() => any
+
+    <Foo<any>></Foo>
+><Foo<any>></Foo> : JSX.Element
+>Foo : <T>() => any
+>Foo : <T>() => any
+
+    <Foo<never>></Foo>
+><Foo<never>></Foo> : JSX.Element
+>Foo : <T>() => any
+>Foo : <T>() => any
+
+    <Foo<undefined>></Foo>
+><Foo<undefined>></Foo> : JSX.Element
+>Foo : <T>() => any
+>Foo : <T>() => any
+
+    <Foo<TypeProps>></Foo>
+><Foo<TypeProps>></Foo> : JSX.Element
+>Foo : <T>() => any
+>Foo : <T>() => any
+
+    <Foo<InterfaceProps>></Foo>
+><Foo<InterfaceProps>></Foo> : JSX.Element
+>Foo : <T>() => any
+>Foo : <T>() => any
+
 </>
+

--- a/tests/cases/conformance/jsx/tsxTypeArgumentsJsxPreserveOutput.tsx
+++ b/tests/cases/conformance/jsx/tsxTypeArgumentsJsxPreserveOutput.tsx
@@ -14,6 +14,7 @@ function Foo<T>() {
 }
 
 <>
+    {/* JsxSelfClosingElement */}
     <Foo<unknown> />
     <Foo<string> />
     <Foo<boolean> />
@@ -24,4 +25,16 @@ function Foo<T>() {
     <Foo<undefined> />
     <Foo<TypeProps> />
     <Foo<InterfaceProps> />
+
+    {/* JsxOpeningElement */}
+    <Foo<unknown>></Foo>
+    <Foo<string>></Foo>
+    <Foo<boolean>></Foo>
+    <Foo<object>></Foo>
+    <Foo<null>></Foo>
+    <Foo<any>></Foo>
+    <Foo<never>></Foo>
+    <Foo<undefined>></Foo>
+    <Foo<TypeProps>></Foo>
+    <Foo<InterfaceProps>></Foo>
 </>


### PR DESCRIPTION
This PR adds tests for `JsxOpeningElement` nodes - #37739