### PR TITLE
convertToAsync: Fix variable name collisions

### DIFF
--- a/src/testRunner/unittests/services/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/services/convertToAsyncFunction.ts
@@ -1113,7 +1113,16 @@ function rej(reject): a{
 `
         );
 
+        _testConvertToAsyncFunction("convertToAsyncFunction_ParameterNameCollision", `
+async function foo<T>(x: T): Promise<T> {
+    return x;
+}
 
+function [#|bar|]<T>(x: T): Promise<T> {
+    return foo(x).then(foo)
+}
+`
+        );
 
 
         _testConvertToAsyncFunction("convertToAsyncFunction_LocalReturn", `

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding1.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding1.ts
@@ -12,13 +12,13 @@ function /*[#|*/innerPromise/*|]*/(): Promise<string> {
 
 async function innerPromise(): Promise<string> {
     const resp = await fetch("https://typescriptlang.org");
-    let blob: any;
+    let blob_1: any;
     try {
         const { blob } = await resp.blob();
-        blob = blob.byteOffset;
+        blob_1 = blob.byteOffset;
     }
     catch ({ message }) {
-        blob = 'Error ' + message;
+        blob_1 = 'Error ' + message;
     }
-    return blob.toString();
+    return blob_1.toString();
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_ParameterNameCollision.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_ParameterNameCollision.ts
@@ -1,0 +1,20 @@
+// ==ORIGINAL==
+
+async function foo<T>(x: T): Promise<T> {
+    return x;
+}
+
+function /*[#|*/bar/*|]*/<T>(x: T): Promise<T> {
+    return foo(x).then(foo)
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function foo<T>(x: T): Promise<T> {
+    return x;
+}
+
+async function bar<T>(x: T): Promise<T> {
+    const x_1 = await foo(x);
+    return foo(x_1);
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_basicWithComments.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_basicWithComments.ts
@@ -14,6 +14,6 @@ async function f(): Promise<void>{
 
     // a
     /*b*/ const result /*g*/ = await fetch(/*d*/ 'https://typescriptlang.org' /*e*/);
-    console.log(result); /*k*/
+    console.log(/*i*/ result /*j*/); /*k*/
     // m
 }


### PR DESCRIPTION
As I’ve grown to expect, the more code I delete from this refactor, the more bugs are fixed.

Fixes #28530 
