### PR TITLE
Fix serialisation of static class members in JS

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6200,7 +6200,7 @@ namespace ts {
                     // Consider static members empty if symbol also has function or module meaning - function namespacey emit will handle statics
                     const staticMembers = flatMap(filter(
                             getPropertiesOfType(staticType),
-                        p => !(p.flags & SymbolFlags.Prototype) && p.escapedName !== "prototype" && p.valueDeclaration && isClassLike(p.valueDeclaration.parent)
+                            p => !(p.flags & SymbolFlags.Prototype) && p.escapedName !== "prototype" && p.valueDeclaration && isClassLike(p.valueDeclaration.parent)
                         ), p => serializePropertySymbolForClass(p, /*isStatic*/ true, staticBaseType));
                     const constructors = serializeSignatures(SignatureKind.Construct, staticType, baseTypes[0], SyntaxKind.Constructor) as ConstructorDeclaration[];
                     for (const c of constructors) {

--- a/tests/baselines/reference/jsDeclarationsClassStatic.js
+++ b/tests/baselines/reference/jsDeclarationsClassStatic.js
@@ -1,0 +1,74 @@
+//// [source.js]
+class Handler {
+	static get OPTIONS() {
+		return 1;
+	}
+
+	process() {
+	}
+}
+Handler.statische = function() { }
+const Strings = {
+    a: "A",
+    b: "B"
+}
+
+module.exports = Handler;
+module.exports.Strings = Strings
+
+/**
+ * @typedef {Object} HandlerOptions
+ * @property {String} name
+ * Should be able to export a type alias at the same time.
+ */
+
+
+//// [source.js]
+var Handler = /** @class */ (function () {
+    function Handler() {
+    }
+    Object.defineProperty(Handler, "OPTIONS", {
+        get: function () {
+            return 1;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Handler.prototype.process = function () {
+    };
+    return Handler;
+}());
+Handler.statische = function () { };
+var Strings = {
+    a: "A",
+    b: "B"
+};
+module.exports = Handler;
+module.exports.Strings = Strings;
+/**
+ * @typedef {Object} HandlerOptions
+ * @property {String} name
+ * Should be able to export a type alias at the same time.
+ */
+
+
+//// [source.d.ts]
+export = Handler;
+declare class Handler {
+    static get OPTIONS(): number;
+    process(): void;
+}
+declare namespace Handler {
+    export { statische, Strings, HandlerOptions };
+}
+declare function statische(): void;
+declare namespace Strings {
+    export const a: string;
+    export const b: string;
+}
+type HandlerOptions = {
+    /**
+     * Should be able to export a type alias at the same time.
+     */
+    name: String;
+};

--- a/tests/baselines/reference/jsDeclarationsClassStatic.symbols
+++ b/tests/baselines/reference/jsDeclarationsClassStatic.symbols
@@ -1,0 +1,49 @@
+=== tests/cases/conformance/jsdoc/declarations/source.js ===
+class Handler {
+>Handler : Symbol(Handler, Decl(source.js, 0, 0), Decl(source.js, 7, 1))
+
+	static get OPTIONS() {
+>OPTIONS : Symbol(Handler.OPTIONS, Decl(source.js, 0, 15))
+
+		return 1;
+	}
+
+	process() {
+>process : Symbol(Handler.process, Decl(source.js, 3, 2))
+	}
+}
+Handler.statische = function() { }
+>Handler.statische : Symbol(Handler.statische, Decl(source.js, 7, 1))
+>Handler : Symbol(Handler, Decl(source.js, 0, 0), Decl(source.js, 7, 1))
+>statische : Symbol(Handler.statische, Decl(source.js, 7, 1))
+
+const Strings = {
+>Strings : Symbol(Strings, Decl(source.js, 9, 5))
+
+    a: "A",
+>a : Symbol(a, Decl(source.js, 9, 17))
+
+    b: "B"
+>b : Symbol(b, Decl(source.js, 10, 11))
+}
+
+module.exports = Handler;
+>module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/source", Decl(source.js, 0, 0))
+>module : Symbol(export=, Decl(source.js, 12, 1))
+>exports : Symbol(export=, Decl(source.js, 12, 1))
+>Handler : Symbol(Handler, Decl(source.js, 0, 0), Decl(source.js, 7, 1))
+
+module.exports.Strings = Strings
+>module.exports.Strings : Symbol(Strings)
+>module.exports : Symbol(Strings, Decl(source.js, 14, 25))
+>module : Symbol(module, Decl(source.js, 12, 1))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/source", Decl(source.js, 0, 0))
+>Strings : Symbol(Strings, Decl(source.js, 14, 25))
+>Strings : Symbol(Strings, Decl(source.js, 9, 5))
+
+/**
+ * @typedef {Object} HandlerOptions
+ * @property {String} name
+ * Should be able to export a type alias at the same time.
+ */
+

--- a/tests/baselines/reference/jsDeclarationsClassStatic.types
+++ b/tests/baselines/reference/jsDeclarationsClassStatic.types
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/jsdoc/declarations/source.js ===
+class Handler {
+>Handler : Handler
+
+	static get OPTIONS() {
+>OPTIONS : number
+
+		return 1;
+>1 : 1
+	}
+
+	process() {
+>process : () => void
+	}
+}
+Handler.statische = function() { }
+>Handler.statische = function() { } : () => void
+>Handler.statische : () => void
+>Handler : typeof Handler
+>statische : () => void
+>function() { } : () => void
+
+const Strings = {
+>Strings : { a: string; b: string; }
+>{    a: "A",    b: "B"} : { a: string; b: string; }
+
+    a: "A",
+>a : string
+>"A" : "A"
+
+    b: "B"
+>b : string
+>"B" : "B"
+}
+
+module.exports = Handler;
+>module.exports = Handler : typeof Handler
+>module.exports : typeof Handler
+>module : { "\"tests/cases/conformance/jsdoc/declarations/source\"": typeof Handler; }
+>exports : typeof Handler
+>Handler : typeof Handler
+
+module.exports.Strings = Strings
+>module.exports.Strings = Strings : { a: string; b: string; }
+>module.exports.Strings : { a: string; b: string; }
+>module.exports : typeof Handler
+>module : { "\"tests/cases/conformance/jsdoc/declarations/source\"": typeof Handler; }
+>exports : typeof Handler
+>Strings : { a: string; b: string; }
+>Strings : { a: string; b: string; }
+
+/**
+ * @typedef {Object} HandlerOptions
+ * @property {String} name
+ * Should be able to export a type alias at the same time.
+ */
+

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassStatic.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassStatic.ts
@@ -1,0 +1,28 @@
+// @allowJs: true
+// @checkJs: true
+// @target: es5
+// @outDir: ./out
+// @declaration: true
+// @filename: source.js
+class Handler {
+	static get OPTIONS() {
+		return 1;
+	}
+
+	process() {
+	}
+}
+Handler.statische = function() { }
+const Strings = {
+    a: "A",
+    b: "B"
+}
+
+module.exports = Handler;
+module.exports.Strings = Strings
+
+/**
+ * @typedef {Object} HandlerOptions
+ * @property {String} name
+ * Should be able to export a type alias at the same time.
+ */


### PR DESCRIPTION
Previously static class members would be treated the same way as expando
namespace assignments to a class:

```ts
class C {
  static get x() { return 1 }
}
C.y = 12
```

This PR adds a syntactic check to the static/namespace filter that
treats symbols whose valueDeclaration.parent is a class as statics.

Fixes #37289