### PR TITLE
this: undefined in modules

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21460,6 +21460,10 @@ namespace ts {
                     const fileSymbol = getSymbolOfNode(container);
                     return fileSymbol && getTypeOfSymbol(fileSymbol);
                 }
+                else if (container.externalModuleIndicator) {
+                    // TODO: Maybe issue a better error than 'object is possibly undefined'
+                    return undefinedType;
+                }
                 else if (includeGlobalThis) {
                     return getTypeOfSymbol(globalThisSymbol);
                 }

--- a/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.errors.txt
+++ b/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.errors.txt
@@ -1,3 +1,5 @@
+tests/cases/conformance/jsx/inline/component.tsx(4,136): error TS2609: JSX spread child must be an array type.
+tests/cases/conformance/jsx/inline/component.tsx(4,140): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/jsx/inline/index.tsx(5,1): error TS2741: Property '__predomBrand' is missing in type 'import("tests/cases/conformance/jsx/inline/renderer").dom.JSX.Element' but required in type 'import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element'.
 tests/cases/conformance/jsx/inline/index.tsx(21,22): error TS2786: 'MySFC' cannot be used as a JSX component.
   Its return type 'import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element' is not a valid JSX element.
@@ -53,11 +55,15 @@ tests/cases/conformance/jsx/inline/index.tsx(24,48): error TS2322: Type 'import(
         }
     }
     export function predom(): predom.JSX.Element;
-==== tests/cases/conformance/jsx/inline/component.tsx (0 errors) ====
+==== tests/cases/conformance/jsx/inline/component.tsx (2 errors) ====
     /** @jsx predom */
     import { predom } from "./renderer2"
     
     export const MySFC = (props: {x: number, y: number, children?: predom.JSX.Element[]}) => <p>{props.x} + {props.y} = {props.x + props.y}{...this.props.children}</p>;
+                                                                                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2609: JSX spread child must be an array type.
+                                                                                                                                               ~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     
     export class MyClass implements predom.JSX.Element {
         __predomBrand!: void;

--- a/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.symbols
+++ b/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.symbols
@@ -127,7 +127,6 @@ export const MySFC = (props: {x: number, y: number, children?: predom.JSX.Elemen
 >props.y : Symbol(y, Decl(component.tsx, 3, 40))
 >props : Symbol(props, Decl(component.tsx, 3, 22))
 >y : Symbol(y, Decl(component.tsx, 3, 40))
->this : Symbol(globalThis)
 >p : Symbol(predom.JSX.IntrinsicElements, Decl(renderer2.d.ts, 1, 19))
 
 export class MyClass implements predom.JSX.Element {

--- a/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.types
+++ b/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.types
@@ -99,7 +99,7 @@ export const MySFC = (props: {x: number, y: number, children?: predom.JSX.Elemen
 >y : number
 >this.props.children : any
 >this.props : any
->this : typeof globalThis
+>this : undefined
 >props : any
 >children : any
 >p : any

--- a/tests/baselines/reference/thisInInvalidContextsExternalModule.errors.txt
+++ b/tests/baselines/reference/thisInInvalidContextsExternalModule.errors.txt
@@ -3,7 +3,7 @@ tests/cases/conformance/expressions/thisKeyword/thisInInvalidContextsExternalMod
 tests/cases/conformance/expressions/thisKeyword/thisInInvalidContextsExternalModule.ts(22,15): error TS17009: 'super' must be called before accessing 'this' in the constructor of a derived class.
 tests/cases/conformance/expressions/thisKeyword/thisInInvalidContextsExternalModule.ts(28,13): error TS2331: 'this' cannot be referenced in a module or namespace body.
 tests/cases/conformance/expressions/thisKeyword/thisInInvalidContextsExternalModule.ts(36,13): error TS2526: A 'this' type is available only in a non-static member of a class or interface.
-tests/cases/conformance/expressions/thisKeyword/thisInInvalidContextsExternalModule.ts(38,25): error TS2507: Type 'typeof globalThis' is not a constructor function type.
+tests/cases/conformance/expressions/thisKeyword/thisInInvalidContextsExternalModule.ts(38,25): error TS2507: Type 'undefined' is not a constructor function type.
 tests/cases/conformance/expressions/thisKeyword/thisInInvalidContextsExternalModule.ts(44,9): error TS2332: 'this' cannot be referenced in current location.
 tests/cases/conformance/expressions/thisKeyword/thisInInvalidContextsExternalModule.ts(45,9): error TS2332: 'this' cannot be referenced in current location.
 
@@ -58,7 +58,7 @@ tests/cases/conformance/expressions/thisKeyword/thisInInvalidContextsExternalMod
     
     class ErrClass3 extends this {
                             ~~~~
-!!! error TS2507: Type 'typeof globalThis' is not a constructor function type.
+!!! error TS2507: Type 'undefined' is not a constructor function type.
     
     }
     

--- a/tests/baselines/reference/thisInInvalidContextsExternalModule.symbols
+++ b/tests/baselines/reference/thisInInvalidContextsExternalModule.symbols
@@ -69,7 +69,6 @@ genericFunc<this>(undefined);  // Should be an error
 
 class ErrClass3 extends this {
 >ErrClass3 : Symbol(ErrClass3, Decl(thisInInvalidContextsExternalModule.ts, 35, 29))
->this : Symbol(globalThis)
 
 }
 

--- a/tests/baselines/reference/thisInInvalidContextsExternalModule.types
+++ b/tests/baselines/reference/thisInInvalidContextsExternalModule.types
@@ -72,7 +72,7 @@ genericFunc<this>(undefined);  // Should be an error
 
 class ErrClass3 extends this {
 >ErrClass3 : ErrClass3
->this : typeof globalThis
+>this : undefined
 
 }
 

--- a/tests/baselines/reference/topLevelLambda4.errors.txt
+++ b/tests/baselines/reference/topLevelLambda4.errors.txt
@@ -1,0 +1,7 @@
+tests/cases/compiler/topLevelLambda4.ts(1,22): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/compiler/topLevelLambda4.ts (1 errors) ====
+    export var x = () => this.window;
+                         ~~~~
+!!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/topLevelLambda4.symbols
+++ b/tests/baselines/reference/topLevelLambda4.symbols
@@ -1,7 +1,4 @@
 === tests/cases/compiler/topLevelLambda4.ts ===
 export var x = () => this.window;
 >x : Symbol(x, Decl(topLevelLambda4.ts, 0, 10))
->this.window : Symbol(window, Decl(lib.dom.d.ts, --, --))
->this : Symbol(globalThis)
->window : Symbol(window, Decl(lib.dom.d.ts, --, --))
 

--- a/tests/baselines/reference/topLevelLambda4.types
+++ b/tests/baselines/reference/topLevelLambda4.types
@@ -1,8 +1,8 @@
 === tests/cases/compiler/topLevelLambda4.ts ===
 export var x = () => this.window;
->x : () => Window & typeof globalThis
->() => this.window : () => Window & typeof globalThis
->this.window : Window & typeof globalThis
->this : typeof globalThis
->window : Window & typeof globalThis
+>x : () => any
+>() => this.window : () => any
+>this.window : any
+>this : undefined
+>window : any
 

--- a/tests/baselines/reference/tsxAttributeResolution15.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution15.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/jsx/file.tsx(11,21): error TS2322: Type '{ prop1: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
   Property 'prop1' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
-tests/cases/conformance/jsx/file.tsx(14,44): error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
+tests/cases/conformance/jsx/file.tsx(14,39): error TS2532: Object is possibly 'undefined'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (2 errors) ====
@@ -21,6 +21,6 @@ tests/cases/conformance/jsx/file.tsx(14,44): error TS7017: Element implicitly ha
     
     // OK
     let b = <BigGreeter ref={(input) => { this.textInput = input; }} />
-                                               ~~~~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
+                                          ~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     let c = <BigGreeter data-extra="hi" />

--- a/tests/baselines/reference/tsxAttributeResolution15.symbols
+++ b/tests/baselines/reference/tsxAttributeResolution15.symbols
@@ -31,7 +31,6 @@ let b = <BigGreeter ref={(input) => { this.textInput = input; }} />
 >BigGreeter : Symbol(BigGreeter, Decl(file.tsx, 0, 32))
 >ref : Symbol(ref, Decl(file.tsx, 13, 19))
 >input : Symbol(input, Decl(file.tsx, 13, 26))
->this : Symbol(globalThis)
 >input : Symbol(input, Decl(file.tsx, 13, 26))
 
 let c = <BigGreeter data-extra="hi" />

--- a/tests/baselines/reference/tsxAttributeResolution15.types
+++ b/tests/baselines/reference/tsxAttributeResolution15.types
@@ -37,7 +37,7 @@ let b = <BigGreeter ref={(input) => { this.textInput = input; }} />
 >input : BigGreeter
 >this.textInput = input : BigGreeter
 >this.textInput : any
->this : typeof globalThis
+>this : undefined
 >textInput : any
 >input : BigGreeter
 

--- a/tests/baselines/reference/tsxSpreadAttributesResolution4.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution4.errors.txt
@@ -1,0 +1,40 @@
+tests/cases/conformance/jsx/file.tsx(32,45): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
+    import React = require('react');
+    
+    interface PoisonedProp {
+        x: string;
+        y: 2;
+    }
+    
+    class Poisoned extends React.Component<PoisonedProp, {}> {
+        render() {
+            return <div>Hello</div>;
+        }
+    }
+    
+    const obj: PoisonedProp = {
+        x: "hello world",
+        y: 2
+    };
+    
+    // OK
+    let p = <Poisoned {...obj} />;
+    
+    class EmptyProp extends React.Component<{}, {}> {
+        render() {
+            return <div>Default hi</div>;
+        }
+    }
+    
+    // OK
+    let j: any;
+    let e1 = <EmptyProp {...{}} />;
+    let e2 = <EmptyProp {...j} />
+    let e3 = <EmptyProp {...{ ref: (input) => { this.textInput = input; } }} />
+                                                ~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    let e4 = <EmptyProp data-prop />
+    let e5 = <EmptyProp {...{ "data-prop": true}} />

--- a/tests/baselines/reference/tsxSpreadAttributesResolution4.symbols
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution4.symbols
@@ -79,7 +79,6 @@ let e3 = <EmptyProp {...{ ref: (input) => { this.textInput = input; } }} />
 >EmptyProp : Symbol(EmptyProp, Decl(file.tsx, 19, 30))
 >ref : Symbol(ref, Decl(file.tsx, 31, 25))
 >input : Symbol(input, Decl(file.tsx, 31, 32))
->this : Symbol(globalThis)
 >input : Symbol(input, Decl(file.tsx, 31, 32))
 
 let e4 = <EmptyProp data-prop />

--- a/tests/baselines/reference/tsxSpreadAttributesResolution4.types
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution4.types
@@ -89,7 +89,7 @@ let e3 = <EmptyProp {...{ ref: (input) => { this.textInput = input; } }} />
 >input : EmptyProp
 >this.textInput = input : EmptyProp
 >this.textInput : any
->this : typeof globalThis
+>this : undefined
 >textInput : any
 >input : EmptyProp
 


### PR DESCRIPTION
It's always supposed to have been this way, but I was worried about how breaky the change would be when adding globalThisType. This PR is an experiment to see how much.

Fixes #35882 maybe