### PR TITLE
Add a switch for reporting expensive statements

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -35668,7 +35668,7 @@ namespace ts {
                 checkSourceElementWorker(node);
 
                 // Never report expensive statements in .d.ts files
-                if (!checkingDtsFile) {
+                if (!checkingDtsFile && maxExpensiveStatementCount > 0) {
                     if (node.kind >= SyntaxKind.FirstStatement && node.kind <= SyntaxKind.LastStatement ||
                         node.kind === SyntaxKind.TypeAliasDeclaration ||
                         node.kind === SyntaxKind.InterfaceDeclaration) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -317,16 +317,6 @@ namespace ts {
         let constraintDepth = 0;
         let currentNode: Node | undefined;
 
-        interface ExpensiveStatement {
-            node: Node;
-            typeDelta: number;
-            symbolDelta: number;
-        }
-
-        let ignoreExpensiveStatement = true;
-        const maxExpensiveStatementCount = 5;
-        const expensiveStatements: ExpensiveStatement[] = [];
-
         const emptySymbols = createSymbolTable();
         const arrayVariances = [VarianceFlags.Covariant];
 
@@ -342,6 +332,16 @@ namespace ts {
         const noImplicitThis = getStrictOptionValue(compilerOptions, "noImplicitThis");
         const keyofStringsOnly = !!compilerOptions.keyofStringsOnly;
         const freshObjectLiteralFlag = compilerOptions.suppressExcessPropertyErrors ? 0 : ObjectFlags.FreshLiteral;
+
+        interface ExpensiveStatement {
+            node: Node;
+            typeDelta: number;
+            symbolDelta: number;
+        }
+
+        let ignoreExpensiveStatement = true;
+        const maxExpensiveStatementCount = compilerOptions.expensiveStatements ?? 0;
+        const expensiveStatements: ExpensiveStatement[] = [];
 
         const emitResolver = createResolver();
         const nodeBuilder = createNodeBuilder();

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -333,12 +333,6 @@ namespace ts {
         const keyofStringsOnly = !!compilerOptions.keyofStringsOnly;
         const freshObjectLiteralFlag = compilerOptions.suppressExcessPropertyErrors ? 0 : ObjectFlags.FreshLiteral;
 
-        interface ExpensiveStatement {
-            node: Node;
-            typeDelta: number;
-            symbolDelta: number;
-        }
-
         let ignoreExpensiveStatement = true;
         const maxExpensiveStatementCount = compilerOptions.expensiveStatements ?? 0;
         const expensiveStatements: ExpensiveStatement[] = [];
@@ -378,6 +372,7 @@ namespace ts {
                 subtype: subtypeRelation.size,
                 strictSubtype: strictSubtypeRelation.size,
             }),
+            getExpensiveStatements: () => expensiveStatements,
             isUndefinedSymbol: symbol => symbol === undefinedSymbol,
             isArgumentsSymbol: symbol => symbol === argumentsSymbol,
             isUnknownSymbol: symbol => symbol === unknownSymbol,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -35685,9 +35685,21 @@ namespace ts {
                         }
 
                         if (i < maxExpensiveStatementCount) {
-                            expensiveStatements.splice(i, 0, record);
-                            if (expensiveStatements.length > maxExpensiveStatementCount) {
-                                expensiveStatements.pop();
+                            let hasExpensiveDescendent = false;
+                            // Search forward since descendants cannot be more expensive
+                            for (let j = i; j < expensiveStatements.length; j++) {
+                                const candidate = expensiveStatements[j];
+                                if (isNodeDescendantOf(candidate.node, record.node)) {
+                                    // A node that isn't at least 50% more expensive than one of its descendants isn't interesting
+                                    hasExpensiveDescendent = (record.typeDelta / candidate.typeDelta) < 1.5;
+                                    break; // Stop looking since all subsequent nodes are less expensive
+                                }
+                            }
+                            if (!hasExpensiveDescendent) {
+                                expensiveStatements.splice(i, 0, record);
+                                if (expensiveStatements.length > maxExpensiveStatementCount) {
+                                    expensiveStatements.pop();
+                                }
                             }
                         }
                     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -35669,7 +35669,9 @@ namespace ts {
 
                 // Never report expensive statements in .d.ts files
                 if (!checkingDtsFile) {
-                    if (node.kind >= SyntaxKind.FirstStatement && node.kind <= SyntaxKind.LastStatement) {
+                    if (node.kind >= SyntaxKind.FirstStatement && node.kind <= SyntaxKind.LastStatement ||
+                        node.kind === SyntaxKind.TypeAliasDeclaration ||
+                        node.kind === SyntaxKind.InterfaceDeclaration) {
                         const typeDelta = typeCount - oldTypeCount;
                         const symbolDelta = symbolCount - oldSymbolCount;
                         const record = { node, typeDelta, symbolDelta };

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -35709,7 +35709,7 @@ namespace ts {
                     const candidate = expensiveStatements[j];
                     if (isNodeDescendantOf(candidate.node, record.node)) {
                         // If a single descendant makes up the majority of the cost, this node isn't interesting
-                        hasExpensiveDescendent = (record.typeDelta / candidate.typeDelta) < 2
+                        hasExpensiveDescendent = (record.typeDelta / candidate.typeDelta) < 2;
                         break; // Stop looking since all subsequent nodes are less expensive
                     }
                 }

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -219,6 +219,12 @@ namespace ts {
             category: Diagnostics.Advanced_Options,
             description: Diagnostics.The_locale_used_when_displaying_messages_to_the_user_e_g_en_us
         },
+        {
+            name: "expensiveStatements",
+            type: "number",
+            category: Diagnostics.Advanced_Options,
+            description: Diagnostics.Heuristically_reports_statements_that_appear_to_contribute_disproportionately_to_check_time
+        },
     ];
 
     /* @internal */

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4482,6 +4482,10 @@
         "category": "Error",
         "code": 6236
     },
+    "Heuristically reports statements that appear to contribute disproportionately to check time.": {
+        "category": "Message",
+        "code": 6237
+    },
 
     "Projects to reference": {
         "category": "Message",
@@ -5984,5 +5988,10 @@
     "Invalid value for 'jsxFragmentFactory'. '{0}' is not a valid identifier or qualified-name.": {
         "category": "Error",
         "code": 18035
+    },
+
+    "Checking this statement may result in the creation of as many as {0} types and {1} symbols.": {
+        "category": "Warning",
+        "code": 19000
     }
 }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -895,7 +895,14 @@ namespace ts {
             }
 
             missingFilePaths = arrayFrom(mapDefinedIterator(filesByName.entries(), ([path, file]) => file === undefined ? path as Path : undefined));
-            files = stableSort(processingDefaultLibFiles, compareDefaultLibFiles).concat(processingOtherFiles);
+
+            const dtsFiles: SourceFile[] = [];
+            const otherFiles: SourceFile[] = [];
+            for (const file of processingOtherFiles) {
+                (fileExtensionIs(file.path, Extension.Dts) ? dtsFiles : otherFiles).push(file);
+            }
+
+            files = stableSort(processingDefaultLibFiles, compareDefaultLibFiles).concat(dtsFiles).concat(otherFiles);
             processingDefaultLibFiles = undefined;
             processingOtherFiles = undefined;
         }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -954,6 +954,7 @@ namespace ts {
             getTypeCount: () => getDiagnosticsProducingTypeChecker().getTypeCount(),
             getInstantiationCount: () => getDiagnosticsProducingTypeChecker().getInstantiationCount(),
             getRelationCacheSizes: () => getDiagnosticsProducingTypeChecker().getRelationCacheSizes(),
+            getExpensiveStatements: () => getDiagnosticsProducingTypeChecker().getExpensiveStatements(),
             getFileProcessingDiagnostics: () => fileProcessingDiagnostics,
             getResolvedTypeReferenceDirectives: () => resolvedTypeReferenceDirectives,
             isSourceFileFromExternalLibrary,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5675,6 +5675,7 @@ namespace ts {
         downlevelIteration?: boolean;
         emitBOM?: boolean;
         emitDecoratorMetadata?: boolean;
+        /*@internal*/ expensiveStatements?: number;
         experimentalDecorators?: boolean;
         forceConsistentCasingInFileNames?: boolean;
         /*@internal*/generateCpuProfile?: string;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3737,6 +3737,7 @@ namespace ts {
         getTypeCount(): number;
         getInstantiationCount(): number;
         getRelationCacheSizes(): { assignable: number, identity: number, subtype: number, strictSubtype: number };
+        /* @internal */ getExpensiveStatements(): readonly ExpensiveStatement[];
 
         /* @internal */ getFileProcessingDiagnostics(): DiagnosticCollection;
         /* @internal */ getResolvedTypeReferenceDirectives(): ESMap<string, ResolvedTypeReferenceDirective | undefined>;
@@ -4070,6 +4071,7 @@ namespace ts {
         /* @internal */ getTypeCount(): number;
         /* @internal */ getInstantiationCount(): number;
         /* @internal */ getRelationCacheSizes(): { assignable: number, identity: number, subtype: number, strictSubtype: number };
+        /* @internal */ getExpensiveStatements(): readonly ExpensiveStatement[];
 
         /* @internal */ isArrayType(type: Type): boolean;
         /* @internal */ isTupleType(type: Type): boolean;
@@ -8067,5 +8069,12 @@ namespace ts {
     export interface PseudoBigInt {
         negative: boolean;
         base10Value: string;
+    }
+
+    /* @internal */
+    export interface ExpensiveStatement {
+        node: Node;
+        typeDelta: number;
+        symbolDelta: number;
     }
 }

--- a/tests/baselines/reference/moduleAugmentationDuringSyntheticDefaultCheck.symbols
+++ b/tests/baselines/reference/moduleAugmentationDuringSyntheticDefaultCheck.symbols
@@ -6,15 +6,15 @@ import moment = require("moment-timezone");
 
 === tests/cases/compiler/node_modules/moment/index.d.ts ===
 declare function moment(): moment.Moment;
->moment : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(index.d.ts, 1, 16))
->moment : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(index.d.ts, 1, 16))
->Moment : Symbol(moment.Moment, Decl(index.d.ts, 1, 26), Decl(idx.ts, 1, 25), Decl(idx.ts, 6, 34), Decl(index.d.ts, 2, 25))
+>moment : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(index.d.ts, 1, 16), Decl(idx.ts, 0, 34))
+>moment : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(index.d.ts, 1, 16), Decl(idx.ts, 0, 34))
+>Moment : Symbol(moment.Moment, Decl(index.d.ts, 1, 26), Decl(index.d.ts, 2, 25), Decl(idx.ts, 1, 25), Decl(idx.ts, 6, 34))
 
 declare namespace moment {
->moment : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(index.d.ts, 1, 16))
+>moment : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(index.d.ts, 1, 16), Decl(idx.ts, 0, 34))
 
   interface Moment extends Object {
->Moment : Symbol(Moment, Decl(index.d.ts, 1, 26), Decl(idx.ts, 1, 25), Decl(idx.ts, 6, 34), Decl(index.d.ts, 2, 25))
+>Moment : Symbol(Moment, Decl(index.d.ts, 1, 26), Decl(index.d.ts, 2, 25), Decl(idx.ts, 1, 25), Decl(idx.ts, 6, 34))
 >Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
     valueOf(): number;
@@ -22,7 +22,7 @@ declare namespace moment {
   }
 }
 export = moment;
->moment : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(index.d.ts, 1, 16))
+>moment : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(index.d.ts, 1, 16), Decl(idx.ts, 0, 34))
 
 === tests/cases/compiler/node_modules/moment-timezone/index.d.ts ===
 import * as moment from 'moment';
@@ -32,10 +32,10 @@ export = moment;
 >moment : Symbol(moment, Decl(index.d.ts, 0, 6))
 
 declare module "moment" {
->"moment" : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(index.d.ts, 1, 16))
+>"moment" : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(index.d.ts, 1, 16), Decl(idx.ts, 0, 34))
 
     interface Moment {
->Moment : Symbol(Moment, Decl(index.d.ts, 1, 26), Decl(idx.ts, 1, 25), Decl(idx.ts, 6, 34), Decl(index.d.ts, 2, 25))
+>Moment : Symbol(Moment, Decl(index.d.ts, 1, 26), Decl(index.d.ts, 2, 25), Decl(idx.ts, 1, 25), Decl(idx.ts, 6, 34))
 
         tz(): string;
 >tz : Symbol(Moment.tz, Decl(index.d.ts, 3, 22))
@@ -46,10 +46,10 @@ import * as _moment from "moment";
 >_moment : Symbol(_moment, Decl(idx.ts, 0, 6))
 
 declare module "moment" {
->"moment" : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(index.d.ts, 1, 16))
+>"moment" : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(index.d.ts, 1, 16), Decl(idx.ts, 0, 34))
 
     interface Moment {
->Moment : Symbol(Moment, Decl(index.d.ts, 1, 26), Decl(idx.ts, 1, 25), Decl(idx.ts, 6, 34), Decl(index.d.ts, 2, 25))
+>Moment : Symbol(Moment, Decl(index.d.ts, 1, 26), Decl(index.d.ts, 2, 25), Decl(idx.ts, 1, 25), Decl(idx.ts, 6, 34))
 
         strftime(pattern: string): string;
 >strftime : Symbol(Moment.strftime, Decl(idx.ts, 2, 22), Decl(idx.ts, 7, 22))
@@ -57,10 +57,10 @@ declare module "moment" {
     }
 }
 declare module "moment-timezone" {
->"moment-timezone" : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(idx.ts, 5, 1))
+>"moment-timezone" : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(index.d.ts, 1, 16), Decl(idx.ts, 0, 34), Decl(idx.ts, 5, 1))
 
     interface Moment {
->Moment : Symbol(Moment, Decl(index.d.ts, 1, 26), Decl(idx.ts, 1, 25), Decl(idx.ts, 6, 34), Decl(index.d.ts, 2, 25))
+>Moment : Symbol(Moment, Decl(index.d.ts, 1, 26), Decl(index.d.ts, 2, 25), Decl(idx.ts, 1, 25), Decl(idx.ts, 6, 34))
 
         strftime(pattern: string): string;
 >strftime : Symbol(Moment.strftime, Decl(idx.ts, 2, 22), Decl(idx.ts, 7, 22))

--- a/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/amd/nodeModulesMaxDepthIncreased.errors.txt
+++ b/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/amd/nodeModulesMaxDepthIncreased.errors.txt
@@ -9,6 +9,9 @@ maxDepthIncreased/root.ts(7,1): error TS2322: Type 'string' is not assignable to
       }
     }
     
+==== entry.d.ts (0 errors) ====
+    export declare var foo: number;
+    
 ==== index.js (0 errors) ====
     exports.person = {
         "name": "John Doe",
@@ -35,9 +38,6 @@ maxDepthIncreased/root.ts(7,1): error TS2322: Type 'string' is not assignable to
     };
     
     exports.f2 = m2;
-    
-==== entry.d.ts (0 errors) ====
-    export declare var foo: number;
     
 ==== maxDepthIncreased/root.ts (1 errors) ====
     import * as m1 from "m1";

--- a/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/amd/nodeModulesMaxDepthIncreased.json
+++ b/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/amd/nodeModulesMaxDepthIncreased.json
@@ -7,10 +7,10 @@
     "project": "maxDepthIncreased",
     "resolvedInputFiles": [
         "lib.es5.d.ts",
+        "maxDepthIncreased/node_modules/@types/m4/entry.d.ts",
         "maxDepthIncreased/node_modules/m2/node_modules/m3/index.js",
         "maxDepthIncreased/node_modules/m2/entry.js",
         "maxDepthIncreased/node_modules/m1/index.js",
-        "maxDepthIncreased/node_modules/@types/m4/entry.d.ts",
         "maxDepthIncreased/root.ts"
     ],
     "emittedFiles": [

--- a/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/node/nodeModulesMaxDepthIncreased.errors.txt
+++ b/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/node/nodeModulesMaxDepthIncreased.errors.txt
@@ -9,6 +9,9 @@ maxDepthIncreased/root.ts(7,1): error TS2322: Type 'string' is not assignable to
       }
     }
     
+==== entry.d.ts (0 errors) ====
+    export declare var foo: number;
+    
 ==== index.js (0 errors) ====
     exports.person = {
         "name": "John Doe",
@@ -35,9 +38,6 @@ maxDepthIncreased/root.ts(7,1): error TS2322: Type 'string' is not assignable to
     };
     
     exports.f2 = m2;
-    
-==== entry.d.ts (0 errors) ====
-    export declare var foo: number;
     
 ==== maxDepthIncreased/root.ts (1 errors) ====
     import * as m1 from "m1";

--- a/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/node/nodeModulesMaxDepthIncreased.json
+++ b/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/node/nodeModulesMaxDepthIncreased.json
@@ -7,10 +7,10 @@
     "project": "maxDepthIncreased",
     "resolvedInputFiles": [
         "lib.es5.d.ts",
+        "maxDepthIncreased/node_modules/@types/m4/entry.d.ts",
         "maxDepthIncreased/node_modules/m2/node_modules/m3/index.js",
         "maxDepthIncreased/node_modules/m2/entry.js",
         "maxDepthIncreased/node_modules/m1/index.js",
-        "maxDepthIncreased/node_modules/@types/m4/entry.d.ts",
         "maxDepthIncreased/root.ts"
     ],
     "emittedFiles": [

--- a/tests/baselines/reference/showConfig/Shows tsconfig for single option/expensiveStatements/tsconfig.json
+++ b/tests/baselines/reference/showConfig/Shows tsconfig for single option/expensiveStatements/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "expensiveStatements": 0
+    }
+}

--- a/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-build/inferred-type-from-transitive-module-with-isolatedModules.js
+++ b/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-build/inferred-type-from-transitive-module-with-isolatedModules.js
@@ -160,6 +160,11 @@ Object.defineProperty(exports, "bar", { enumerable: true, get: function () { ret
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "../global.d.ts": {
+        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "affectsGlobalScope": true
+      },
       "../bar.ts": {
         "version": "5936740878-interface RawAction {\r\n    (...args: any[]): Promise<any> | void;\r\n}\r\ninterface ActionFactory {\r\n    <T extends RawAction>(target: T): T;\r\n}\r\ndeclare function foo<U extends any[] = any[]>(): ActionFactory;\r\nexport default foo()(function foobar(param: string): void {\r\n});",
         "signature": "11191036521-declare const _default: (param: string) => void;\r\nexport default _default;\r\n",
@@ -169,11 +174,6 @@ Object.defineProperty(exports, "bar", { enumerable: true, get: function () { ret
         "version": "-21659820217-export class LazyModule<TModule> {\r\n    constructor(private importCallback: () => Promise<TModule>) {}\r\n}\r\n\r\nexport class LazyAction<\r\n    TAction extends (...args: any[]) => any,\r\n    TModule\r\n>  {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction) {\r\n    }\r\n}\r\n",
         "signature": "-40032907372-export declare class LazyModule<TModule> {\r\n    private importCallback;\r\n    constructor(importCallback: () => Promise<TModule>);\r\n}\r\nexport declare class LazyAction<TAction extends (...args: any[]) => any, TModule> {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction);\r\n}\r\n",
         "affectsGlobalScope": false
-      },
-      "../global.d.ts": {
-        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
-        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
-        "affectsGlobalScope": true
       },
       "../lazyindex.ts": {
         "version": "-6956449754-export { default as bar } from './bar';\n",
@@ -282,6 +282,11 @@ export declare const lazyBar: LazyAction<() => void, typeof import("./lazyIndex"
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "../global.d.ts": {
+        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "affectsGlobalScope": true
+      },
       "../bar.ts": {
         "version": "747071916-interface RawAction {\r\n    (...args: any[]): Promise<any> | void;\r\n}\r\ninterface ActionFactory {\r\n    <T extends RawAction>(target: T): T;\r\n}\r\ndeclare function foo<U extends any[] = any[]>(): ActionFactory;\r\nexport default foo()(function foobar(): void {\r\n});",
         "signature": "-9232740537-declare const _default: () => void;\r\nexport default _default;\r\n",
@@ -291,11 +296,6 @@ export declare const lazyBar: LazyAction<() => void, typeof import("./lazyIndex"
         "version": "-21659820217-export class LazyModule<TModule> {\r\n    constructor(private importCallback: () => Promise<TModule>) {}\r\n}\r\n\r\nexport class LazyAction<\r\n    TAction extends (...args: any[]) => any,\r\n    TModule\r\n>  {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction) {\r\n    }\r\n}\r\n",
         "signature": "-40032907372-export declare class LazyModule<TModule> {\r\n    private importCallback;\r\n    constructor(importCallback: () => Promise<TModule>);\r\n}\r\nexport declare class LazyAction<TAction extends (...args: any[]) => any, TModule> {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction);\r\n}\r\n",
         "affectsGlobalScope": false
-      },
-      "../global.d.ts": {
-        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
-        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
-        "affectsGlobalScope": true
       },
       "../lazyindex.ts": {
         "version": "-6956449754-export { default as bar } from './bar';\n",

--- a/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-build/inferred-type-from-transitive-module.js
+++ b/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-build/inferred-type-from-transitive-module.js
@@ -160,6 +160,11 @@ Object.defineProperty(exports, "bar", { enumerable: true, get: function () { ret
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "../global.d.ts": {
+        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "affectsGlobalScope": true
+      },
       "../bar.ts": {
         "version": "5936740878-interface RawAction {\r\n    (...args: any[]): Promise<any> | void;\r\n}\r\ninterface ActionFactory {\r\n    <T extends RawAction>(target: T): T;\r\n}\r\ndeclare function foo<U extends any[] = any[]>(): ActionFactory;\r\nexport default foo()(function foobar(param: string): void {\r\n});",
         "signature": "11191036521-declare const _default: (param: string) => void;\r\nexport default _default;\r\n",
@@ -169,11 +174,6 @@ Object.defineProperty(exports, "bar", { enumerable: true, get: function () { ret
         "version": "-21659820217-export class LazyModule<TModule> {\r\n    constructor(private importCallback: () => Promise<TModule>) {}\r\n}\r\n\r\nexport class LazyAction<\r\n    TAction extends (...args: any[]) => any,\r\n    TModule\r\n>  {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction) {\r\n    }\r\n}\r\n",
         "signature": "-40032907372-export declare class LazyModule<TModule> {\r\n    private importCallback;\r\n    constructor(importCallback: () => Promise<TModule>);\r\n}\r\nexport declare class LazyAction<TAction extends (...args: any[]) => any, TModule> {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction);\r\n}\r\n",
         "affectsGlobalScope": false
-      },
-      "../global.d.ts": {
-        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
-        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
-        "affectsGlobalScope": true
       },
       "../lazyindex.ts": {
         "version": "-6956449754-export { default as bar } from './bar';\n",
@@ -282,6 +282,11 @@ export declare const lazyBar: LazyAction<() => void, typeof import("./lazyIndex"
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "../global.d.ts": {
+        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "affectsGlobalScope": true
+      },
       "../bar.ts": {
         "version": "747071916-interface RawAction {\r\n    (...args: any[]): Promise<any> | void;\r\n}\r\ninterface ActionFactory {\r\n    <T extends RawAction>(target: T): T;\r\n}\r\ndeclare function foo<U extends any[] = any[]>(): ActionFactory;\r\nexport default foo()(function foobar(): void {\r\n});",
         "signature": "-9232740537-declare const _default: () => void;\r\nexport default _default;\r\n",
@@ -291,11 +296,6 @@ export declare const lazyBar: LazyAction<() => void, typeof import("./lazyIndex"
         "version": "-21659820217-export class LazyModule<TModule> {\r\n    constructor(private importCallback: () => Promise<TModule>) {}\r\n}\r\n\r\nexport class LazyAction<\r\n    TAction extends (...args: any[]) => any,\r\n    TModule\r\n>  {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction) {\r\n    }\r\n}\r\n",
         "signature": "-40032907372-export declare class LazyModule<TModule> {\r\n    private importCallback;\r\n    constructor(importCallback: () => Promise<TModule>);\r\n}\r\nexport declare class LazyAction<TAction extends (...args: any[]) => any, TModule> {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction);\r\n}\r\n",
         "affectsGlobalScope": false
-      },
-      "../global.d.ts": {
-        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
-        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
-        "affectsGlobalScope": true
       },
       "../lazyindex.ts": {
         "version": "-6956449754-export { default as bar } from './bar';\n",

--- a/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-build/reports-errors-in-files-affected-by-change-in-signature-with-isolatedModules.js
+++ b/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-build/reports-errors-in-files-affected-by-change-in-signature-with-isolatedModules.js
@@ -164,6 +164,11 @@ bar_2.default("hello");
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "../global.d.ts": {
+        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "affectsGlobalScope": true
+      },
       "../bar.ts": {
         "version": "5936740878-interface RawAction {\r\n    (...args: any[]): Promise<any> | void;\r\n}\r\ninterface ActionFactory {\r\n    <T extends RawAction>(target: T): T;\r\n}\r\ndeclare function foo<U extends any[] = any[]>(): ActionFactory;\r\nexport default foo()(function foobar(param: string): void {\r\n});",
         "signature": "11191036521-declare const _default: (param: string) => void;\r\nexport default _default;\r\n",
@@ -173,11 +178,6 @@ bar_2.default("hello");
         "version": "-21659820217-export class LazyModule<TModule> {\r\n    constructor(private importCallback: () => Promise<TModule>) {}\r\n}\r\n\r\nexport class LazyAction<\r\n    TAction extends (...args: any[]) => any,\r\n    TModule\r\n>  {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction) {\r\n    }\r\n}\r\n",
         "signature": "-40032907372-export declare class LazyModule<TModule> {\r\n    private importCallback;\r\n    constructor(importCallback: () => Promise<TModule>);\r\n}\r\nexport declare class LazyAction<TAction extends (...args: any[]) => any, TModule> {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction);\r\n}\r\n",
         "affectsGlobalScope": false
-      },
-      "../global.d.ts": {
-        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
-        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
-        "affectsGlobalScope": true
       },
       "../lazyindex.ts": {
         "version": "3017320451-export { default as bar } from './bar';\n\nimport { default as bar } from './bar';\nbar(\"hello\");",
@@ -274,6 +274,11 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "../global.d.ts": {
+        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "affectsGlobalScope": true
+      },
       "../bar.ts": {
         "version": "747071916-interface RawAction {\r\n    (...args: any[]): Promise<any> | void;\r\n}\r\ninterface ActionFactory {\r\n    <T extends RawAction>(target: T): T;\r\n}\r\ndeclare function foo<U extends any[] = any[]>(): ActionFactory;\r\nexport default foo()(function foobar(): void {\r\n});",
         "signature": "-9232740537-declare const _default: () => void;\r\nexport default _default;\r\n",
@@ -283,11 +288,6 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
         "version": "-21659820217-export class LazyModule<TModule> {\r\n    constructor(private importCallback: () => Promise<TModule>) {}\r\n}\r\n\r\nexport class LazyAction<\r\n    TAction extends (...args: any[]) => any,\r\n    TModule\r\n>  {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction) {\r\n    }\r\n}\r\n",
         "signature": "-40032907372-export declare class LazyModule<TModule> {\r\n    private importCallback;\r\n    constructor(importCallback: () => Promise<TModule>);\r\n}\r\nexport declare class LazyAction<TAction extends (...args: any[]) => any, TModule> {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction);\r\n}\r\n",
         "affectsGlobalScope": false
-      },
-      "../global.d.ts": {
-        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
-        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
-        "affectsGlobalScope": true
       },
       "../lazyindex.ts": {
         "version": "3017320451-export { default as bar } from './bar';\n\nimport { default as bar } from './bar';\nbar(\"hello\");",
@@ -427,6 +427,11 @@ bar_2.default();
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "../global.d.ts": {
+        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "affectsGlobalScope": true
+      },
       "../bar.ts": {
         "version": "747071916-interface RawAction {\r\n    (...args: any[]): Promise<any> | void;\r\n}\r\ninterface ActionFactory {\r\n    <T extends RawAction>(target: T): T;\r\n}\r\ndeclare function foo<U extends any[] = any[]>(): ActionFactory;\r\nexport default foo()(function foobar(): void {\r\n});",
         "signature": "-9232740537-declare const _default: () => void;\r\nexport default _default;\r\n",
@@ -436,11 +441,6 @@ bar_2.default();
         "version": "-21659820217-export class LazyModule<TModule> {\r\n    constructor(private importCallback: () => Promise<TModule>) {}\r\n}\r\n\r\nexport class LazyAction<\r\n    TAction extends (...args: any[]) => any,\r\n    TModule\r\n>  {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction) {\r\n    }\r\n}\r\n",
         "signature": "-40032907372-export declare class LazyModule<TModule> {\r\n    private importCallback;\r\n    constructor(importCallback: () => Promise<TModule>);\r\n}\r\nexport declare class LazyAction<TAction extends (...args: any[]) => any, TModule> {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction);\r\n}\r\n",
         "affectsGlobalScope": false
-      },
-      "../global.d.ts": {
-        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
-        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
-        "affectsGlobalScope": true
       },
       "../lazyindex.ts": {
         "version": "-3721262293-export { default as bar } from './bar';\n\nimport { default as bar } from './bar';\nbar();",

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/Detects-type-only-changes-in-upstream-projects.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/Detects-type-only-changes-in-upstream-projects.js
@@ -55,6 +55,11 @@ exports.multiply = multiply;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -64,11 +69,6 @@ exports.multiply = multiply;
         "version": "-2157245566-export const someString: string = \"WELCOME PLANET\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "-13851440507-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/always-builds-under-with-force-option.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/always-builds-under-with-force-option.js
@@ -144,6 +144,11 @@ exports.multiply = multiply;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -153,11 +158,6 @@ exports.multiply = multiply;
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "-13851440507-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/builds-correctly-when-declarationDir-is-specified.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/builds-correctly-when-declarationDir-is-specified.js
@@ -132,6 +132,11 @@ exports.multiply = multiply;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -141,11 +146,6 @@ exports.multiply = multiply;
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "-13851440507-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/builds-correctly-when-outDir-is-specified.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/builds-correctly-when-outDir-is-specified.js
@@ -132,6 +132,11 @@ exports.multiply = multiply;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -141,11 +146,6 @@ exports.multiply = multiply;
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "-13851440507-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/can-detect-when-and-what-to-rebuild.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/can-detect-when-and-what-to-rebuild.js
@@ -48,6 +48,11 @@ Input::
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -57,11 +62,6 @@ Input::
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "-13851440507-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/does-not-build-downstream-projects-if-upstream-projects-have-errors.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/does-not-build-downstream-projects-if-upstream-projects-have-errors.js
@@ -161,6 +161,11 @@ exports.multiply = multiply;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -170,11 +175,6 @@ exports.multiply = multiply;
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "-13851440507-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/listEmittedFiles.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/listEmittedFiles.js
@@ -158,6 +158,11 @@ exports.multiply = multiply;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -167,11 +172,6 @@ exports.multiply = multiply;
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "-13851440507-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {
@@ -421,6 +421,11 @@ exports.someClass = someClass;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -430,11 +435,6 @@ exports.someClass = someClass;
         "version": "-13387000654-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n\nexport class someClass { }",
         "signature": "-2069755619-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\nexport declare class someClass {\r\n}\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {
@@ -640,6 +640,11 @@ var someClass2 = /** @class */ (function () {
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -649,11 +654,6 @@ var someClass2 = /** @class */ (function () {
         "version": "-11293323834-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n\nexport class someClass { }\nclass someClass2 { }",
         "signature": "-2069755619-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\nexport declare class someClass {\r\n}\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/listFiles.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/listFiles.js
@@ -99,9 +99,9 @@ export const m = mod;
 Output::
 /lib/tsc --b /src/tests --listFiles
 /lib/lib.d.ts
+/src/core/some_decl.d.ts
 /src/core/anotherModule.ts
 /src/core/index.ts
-/src/core/some_decl.d.ts
 /lib/lib.d.ts
 /src/core/index.d.ts
 /src/core/anotherModule.d.ts
@@ -157,6 +157,11 @@ exports.multiply = multiply;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -166,11 +171,6 @@ exports.multiply = multiply;
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "-13851440507-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {
@@ -370,9 +370,9 @@ export class someClass { }
 Output::
 /lib/tsc --b /src/tests --listFiles
 /lib/lib.d.ts
+/src/core/some_decl.d.ts
 /src/core/anotherModule.ts
 /src/core/index.ts
-/src/core/some_decl.d.ts
 /lib/lib.d.ts
 /src/core/index.d.ts
 /src/core/anotherModule.d.ts
@@ -422,6 +422,11 @@ exports.someClass = someClass;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -431,11 +436,6 @@ exports.someClass = someClass;
         "version": "-13387000654-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n\nexport class someClass { }",
         "signature": "-2069755619-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\nexport declare class someClass {\r\n}\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {
@@ -602,9 +602,9 @@ class someClass2 { }
 Output::
 /lib/tsc --b /src/tests --listFiles
 /lib/lib.d.ts
+/src/core/some_decl.d.ts
 /src/core/anotherModule.ts
 /src/core/index.ts
-/src/core/some_decl.d.ts
 exitCode:: ExitStatus.Success
 
 
@@ -641,6 +641,11 @@ var someClass2 = /** @class */ (function () {
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -650,11 +655,6 @@ var someClass2 = /** @class */ (function () {
         "version": "-11293323834-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n\nexport class someClass { }\nclass someClass2 { }",
         "signature": "-2069755619-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\nexport declare class someClass {\r\n}\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/rebuilds-when-extended-config-file-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/rebuilds-when-extended-config-file-changes.js
@@ -164,6 +164,11 @@ exports.multiply = multiply;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -173,11 +178,6 @@ exports.multiply = multiply;
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "-13851440507-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/sample.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/sample.js
@@ -326,6 +326,11 @@ exports.multiply = multiply;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -335,11 +340,6 @@ exports.multiply = multiply;
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "-13851440507-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {
@@ -870,6 +870,11 @@ exports.someClass = someClass;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -879,11 +884,6 @@ exports.someClass = someClass;
         "version": "-13387000654-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n\nexport class someClass { }",
         "signature": "-2069755619-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\nexport declare class someClass {\r\n}\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {
@@ -1114,6 +1114,11 @@ var someClass2 = /** @class */ (function () {
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -1123,11 +1128,6 @@ var someClass2 = /** @class */ (function () {
         "version": "-11293323834-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n\nexport class someClass { }\nclass someClass2 { }",
         "signature": "-2069755619-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\nexport declare class someClass {\r\n}\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/when-declaration-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/when-declaration-option-changes.js
@@ -95,6 +95,11 @@ exports.multiply = multiply;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "-8396256275-export declare const World = \"hello\";\r\n",
@@ -104,11 +109,6 @@ exports.multiply = multiply;
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "1874987148-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {
@@ -175,6 +175,11 @@ export declare function multiply(a: number, b: number): number;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "-8396256275-export declare const World = \"hello\";\r\n",
@@ -184,11 +189,6 @@ export declare function multiply(a: number, b: number): number;
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "1874987148-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/when-esModuleInterop-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/when-esModuleInterop-option-changes.js
@@ -162,6 +162,11 @@ exports.multiply = multiply;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -171,11 +176,6 @@ exports.multiply = multiply;
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "-13851440507-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/when-logic-specifies-tsBuildInfoFile.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/when-logic-specifies-tsBuildInfoFile.js
@@ -327,6 +327,11 @@ exports.multiply = multiply;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "7652028357-export declare const World = \"hello\";\r\n//# sourceMappingURL=anotherModule.d.ts.map",
@@ -336,11 +341,6 @@ exports.multiply = multiply;
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "-13851440507-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n//# sourceMappingURL=index.d.ts.map",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/when-module-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/when-module-option-changes.js
@@ -95,6 +95,11 @@ exports.multiply = multiply;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "-8396256275-export declare const World = \"hello\";\r\n",
@@ -104,11 +109,6 @@ exports.multiply = multiply;
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "1874987148-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {
@@ -185,6 +185,11 @@ define(["require", "exports"], function (require, exports) {
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "-8396256275-export declare const World = \"hello\";\r\n",
@@ -194,11 +199,6 @@ define(["require", "exports"], function (require, exports) {
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "1874987148-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/when-target-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/when-target-option-changes.js
@@ -80,9 +80,9 @@ TSFILE: /src/core/index.js
 TSFILE: /src/core/tsconfig.tsbuildinfo
 /lib/lib.esnext.d.ts
 /lib/lib.esnext.full.d.ts
+/src/core/some_decl.d.ts
 /src/core/anotherModule.ts
 /src/core/index.ts
-/src/core/some_decl.d.ts
 exitCode:: ExitStatus.Success
 
 
@@ -110,6 +110,11 @@ export function multiply(a, b) { return a * b; }
         "signature": "8926001564-/// <reference no-default-lib=\"true\"/>\n/// <reference lib=\"esnext\" />",
         "affectsGlobalScope": false
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "-8396256275-export declare const World = \"hello\";\r\n",
@@ -119,11 +124,6 @@ export function multiply(a, b) { return a * b; }
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "1874987148-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {
@@ -176,9 +176,9 @@ TSFILE: /src/core/index.js
 TSFILE: /src/core/tsconfig.tsbuildinfo
 /lib/lib.d.ts
 /lib/lib.esnext.d.ts
+/src/core/some_decl.d.ts
 /src/core/anotherModule.ts
 /src/core/index.ts
-/src/core/some_decl.d.ts
 exitCode:: ExitStatus.Success
 
 
@@ -214,6 +214,11 @@ exports.multiply = multiply;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "./some_decl.d.ts": {
+        "version": "-9253692965-declare const dts: any;\r\n",
+        "signature": "-9253692965-declare const dts: any;\r\n",
+        "affectsGlobalScope": true
+      },
       "./anothermodule.ts": {
         "version": "-2676574883-export const World = \"hello\";\r\n",
         "signature": "-8396256275-export declare const World = \"hello\";\r\n",
@@ -223,11 +228,6 @@ exports.multiply = multiply;
         "version": "-18749805970-export const someString: string = \"HELLO WORLD\";\r\nexport function leftPad(s: string, n: number) { return s + n; }\r\nexport function multiply(a: number, b: number) { return a * b; }\r\n",
         "signature": "1874987148-export declare const someString: string;\r\nexport declare function leftPad(s: string, n: number): string;\r\nexport declare function multiply(a: number, b: number): number;\r\n",
         "affectsGlobalScope": false
-      },
-      "./some_decl.d.ts": {
-        "version": "-9253692965-declare const dts: any;\r\n",
-        "signature": "-9253692965-declare const dts: any;\r\n",
-        "affectsGlobalScope": true
       }
     },
     "options": {

--- a/tests/baselines/reference/tsbuild/transitiveReferences/initial-build/builds-correctly-when-the-referenced-project-uses-different-module-resolution.js
+++ b/tests/baselines/reference/tsbuild/transitiveReferences/initial-build/builds-correctly-when-the-referenced-project-uses-different-module-resolution.js
@@ -63,9 +63,9 @@ Output::
 /src/a.d.ts
 /src/b.ts
 /lib/lib.d.ts
+/src/refs/a.d.ts
 /src/a.d.ts
 /src/b.d.ts
-/src/refs/a.d.ts
 /src/c.ts
 exitCode:: ExitStatus.Success
 

--- a/tests/baselines/reference/tsbuild/transitiveReferences/initial-build/builds-correctly.js
+++ b/tests/baselines/reference/tsbuild/transitiveReferences/initial-build/builds-correctly.js
@@ -75,9 +75,9 @@ Output::
 /src/a.d.ts
 /src/b.ts
 /lib/lib.d.ts
+/src/refs/a.d.ts
 /src/a.d.ts
 /src/b.d.ts
-/src/refs/a.d.ts
 /src/c.ts
 exitCode:: ExitStatus.Success
 

--- a/tests/baselines/reference/tsc/declarationEmit/when-same-version-is-referenced-through-source-and-another-symlinked-package-moduleCaseChange.js
+++ b/tests/baselines/reference/tsc/declarationEmit/when-same-version-is-referenced-through-source-and-another-symlinked-package-moduleCaseChange.js
@@ -179,11 +179,11 @@ Resolving real path for '/user/username/projects/myProject/plugin-two/node_modul
 
 /user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts
 
-/user/username/projects/myproject/plugin-one/action.ts
-
 /user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.d.ts
 
 /user/username/projects/myProject/plugin-two/index.d.ts
+
+/user/username/projects/myproject/plugin-one/action.ts
 
 /user/username/projects/myproject/plugin-one/index.ts
 
@@ -194,9 +194,9 @@ Program options: {"target":1,"declaration":true,"traceResolution":true,"project"
 Program files::
 /a/lib/lib.d.ts
 /user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts
-/user/username/projects/myproject/plugin-one/action.ts
 /user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.d.ts
 /user/username/projects/myProject/plugin-two/index.d.ts
+/user/username/projects/myproject/plugin-one/action.ts
 /user/username/projects/myproject/plugin-one/index.ts
 
 WatchedFiles::

--- a/tests/baselines/reference/tsc/declarationEmit/when-same-version-is-referenced-through-source-and-another-symlinked-package.js
+++ b/tests/baselines/reference/tsc/declarationEmit/when-same-version-is-referenced-through-source-and-another-symlinked-package.js
@@ -179,11 +179,11 @@ Resolving real path for '/user/username/projects/myproject/plugin-two/node_modul
 
 /user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts
 
-/user/username/projects/myproject/plugin-one/action.ts
-
 /user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.d.ts
 
 /user/username/projects/myproject/plugin-two/index.d.ts
+
+/user/username/projects/myproject/plugin-one/action.ts
 
 /user/username/projects/myproject/plugin-one/index.ts
 
@@ -194,9 +194,9 @@ Program options: {"target":1,"declaration":true,"traceResolution":true,"project"
 Program files::
 /a/lib/lib.d.ts
 /user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts
-/user/username/projects/myproject/plugin-one/action.ts
 /user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.d.ts
 /user/username/projects/myproject/plugin-two/index.d.ts
+/user/username/projects/myproject/plugin-one/action.ts
 /user/username/projects/myproject/plugin-one/index.ts
 
 WatchedFiles::

--- a/tests/baselines/reference/tscWatch/consoleClearing/when-preserveWatchOutput-is-true-in-config-file/createWatchOfConfigFile.js
+++ b/tests/baselines/reference/tscWatch/consoleClearing/when-preserveWatchOutput-is-true-in-config-file/createWatchOfConfigFile.js
@@ -32,12 +32,12 @@ Output::
 Program root files: ["/f.ts","/a/lib/lib.d.ts"]
 Program options: {"preserveWatchOutput":true,"configFilePath":"/tsconfig.json"}
 Program files::
-/f.ts
 /a/lib/lib.d.ts
+/f.ts
 
 Semantic diagnostics in builder refreshed for::
-/f.ts
 /a/lib/lib.d.ts
+/f.ts
 
 WatchedFiles::
 /tsconfig.json:
@@ -78,8 +78,8 @@ Output::
 Program root files: ["/f.ts","/a/lib/lib.d.ts"]
 Program options: {"preserveWatchOutput":true,"configFilePath":"/tsconfig.json"}
 Program files::
-/f.ts
 /a/lib/lib.d.ts
+/f.ts
 
 Semantic diagnostics in builder refreshed for::
 /f.ts

--- a/tests/baselines/reference/tscWatch/consoleClearing/when-preserveWatchOutput-is-true-in-config-file/when-createWatchProgram-is-invoked-with-configFileParseResult-on-WatchCompilerHostOfConfigFile.js
+++ b/tests/baselines/reference/tscWatch/consoleClearing/when-preserveWatchOutput-is-true-in-config-file/when-createWatchProgram-is-invoked-with-configFileParseResult-on-WatchCompilerHostOfConfigFile.js
@@ -31,12 +31,12 @@ Output::
 Program root files: ["/f.ts","/a/lib/lib.d.ts"]
 Program options: {"preserveWatchOutput":true,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
 Program files::
-/f.ts
 /a/lib/lib.d.ts
+/f.ts
 
 Semantic diagnostics in builder refreshed for::
-/f.ts
 /a/lib/lib.d.ts
+/f.ts
 
 WatchedFiles::
 /tsconfig.json:
@@ -76,8 +76,8 @@ Output::
 Program root files: ["/f.ts","/a/lib/lib.d.ts"]
 Program options: {"preserveWatchOutput":true,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
 Program files::
-/f.ts
 /a/lib/lib.d.ts
+/f.ts
 
 Semantic diagnostics in builder refreshed for::
 /f.ts

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-does-not-have-out-or-outFile.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-does-not-have-out-or-outFile.js
@@ -35,14 +35,14 @@ Output::
 Program root files: ["/a/a.ts","/a/b.ts","/a/lib/lib.d.ts"]
 Program options: {"watch":true,"project":"/a/tsconfig.json","configFilePath":"/a/tsconfig.json"}
 Program files::
+/a/lib/lib.d.ts
 /a/a.ts
 /a/b.ts
-/a/lib/lib.d.ts
 
 Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
 /a/a.ts
 /a/b.ts
-/a/lib/lib.d.ts
 
 WatchedFiles::
 /a/tsconfig.json:
@@ -92,9 +92,9 @@ Output::
 Program root files: ["/a/a.ts","/a/b.ts","/a/lib/lib.d.ts"]
 Program options: {"watch":true,"project":"/a/tsconfig.json","configFilePath":"/a/tsconfig.json"}
 Program files::
+/a/lib/lib.d.ts
 /a/a.ts
 /a/b.ts
-/a/lib/lib.d.ts
 
 Semantic diagnostics in builder refreshed for::
 /a/a.ts

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-out.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-out.js
@@ -35,9 +35,9 @@ Output::
 Program root files: ["/a/a.ts","/a/b.ts","/a/lib/lib.d.ts"]
 Program options: {"out":"/a/out.js","watch":true,"project":"/a/tsconfig.json","configFilePath":"/a/tsconfig.json"}
 Program files::
+/a/lib/lib.d.ts
 /a/a.ts
 /a/b.ts
-/a/lib/lib.d.ts
 
 No cached semantic diagnostics in the builder::
 
@@ -86,9 +86,9 @@ Output::
 Program root files: ["/a/a.ts","/a/b.ts","/a/lib/lib.d.ts"]
 Program options: {"out":"/a/out.js","watch":true,"project":"/a/tsconfig.json","configFilePath":"/a/tsconfig.json"}
 Program files::
+/a/lib/lib.d.ts
 /a/a.ts
 /a/b.ts
-/a/lib/lib.d.ts
 
 No cached semantic diagnostics in the builder::
 

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-outFile.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-outFile.js
@@ -35,9 +35,9 @@ Output::
 Program root files: ["/a/a.ts","/a/b.ts","/a/lib/lib.d.ts"]
 Program options: {"outFile":"/a/out.js","watch":true,"project":"/a/tsconfig.json","configFilePath":"/a/tsconfig.json"}
 Program files::
+/a/lib/lib.d.ts
 /a/a.ts
 /a/b.ts
-/a/lib/lib.d.ts
 
 No cached semantic diagnostics in the builder::
 
@@ -86,9 +86,9 @@ Output::
 Program root files: ["/a/a.ts","/a/b.ts","/a/lib/lib.d.ts"]
 Program options: {"outFile":"/a/out.js","watch":true,"project":"/a/tsconfig.json","configFilePath":"/a/tsconfig.json"}
 Program files::
+/a/lib/lib.d.ts
 /a/a.ts
 /a/b.ts
-/a/lib/lib.d.ts
 
 No cached semantic diagnostics in the builder::
 

--- a/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--noUnusedLabels'-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--noUnusedLabels'-changes.js
@@ -32,12 +32,12 @@ Output::
 Program root files: ["/a.ts","/a/lib/lib.d.ts"]
 Program options: {"allowUnusedLabels":true,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
 Program files::
-/a.ts
 /a/lib/lib.d.ts
+/a.ts
 
 Semantic diagnostics in builder refreshed for::
-/a.ts
 /a/lib/lib.d.ts
+/a.ts
 
 WatchedFiles::
 /tsconfig.json:
@@ -85,12 +85,12 @@ Output::
 Program root files: ["/a.ts","/a/lib/lib.d.ts"]
 Program options: {"allowUnusedLabels":false,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
 Program files::
-/a.ts
 /a/lib/lib.d.ts
+/a.ts
 
 Semantic diagnostics in builder refreshed for::
-/a.ts
 /a/lib/lib.d.ts
+/a.ts
 
 WatchedFiles::
 /tsconfig.json:
@@ -128,12 +128,12 @@ Output::
 Program root files: ["/a.ts","/a/lib/lib.d.ts"]
 Program options: {"allowUnusedLabels":true,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
 Program files::
-/a.ts
 /a/lib/lib.d.ts
+/a.ts
 
 Semantic diagnostics in builder refreshed for::
-/a.ts
 /a/lib/lib.d.ts
+/a.ts
 
 WatchedFiles::
 /tsconfig.json:

--- a/tests/baselines/reference/tscWatch/programUpdates/types-should-load-from-config-file-path-if-config-exists.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/types-should-load-from-config-file-path-if-config-exists.js
@@ -36,13 +36,13 @@ Program root files: ["/a/b/app.ts"]
 Program options: {"types":["node"],"typeRoots":[],"watch":true,"project":"/a/b/tsconfig.json","configFilePath":"/a/b/tsconfig.json"}
 Program files::
 /a/lib/lib.d.ts
-/a/b/app.ts
 /a/b/node_modules/@types/node/index.d.ts
+/a/b/app.ts
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts
-/a/b/app.ts
 /a/b/node_modules/@types/node/index.d.ts
+/a/b/app.ts
 
 WatchedFiles::
 /a/b/tsconfig.json:

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-for-decorators.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-for-decorators.js
@@ -51,14 +51,14 @@ Output::
 Program root files: ["/a.ts","/b.ts","/a/lib/lib.d.ts"]
 Program options: {"target":2,"importsNotUsedAsValues":2,"watch":true,"configFilePath":"/tsconfig.json"}
 Program files::
+/a/lib/lib.d.ts
 /b.ts
 /a.ts
-/a/lib/lib.d.ts
 
 Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
 /b.ts
 /a.ts
-/a/lib/lib.d.ts
 
 WatchedFiles::
 /tsconfig.json:
@@ -126,14 +126,14 @@ Output::
 Program root files: ["/a.ts","/b.ts","/a/lib/lib.d.ts"]
 Program options: {"target":2,"importsNotUsedAsValues":2,"experimentalDecorators":true,"watch":true,"configFilePath":"/tsconfig.json"}
 Program files::
+/a/lib/lib.d.ts
 /b.ts
 /a.ts
-/a/lib/lib.d.ts
 
 Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
 /b.ts
 /a.ts
-/a/lib/lib.d.ts
 
 WatchedFiles::
 /tsconfig.json:
@@ -173,14 +173,14 @@ Output::
 Program root files: ["/a.ts","/b.ts","/a/lib/lib.d.ts"]
 Program options: {"target":2,"importsNotUsedAsValues":2,"experimentalDecorators":true,"emitDecoratorMetadata":true,"watch":true,"configFilePath":"/tsconfig.json"}
 Program files::
+/a/lib/lib.d.ts
 /b.ts
 /a.ts
-/a/lib/lib.d.ts
 
 Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
 /b.ts
 /a.ts
-/a/lib/lib.d.ts
 
 WatchedFiles::
 /tsconfig.json:

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-when-useDefineForClassFields-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-when-useDefineForClassFields-changes.js
@@ -39,12 +39,12 @@ Output::
 Program root files: ["/a.ts","/a/lib/lib.d.ts"]
 Program options: {"target":2,"watch":true,"configFilePath":"/tsconfig.json"}
 Program files::
-/a.ts
 /a/lib/lib.d.ts
+/a.ts
 
 Semantic diagnostics in builder refreshed for::
-/a.ts
 /a/lib/lib.d.ts
+/a.ts
 
 WatchedFiles::
 /tsconfig.json:
@@ -100,12 +100,12 @@ Output::
 Program root files: ["/a.ts","/a/lib/lib.d.ts"]
 Program options: {"target":2,"useDefineForClassFields":true,"watch":true,"configFilePath":"/tsconfig.json"}
 Program files::
-/a.ts
 /a/lib/lib.d.ts
+/a.ts
 
 Semantic diagnostics in builder refreshed for::
-/a.ts
 /a/lib/lib.d.ts
+/a.ts
 
 WatchedFiles::
 /tsconfig.json:

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-forceConsistentCasingInFileNames-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-forceConsistentCasingInFileNames-changes.js
@@ -35,14 +35,14 @@ Output::
 Program root files: ["/a.ts","/b.ts","/a/lib/lib.d.ts"]
 Program options: {"watch":true,"configFilePath":"/tsconfig.json"}
 Program files::
+/a/lib/lib.d.ts
 /a.ts
 /b.ts
-/a/lib/lib.d.ts
 
 Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
 /a.ts
 /b.ts
-/a/lib/lib.d.ts
 
 WatchedFiles::
 /tsconfig.json:
@@ -105,9 +105,9 @@ Output::
 Program root files: ["/a.ts","/b.ts","/a/lib/lib.d.ts"]
 Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"configFilePath":"/tsconfig.json"}
 Program files::
+/a/lib/lib.d.ts
 /a.ts
 /b.ts
-/a/lib/lib.d.ts
 
 Semantic diagnostics in builder refreshed for::
 

--- a/tests/baselines/reference/tscWatch/programUpdates/when-skipLibCheck-and-skipDefaultLibCheck-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-skipLibCheck-and-skipDefaultLibCheck-changes.js
@@ -61,13 +61,13 @@ Program root files: ["/user/username/projects/myproject/a.ts","/user/username/pr
 Program options: {"watch":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
 Program files::
 /a/lib/lib.d.ts
-/user/username/projects/myproject/a.ts
 /user/username/projects/myproject/b.d.ts
+/user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts
-/user/username/projects/myproject/a.ts
 /user/username/projects/myproject/b.d.ts
+/user/username/projects/myproject/a.ts
 
 WatchedFiles::
 /user/username/projects/myproject/tsconfig.json:
@@ -119,8 +119,8 @@ Program root files: ["/user/username/projects/myproject/a.ts","/user/username/pr
 Program options: {"skipLibCheck":true,"watch":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
 Program files::
 /a/lib/lib.d.ts
-/user/username/projects/myproject/a.ts
 /user/username/projects/myproject/b.d.ts
+/user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts
@@ -179,8 +179,8 @@ Program root files: ["/user/username/projects/myproject/a.ts","/user/username/pr
 Program options: {"skipDefaultLibCheck":true,"watch":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
 Program files::
 /a/lib/lib.d.ts
-/user/username/projects/myproject/a.ts
 /user/username/projects/myproject/b.d.ts
+/user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts
@@ -245,8 +245,8 @@ Program root files: ["/user/username/projects/myproject/a.ts","/user/username/pr
 Program options: {"watch":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
 Program files::
 /a/lib/lib.d.ts
-/user/username/projects/myproject/a.ts
 /user/username/projects/myproject/b.d.ts
+/user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts
@@ -304,8 +304,8 @@ Program root files: ["/user/username/projects/myproject/a.ts","/user/username/pr
 Program options: {"skipDefaultLibCheck":true,"watch":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
 Program files::
 /a/lib/lib.d.ts
-/user/username/projects/myproject/a.ts
 /user/username/projects/myproject/b.d.ts
+/user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts
@@ -357,8 +357,8 @@ Program root files: ["/user/username/projects/myproject/a.ts","/user/username/pr
 Program options: {"skipLibCheck":true,"watch":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
 Program files::
 /a/lib/lib.d.ts
-/user/username/projects/myproject/a.ts
 /user/username/projects/myproject/b.d.ts
+/user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts
@@ -423,8 +423,8 @@ Program root files: ["/user/username/projects/myproject/a.ts","/user/username/pr
 Program options: {"watch":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
 Program files::
 /a/lib/lib.d.ts
-/user/username/projects/myproject/a.ts
 /user/username/projects/myproject/b.d.ts
+/user/username/projects/myproject/a.ts
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts

--- a/tests/baselines/reference/tscWatch/resolutionCache/when-types-in-compiler-option-are-global-and-installed-at-later-point.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/when-types-in-compiler-option-are-global-and-installed-at-later-point.js
@@ -89,13 +89,13 @@ Program root files: ["/user/username/projects/myproject/lib/app.ts"]
 Program options: {"module":0,"types":["@myapp/ts-types"],"watch":true,"project":"/user/username/projects/myproject/tsconfig.json","configFilePath":"/user/username/projects/myproject/tsconfig.json"}
 Program files::
 /a/lib/lib.d.ts
-/user/username/projects/myproject/lib/app.ts
 /user/username/projects/myproject/node_modules/@myapp/ts-types/types/somefile.define.d.ts
+/user/username/projects/myproject/lib/app.ts
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts
-/user/username/projects/myproject/lib/app.ts
 /user/username/projects/myproject/node_modules/@myapp/ts-types/types/somefile.define.d.ts
+/user/username/projects/myproject/lib/app.ts
 
 WatchedFiles::
 /user/username/projects/myproject/tsconfig.json:

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-included-file-with-ambient-module-changes.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-included-file-with-ambient-module-changes.js
@@ -48,13 +48,13 @@ Program root files: ["/a/b/foo.ts","/a/b/bar.d.ts"]
 Program options: {"watch":true}
 Program files::
 /a/lib/lib.d.ts
-/a/b/foo.ts
 /a/b/bar.d.ts
+/a/b/foo.ts
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts
-/a/b/foo.ts
 /a/b/bar.d.ts
+/a/b/foo.ts
 
 WatchedFiles::
 /a/b/foo.ts:
@@ -112,12 +112,12 @@ Program root files: ["/a/b/foo.ts","/a/b/bar.d.ts"]
 Program options: {"watch":true}
 Program files::
 /a/lib/lib.d.ts
-/a/b/foo.ts
 /a/b/bar.d.ts
+/a/b/foo.ts
 
 Semantic diagnostics in builder refreshed for::
-/a/b/foo.ts
 /a/b/bar.d.ts
+/a/b/foo.ts
 
 WatchedFiles::
 /a/b/foo.ts:

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-module-resolution-changes-to-ambient-module.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-module-resolution-changes-to-ambient-module.js
@@ -96,12 +96,12 @@ Program root files: ["/a/b/foo.ts"]
 Program options: {"watch":true}
 Program files::
 /a/lib/lib.d.ts
-/a/b/foo.ts
 /a/b/node_modules/@types/node/index.d.ts
+/a/b/foo.ts
 
 Semantic diagnostics in builder refreshed for::
-/a/b/foo.ts
 /a/b/node_modules/@types/node/index.d.ts
+/a/b/foo.ts
 
 WatchedFiles::
 /a/b/foo.ts:

--- a/tests/cases/fourslash/importNameCodeFix_noDestructureNonObjectLiteral.ts
+++ b/tests/cases/fourslash/importNameCodeFix_noDestructureNonObjectLiteral.ts
@@ -29,4 +29,4 @@
 // @Filename: /index.ts
 ////filter/**/
 
-verify.importFixModuleSpecifiers('', ['./object-literal', './jquery']);
+verify.importFixModuleSpecifiers('', ['./jquery', './object-literal']);


### PR DESCRIPTION
Multiple customers have reported that having expensive statements identified (thus far, with private builds) has been helpful in reducing their check time - even without explanations of why the statements are expensive.  This PR attempts to formalize that instrumentation so that it can be used more widely.