### PR TITLE
fix(36055): `prop in dict` does not report error if `prop` is union type such as `MyClass | string`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27797,7 +27797,8 @@ namespace ts {
             // The in operator requires the left operand to be of type Any, the String primitive type, or the Number primitive type,
             // and the right operand to be of type Any, an object type, or a type parameter type.
             // The result is always of the Boolean primitive type.
-            if (!(isTypeComparableTo(leftType, stringType) || isTypeAssignableToKind(leftType, TypeFlags.NumberLike | TypeFlags.ESSymbolLike))) {
+            if (!(allTypesAssignableToKind(leftType, TypeFlags.StringLike | TypeFlags.NumberLike | TypeFlags.ESSymbolLike) ||
+                  isTypeAssignableToKind(leftType, TypeFlags.Index | TypeFlags.TypeParameter))) {
                 error(left, Diagnostics.The_left_hand_side_of_an_in_expression_must_be_of_type_any_string_number_or_symbol);
             }
             if (!allTypesAssignableToKind(rightType, TypeFlags.NonPrimitive | TypeFlags.InstantiableNonPrimitive)) {

--- a/tests/baselines/reference/inOperatorWithInvalidOperands.errors.txt
+++ b/tests/baselines/reference/inOperatorWithInvalidOperands.errors.txt
@@ -1,25 +1,28 @@
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(12,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(13,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(14,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(16,11): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(17,11): error TS2532: Object is possibly 'undefined'.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(19,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(20,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(30,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(31,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(32,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(33,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(34,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(15,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(16,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(17,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(19,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(20,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(22,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(23,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(24,12): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(25,12): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
 tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(35,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
 tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(36,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
 tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(37,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(38,16): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(39,17): error TS2532: Object is possibly 'undefined'.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(43,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(43,17): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(38,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(39,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(40,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(41,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(42,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(43,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(44,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(47,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(47,17): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter.
 
 
-==== tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts (19 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts (21 errors) ====
+    class Foo {}
     enum E { a }
     
     var x: any;
@@ -29,7 +32,9 @@ tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInv
     var a1: boolean;
     var a2: void;
     var a3: {};
-    var a4: E
+    var a4: E;
+    var a5: Foo | string;
+    var a6: Foo;
     
     var ra1 = a1 in x;
               ~~
@@ -53,6 +58,12 @@ tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInv
 !!! error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
     var ra9 = {} in x;
               ~~
+!!! error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
+    var ra10 = a5 in x;
+               ~~
+!!! error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
+    var ra11 = a6 in x;
+               ~~
 !!! error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
     
     // invalid right operands
@@ -93,7 +104,6 @@ tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInv
     var rb10 = x in undefined;
                     ~~~~~~~~~
 !!! error TS2532: Object is possibly 'undefined'.
-    
     
     // both operands are invalid
     var rc1 = {} in '';

--- a/tests/baselines/reference/inOperatorWithInvalidOperands.js
+++ b/tests/baselines/reference/inOperatorWithInvalidOperands.js
@@ -1,4 +1,5 @@
 //// [inOperatorWithInvalidOperands.ts]
+class Foo {}
 enum E { a }
 
 var x: any;
@@ -8,7 +9,9 @@ var x: any;
 var a1: boolean;
 var a2: void;
 var a3: {};
-var a4: E
+var a4: E;
+var a5: Foo | string;
+var a6: Foo;
 
 var ra1 = a1 in x;
 var ra2 = a2 in x;
@@ -19,6 +22,8 @@ var ra6 = undefined in x;
 var ra7 = E.a in x;
 var ra8 = false in x;
 var ra9 = {} in x;
+var ra10 = a5 in x;
+var ra11 = a6 in x;
 
 // invalid right operands
 // the right operand is required to be of type Any, an object type, or a type parameter type
@@ -39,11 +44,15 @@ var rb8 = x in '';
 var rb9 = x in null;
 var rb10 = x in undefined;
 
-
 // both operands are invalid
 var rc1 = {} in '';
 
 //// [inOperatorWithInvalidOperands.js]
+var Foo = /** @class */ (function () {
+    function Foo() {
+    }
+    return Foo;
+}());
 var E;
 (function (E) {
     E[E["a"] = 0] = "a";
@@ -55,6 +64,8 @@ var a1;
 var a2;
 var a3;
 var a4;
+var a5;
+var a6;
 var ra1 = a1 in x;
 var ra2 = a2 in x;
 var ra3 = a3 in x;
@@ -64,6 +75,8 @@ var ra6 = undefined in x;
 var ra7 = E.a in x;
 var ra8 = false in x;
 var ra9 = {} in x;
+var ra10 = a5 in x;
+var ra11 = a6 in x;
 // invalid right operands
 // the right operand is required to be of type Any, an object type, or a type parameter type
 var b1;

--- a/tests/baselines/reference/inOperatorWithInvalidOperands.symbols
+++ b/tests/baselines/reference/inOperatorWithInvalidOperands.symbols
@@ -1,135 +1,155 @@
 === tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts ===
+class Foo {}
+>Foo : Symbol(Foo, Decl(inOperatorWithInvalidOperands.ts, 0, 0))
+
 enum E { a }
->E : Symbol(E, Decl(inOperatorWithInvalidOperands.ts, 0, 0))
->a : Symbol(E.a, Decl(inOperatorWithInvalidOperands.ts, 0, 8))
+>E : Symbol(E, Decl(inOperatorWithInvalidOperands.ts, 0, 12))
+>a : Symbol(E.a, Decl(inOperatorWithInvalidOperands.ts, 1, 8))
 
 var x: any;
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 
 // invalid left operands
 // the left operand is required to be of type Any, the String primitive type, or the Number primitive type
 var a1: boolean;
->a1 : Symbol(a1, Decl(inOperatorWithInvalidOperands.ts, 6, 3))
+>a1 : Symbol(a1, Decl(inOperatorWithInvalidOperands.ts, 7, 3))
 
 var a2: void;
->a2 : Symbol(a2, Decl(inOperatorWithInvalidOperands.ts, 7, 3))
+>a2 : Symbol(a2, Decl(inOperatorWithInvalidOperands.ts, 8, 3))
 
 var a3: {};
->a3 : Symbol(a3, Decl(inOperatorWithInvalidOperands.ts, 8, 3))
+>a3 : Symbol(a3, Decl(inOperatorWithInvalidOperands.ts, 9, 3))
 
-var a4: E
->a4 : Symbol(a4, Decl(inOperatorWithInvalidOperands.ts, 9, 3))
->E : Symbol(E, Decl(inOperatorWithInvalidOperands.ts, 0, 0))
+var a4: E;
+>a4 : Symbol(a4, Decl(inOperatorWithInvalidOperands.ts, 10, 3))
+>E : Symbol(E, Decl(inOperatorWithInvalidOperands.ts, 0, 12))
+
+var a5: Foo | string;
+>a5 : Symbol(a5, Decl(inOperatorWithInvalidOperands.ts, 11, 3))
+>Foo : Symbol(Foo, Decl(inOperatorWithInvalidOperands.ts, 0, 0))
+
+var a6: Foo;
+>a6 : Symbol(a6, Decl(inOperatorWithInvalidOperands.ts, 12, 3))
+>Foo : Symbol(Foo, Decl(inOperatorWithInvalidOperands.ts, 0, 0))
 
 var ra1 = a1 in x;
->ra1 : Symbol(ra1, Decl(inOperatorWithInvalidOperands.ts, 11, 3))
->a1 : Symbol(a1, Decl(inOperatorWithInvalidOperands.ts, 6, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>ra1 : Symbol(ra1, Decl(inOperatorWithInvalidOperands.ts, 14, 3))
+>a1 : Symbol(a1, Decl(inOperatorWithInvalidOperands.ts, 7, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 
 var ra2 = a2 in x;
->ra2 : Symbol(ra2, Decl(inOperatorWithInvalidOperands.ts, 12, 3))
->a2 : Symbol(a2, Decl(inOperatorWithInvalidOperands.ts, 7, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>ra2 : Symbol(ra2, Decl(inOperatorWithInvalidOperands.ts, 15, 3))
+>a2 : Symbol(a2, Decl(inOperatorWithInvalidOperands.ts, 8, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 
 var ra3 = a3 in x;
->ra3 : Symbol(ra3, Decl(inOperatorWithInvalidOperands.ts, 13, 3))
->a3 : Symbol(a3, Decl(inOperatorWithInvalidOperands.ts, 8, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>ra3 : Symbol(ra3, Decl(inOperatorWithInvalidOperands.ts, 16, 3))
+>a3 : Symbol(a3, Decl(inOperatorWithInvalidOperands.ts, 9, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 
 var ra4 = a4 in x;
->ra4 : Symbol(ra4, Decl(inOperatorWithInvalidOperands.ts, 14, 3))
->a4 : Symbol(a4, Decl(inOperatorWithInvalidOperands.ts, 9, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>ra4 : Symbol(ra4, Decl(inOperatorWithInvalidOperands.ts, 17, 3))
+>a4 : Symbol(a4, Decl(inOperatorWithInvalidOperands.ts, 10, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 
 var ra5 = null in x;
->ra5 : Symbol(ra5, Decl(inOperatorWithInvalidOperands.ts, 15, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>ra5 : Symbol(ra5, Decl(inOperatorWithInvalidOperands.ts, 18, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 
 var ra6 = undefined in x;
->ra6 : Symbol(ra6, Decl(inOperatorWithInvalidOperands.ts, 16, 3))
+>ra6 : Symbol(ra6, Decl(inOperatorWithInvalidOperands.ts, 19, 3))
 >undefined : Symbol(undefined)
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 
 var ra7 = E.a in x;
->ra7 : Symbol(ra7, Decl(inOperatorWithInvalidOperands.ts, 17, 3))
->E.a : Symbol(E.a, Decl(inOperatorWithInvalidOperands.ts, 0, 8))
->E : Symbol(E, Decl(inOperatorWithInvalidOperands.ts, 0, 0))
->a : Symbol(E.a, Decl(inOperatorWithInvalidOperands.ts, 0, 8))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>ra7 : Symbol(ra7, Decl(inOperatorWithInvalidOperands.ts, 20, 3))
+>E.a : Symbol(E.a, Decl(inOperatorWithInvalidOperands.ts, 1, 8))
+>E : Symbol(E, Decl(inOperatorWithInvalidOperands.ts, 0, 12))
+>a : Symbol(E.a, Decl(inOperatorWithInvalidOperands.ts, 1, 8))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 
 var ra8 = false in x;
->ra8 : Symbol(ra8, Decl(inOperatorWithInvalidOperands.ts, 18, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>ra8 : Symbol(ra8, Decl(inOperatorWithInvalidOperands.ts, 21, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 
 var ra9 = {} in x;
->ra9 : Symbol(ra9, Decl(inOperatorWithInvalidOperands.ts, 19, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>ra9 : Symbol(ra9, Decl(inOperatorWithInvalidOperands.ts, 22, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
+
+var ra10 = a5 in x;
+>ra10 : Symbol(ra10, Decl(inOperatorWithInvalidOperands.ts, 23, 3))
+>a5 : Symbol(a5, Decl(inOperatorWithInvalidOperands.ts, 11, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
+
+var ra11 = a6 in x;
+>ra11 : Symbol(ra11, Decl(inOperatorWithInvalidOperands.ts, 24, 3))
+>a6 : Symbol(a6, Decl(inOperatorWithInvalidOperands.ts, 12, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 
 // invalid right operands
 // the right operand is required to be of type Any, an object type, or a type parameter type
 var b1: number;
->b1 : Symbol(b1, Decl(inOperatorWithInvalidOperands.ts, 23, 3))
+>b1 : Symbol(b1, Decl(inOperatorWithInvalidOperands.ts, 28, 3))
 
 var b2: boolean;
->b2 : Symbol(b2, Decl(inOperatorWithInvalidOperands.ts, 24, 3))
+>b2 : Symbol(b2, Decl(inOperatorWithInvalidOperands.ts, 29, 3))
 
 var b3: string;
->b3 : Symbol(b3, Decl(inOperatorWithInvalidOperands.ts, 25, 3))
+>b3 : Symbol(b3, Decl(inOperatorWithInvalidOperands.ts, 30, 3))
 
 var b4: void;
->b4 : Symbol(b4, Decl(inOperatorWithInvalidOperands.ts, 26, 3))
+>b4 : Symbol(b4, Decl(inOperatorWithInvalidOperands.ts, 31, 3))
 
 var b5: string | number;
->b5 : Symbol(b5, Decl(inOperatorWithInvalidOperands.ts, 27, 3))
+>b5 : Symbol(b5, Decl(inOperatorWithInvalidOperands.ts, 32, 3))
 
 var rb1 = x in b1;
->rb1 : Symbol(rb1, Decl(inOperatorWithInvalidOperands.ts, 29, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
->b1 : Symbol(b1, Decl(inOperatorWithInvalidOperands.ts, 23, 3))
+>rb1 : Symbol(rb1, Decl(inOperatorWithInvalidOperands.ts, 34, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
+>b1 : Symbol(b1, Decl(inOperatorWithInvalidOperands.ts, 28, 3))
 
 var rb2 = x in b2;
->rb2 : Symbol(rb2, Decl(inOperatorWithInvalidOperands.ts, 30, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
->b2 : Symbol(b2, Decl(inOperatorWithInvalidOperands.ts, 24, 3))
+>rb2 : Symbol(rb2, Decl(inOperatorWithInvalidOperands.ts, 35, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
+>b2 : Symbol(b2, Decl(inOperatorWithInvalidOperands.ts, 29, 3))
 
 var rb3 = x in b3;
->rb3 : Symbol(rb3, Decl(inOperatorWithInvalidOperands.ts, 31, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
->b3 : Symbol(b3, Decl(inOperatorWithInvalidOperands.ts, 25, 3))
+>rb3 : Symbol(rb3, Decl(inOperatorWithInvalidOperands.ts, 36, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
+>b3 : Symbol(b3, Decl(inOperatorWithInvalidOperands.ts, 30, 3))
 
 var rb4 = x in b4;
->rb4 : Symbol(rb4, Decl(inOperatorWithInvalidOperands.ts, 32, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
->b4 : Symbol(b4, Decl(inOperatorWithInvalidOperands.ts, 26, 3))
+>rb4 : Symbol(rb4, Decl(inOperatorWithInvalidOperands.ts, 37, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
+>b4 : Symbol(b4, Decl(inOperatorWithInvalidOperands.ts, 31, 3))
 
 var rb5 = x in b5;
->rb5 : Symbol(rb5, Decl(inOperatorWithInvalidOperands.ts, 33, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
->b5 : Symbol(b5, Decl(inOperatorWithInvalidOperands.ts, 27, 3))
+>rb5 : Symbol(rb5, Decl(inOperatorWithInvalidOperands.ts, 38, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
+>b5 : Symbol(b5, Decl(inOperatorWithInvalidOperands.ts, 32, 3))
 
 var rb6 = x in 0;
->rb6 : Symbol(rb6, Decl(inOperatorWithInvalidOperands.ts, 34, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>rb6 : Symbol(rb6, Decl(inOperatorWithInvalidOperands.ts, 39, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 
 var rb7 = x in false;
->rb7 : Symbol(rb7, Decl(inOperatorWithInvalidOperands.ts, 35, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>rb7 : Symbol(rb7, Decl(inOperatorWithInvalidOperands.ts, 40, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 
 var rb8 = x in '';
->rb8 : Symbol(rb8, Decl(inOperatorWithInvalidOperands.ts, 36, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>rb8 : Symbol(rb8, Decl(inOperatorWithInvalidOperands.ts, 41, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 
 var rb9 = x in null;
->rb9 : Symbol(rb9, Decl(inOperatorWithInvalidOperands.ts, 37, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>rb9 : Symbol(rb9, Decl(inOperatorWithInvalidOperands.ts, 42, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 
 var rb10 = x in undefined;
->rb10 : Symbol(rb10, Decl(inOperatorWithInvalidOperands.ts, 38, 3))
->x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 2, 3))
+>rb10 : Symbol(rb10, Decl(inOperatorWithInvalidOperands.ts, 43, 3))
+>x : Symbol(x, Decl(inOperatorWithInvalidOperands.ts, 3, 3))
 >undefined : Symbol(undefined)
-
 
 // both operands are invalid
 var rc1 = {} in '';
->rc1 : Symbol(rc1, Decl(inOperatorWithInvalidOperands.ts, 42, 3))
+>rc1 : Symbol(rc1, Decl(inOperatorWithInvalidOperands.ts, 46, 3))
 

--- a/tests/baselines/reference/inOperatorWithInvalidOperands.types
+++ b/tests/baselines/reference/inOperatorWithInvalidOperands.types
@@ -1,4 +1,7 @@
 === tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts ===
+class Foo {}
+>Foo : Foo
+
 enum E { a }
 >E : E
 >a : E.a
@@ -17,8 +20,14 @@ var a2: void;
 var a3: {};
 >a3 : {}
 
-var a4: E
+var a4: E;
 >a4 : E
+
+var a5: Foo | string;
+>a5 : string | Foo
+
+var a6: Foo;
+>a6 : Foo
 
 var ra1 = a1 in x;
 >ra1 : boolean
@@ -74,6 +83,18 @@ var ra9 = {} in x;
 >ra9 : boolean
 >{} in x : boolean
 >{} : {}
+>x : any
+
+var ra10 = a5 in x;
+>ra10 : boolean
+>a5 in x : boolean
+>a5 : string | Foo
+>x : any
+
+var ra11 = a6 in x;
+>ra11 : boolean
+>a6 in x : boolean
+>a6 : Foo
 >x : any
 
 // invalid right operands
@@ -152,7 +173,6 @@ var rb10 = x in undefined;
 >x in undefined : boolean
 >x : any
 >undefined : undefined
-
 
 // both operands are invalid
 var rc1 = {} in '';

--- a/tests/baselines/reference/inOperatorWithValidOperands.js
+++ b/tests/baselines/reference/inOperatorWithValidOperands.js
@@ -5,12 +5,16 @@ var x: any;
 // the left operand is required to be of type Any, the String primitive type, or the Number primitive type
 var a1: string;
 var a2: number;
+var a3: string | number | symbol;
+var a4: any;
 
 var ra1 = x in x;
 var ra2 = a1 in x;
 var ra3 = a2 in x;
 var ra4 = '' in x;
 var ra5 = 0 in x;
+var ra6 = a3 in x;
+var ra7 = a4 in x;
 
 // valid right operands
 // the right operand is required to be of type Any, an object type, or a type parameter type
@@ -48,11 +52,15 @@ var x;
 // the left operand is required to be of type Any, the String primitive type, or the Number primitive type
 var a1;
 var a2;
+var a3;
+var a4;
 var ra1 = x in x;
 var ra2 = a1 in x;
 var ra3 = a2 in x;
 var ra4 = '' in x;
 var ra5 = 0 in x;
+var ra6 = a3 in x;
+var ra7 = a4 in x;
 // valid right operands
 // the right operand is required to be of type Any, an object type, or a type parameter type
 var b1;

--- a/tests/baselines/reference/inOperatorWithValidOperands.symbols
+++ b/tests/baselines/reference/inOperatorWithValidOperands.symbols
@@ -10,110 +10,126 @@ var a1: string;
 var a2: number;
 >a2 : Symbol(a2, Decl(inOperatorWithValidOperands.ts, 5, 3))
 
+var a3: string | number | symbol;
+>a3 : Symbol(a3, Decl(inOperatorWithValidOperands.ts, 6, 3))
+
+var a4: any;
+>a4 : Symbol(a4, Decl(inOperatorWithValidOperands.ts, 7, 3))
+
 var ra1 = x in x;
->ra1 : Symbol(ra1, Decl(inOperatorWithValidOperands.ts, 7, 3))
+>ra1 : Symbol(ra1, Decl(inOperatorWithValidOperands.ts, 9, 3))
 >x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
 >x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
 
 var ra2 = a1 in x;
->ra2 : Symbol(ra2, Decl(inOperatorWithValidOperands.ts, 8, 3))
+>ra2 : Symbol(ra2, Decl(inOperatorWithValidOperands.ts, 10, 3))
 >a1 : Symbol(a1, Decl(inOperatorWithValidOperands.ts, 4, 3))
 >x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
 
 var ra3 = a2 in x;
->ra3 : Symbol(ra3, Decl(inOperatorWithValidOperands.ts, 9, 3))
+>ra3 : Symbol(ra3, Decl(inOperatorWithValidOperands.ts, 11, 3))
 >a2 : Symbol(a2, Decl(inOperatorWithValidOperands.ts, 5, 3))
 >x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
 
 var ra4 = '' in x;
->ra4 : Symbol(ra4, Decl(inOperatorWithValidOperands.ts, 10, 3))
+>ra4 : Symbol(ra4, Decl(inOperatorWithValidOperands.ts, 12, 3))
 >x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
 
 var ra5 = 0 in x;
->ra5 : Symbol(ra5, Decl(inOperatorWithValidOperands.ts, 11, 3))
+>ra5 : Symbol(ra5, Decl(inOperatorWithValidOperands.ts, 13, 3))
+>x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
+
+var ra6 = a3 in x;
+>ra6 : Symbol(ra6, Decl(inOperatorWithValidOperands.ts, 14, 3))
+>a3 : Symbol(a3, Decl(inOperatorWithValidOperands.ts, 6, 3))
+>x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
+
+var ra7 = a4 in x;
+>ra7 : Symbol(ra7, Decl(inOperatorWithValidOperands.ts, 15, 3))
+>a4 : Symbol(a4, Decl(inOperatorWithValidOperands.ts, 7, 3))
 >x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
 
 // valid right operands
 // the right operand is required to be of type Any, an object type, or a type parameter type
 var b1: {};
->b1 : Symbol(b1, Decl(inOperatorWithValidOperands.ts, 15, 3))
+>b1 : Symbol(b1, Decl(inOperatorWithValidOperands.ts, 19, 3))
 
 var rb1 = x in b1;
->rb1 : Symbol(rb1, Decl(inOperatorWithValidOperands.ts, 17, 3))
+>rb1 : Symbol(rb1, Decl(inOperatorWithValidOperands.ts, 21, 3))
 >x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
->b1 : Symbol(b1, Decl(inOperatorWithValidOperands.ts, 15, 3))
+>b1 : Symbol(b1, Decl(inOperatorWithValidOperands.ts, 19, 3))
 
 var rb2 = x in {};
->rb2 : Symbol(rb2, Decl(inOperatorWithValidOperands.ts, 18, 3))
+>rb2 : Symbol(rb2, Decl(inOperatorWithValidOperands.ts, 22, 3))
 >x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
 
 function foo<T>(t: T) {
->foo : Symbol(foo, Decl(inOperatorWithValidOperands.ts, 18, 18))
->T : Symbol(T, Decl(inOperatorWithValidOperands.ts, 20, 13))
->t : Symbol(t, Decl(inOperatorWithValidOperands.ts, 20, 16))
->T : Symbol(T, Decl(inOperatorWithValidOperands.ts, 20, 13))
+>foo : Symbol(foo, Decl(inOperatorWithValidOperands.ts, 22, 18))
+>T : Symbol(T, Decl(inOperatorWithValidOperands.ts, 24, 13))
+>t : Symbol(t, Decl(inOperatorWithValidOperands.ts, 24, 16))
+>T : Symbol(T, Decl(inOperatorWithValidOperands.ts, 24, 13))
 
     var rb3 = x in t;
->rb3 : Symbol(rb3, Decl(inOperatorWithValidOperands.ts, 21, 7))
+>rb3 : Symbol(rb3, Decl(inOperatorWithValidOperands.ts, 25, 7))
 >x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
->t : Symbol(t, Decl(inOperatorWithValidOperands.ts, 20, 16))
+>t : Symbol(t, Decl(inOperatorWithValidOperands.ts, 24, 16))
 }
 
 function unionCase<T, U>(t: T | U) {
->unionCase : Symbol(unionCase, Decl(inOperatorWithValidOperands.ts, 22, 1))
->T : Symbol(T, Decl(inOperatorWithValidOperands.ts, 24, 19))
->U : Symbol(U, Decl(inOperatorWithValidOperands.ts, 24, 21))
->t : Symbol(t, Decl(inOperatorWithValidOperands.ts, 24, 25))
->T : Symbol(T, Decl(inOperatorWithValidOperands.ts, 24, 19))
->U : Symbol(U, Decl(inOperatorWithValidOperands.ts, 24, 21))
+>unionCase : Symbol(unionCase, Decl(inOperatorWithValidOperands.ts, 26, 1))
+>T : Symbol(T, Decl(inOperatorWithValidOperands.ts, 28, 19))
+>U : Symbol(U, Decl(inOperatorWithValidOperands.ts, 28, 21))
+>t : Symbol(t, Decl(inOperatorWithValidOperands.ts, 28, 25))
+>T : Symbol(T, Decl(inOperatorWithValidOperands.ts, 28, 19))
+>U : Symbol(U, Decl(inOperatorWithValidOperands.ts, 28, 21))
 
     var rb4 = x in t;
->rb4 : Symbol(rb4, Decl(inOperatorWithValidOperands.ts, 25, 7))
+>rb4 : Symbol(rb4, Decl(inOperatorWithValidOperands.ts, 29, 7))
 >x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
->t : Symbol(t, Decl(inOperatorWithValidOperands.ts, 24, 25))
+>t : Symbol(t, Decl(inOperatorWithValidOperands.ts, 28, 25))
 }
 
 function unionCase2<T>(t: T | object) {
->unionCase2 : Symbol(unionCase2, Decl(inOperatorWithValidOperands.ts, 26, 1))
->T : Symbol(T, Decl(inOperatorWithValidOperands.ts, 28, 20))
->t : Symbol(t, Decl(inOperatorWithValidOperands.ts, 28, 23))
->T : Symbol(T, Decl(inOperatorWithValidOperands.ts, 28, 20))
+>unionCase2 : Symbol(unionCase2, Decl(inOperatorWithValidOperands.ts, 30, 1))
+>T : Symbol(T, Decl(inOperatorWithValidOperands.ts, 32, 20))
+>t : Symbol(t, Decl(inOperatorWithValidOperands.ts, 32, 23))
+>T : Symbol(T, Decl(inOperatorWithValidOperands.ts, 32, 20))
 
     var rb5 = x in t;
->rb5 : Symbol(rb5, Decl(inOperatorWithValidOperands.ts, 29, 7))
+>rb5 : Symbol(rb5, Decl(inOperatorWithValidOperands.ts, 33, 7))
 >x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
->t : Symbol(t, Decl(inOperatorWithValidOperands.ts, 28, 23))
+>t : Symbol(t, Decl(inOperatorWithValidOperands.ts, 32, 23))
 }
 
 interface X { x: number }
->X : Symbol(X, Decl(inOperatorWithValidOperands.ts, 30, 1))
->x : Symbol(X.x, Decl(inOperatorWithValidOperands.ts, 32, 13))
+>X : Symbol(X, Decl(inOperatorWithValidOperands.ts, 34, 1))
+>x : Symbol(X.x, Decl(inOperatorWithValidOperands.ts, 36, 13))
 
 interface Y { y: number }
->Y : Symbol(Y, Decl(inOperatorWithValidOperands.ts, 32, 25))
->y : Symbol(Y.y, Decl(inOperatorWithValidOperands.ts, 33, 13))
+>Y : Symbol(Y, Decl(inOperatorWithValidOperands.ts, 36, 25))
+>y : Symbol(Y.y, Decl(inOperatorWithValidOperands.ts, 37, 13))
 
 var c1: X | Y;
->c1 : Symbol(c1, Decl(inOperatorWithValidOperands.ts, 35, 3))
->X : Symbol(X, Decl(inOperatorWithValidOperands.ts, 30, 1))
->Y : Symbol(Y, Decl(inOperatorWithValidOperands.ts, 32, 25))
+>c1 : Symbol(c1, Decl(inOperatorWithValidOperands.ts, 39, 3))
+>X : Symbol(X, Decl(inOperatorWithValidOperands.ts, 34, 1))
+>Y : Symbol(Y, Decl(inOperatorWithValidOperands.ts, 36, 25))
 
 var c2: X;
->c2 : Symbol(c2, Decl(inOperatorWithValidOperands.ts, 36, 3))
->X : Symbol(X, Decl(inOperatorWithValidOperands.ts, 30, 1))
+>c2 : Symbol(c2, Decl(inOperatorWithValidOperands.ts, 40, 3))
+>X : Symbol(X, Decl(inOperatorWithValidOperands.ts, 34, 1))
 
 var c3: Y;
->c3 : Symbol(c3, Decl(inOperatorWithValidOperands.ts, 37, 3))
->Y : Symbol(Y, Decl(inOperatorWithValidOperands.ts, 32, 25))
+>c3 : Symbol(c3, Decl(inOperatorWithValidOperands.ts, 41, 3))
+>Y : Symbol(Y, Decl(inOperatorWithValidOperands.ts, 36, 25))
 
 var rc1 = x in c1;
->rc1 : Symbol(rc1, Decl(inOperatorWithValidOperands.ts, 39, 3))
+>rc1 : Symbol(rc1, Decl(inOperatorWithValidOperands.ts, 43, 3))
 >x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
->c1 : Symbol(c1, Decl(inOperatorWithValidOperands.ts, 35, 3))
+>c1 : Symbol(c1, Decl(inOperatorWithValidOperands.ts, 39, 3))
 
 var rc2 = x in (c2 || c3);
->rc2 : Symbol(rc2, Decl(inOperatorWithValidOperands.ts, 40, 3))
+>rc2 : Symbol(rc2, Decl(inOperatorWithValidOperands.ts, 44, 3))
 >x : Symbol(x, Decl(inOperatorWithValidOperands.ts, 0, 3))
->c2 : Symbol(c2, Decl(inOperatorWithValidOperands.ts, 36, 3))
->c3 : Symbol(c3, Decl(inOperatorWithValidOperands.ts, 37, 3))
+>c2 : Symbol(c2, Decl(inOperatorWithValidOperands.ts, 40, 3))
+>c3 : Symbol(c3, Decl(inOperatorWithValidOperands.ts, 41, 3))
 

--- a/tests/baselines/reference/inOperatorWithValidOperands.types
+++ b/tests/baselines/reference/inOperatorWithValidOperands.types
@@ -10,6 +10,12 @@ var a1: string;
 var a2: number;
 >a2 : number
 
+var a3: string | number | symbol;
+>a3 : string | number | symbol
+
+var a4: any;
+>a4 : any
+
 var ra1 = x in x;
 >ra1 : boolean
 >x in x : boolean
@@ -38,6 +44,18 @@ var ra5 = 0 in x;
 >ra5 : boolean
 >0 in x : boolean
 >0 : 0
+>x : any
+
+var ra6 = a3 in x;
+>ra6 : boolean
+>a3 in x : boolean
+>a3 : string | number | symbol
+>x : any
+
+var ra7 = a4 in x;
+>ra7 : boolean
+>a4 in x : boolean
+>a4 : any
 >x : any
 
 // valid right operands

--- a/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts
+++ b/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts
@@ -1,3 +1,4 @@
+class Foo {}
 enum E { a }
 
 var x: any;
@@ -7,7 +8,9 @@ var x: any;
 var a1: boolean;
 var a2: void;
 var a3: {};
-var a4: E
+var a4: E;
+var a5: Foo | string;
+var a6: Foo;
 
 var ra1 = a1 in x;
 var ra2 = a2 in x;
@@ -18,6 +21,8 @@ var ra6 = undefined in x;
 var ra7 = E.a in x;
 var ra8 = false in x;
 var ra9 = {} in x;
+var ra10 = a5 in x;
+var ra11 = a6 in x;
 
 // invalid right operands
 // the right operand is required to be of type Any, an object type, or a type parameter type
@@ -37,7 +42,6 @@ var rb7 = x in false;
 var rb8 = x in '';
 var rb9 = x in null;
 var rb10 = x in undefined;
-
 
 // both operands are invalid
 var rc1 = {} in '';

--- a/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithValidOperands.ts
+++ b/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithValidOperands.ts
@@ -4,12 +4,16 @@ var x: any;
 // the left operand is required to be of type Any, the String primitive type, or the Number primitive type
 var a1: string;
 var a2: number;
+var a3: string | number | symbol;
+var a4: any;
 
 var ra1 = x in x;
 var ra2 = a1 in x;
 var ra3 = a2 in x;
 var ra4 = '' in x;
 var ra5 = 0 in x;
+var ra6 = a3 in x;
+var ra7 = a4 in x;
 
 // valid right operands
 // the right operand is required to be of type Any, an object type, or a type parameter type


### PR DESCRIPTION
Fixes #36055