### PR TITLE
Generic functions are never context sensitive

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14251,7 +14251,7 @@ namespace ts {
 
         function hasContextSensitiveReturnExpression(node: FunctionLikeDeclaration) {
             // TODO(anhans): A block should be context-sensitive if it has a context-sensitive return value.
-            return !getEffectiveReturnTypeNode(node) && !!node.body && node.body.kind !== SyntaxKind.Block && isContextSensitive(node.body);
+            return !node.typeParameters && !getEffectiveReturnTypeNode(node) && !!node.body && node.body.kind !== SyntaxKind.Block && isContextSensitive(node.body);
         }
 
         function isContextSensitiveFunctionOrObjectLiteralMethod(func: Node): func is FunctionExpression | ArrowFunction | MethodDeclaration {

--- a/tests/baselines/reference/genericFunctionsNotContextSensitive.js
+++ b/tests/baselines/reference/genericFunctionsNotContextSensitive.js
@@ -1,0 +1,13 @@
+//// [genericFunctionsNotContextSensitive.ts]
+// Repro from #37110
+
+const f = <F extends (...args: any[]) => <G>(x: G) => void>(_: F): F => _;
+
+const a = f(<K extends string>(_: K) => _ => ({}));  // <K extends string>(_: K) => <G>(_: G) => {}
+
+
+//// [genericFunctionsNotContextSensitive.js]
+"use strict";
+// Repro from #37110
+var f = function (_) { return _; };
+var a = f(function (_) { return function (_) { return ({}); }; }); // <K extends string>(_: K) => <G>(_: G) => {}

--- a/tests/baselines/reference/genericFunctionsNotContextSensitive.symbols
+++ b/tests/baselines/reference/genericFunctionsNotContextSensitive.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/genericFunctionsNotContextSensitive.ts ===
+// Repro from #37110
+
+const f = <F extends (...args: any[]) => <G>(x: G) => void>(_: F): F => _;
+>f : Symbol(f, Decl(genericFunctionsNotContextSensitive.ts, 2, 5))
+>F : Symbol(F, Decl(genericFunctionsNotContextSensitive.ts, 2, 11))
+>args : Symbol(args, Decl(genericFunctionsNotContextSensitive.ts, 2, 22))
+>G : Symbol(G, Decl(genericFunctionsNotContextSensitive.ts, 2, 42))
+>x : Symbol(x, Decl(genericFunctionsNotContextSensitive.ts, 2, 45))
+>G : Symbol(G, Decl(genericFunctionsNotContextSensitive.ts, 2, 42))
+>_ : Symbol(_, Decl(genericFunctionsNotContextSensitive.ts, 2, 60))
+>F : Symbol(F, Decl(genericFunctionsNotContextSensitive.ts, 2, 11))
+>F : Symbol(F, Decl(genericFunctionsNotContextSensitive.ts, 2, 11))
+>_ : Symbol(_, Decl(genericFunctionsNotContextSensitive.ts, 2, 60))
+
+const a = f(<K extends string>(_: K) => _ => ({}));  // <K extends string>(_: K) => <G>(_: G) => {}
+>a : Symbol(a, Decl(genericFunctionsNotContextSensitive.ts, 4, 5))
+>f : Symbol(f, Decl(genericFunctionsNotContextSensitive.ts, 2, 5))
+>K : Symbol(K, Decl(genericFunctionsNotContextSensitive.ts, 4, 13))
+>_ : Symbol(_, Decl(genericFunctionsNotContextSensitive.ts, 4, 31))
+>K : Symbol(K, Decl(genericFunctionsNotContextSensitive.ts, 4, 13))
+>_ : Symbol(_, Decl(genericFunctionsNotContextSensitive.ts, 4, 39))
+

--- a/tests/baselines/reference/genericFunctionsNotContextSensitive.types
+++ b/tests/baselines/reference/genericFunctionsNotContextSensitive.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/genericFunctionsNotContextSensitive.ts ===
+// Repro from #37110
+
+const f = <F extends (...args: any[]) => <G>(x: G) => void>(_: F): F => _;
+>f : <F extends (...args: any[]) => <G>(x: G) => void>(_: F) => F
+><F extends (...args: any[]) => <G>(x: G) => void>(_: F): F => _ : <F extends (...args: any[]) => <G>(x: G) => void>(_: F) => F
+>args : any[]
+>x : G
+>_ : F
+>_ : F
+
+const a = f(<K extends string>(_: K) => _ => ({}));  // <K extends string>(_: K) => <G>(_: G) => {}
+>a : <K extends string>(_: K) => <G>(_: G) => {}
+>f(<K extends string>(_: K) => _ => ({})) : <K extends string>(_: K) => <G>(_: G) => {}
+>f : <F extends (...args: any[]) => <G>(x: G) => void>(_: F) => F
+><K extends string>(_: K) => _ => ({}) : <K extends string>(_: K) => <G>(_: G) => {}
+>_ : K
+>_ => ({}) : <G>(_: G) => {}
+>_ : G
+>({}) : {}
+>{} : {}
+

--- a/tests/cases/compiler/genericFunctionsNotContextSensitive.ts
+++ b/tests/cases/compiler/genericFunctionsNotContextSensitive.ts
@@ -1,0 +1,7 @@
+// @strict: true
+
+// Repro from #37110
+
+const f = <F extends (...args: any[]) => <G>(x: G) => void>(_: F): F => _;
+
+const a = f(<K extends string>(_: K) => _ => ({}));  // <K extends string>(_: K) => <G>(_: G) => {}


### PR DESCRIPTION
This PR fixes an issue introduced by #36476 where a generic function would be considered context sensitive even though it never should be (and never was before that PR).

Fixes #37110.