### PR TITLE
Look for outer type parameters on VariableStatements

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8238,6 +8238,7 @@ namespace ts {
                     return undefined;
                 }
                 switch (node.kind) {
+                    case SyntaxKind.VariableStatement:
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.ClassExpression:
                     case SyntaxKind.InterfaceDeclaration:
@@ -8264,6 +8265,9 @@ namespace ts {
                         }
                         else if (node.kind === SyntaxKind.ConditionalType) {
                             return concatenate(outerTypeParameters, getInferTypeParameters(<ConditionalTypeNode>node));
+                        }
+                        else if (node.kind === SyntaxKind.VariableStatement && !isInJSFile(node)) {
+                            break;
                         }
                         const outerAndOwnTypeParameters = appendTypeParameters(outerTypeParameters, getEffectiveTypeParameterDeclarations(<DeclarationWithTypeParameters>node));
                         const thisType = includeThisTypes &&

--- a/tests/baselines/reference/instantiateTemplateTagTypeParameterOnVariableStatement.js
+++ b/tests/baselines/reference/instantiateTemplateTagTypeParameterOnVariableStatement.js
@@ -1,0 +1,23 @@
+//// [instantiateTemplateTagTypeParameterOnVariableStatement.js]
+/**
+ * @template T
+ * @param {T} a
+ * @returns {(b: T) => T}
+ */
+const seq = a => b => b;
+
+const text1 = "hello";
+const text2 = "world";
+
+/** @type {string} */
+var text3 = seq(text1)(text2);
+
+
+
+
+//// [instantiateTemplateTagTypeParameterOnVariableStatement.d.ts]
+declare function seq<T>(a: T): (b: T) => T;
+declare const text1: "hello";
+declare const text2: "world";
+/** @type {string} */
+declare var text3: string;

--- a/tests/baselines/reference/instantiateTemplateTagTypeParameterOnVariableStatement.symbols
+++ b/tests/baselines/reference/instantiateTemplateTagTypeParameterOnVariableStatement.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/jsdoc/instantiateTemplateTagTypeParameterOnVariableStatement.js ===
+/**
+ * @template T
+ * @param {T} a
+ * @returns {(b: T) => T}
+ */
+const seq = a => b => b;
+>seq : Symbol(seq, Decl(instantiateTemplateTagTypeParameterOnVariableStatement.js, 5, 5))
+>a : Symbol(a, Decl(instantiateTemplateTagTypeParameterOnVariableStatement.js, 5, 11))
+>b : Symbol(b, Decl(instantiateTemplateTagTypeParameterOnVariableStatement.js, 5, 16))
+>b : Symbol(b, Decl(instantiateTemplateTagTypeParameterOnVariableStatement.js, 5, 16))
+
+const text1 = "hello";
+>text1 : Symbol(text1, Decl(instantiateTemplateTagTypeParameterOnVariableStatement.js, 7, 5))
+
+const text2 = "world";
+>text2 : Symbol(text2, Decl(instantiateTemplateTagTypeParameterOnVariableStatement.js, 8, 5))
+
+/** @type {string} */
+var text3 = seq(text1)(text2);
+>text3 : Symbol(text3, Decl(instantiateTemplateTagTypeParameterOnVariableStatement.js, 11, 3))
+>seq : Symbol(seq, Decl(instantiateTemplateTagTypeParameterOnVariableStatement.js, 5, 5))
+>text1 : Symbol(text1, Decl(instantiateTemplateTagTypeParameterOnVariableStatement.js, 7, 5))
+>text2 : Symbol(text2, Decl(instantiateTemplateTagTypeParameterOnVariableStatement.js, 8, 5))
+

--- a/tests/baselines/reference/instantiateTemplateTagTypeParameterOnVariableStatement.types
+++ b/tests/baselines/reference/instantiateTemplateTagTypeParameterOnVariableStatement.types
@@ -1,0 +1,31 @@
+=== tests/cases/conformance/jsdoc/instantiateTemplateTagTypeParameterOnVariableStatement.js ===
+/**
+ * @template T
+ * @param {T} a
+ * @returns {(b: T) => T}
+ */
+const seq = a => b => b;
+>seq : <T>(a: T) => (b: T) => T
+>a => b => b : <T>(a: T) => (b: T) => T
+>a : T
+>b => b : (b: T) => T
+>b : T
+>b : T
+
+const text1 = "hello";
+>text1 : "hello"
+>"hello" : "hello"
+
+const text2 = "world";
+>text2 : "world"
+>"world" : "world"
+
+/** @type {string} */
+var text3 = seq(text1)(text2);
+>text3 : string
+>seq(text1)(text2) : string
+>seq(text1) : (b: string) => string
+>seq : <T>(a: T) => (b: T) => T
+>text1 : "hello"
+>text2 : "world"
+

--- a/tests/cases/conformance/jsdoc/instantiateTemplateTagTypeParameterOnVariableStatement.ts
+++ b/tests/cases/conformance/jsdoc/instantiateTemplateTagTypeParameterOnVariableStatement.ts
@@ -1,0 +1,17 @@
+// @checkJs: true
+// @allowJs: true
+// @declaration: true
+// @emitDeclarationOnly: true
+// @filename: instantiateTemplateTagTypeParameterOnVariableStatement.js
+/**
+ * @template T
+ * @param {T} a
+ * @returns {(b: T) => T}
+ */
+const seq = a => b => b;
+
+const text1 = "hello";
+const text2 = "world";
+
+/** @type {string} */
+var text3 = seq(text1)(text2);


### PR DESCRIPTION
This only applies in JS, where `@template` tags can apply to initialisers of variable declarations:

```js
/**
 * @template T
 * @returns {(b: T) => T}
 */
const seq = a => b => b
```

Fixes #36201