### PR TITLE
Set contextual type on elaborated error node rather than passing it, …

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14544,6 +14544,16 @@ namespace ts {
             }
         }
 
+        function checkExpressionForMutableLocationWithContextualType(next: Expression, sourcePropType: Type) {
+            next.contextualType = sourcePropType;
+            try {
+                return checkExpressionForMutableLocation(next, CheckMode.Contextual, sourcePropType);
+            }
+            finally {
+                next.contextualType = undefined;
+            }
+        }
+
         type ElaborationIterator = IterableIterator<{ errorNode: Node, innerExpression: Expression | undefined, nameType: Type, errorMessage?: DiagnosticMessage | undefined }>;
         /**
          * For every element returned from the iterator, checks that element to issue an error on a property of that element's type
@@ -14574,7 +14584,7 @@ namespace ts {
                         // Issue error on the prop itself, since the prop couldn't elaborate the error
                         const resultObj: { errors?: Diagnostic[] } = errorOutputContainer || {};
                         // Use the expression type, if available
-                        const specificSource = next ? checkExpressionForMutableLocation(next, CheckMode.Normal, sourcePropType) : sourcePropType;
+                        const specificSource = next ? checkExpressionForMutableLocationWithContextualType(next, sourcePropType) : sourcePropType;
                         const result = checkTypeRelatedTo(specificSource, targetPropType, relation, prop, errorMessage, containingMessageChain, resultObj);
                         if (result && specificSource !== sourcePropType) {
                             // If for whatever reason the expression type doesn't yield an error, make sure we still issue an error on the sourcePropType

--- a/tests/baselines/reference/arrayLiteralTypeInference.errors.txt
+++ b/tests/baselines/reference/arrayLiteralTypeInference.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/compiler/arrayLiteralTypeInference.ts(14,14): error TS2322: Type '{ id: number; trueness: boolean; }' is not assignable to type 'Action'.
+tests/cases/compiler/arrayLiteralTypeInference.ts(14,14): error TS2322: Type '{ id: number; trueness: false; }' is not assignable to type 'Action'.
   Object literal may only specify known properties, and 'trueness' does not exist in type 'Action'.
 tests/cases/compiler/arrayLiteralTypeInference.ts(15,14): error TS2322: Type '{ id: number; name: string; }' is not assignable to type 'Action'.
   Object literal may only specify known properties, and 'name' does not exist in type 'Action'.
-tests/cases/compiler/arrayLiteralTypeInference.ts(31,18): error TS2322: Type '{ id: number; trueness: boolean; }' is not assignable to type '{ id: number; }'.
+tests/cases/compiler/arrayLiteralTypeInference.ts(31,18): error TS2322: Type '{ id: number; trueness: false; }' is not assignable to type '{ id: number; }'.
   Object literal may only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
 tests/cases/compiler/arrayLiteralTypeInference.ts(32,18): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
@@ -24,7 +24,7 @@ tests/cases/compiler/arrayLiteralTypeInference.ts(32,18): error TS2322: Type '{ 
     var x1: Action[] = [
         { id: 2, trueness: false },
                  ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ id: number; trueness: boolean; }' is not assignable to type 'Action'.
+!!! error TS2322: Type '{ id: number; trueness: false; }' is not assignable to type 'Action'.
 !!! error TS2322:   Object literal may only specify known properties, and 'trueness' does not exist in type 'Action'.
         { id: 3, name: "three" }
                  ~~~~~~~~~~~~~
@@ -47,7 +47,7 @@ tests/cases/compiler/arrayLiteralTypeInference.ts(32,18): error TS2322: Type '{ 
         [
             { id: 2, trueness: false },
                      ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ id: number; trueness: boolean; }' is not assignable to type '{ id: number; }'.
+!!! error TS2322: Type '{ id: number; trueness: false; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
             { id: 3, name: "three" }
                      ~~~~~~~~~~~~~

--- a/tests/baselines/reference/declarationsAndAssignments.errors.txt
+++ b/tests/baselines/reference/declarationsAndAssignments.errors.txt
@@ -17,7 +17,7 @@ tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(73,11): 
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(73,14): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(74,11): error TS2339: Property 'a' does not exist on type 'undefined[]'.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(74,14): error TS2339: Property 'b' does not exist on type 'undefined[]'.
-tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(106,17): error TS2741: Property 'x' is missing in type '{ y: boolean; }' but required in type '{ x: any; y?: boolean; }'.
+tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(106,17): error TS2741: Property 'x' is missing in type '{ y: false; }' but required in type '{ x: any; y?: boolean; }'.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,6): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,9): error TS2322: Type 'number' is not assignable to type 'string'.
 
@@ -169,7 +169,7 @@ tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,9): 
     f14([2, ["abc", { x: 0 }]]);
     f14([2, ["abc", { y: false }]]);  // Error, no x
                     ~~~~~~~~~~~~
-!!! error TS2741: Property 'x' is missing in type '{ y: boolean; }' but required in type '{ x: any; y?: boolean; }'.
+!!! error TS2741: Property 'x' is missing in type '{ y: false; }' but required in type '{ x: any; y?: boolean; }'.
     
     module M {
         export var [a, b] = [1, 2];

--- a/tests/baselines/reference/destructuringParameterProperties5.errors.txt
+++ b/tests/baselines/reference/destructuringParameterProperties5.errors.txt
@@ -7,7 +7,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7,51): error TS2339: Property 'x3' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7,62): error TS2339: Property 'y' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7,72): error TS2339: Property 'z' does not exist on type 'C1'.
-tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,19): error TS2322: Type '{ x1: number; x2: string; x3: boolean; }' is not assignable to type 'ObjType1'.
+tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,19): error TS2322: Type '{ x1: number; x2: string; x3: true; }' is not assignable to type 'ObjType1'.
   Object literal may only specify known properties, and 'x1' does not exist in type 'ObjType1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,47): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,51): error TS2322: Type 'false' is not assignable to type 'string'.
@@ -49,7 +49,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(1
     
     var a = new C1([{ x1: 10, x2: "", x3: true }, "", false]);
                       ~~~~~~
-!!! error TS2322: Type '{ x1: number; x2: string; x3: boolean; }' is not assignable to type 'ObjType1'.
+!!! error TS2322: Type '{ x1: number; x2: string; x3: true; }' is not assignable to type 'ObjType1'.
 !!! error TS2322:   Object literal may only specify known properties, and 'x1' does not exist in type 'ObjType1'.
                                                   ~~
 !!! error TS2322: Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.errors.txt
+++ b/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.errors.txt
@@ -10,7 +10,7 @@ tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts(43,9): error
   Object literal may only specify known properties, and 'xyz' does not exist in type '{ id: number; } & { url: string; }'.
 tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts(68,32): error TS2322: Type '{ foo: true; bar: true; boo: boolean; }' is not assignable to type 'View<TypeA>'.
   Object literal may only specify known properties, and 'boo' does not exist in type 'View<TypeA>'.
-tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts(70,50): error TS2322: Type '{ foo: true; bar: true; boo: boolean; }' is not assignable to type 'boolean | View<TypeB>'.
+tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts(70,50): error TS2322: Type '{ foo: true; bar: true; boo: true; }' is not assignable to type 'boolean | View<TypeB>'.
   Object literal may only specify known properties, and 'boo' does not exist in type 'View<TypeB>'.
 
 
@@ -110,7 +110,7 @@ tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts(70,50): erro
     
     test = { foo: true, bar: { foo: true, bar: true, boo: true } }
                                                      ~~~~~~~~~
-!!! error TS2322: Type '{ foo: true; bar: true; boo: boolean; }' is not assignable to type 'boolean | View<TypeB>'.
+!!! error TS2322: Type '{ foo: true; bar: true; boo: true; }' is not assignable to type 'boolean | View<TypeB>'.
 !!! error TS2322:   Object literal may only specify known properties, and 'boo' does not exist in type 'View<TypeB>'.
 !!! related TS6500 tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts:63:5: The expected type comes from property 'bar' which is declared here on type 'View<TypeA>'
     

--- a/tests/baselines/reference/partialDiscriminatedUnionMemberHasGoodError.errors.txt
+++ b/tests/baselines/reference/partialDiscriminatedUnionMemberHasGoodError.errors.txt
@@ -1,0 +1,34 @@
+tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts(20,13): error TS2322: Type '{ type: "A"; }' is not assignable to type 'ValidType'.
+  Property 'param' is missing in type '{ type: "A"; }' but required in type 'TypeA'.
+
+
+==== tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts (1 errors) ====
+    interface TypeA {
+        type: "A";
+        param: string;
+    }
+    
+    interface TypeB {
+        type: "B";
+        param: string;
+    }
+    
+    type ValidType = TypeA | TypeB;
+    
+    interface Wrapper {
+        types: ValidType[];
+    }
+    
+    const foo: Wrapper[] = [];
+    
+    foo.push({
+        types: [{
+                ~
+            type: "A"
+    ~~~~~~~~~~~~~~~~~
+        }]
+    ~~~~~
+!!! error TS2322: Type '{ type: "A"; }' is not assignable to type 'ValidType'.
+!!! error TS2322:   Property 'param' is missing in type '{ type: "A"; }' but required in type 'TypeA'.
+!!! related TS2728 tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts:3:5: 'param' is declared here.
+    });

--- a/tests/baselines/reference/partialDiscriminatedUnionMemberHasGoodError.js
+++ b/tests/baselines/reference/partialDiscriminatedUnionMemberHasGoodError.js
@@ -1,0 +1,32 @@
+//// [partialDiscriminatedUnionMemberHasGoodError.ts]
+interface TypeA {
+    type: "A";
+    param: string;
+}
+
+interface TypeB {
+    type: "B";
+    param: string;
+}
+
+type ValidType = TypeA | TypeB;
+
+interface Wrapper {
+    types: ValidType[];
+}
+
+const foo: Wrapper[] = [];
+
+foo.push({
+    types: [{
+        type: "A"
+    }]
+});
+
+//// [partialDiscriminatedUnionMemberHasGoodError.js]
+var foo = [];
+foo.push({
+    types: [{
+            type: "A"
+        }]
+});

--- a/tests/baselines/reference/partialDiscriminatedUnionMemberHasGoodError.symbols
+++ b/tests/baselines/reference/partialDiscriminatedUnionMemberHasGoodError.symbols
@@ -1,0 +1,51 @@
+=== tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts ===
+interface TypeA {
+>TypeA : Symbol(TypeA, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 0, 0))
+
+    type: "A";
+>type : Symbol(TypeA.type, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 0, 17))
+
+    param: string;
+>param : Symbol(TypeA.param, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 1, 14))
+}
+
+interface TypeB {
+>TypeB : Symbol(TypeB, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 3, 1))
+
+    type: "B";
+>type : Symbol(TypeB.type, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 5, 17))
+
+    param: string;
+>param : Symbol(TypeB.param, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 6, 14))
+}
+
+type ValidType = TypeA | TypeB;
+>ValidType : Symbol(ValidType, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 8, 1))
+>TypeA : Symbol(TypeA, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 0, 0))
+>TypeB : Symbol(TypeB, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 3, 1))
+
+interface Wrapper {
+>Wrapper : Symbol(Wrapper, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 10, 31))
+
+    types: ValidType[];
+>types : Symbol(Wrapper.types, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 12, 19))
+>ValidType : Symbol(ValidType, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 8, 1))
+}
+
+const foo: Wrapper[] = [];
+>foo : Symbol(foo, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 16, 5))
+>Wrapper : Symbol(Wrapper, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 10, 31))
+
+foo.push({
+>foo.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>foo : Symbol(foo, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 16, 5))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+
+    types: [{
+>types : Symbol(types, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 18, 10))
+
+        type: "A"
+>type : Symbol(type, Decl(partialDiscriminatedUnionMemberHasGoodError.ts, 19, 13))
+
+    }]
+});

--- a/tests/baselines/reference/partialDiscriminatedUnionMemberHasGoodError.types
+++ b/tests/baselines/reference/partialDiscriminatedUnionMemberHasGoodError.types
@@ -1,0 +1,47 @@
+=== tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts ===
+interface TypeA {
+    type: "A";
+>type : "A"
+
+    param: string;
+>param : string
+}
+
+interface TypeB {
+    type: "B";
+>type : "B"
+
+    param: string;
+>param : string
+}
+
+type ValidType = TypeA | TypeB;
+>ValidType : ValidType
+
+interface Wrapper {
+    types: ValidType[];
+>types : ValidType[]
+}
+
+const foo: Wrapper[] = [];
+>foo : Wrapper[]
+>[] : undefined[]
+
+foo.push({
+>foo.push({    types: [{        type: "A"    }]}) : number
+>foo.push : (...items: Wrapper[]) => number
+>foo : Wrapper[]
+>push : (...items: Wrapper[]) => number
+>{    types: [{        type: "A"    }]} : { types: { type: "A"; }[]; }
+
+    types: [{
+>types : { type: "A"; }[]
+>[{        type: "A"    }] : { type: "A"; }[]
+>{        type: "A"    } : { type: "A"; }
+
+        type: "A"
+>type : "A"
+>"A" : "A"
+
+    }]
+});

--- a/tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts
+++ b/tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts
@@ -1,0 +1,23 @@
+interface TypeA {
+    type: "A";
+    param: string;
+}
+
+interface TypeB {
+    type: "B";
+    param: string;
+}
+
+type ValidType = TypeA | TypeB;
+
+interface Wrapper {
+    types: ValidType[];
+}
+
+const foo: Wrapper[] = [];
+
+foo.push({
+    types: [{
+        type: "A"
+    }]
+});


### PR DESCRIPTION
…so its discriminated, and so the contextual type is used when rechecking the expression, and not just when comparing the expression type to the context.

Fixes #37725
