### PR TITLE
Fix metadata serialization for invalid jsdoc types

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1590,6 +1590,18 @@ namespace ts {
                 case SyntaxKind.ImportType:
                     break;
 
+                // handle JSDoc types from an invalid parse
+                case SyntaxKind.JSDocAllType:
+                case SyntaxKind.JSDocUnknownType:
+                case SyntaxKind.JSDocFunctionType:
+                case SyntaxKind.JSDocVariadicType:
+                case SyntaxKind.JSDocNamepathType:
+                    break;
+
+                case SyntaxKind.JSDocNullableType:
+                case SyntaxKind.JSDocNonNullableType:
+                case SyntaxKind.JSDocOptionalType:
+                    return serializeTypeNode((<JSDocNullableType | JSDocNonNullableType | JSDocOptionalType>node).type);
 
                 default:
                     return Debug.failBadSyntaxKind(node);

--- a/tests/baselines/reference/decoratorMetadata-jsdoc.errors.txt
+++ b/tests/baselines/reference/decoratorMetadata-jsdoc.errors.txt
@@ -1,0 +1,22 @@
+tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts(5,9): error TS8020: JSDoc types can only be used inside documentation comments.
+tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts(7,9): error TS8020: JSDoc types can only be used inside documentation comments.
+tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts(9,9): error TS8020: JSDoc types can only be used inside documentation comments.
+
+
+==== tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts (3 errors) ====
+    declare var decorator: any;
+    
+    class X {
+        @decorator()
+        a?: string?;
+            ~~~~~~~
+!!! error TS8020: JSDoc types can only be used inside documentation comments.
+        @decorator()
+        b?: string!;
+            ~~~~~~~
+!!! error TS8020: JSDoc types can only be used inside documentation comments.
+        @decorator()
+        c?: *;
+            ~
+!!! error TS8020: JSDoc types can only be used inside documentation comments.
+    }

--- a/tests/baselines/reference/decoratorMetadata-jsdoc.js
+++ b/tests/baselines/reference/decoratorMetadata-jsdoc.js
@@ -1,0 +1,39 @@
+//// [decoratorMetadata-jsdoc.ts]
+declare var decorator: any;
+
+class X {
+    @decorator()
+    a?: string?;
+    @decorator()
+    b?: string!;
+    @decorator()
+    c?: *;
+}
+
+//// [decoratorMetadata-jsdoc.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var X = /** @class */ (function () {
+    function X() {
+    }
+    __decorate([
+        decorator(),
+        __metadata("design:type", String)
+    ], X.prototype, "a", void 0);
+    __decorate([
+        decorator(),
+        __metadata("design:type", String)
+    ], X.prototype, "b", void 0);
+    __decorate([
+        decorator(),
+        __metadata("design:type", Object)
+    ], X.prototype, "c", void 0);
+    return X;
+}());

--- a/tests/baselines/reference/decoratorMetadata-jsdoc.symbols
+++ b/tests/baselines/reference/decoratorMetadata-jsdoc.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts ===
+declare var decorator: any;
+>decorator : Symbol(decorator, Decl(decoratorMetadata-jsdoc.ts, 0, 11))
+
+class X {
+>X : Symbol(X, Decl(decoratorMetadata-jsdoc.ts, 0, 27))
+
+    @decorator()
+>decorator : Symbol(decorator, Decl(decoratorMetadata-jsdoc.ts, 0, 11))
+
+    a?: string?;
+>a : Symbol(X.a, Decl(decoratorMetadata-jsdoc.ts, 2, 9))
+
+    @decorator()
+>decorator : Symbol(decorator, Decl(decoratorMetadata-jsdoc.ts, 0, 11))
+
+    b?: string!;
+>b : Symbol(X.b, Decl(decoratorMetadata-jsdoc.ts, 4, 16))
+
+    @decorator()
+>decorator : Symbol(decorator, Decl(decoratorMetadata-jsdoc.ts, 0, 11))
+
+    c?: *;
+>c : Symbol(X.c, Decl(decoratorMetadata-jsdoc.ts, 6, 16))
+}

--- a/tests/baselines/reference/decoratorMetadata-jsdoc.types
+++ b/tests/baselines/reference/decoratorMetadata-jsdoc.types
@@ -1,0 +1,28 @@
+=== tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts ===
+declare var decorator: any;
+>decorator : any
+
+class X {
+>X : X
+
+    @decorator()
+>decorator() : any
+>decorator : any
+
+    a?: string?;
+>a : string
+
+    @decorator()
+>decorator() : any
+>decorator : any
+
+    b?: string!;
+>b : string
+
+    @decorator()
+>decorator() : any
+>decorator : any
+
+    c?: *;
+>c : any
+}

--- a/tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts
+++ b/tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts
@@ -1,0 +1,14 @@
+// @experimentalDecorators: true
+// @emitDecoratorMetadata: true
+// @target: es5
+// @module: commonjs
+declare var decorator: any;
+
+class X {
+    @decorator()
+    a?: string?;
+    @decorator()
+    b?: string!;
+    @decorator()
+    c?: *;
+}


### PR DESCRIPTION
Fixes decorator metadata serialization for cases where we parse an invalid jsdoc type.

Fixes #37276
