### PR TITLE
Fix easy misunderstanding "! ==="

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -307,14 +307,14 @@ namespace ts {
     /* @internal */ export function isUnicodeIdentifierStart(code: number, languageVersion: ScriptTarget | undefined) {
         return languageVersion! >= ScriptTarget.ES2015 ?
             lookupInUnicodeMap(code, unicodeESNextIdentifierStart) :
-            languageVersion! === ScriptTarget.ES5 ? lookupInUnicodeMap(code, unicodeES5IdentifierStart) :
+            languageVersion === ScriptTarget.ES5 ? lookupInUnicodeMap(code, unicodeES5IdentifierStart) :
                 lookupInUnicodeMap(code, unicodeES3IdentifierStart);
     }
 
     function isUnicodeIdentifierPart(code: number, languageVersion: ScriptTarget | undefined) {
         return languageVersion! >= ScriptTarget.ES2015 ?
             lookupInUnicodeMap(code, unicodeESNextIdentifierPart) :
-            languageVersion! === ScriptTarget.ES5 ? lookupInUnicodeMap(code, unicodeES5IdentifierPart) :
+            languageVersion === ScriptTarget.ES5 ? lookupInUnicodeMap(code, unicodeES5IdentifierPart) :
                 lookupInUnicodeMap(code, unicodeES3IdentifierPart);
     }
 

--- a/src/services/codefixes/addMissingAwait.ts
+++ b/src/services/codefixes/addMissingAwait.ts
@@ -211,7 +211,7 @@ namespace ts.codefix {
             reference;
         const diagnostic = find(diagnostics, diagnostic =>
             diagnostic.start === errorNode.getStart(sourceFile) &&
-            diagnostic.start + diagnostic.length! === errorNode.getEnd());
+            (diagnostic.start + diagnostic.length!) === errorNode.getEnd());
 
         return diagnostic && contains(errorCodes, diagnostic.code) ||
             // A Promise is usually not correct in a binary expression (it’s not valid


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #37837

Some Non-null assertion operators are just unnecessary,
And wrap another one inside parentheses,
To eliminate misunderstandings of `! ===` with `!==`

