### PR TITLE
Fix parenthesization rules for yield

### DIFF
--- a/src/compiler/factoryPublic.ts
+++ b/src/compiler/factoryPublic.ts
@@ -1555,9 +1555,11 @@ namespace ts {
     export function createYield(expression?: Expression): YieldExpression;
     export function createYield(asteriskToken: AsteriskToken | undefined, expression: Expression): YieldExpression;
     export function createYield(asteriskTokenOrExpression?: AsteriskToken | undefined | Expression, expression?: Expression) {
+        const asteriskToken = asteriskTokenOrExpression && asteriskTokenOrExpression.kind === SyntaxKind.AsteriskToken ? <AsteriskToken>asteriskTokenOrExpression : undefined;
+        expression = asteriskTokenOrExpression && asteriskTokenOrExpression.kind !== SyntaxKind.AsteriskToken ? asteriskTokenOrExpression : expression;
         const node = <YieldExpression>createSynthesizedNode(SyntaxKind.YieldExpression);
-        node.asteriskToken = asteriskTokenOrExpression && asteriskTokenOrExpression.kind === SyntaxKind.AsteriskToken ? <AsteriskToken>asteriskTokenOrExpression : undefined;
-        node.expression = asteriskTokenOrExpression && asteriskTokenOrExpression.kind !== SyntaxKind.AsteriskToken ? asteriskTokenOrExpression : expression;
+        node.asteriskToken = asteriskToken;
+        node.expression = expression && parenthesizeExpressionForList(expression);
         return node;
     }
 

--- a/tests/baselines/reference/importCallExpressionInUMD5.js
+++ b/tests/baselines/reference/importCallExpressionInUMD5.js
@@ -1,14 +1,17 @@
-//// [tests/cases/conformance/dynamicImport/importCallExpressionNestedUMD.ts] ////
+//// [tests/cases/conformance/dynamicImport/importCallExpressionInUMD5.ts] ////
 
-//// [foo.ts]
-export default "./foo";
+//// [0.ts]
+export function foo() { return "foo"; }
 
-//// [index.ts]
-async function foo() {
-    return await import((await import("./foo")).default);
+//// [1.ts]
+// https://github.com/microsoft/TypeScript/issues/36780
+async function func() {
+    const packageName = '.';
+    const packageJson = await import(packageName + '/package.json');
 }
 
-//// [foo.js]
+
+//// [0.js]
 (function (factory) {
     if (typeof module === "object" && typeof module.exports === "object") {
         var v = factory(require, exports);
@@ -20,9 +23,11 @@ async function foo() {
 })(function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
-    exports.default = "./foo";
+    exports.foo = void 0;
+    function foo() { return "foo"; }
+    exports.foo = foo;
 });
-//// [index.js]
+//// [1.js]
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -43,10 +48,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 })(function (require, exports) {
     "use strict";
     var __syncRequire = typeof module === "object" && typeof module.exports === "object";
-    function foo() {
+    // https://github.com/microsoft/TypeScript/issues/36780
+    function func() {
         return __awaiter(this, void 0, void 0, function* () {
             var _a;
-            return yield (_a = (yield __syncRequire ? Promise.resolve().then(() => require("./foo")) : new Promise((resolve_1, reject_1) => { require(["./foo"], resolve_1, reject_1); })).default, __syncRequire ? Promise.resolve().then(() => require(_a)) : new Promise((resolve_2, reject_2) => { require([_a], resolve_2, reject_2); }));
+            const packageName = '.';
+            const packageJson = yield (_a = packageName + '/package.json', __syncRequire ? Promise.resolve().then(() => require(_a)) : new Promise((resolve_1, reject_1) => { require([_a], resolve_1, reject_1); }));
         });
     }
 });

--- a/tests/baselines/reference/importCallExpressionInUMD5.symbols
+++ b/tests/baselines/reference/importCallExpressionInUMD5.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/dynamicImport/0.ts ===
+export function foo() { return "foo"; }
+>foo : Symbol(foo, Decl(0.ts, 0, 0))
+
+=== tests/cases/conformance/dynamicImport/1.ts ===
+// https://github.com/microsoft/TypeScript/issues/36780
+async function func() {
+>func : Symbol(func, Decl(1.ts, 0, 0))
+
+    const packageName = '.';
+>packageName : Symbol(packageName, Decl(1.ts, 2, 9))
+
+    const packageJson = await import(packageName + '/package.json');
+>packageJson : Symbol(packageJson, Decl(1.ts, 3, 9))
+>packageName : Symbol(packageName, Decl(1.ts, 2, 9))
+}
+

--- a/tests/baselines/reference/importCallExpressionInUMD5.types
+++ b/tests/baselines/reference/importCallExpressionInUMD5.types
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/dynamicImport/0.ts ===
+export function foo() { return "foo"; }
+>foo : () => string
+>"foo" : "foo"
+
+=== tests/cases/conformance/dynamicImport/1.ts ===
+// https://github.com/microsoft/TypeScript/issues/36780
+async function func() {
+>func : () => Promise<void>
+
+    const packageName = '.';
+>packageName : "."
+>'.' : "."
+
+    const packageJson = await import(packageName + '/package.json');
+>packageJson : any
+>await import(packageName + '/package.json') : any
+>import(packageName + '/package.json') : Promise<any>
+>packageName + '/package.json' : string
+>packageName : "."
+>'/package.json' : "/package.json"
+}
+

--- a/tests/cases/conformance/dynamicImport/importCallExpressionInUMD5.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionInUMD5.ts
@@ -1,0 +1,12 @@
+﻿// @module: umd
+// @target: es2015
+// @filename: 0.ts
+export function foo() { return "foo"; }
+
+// @filename: 1.ts
+
+// https://github.com/microsoft/TypeScript/issues/36780
+async function func() {
+    const packageName = '.';
+    const packageJson = await import(packageName + '/package.json');
+}


### PR DESCRIPTION
Fixes the parenthesization rules for `yield` so that we correctly add parens around synthetic comma expressions.

Fixes #36780
