### PR TITLE
Add support for in narrowing

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20315,7 +20315,7 @@ namespace ts {
                         return resultType;
                     }
                     return narrowTypeByInKeywordWithExistedPropName(type, propName);
-                }                
+                }
                 return type;
             }
 

--- a/tests/baselines/reference/inKeywordTypeguard.errors.txt
+++ b/tests/baselines/reference/inKeywordTypeguard.errors.txt
@@ -5,8 +5,10 @@ tests/cases/compiler/inKeywordTypeguard.ts(16,11): error TS2339: Property 'a' do
 tests/cases/compiler/inKeywordTypeguard.ts(27,11): error TS2339: Property 'b' does not exist on type 'AWithOptionalProp | BWithOptionalProp'.
   Property 'b' does not exist on type 'AWithOptionalProp'.
 tests/cases/compiler/inKeywordTypeguard.ts(42,11): error TS2339: Property 'b' does not exist on type 'AWithMethod'.
-tests/cases/compiler/inKeywordTypeguard.ts(49,11): error TS2339: Property 'a' does not exist on type 'never'.
-tests/cases/compiler/inKeywordTypeguard.ts(50,11): error TS2339: Property 'b' does not exist on type 'never'.
+tests/cases/compiler/inKeywordTypeguard.ts(49,11): error TS2339: Property 'a' does not exist on type '(AWithMethod & { c: unknown; }) | (BWithMethod & { c: unknown; })'.
+  Property 'a' does not exist on type 'BWithMethod & { c: unknown; }'.
+tests/cases/compiler/inKeywordTypeguard.ts(50,11): error TS2339: Property 'b' does not exist on type '(AWithMethod & { c: unknown; }) | (BWithMethod & { c: unknown; })'.
+  Property 'b' does not exist on type 'AWithMethod & { c: unknown; }'.
 tests/cases/compiler/inKeywordTypeguard.ts(52,11): error TS2339: Property 'a' does not exist on type 'AWithMethod | BWithMethod'.
   Property 'a' does not exist on type 'BWithMethod'.
 tests/cases/compiler/inKeywordTypeguard.ts(53,11): error TS2339: Property 'b' does not exist on type 'AWithMethod | BWithMethod'.
@@ -85,10 +87,12 @@ tests/cases/compiler/inKeywordTypeguard.ts(94,26): error TS2339: Property 'a' do
         if ("c" in x) {
             x.a();
               ~
-!!! error TS2339: Property 'a' does not exist on type 'never'.
+!!! error TS2339: Property 'a' does not exist on type '(AWithMethod & { c: unknown; }) | (BWithMethod & { c: unknown; })'.
+!!! error TS2339:   Property 'a' does not exist on type 'BWithMethod & { c: unknown; }'.
             x.b();
               ~
-!!! error TS2339: Property 'b' does not exist on type 'never'.
+!!! error TS2339: Property 'b' does not exist on type '(AWithMethod & { c: unknown; }) | (BWithMethod & { c: unknown; })'.
+!!! error TS2339:   Property 'b' does not exist on type 'AWithMethod & { c: unknown; }'.
         } else {
             x.a();
               ~

--- a/tests/baselines/reference/inKeywordTypeguard.types
+++ b/tests/baselines/reference/inKeywordTypeguard.types
@@ -146,13 +146,13 @@ function negativeTestClassesWithMemberMissingInBothClasses(x: AWithMethod | BWit
         x.a();
 >x.a() : any
 >x.a : any
->x : never
+>x : (AWithMethod & { c: unknown; }) | (BWithMethod & { c: unknown; })
 >a : any
 
         x.b();
 >x.b() : any
 >x.b : any
->x : never
+>x : (AWithMethod & { c: unknown; }) | (BWithMethod & { c: unknown; })
 >b : any
 
     } else {

--- a/tests/baselines/reference/narrowiinigInWithExistedProperty.errors.txt
+++ b/tests/baselines/reference/narrowiinigInWithExistedProperty.errors.txt
@@ -1,0 +1,37 @@
+tests/cases/compiler/narrowiinigInWithExistedProperty.ts(23,9): error TS2339: Property 'd' does not exist on type 'never'.
+tests/cases/compiler/narrowiinigInWithExistedProperty.ts(26,12): error TS2571: Object is of type 'unknown'.
+
+
+==== tests/cases/compiler/narrowiinigInWithExistedProperty.ts (2 errors) ====
+    interface A {
+        a: number
+    }
+    
+    interface B {
+        b: number
+    }
+    
+    interface C {
+        c: number
+    }
+    
+    declare const foo: A | B | C;
+    declare const bar: unknown;
+    
+    if ('a' in foo) {
+        foo.a
+    } else if ('b' in foo) {
+        foo.b
+    } else if ('c' in foo) {
+        foo.c
+    } else if ('d' in foo) {
+        foo.d
+            ~
+!!! error TS2339: Property 'd' does not exist on type 'never'.
+    }
+    
+    if ('a' in bar) {
+               ~~~
+!!! error TS2571: Object is of type 'unknown'.
+        bar.a
+    }

--- a/tests/baselines/reference/narrowiinigInWithExistedProperty.errors.txt
+++ b/tests/baselines/reference/narrowiinigInWithExistedProperty.errors.txt
@@ -1,8 +1,7 @@
 tests/cases/compiler/narrowiinigInWithExistedProperty.ts(23,9): error TS2339: Property 'd' does not exist on type 'never'.
-tests/cases/compiler/narrowiinigInWithExistedProperty.ts(26,12): error TS2571: Object is of type 'unknown'.
 
 
-==== tests/cases/compiler/narrowiinigInWithExistedProperty.ts (2 errors) ====
+==== tests/cases/compiler/narrowiinigInWithExistedProperty.ts (1 errors) ====
     interface A {
         a: number
     }
@@ -16,7 +15,7 @@ tests/cases/compiler/narrowiinigInWithExistedProperty.ts(26,12): error TS2571: O
     }
     
     declare const foo: A | B | C;
-    declare const bar: unknown;
+    declare const bar: {};
     
     if ('a' in foo) {
         foo.a
@@ -31,7 +30,5 @@ tests/cases/compiler/narrowiinigInWithExistedProperty.ts(26,12): error TS2571: O
     }
     
     if ('a' in bar) {
-               ~~~
-!!! error TS2571: Object is of type 'unknown'.
         bar.a
     }

--- a/tests/baselines/reference/narrowiinigInWithExistedProperty.js
+++ b/tests/baselines/reference/narrowiinigInWithExistedProperty.js
@@ -12,7 +12,7 @@ interface C {
 }
 
 declare const foo: A | B | C;
-declare const bar: unknown;
+declare const bar: {};
 
 if ('a' in foo) {
     foo.a

--- a/tests/baselines/reference/narrowiinigInWithExistedProperty.js
+++ b/tests/baselines/reference/narrowiinigInWithExistedProperty.js
@@ -1,0 +1,47 @@
+//// [narrowiinigInWithExistedProperty.ts]
+interface A {
+    a: number
+}
+
+interface B {
+    b: number
+}
+
+interface C {
+    c: number
+}
+
+declare const foo: A | B | C;
+declare const bar: unknown;
+
+if ('a' in foo) {
+    foo.a
+} else if ('b' in foo) {
+    foo.b
+} else if ('c' in foo) {
+    foo.c
+} else if ('d' in foo) {
+    foo.d
+}
+
+if ('a' in bar) {
+    bar.a
+}
+
+//// [narrowiinigInWithExistedProperty.js]
+"use strict";
+if ('a' in foo) {
+    foo.a;
+}
+else if ('b' in foo) {
+    foo.b;
+}
+else if ('c' in foo) {
+    foo.c;
+}
+else if ('d' in foo) {
+    foo.d;
+}
+if ('a' in bar) {
+    bar.a;
+}

--- a/tests/baselines/reference/narrowiinigInWithExistedProperty.symbols
+++ b/tests/baselines/reference/narrowiinigInWithExistedProperty.symbols
@@ -26,7 +26,7 @@ declare const foo: A | B | C;
 >B : Symbol(B, Decl(narrowiinigInWithExistedProperty.ts, 2, 1))
 >C : Symbol(C, Decl(narrowiinigInWithExistedProperty.ts, 6, 1))
 
-declare const bar: unknown;
+declare const bar: {};
 >bar : Symbol(bar, Decl(narrowiinigInWithExistedProperty.ts, 13, 13))
 
 if ('a' in foo) {

--- a/tests/baselines/reference/narrowiinigInWithExistedProperty.symbols
+++ b/tests/baselines/reference/narrowiinigInWithExistedProperty.symbols
@@ -1,0 +1,70 @@
+=== tests/cases/compiler/narrowiinigInWithExistedProperty.ts ===
+interface A {
+>A : Symbol(A, Decl(narrowiinigInWithExistedProperty.ts, 0, 0))
+
+    a: number
+>a : Symbol(A.a, Decl(narrowiinigInWithExistedProperty.ts, 0, 13))
+}
+
+interface B {
+>B : Symbol(B, Decl(narrowiinigInWithExistedProperty.ts, 2, 1))
+
+    b: number
+>b : Symbol(B.b, Decl(narrowiinigInWithExistedProperty.ts, 4, 13))
+}
+
+interface C {
+>C : Symbol(C, Decl(narrowiinigInWithExistedProperty.ts, 6, 1))
+
+    c: number
+>c : Symbol(C.c, Decl(narrowiinigInWithExistedProperty.ts, 8, 13))
+}
+
+declare const foo: A | B | C;
+>foo : Symbol(foo, Decl(narrowiinigInWithExistedProperty.ts, 12, 13))
+>A : Symbol(A, Decl(narrowiinigInWithExistedProperty.ts, 0, 0))
+>B : Symbol(B, Decl(narrowiinigInWithExistedProperty.ts, 2, 1))
+>C : Symbol(C, Decl(narrowiinigInWithExistedProperty.ts, 6, 1))
+
+declare const bar: unknown;
+>bar : Symbol(bar, Decl(narrowiinigInWithExistedProperty.ts, 13, 13))
+
+if ('a' in foo) {
+>foo : Symbol(foo, Decl(narrowiinigInWithExistedProperty.ts, 12, 13))
+
+    foo.a
+>foo.a : Symbol(A.a, Decl(narrowiinigInWithExistedProperty.ts, 0, 13))
+>foo : Symbol(foo, Decl(narrowiinigInWithExistedProperty.ts, 12, 13))
+>a : Symbol(A.a, Decl(narrowiinigInWithExistedProperty.ts, 0, 13))
+
+} else if ('b' in foo) {
+>foo : Symbol(foo, Decl(narrowiinigInWithExistedProperty.ts, 12, 13))
+
+    foo.b
+>foo.b : Symbol(B.b, Decl(narrowiinigInWithExistedProperty.ts, 4, 13))
+>foo : Symbol(foo, Decl(narrowiinigInWithExistedProperty.ts, 12, 13))
+>b : Symbol(B.b, Decl(narrowiinigInWithExistedProperty.ts, 4, 13))
+
+} else if ('c' in foo) {
+>foo : Symbol(foo, Decl(narrowiinigInWithExistedProperty.ts, 12, 13))
+
+    foo.c
+>foo.c : Symbol(C.c, Decl(narrowiinigInWithExistedProperty.ts, 8, 13))
+>foo : Symbol(foo, Decl(narrowiinigInWithExistedProperty.ts, 12, 13))
+>c : Symbol(C.c, Decl(narrowiinigInWithExistedProperty.ts, 8, 13))
+
+} else if ('d' in foo) {
+>foo : Symbol(foo, Decl(narrowiinigInWithExistedProperty.ts, 12, 13))
+
+    foo.d
+>foo : Symbol(foo, Decl(narrowiinigInWithExistedProperty.ts, 12, 13))
+}
+
+if ('a' in bar) {
+>bar : Symbol(bar, Decl(narrowiinigInWithExistedProperty.ts, 13, 13))
+
+    bar.a
+>bar.a : Symbol(a)
+>bar : Symbol(bar, Decl(narrowiinigInWithExistedProperty.ts, 13, 13))
+>a : Symbol(a)
+}

--- a/tests/baselines/reference/narrowiinigInWithExistedProperty.types
+++ b/tests/baselines/reference/narrowiinigInWithExistedProperty.types
@@ -17,8 +17,8 @@ interface C {
 declare const foo: A | B | C;
 >foo : A | B | C
 
-declare const bar: unknown;
->bar : unknown
+declare const bar: {};
+>bar : {}
 
 if ('a' in foo) {
 >'a' in foo : boolean
@@ -64,7 +64,7 @@ if ('a' in foo) {
 if ('a' in bar) {
 >'a' in bar : boolean
 >'a' : "a"
->bar : unknown
+>bar : {}
 
     bar.a
 >bar.a : unknown

--- a/tests/baselines/reference/narrowiinigInWithExistedProperty.types
+++ b/tests/baselines/reference/narrowiinigInWithExistedProperty.types
@@ -1,0 +1,73 @@
+=== tests/cases/compiler/narrowiinigInWithExistedProperty.ts ===
+interface A {
+    a: number
+>a : number
+}
+
+interface B {
+    b: number
+>b : number
+}
+
+interface C {
+    c: number
+>c : number
+}
+
+declare const foo: A | B | C;
+>foo : A | B | C
+
+declare const bar: unknown;
+>bar : unknown
+
+if ('a' in foo) {
+>'a' in foo : boolean
+>'a' : "a"
+>foo : A | B | C
+
+    foo.a
+>foo.a : number
+>foo : A
+>a : number
+
+} else if ('b' in foo) {
+>'b' in foo : boolean
+>'b' : "b"
+>foo : B | C
+
+    foo.b
+>foo.b : number
+>foo : B
+>b : number
+
+} else if ('c' in foo) {
+>'c' in foo : boolean
+>'c' : "c"
+>foo : C
+
+    foo.c
+>foo.c : number
+>foo : C
+>c : number
+
+} else if ('d' in foo) {
+>'d' in foo : boolean
+>'d' : "d"
+>foo : never
+
+    foo.d
+>foo.d : any
+>foo : never
+>d : any
+}
+
+if ('a' in bar) {
+>'a' in bar : boolean
+>'a' : "a"
+>bar : unknown
+
+    bar.a
+>bar.a : unknown
+>bar : { a: unknown; }
+>a : unknown
+}

--- a/tests/cases/compiler/narrowiinigInWithExistedProperty.ts
+++ b/tests/cases/compiler/narrowiinigInWithExistedProperty.ts
@@ -13,7 +13,7 @@ interface C {
 }
 
 declare const foo: A | B | C;
-declare const bar: unknown;
+declare const bar: {};
 
 if ('a' in foo) {
     foo.a

--- a/tests/cases/compiler/narrowiinigInWithExistedProperty.ts
+++ b/tests/cases/compiler/narrowiinigInWithExistedProperty.ts
@@ -1,0 +1,30 @@
+// @strict: true
+
+interface A {
+    a: number
+}
+
+interface B {
+    b: number
+}
+
+interface C {
+    c: number
+}
+
+declare const foo: A | B | C;
+declare const bar: unknown;
+
+if ('a' in foo) {
+    foo.a
+} else if ('b' in foo) {
+    foo.b
+} else if ('c' in foo) {
+    foo.c
+} else if ('d' in foo) {
+    foo.d
+}
+
+if ('a' in bar) {
+    bar.a
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #21732 

This or add existed key narrowing by in operator according https://github.com/microsoft/TypeScript/issues/31132 by `Generate an intersection with { a: unknown }`.  


