### PR TITLE
fix(35779): Comments at the end of an array, when the last item ends with a comma, are not compiled

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4119,11 +4119,17 @@ namespace ts {
                 }
 
                 // Write a trailing comma, if requested.
-                const hasTrailingComma = (format & ListFormat.AllowTrailingComma) && children!.hasTrailingComma;
-                if (format & ListFormat.CommaDelimited && hasTrailingComma) {
-                    writePunctuation(",");
+                const emitFlags = previousSibling ? getEmitFlags(previousSibling) : 0;
+                const skipTrailingComments = commentsDisabled || !!(emitFlags & EmitFlags.NoTrailingComments);
+                const hasTrailingComma = children?.hasTrailingComma && (format & ListFormat.AllowTrailingComma) && (format & ListFormat.CommaDelimited);
+                if (hasTrailingComma) {
+                    if (previousSibling && !skipTrailingComments) {
+                        emitTokenWithComment(SyntaxKind.CommaToken, previousSibling.end, writePunctuation, previousSibling);
+                    }
+                    else {
+                        writePunctuation(",");
+                    }
                 }
-
 
                 // Emit any trailing comment of the last element in the list
                 // i.e
@@ -4131,8 +4137,8 @@ namespace ts {
                 //          2
                 //          /* end of element 2 */
                 //       ];
-                if (previousSibling && format & ListFormat.DelimitersMask && previousSibling.end !== parentNode.end && !(getEmitFlags(previousSibling) & EmitFlags.NoTrailingComments)) {
-                    emitLeadingCommentsOfPosition(previousSibling.end);
+                if (previousSibling && parentNode.end !== previousSibling.end && (format & ListFormat.DelimitersMask) && !skipTrailingComments) {
+                    emitLeadingCommentsOfPosition(hasTrailingComma && children?.end ? children.end : previousSibling.end);
                 }
 
                 // Decrease the indent, if requested.

--- a/tests/baselines/reference/commentOnArrayElement1.js
+++ b/tests/baselines/reference/commentOnArrayElement1.js
@@ -1,5 +1,5 @@
 //// [commentOnArrayElement1.ts]
-var array = [
+const array = [
     /* element 1*/
     1
     /* end of element 1 */,

--- a/tests/baselines/reference/commentOnArrayElement1.symbols
+++ b/tests/baselines/reference/commentOnArrayElement1.symbols
@@ -1,6 +1,6 @@
 === tests/cases/compiler/commentOnArrayElement1.ts ===
-var array = [
->array : Symbol(array, Decl(commentOnArrayElement1.ts, 0, 3))
+const array = [
+>array : Symbol(array, Decl(commentOnArrayElement1.ts, 0, 5))
 
     /* element 1*/
     1

--- a/tests/baselines/reference/commentOnArrayElement1.types
+++ b/tests/baselines/reference/commentOnArrayElement1.types
@@ -1,5 +1,5 @@
 === tests/cases/compiler/commentOnArrayElement1.ts ===
-var array = [
+const array = [
 >array : number[]
 >[    /* element 1*/    1    /* end of element 1 */,    2    /* end of element 2 */] : number[]
 

--- a/tests/baselines/reference/commentOnArrayElement10.js
+++ b/tests/baselines/reference/commentOnArrayElement10.js
@@ -1,0 +1,6 @@
+//// [commentOnArrayElement10.ts]
+const array = [,, /* comment */];
+
+
+//// [commentOnArrayElement10.js]
+var array = [, , /* comment */];

--- a/tests/baselines/reference/commentOnArrayElement10.symbols
+++ b/tests/baselines/reference/commentOnArrayElement10.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/commentOnArrayElement10.ts ===
+const array = [,, /* comment */];
+>array : Symbol(array, Decl(commentOnArrayElement10.ts, 0, 5))
+

--- a/tests/baselines/reference/commentOnArrayElement10.types
+++ b/tests/baselines/reference/commentOnArrayElement10.types
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/commentOnArrayElement10.ts ===
+const array = [,, /* comment */];
+>array : any[]
+>[,, /* comment */] : undefined[]
+> : undefined
+> : undefined
+

--- a/tests/baselines/reference/commentOnArrayElement11.js
+++ b/tests/baselines/reference/commentOnArrayElement11.js
@@ -1,0 +1,10 @@
+//// [commentOnArrayElement11.ts]
+const array = [
+    , /* comment */
+];
+
+
+//// [commentOnArrayElement11.js]
+var array = [
+    , /* comment */
+];

--- a/tests/baselines/reference/commentOnArrayElement11.symbols
+++ b/tests/baselines/reference/commentOnArrayElement11.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/commentOnArrayElement11.ts ===
+const array = [
+>array : Symbol(array, Decl(commentOnArrayElement11.ts, 0, 5))
+
+    , /* comment */
+];
+

--- a/tests/baselines/reference/commentOnArrayElement11.types
+++ b/tests/baselines/reference/commentOnArrayElement11.types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/commentOnArrayElement11.ts ===
+const array = [
+>array : any[]
+>[    , /* comment */] : undefined[]
+
+    , /* comment */
+> : undefined
+
+];
+

--- a/tests/baselines/reference/commentOnArrayElement12.js
+++ b/tests/baselines/reference/commentOnArrayElement12.js
@@ -1,0 +1,11 @@
+//// [commentOnArrayElement12.ts]
+const array = [
+    ,, /* comment */
+];
+
+
+//// [commentOnArrayElement12.js]
+var array = [
+    ,
+    , /* comment */
+];

--- a/tests/baselines/reference/commentOnArrayElement12.symbols
+++ b/tests/baselines/reference/commentOnArrayElement12.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/commentOnArrayElement12.ts ===
+const array = [
+>array : Symbol(array, Decl(commentOnArrayElement12.ts, 0, 5))
+
+    ,, /* comment */
+];
+

--- a/tests/baselines/reference/commentOnArrayElement12.types
+++ b/tests/baselines/reference/commentOnArrayElement12.types
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/commentOnArrayElement12.ts ===
+const array = [
+>array : any[]
+>[    ,, /* comment */] : undefined[]
+
+    ,, /* comment */
+> : undefined
+> : undefined
+
+];
+

--- a/tests/baselines/reference/commentOnArrayElement13.js
+++ b/tests/baselines/reference/commentOnArrayElement13.js
@@ -1,0 +1,6 @@
+//// [commentOnArrayElement13.ts]
+const array = [/* comment */];
+
+
+//// [commentOnArrayElement13.js]
+var array = [ /* comment */];

--- a/tests/baselines/reference/commentOnArrayElement13.symbols
+++ b/tests/baselines/reference/commentOnArrayElement13.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/commentOnArrayElement13.ts ===
+const array = [/* comment */];
+>array : Symbol(array, Decl(commentOnArrayElement13.ts, 0, 5))
+

--- a/tests/baselines/reference/commentOnArrayElement13.types
+++ b/tests/baselines/reference/commentOnArrayElement13.types
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/commentOnArrayElement13.ts ===
+const array = [/* comment */];
+>array : any[]
+>[/* comment */] : undefined[]
+

--- a/tests/baselines/reference/commentOnArrayElement14.js
+++ b/tests/baselines/reference/commentOnArrayElement14.js
@@ -1,0 +1,6 @@
+//// [commentOnArrayElement14.ts]
+const array = [1 /* comment */];
+
+
+//// [commentOnArrayElement14.js]
+var array = [1 /* comment */];

--- a/tests/baselines/reference/commentOnArrayElement14.symbols
+++ b/tests/baselines/reference/commentOnArrayElement14.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/commentOnArrayElement14.ts ===
+const array = [1 /* comment */];
+>array : Symbol(array, Decl(commentOnArrayElement14.ts, 0, 5))
+

--- a/tests/baselines/reference/commentOnArrayElement14.types
+++ b/tests/baselines/reference/commentOnArrayElement14.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/commentOnArrayElement14.ts ===
+const array = [1 /* comment */];
+>array : number[]
+>[1 /* comment */] : number[]
+>1 : 1
+

--- a/tests/baselines/reference/commentOnArrayElement15.js
+++ b/tests/baselines/reference/commentOnArrayElement15.js
@@ -1,0 +1,6 @@
+//// [commentOnArrayElement15.ts]
+const array = [/* comment */ 1 /* comment */];
+
+
+//// [commentOnArrayElement15.js]
+var array = [/* comment */ 1 /* comment */];

--- a/tests/baselines/reference/commentOnArrayElement15.symbols
+++ b/tests/baselines/reference/commentOnArrayElement15.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/commentOnArrayElement15.ts ===
+const array = [/* comment */ 1 /* comment */];
+>array : Symbol(array, Decl(commentOnArrayElement15.ts, 0, 5))
+

--- a/tests/baselines/reference/commentOnArrayElement15.types
+++ b/tests/baselines/reference/commentOnArrayElement15.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/commentOnArrayElement15.ts ===
+const array = [/* comment */ 1 /* comment */];
+>array : number[]
+>[/* comment */ 1 /* comment */] : number[]
+>1 : 1
+

--- a/tests/baselines/reference/commentOnArrayElement16.js
+++ b/tests/baselines/reference/commentOnArrayElement16.js
@@ -1,0 +1,16 @@
+//// [commentOnArrayElement16.ts]
+const array = [
+    // comment start
+    1,
+    2,
+    // comment end
+];
+
+
+//// [commentOnArrayElement16.js]
+var array = [
+    // comment start
+    1,
+    2,
+    // comment end
+];

--- a/tests/baselines/reference/commentOnArrayElement16.symbols
+++ b/tests/baselines/reference/commentOnArrayElement16.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/commentOnArrayElement16.ts ===
+const array = [
+>array : Symbol(array, Decl(commentOnArrayElement16.ts, 0, 5))
+
+    // comment start
+    1,
+    2,
+    // comment end
+];
+

--- a/tests/baselines/reference/commentOnArrayElement16.types
+++ b/tests/baselines/reference/commentOnArrayElement16.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/commentOnArrayElement16.ts ===
+const array = [
+>array : number[]
+>[    // comment start    1,    2,    // comment end] : number[]
+
+    // comment start
+    1,
+>1 : 1
+
+    2,
+>2 : 2
+
+    // comment end
+];
+

--- a/tests/baselines/reference/commentOnArrayElement2.js
+++ b/tests/baselines/reference/commentOnArrayElement2.js
@@ -1,5 +1,5 @@
 //// [commentOnArrayElement2.ts]
-var array = [
+const array = [
     /* element 1*/
     1 /* end of element 1 */,
     2

--- a/tests/baselines/reference/commentOnArrayElement2.symbols
+++ b/tests/baselines/reference/commentOnArrayElement2.symbols
@@ -1,6 +1,6 @@
 === tests/cases/compiler/commentOnArrayElement2.ts ===
-var array = [
->array : Symbol(array, Decl(commentOnArrayElement2.ts, 0, 3))
+const array = [
+>array : Symbol(array, Decl(commentOnArrayElement2.ts, 0, 5))
 
     /* element 1*/
     1 /* end of element 1 */,

--- a/tests/baselines/reference/commentOnArrayElement2.types
+++ b/tests/baselines/reference/commentOnArrayElement2.types
@@ -1,5 +1,5 @@
 === tests/cases/compiler/commentOnArrayElement2.ts ===
-var array = [
+const array = [
 >array : number[]
 >[    /* element 1*/    1 /* end of element 1 */,    2    /* end of element 2 */] : number[]
 

--- a/tests/baselines/reference/commentOnArrayElement3.js
+++ b/tests/baselines/reference/commentOnArrayElement3.js
@@ -1,5 +1,5 @@
 //// [commentOnArrayElement3.ts]
-var array = [
+const array = [
     /* element 1*/
     1
     /* end of element 1 */,
@@ -16,4 +16,5 @@ var array = [
     2
     /* end of element 2 */ ,
     ,
+    /* extra comment */
 ];

--- a/tests/baselines/reference/commentOnArrayElement3.symbols
+++ b/tests/baselines/reference/commentOnArrayElement3.symbols
@@ -1,6 +1,6 @@
 === tests/cases/compiler/commentOnArrayElement3.ts ===
-var array = [
->array : Symbol(array, Decl(commentOnArrayElement3.ts, 0, 3))
+const array = [
+>array : Symbol(array, Decl(commentOnArrayElement3.ts, 0, 5))
 
     /* element 1*/
     1

--- a/tests/baselines/reference/commentOnArrayElement3.types
+++ b/tests/baselines/reference/commentOnArrayElement3.types
@@ -1,5 +1,5 @@
 === tests/cases/compiler/commentOnArrayElement3.ts ===
-var array = [
+const array = [
 >array : number[]
 >[    /* element 1*/    1    /* end of element 1 */,    2    /* end of element 2 */, ,    /* extra comment */] : number[]
 

--- a/tests/baselines/reference/commentOnArrayElement4.js
+++ b/tests/baselines/reference/commentOnArrayElement4.js
@@ -1,0 +1,14 @@
+//// [commentOnArrayElement4.ts]
+const array = [
+    /* element 1 */
+    1,
+    /* end of element 1 */
+];
+
+
+//// [commentOnArrayElement4.js]
+var array = [
+    /* element 1 */
+    1,
+    /* end of element 1 */
+];

--- a/tests/baselines/reference/commentOnArrayElement4.symbols
+++ b/tests/baselines/reference/commentOnArrayElement4.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/commentOnArrayElement4.ts ===
+const array = [
+>array : Symbol(array, Decl(commentOnArrayElement4.ts, 0, 5))
+
+    /* element 1 */
+    1,
+    /* end of element 1 */
+];
+

--- a/tests/baselines/reference/commentOnArrayElement4.types
+++ b/tests/baselines/reference/commentOnArrayElement4.types
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/commentOnArrayElement4.ts ===
+const array = [
+>array : number[]
+>[    /* element 1 */    1,    /* end of element 1 */] : number[]
+
+    /* element 1 */
+    1,
+>1 : 1
+
+    /* end of element 1 */
+];
+

--- a/tests/baselines/reference/commentOnArrayElement5.js
+++ b/tests/baselines/reference/commentOnArrayElement5.js
@@ -1,0 +1,16 @@
+//// [commentOnArrayElement5.ts]
+const array = [
+    /* element 1 */
+    1,
+    /* end of element 1 */
+    /* extra comment */
+];
+
+
+//// [commentOnArrayElement5.js]
+var array = [
+    /* element 1 */
+    1,
+    /* end of element 1 */
+    /* extra comment */
+];

--- a/tests/baselines/reference/commentOnArrayElement5.symbols
+++ b/tests/baselines/reference/commentOnArrayElement5.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/commentOnArrayElement5.ts ===
+const array = [
+>array : Symbol(array, Decl(commentOnArrayElement5.ts, 0, 5))
+
+    /* element 1 */
+    1,
+    /* end of element 1 */
+    /* extra comment */
+];
+

--- a/tests/baselines/reference/commentOnArrayElement5.types
+++ b/tests/baselines/reference/commentOnArrayElement5.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/commentOnArrayElement5.ts ===
+const array = [
+>array : number[]
+>[    /* element 1 */    1,    /* end of element 1 */    /* extra comment */] : number[]
+
+    /* element 1 */
+    1,
+>1 : 1
+
+    /* end of element 1 */
+    /* extra comment */
+];
+

--- a/tests/baselines/reference/commentOnArrayElement6.js
+++ b/tests/baselines/reference/commentOnArrayElement6.js
@@ -1,0 +1,6 @@
+//// [commentOnArrayElement6.ts]
+const array = [1, /* comment */];
+
+
+//// [commentOnArrayElement6.js]
+var array = [1, /* comment */];

--- a/tests/baselines/reference/commentOnArrayElement6.symbols
+++ b/tests/baselines/reference/commentOnArrayElement6.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/commentOnArrayElement6.ts ===
+const array = [1, /* comment */];
+>array : Symbol(array, Decl(commentOnArrayElement6.ts, 0, 5))
+

--- a/tests/baselines/reference/commentOnArrayElement6.types
+++ b/tests/baselines/reference/commentOnArrayElement6.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/commentOnArrayElement6.ts ===
+const array = [1, /* comment */];
+>array : number[]
+>[1, /* comment */] : number[]
+>1 : 1
+

--- a/tests/baselines/reference/commentOnArrayElement7.js
+++ b/tests/baselines/reference/commentOnArrayElement7.js
@@ -1,0 +1,6 @@
+//// [commentOnArrayElement7.ts]
+const array = [/* element 1 */ 1, /* end of element 1 */];
+
+
+//// [commentOnArrayElement7.js]
+var array = [/* element 1 */ 1, /* end of element 1 */];

--- a/tests/baselines/reference/commentOnArrayElement7.symbols
+++ b/tests/baselines/reference/commentOnArrayElement7.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/commentOnArrayElement7.ts ===
+const array = [/* element 1 */ 1, /* end of element 1 */];
+>array : Symbol(array, Decl(commentOnArrayElement7.ts, 0, 5))
+

--- a/tests/baselines/reference/commentOnArrayElement7.types
+++ b/tests/baselines/reference/commentOnArrayElement7.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/commentOnArrayElement7.ts ===
+const array = [/* element 1 */ 1, /* end of element 1 */];
+>array : number[]
+>[/* element 1 */ 1, /* end of element 1 */] : number[]
+>1 : 1
+

--- a/tests/baselines/reference/commentOnArrayElement8.js
+++ b/tests/baselines/reference/commentOnArrayElement8.js
@@ -1,0 +1,10 @@
+//// [commentOnArrayElement8.ts]
+const array = [
+    1, /* comment */
+];
+
+
+//// [commentOnArrayElement8.js]
+var array = [
+    1, /* comment */
+];

--- a/tests/baselines/reference/commentOnArrayElement8.symbols
+++ b/tests/baselines/reference/commentOnArrayElement8.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/commentOnArrayElement8.ts ===
+const array = [
+>array : Symbol(array, Decl(commentOnArrayElement8.ts, 0, 5))
+
+    1, /* comment */
+];
+

--- a/tests/baselines/reference/commentOnArrayElement8.types
+++ b/tests/baselines/reference/commentOnArrayElement8.types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/commentOnArrayElement8.ts ===
+const array = [
+>array : number[]
+>[    1, /* comment */] : number[]
+
+    1, /* comment */
+>1 : 1
+
+];
+

--- a/tests/baselines/reference/commentOnArrayElement9.js
+++ b/tests/baselines/reference/commentOnArrayElement9.js
@@ -1,0 +1,10 @@
+//// [commentOnArrayElement9.ts]
+const array = [
+    /* element 1 */ 1, /* end of element 1 */
+];
+
+
+//// [commentOnArrayElement9.js]
+var array = [
+    /* element 1 */ 1, /* end of element 1 */
+];

--- a/tests/baselines/reference/commentOnArrayElement9.symbols
+++ b/tests/baselines/reference/commentOnArrayElement9.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/commentOnArrayElement9.ts ===
+const array = [
+>array : Symbol(array, Decl(commentOnArrayElement9.ts, 0, 5))
+
+    /* element 1 */ 1, /* end of element 1 */
+];
+

--- a/tests/baselines/reference/commentOnArrayElement9.types
+++ b/tests/baselines/reference/commentOnArrayElement9.types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/commentOnArrayElement9.ts ===
+const array = [
+>array : number[]
+>[    /* element 1 */ 1, /* end of element 1 */] : number[]
+
+    /* element 1 */ 1, /* end of element 1 */
+>1 : 1
+
+];
+

--- a/tests/baselines/reference/duplicateObjectLiteralProperty.js
+++ b/tests/baselines/reference/duplicateObjectLiteralProperty.js
@@ -26,7 +26,7 @@ var x = {
     \u0061: "ss",
     a: {
         c: 1,
-        "c": 56,
+        "c": 56, // Duplicate
     }
 };
 var y = {

--- a/tests/cases/compiler/commentOnArrayElement1.ts
+++ b/tests/cases/compiler/commentOnArrayElement1.ts
@@ -1,4 +1,4 @@
-﻿var array = [
+﻿const array = [
     /* element 1*/
     1
     /* end of element 1 */,

--- a/tests/cases/compiler/commentOnArrayElement10.ts
+++ b/tests/cases/compiler/commentOnArrayElement10.ts
@@ -1,0 +1,1 @@
+﻿const array = [,, /* comment */];

--- a/tests/cases/compiler/commentOnArrayElement11.ts
+++ b/tests/cases/compiler/commentOnArrayElement11.ts
@@ -1,0 +1,3 @@
+﻿const array = [
+    , /* comment */
+];

--- a/tests/cases/compiler/commentOnArrayElement12.ts
+++ b/tests/cases/compiler/commentOnArrayElement12.ts
@@ -1,0 +1,3 @@
+﻿const array = [
+    ,, /* comment */
+];

--- a/tests/cases/compiler/commentOnArrayElement13.ts
+++ b/tests/cases/compiler/commentOnArrayElement13.ts
@@ -1,0 +1,1 @@
+﻿const array = [/* comment */];

--- a/tests/cases/compiler/commentOnArrayElement14.ts
+++ b/tests/cases/compiler/commentOnArrayElement14.ts
@@ -1,0 +1,1 @@
+﻿const array = [1 /* comment */];

--- a/tests/cases/compiler/commentOnArrayElement15.ts
+++ b/tests/cases/compiler/commentOnArrayElement15.ts
@@ -1,0 +1,1 @@
+﻿const array = [/* comment */ 1 /* comment */];

--- a/tests/cases/compiler/commentOnArrayElement16.ts
+++ b/tests/cases/compiler/commentOnArrayElement16.ts
@@ -1,0 +1,6 @@
+﻿const array = [
+    // comment start
+    1,
+    2,
+    // comment end
+];

--- a/tests/cases/compiler/commentOnArrayElement2.ts
+++ b/tests/cases/compiler/commentOnArrayElement2.ts
@@ -1,4 +1,4 @@
-﻿var array = [
+﻿const array = [
     /* element 1*/
     1 /* end of element 1 */,
     2

--- a/tests/cases/compiler/commentOnArrayElement3.ts
+++ b/tests/cases/compiler/commentOnArrayElement3.ts
@@ -1,4 +1,4 @@
-﻿var array = [
+﻿const array = [
     /* element 1*/
     1
     /* end of element 1 */,

--- a/tests/cases/compiler/commentOnArrayElement4.ts
+++ b/tests/cases/compiler/commentOnArrayElement4.ts
@@ -1,0 +1,5 @@
+﻿const array = [
+    /* element 1 */
+    1,
+    /* end of element 1 */
+];

--- a/tests/cases/compiler/commentOnArrayElement5.ts
+++ b/tests/cases/compiler/commentOnArrayElement5.ts
@@ -1,0 +1,6 @@
+﻿const array = [
+    /* element 1 */
+    1,
+    /* end of element 1 */
+    /* extra comment */
+];

--- a/tests/cases/compiler/commentOnArrayElement6.ts
+++ b/tests/cases/compiler/commentOnArrayElement6.ts
@@ -1,0 +1,1 @@
+﻿const array = [1, /* comment */];

--- a/tests/cases/compiler/commentOnArrayElement7.ts
+++ b/tests/cases/compiler/commentOnArrayElement7.ts
@@ -1,0 +1,1 @@
+﻿const array = [/* element 1 */ 1, /* end of element 1 */];

--- a/tests/cases/compiler/commentOnArrayElement8.ts
+++ b/tests/cases/compiler/commentOnArrayElement8.ts
@@ -1,0 +1,3 @@
+﻿const array = [
+    1, /* comment */
+];

--- a/tests/cases/compiler/commentOnArrayElement9.ts
+++ b/tests/cases/compiler/commentOnArrayElement9.ts
@@ -1,0 +1,3 @@
+﻿const array = [
+    /* element 1 */ 1, /* end of element 1 */
+];


### PR DESCRIPTION
Fixes #35779
