### PR TITLE
narrowing return type of "array.includes"

### DIFF
--- a/lib/lib.es2016.array.include.d.ts
+++ b/lib/lib.es2016.array.include.d.ts
@@ -25,6 +25,7 @@ interface Array<T> {
      * @param fromIndex The position in this array at which to begin searching for searchElement.
      */
     includes(searchElement: T, fromIndex?: number): boolean;
+    includes(searchElement: T, fromIndex?: number): searchElement is T;
 }
 
 interface ReadonlyArray<T> {
@@ -34,6 +35,7 @@ interface ReadonlyArray<T> {
      * @param fromIndex The position in this array at which to begin searching for searchElement.
      */
     includes(searchElement: T, fromIndex?: number): boolean;
+    includes(searchElement: T, fromIndex?: number): searchElement is T;
 }
 
 interface Int8Array {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

The array.includes is used usually to check data type, such as:

```ts
const typeList = [ 'apple', 'banana', 'orange' ] as const;

// Return 'apple' | 'banana' | 'orange' is better than any.
function getValueOrDefault(what: any) {
  if (typeList.includes(what)) {
    return what;
  }
  return 'apple';
}
```

Fixes partial #36275

```ts
interface TextMessage { type: 'text', text: string }

interface ImageMessage { type: 'image', url: string }

type Message = TextMessage | ImageMessage;

const message: Message = JSON.parse('{}') as Message;

// Prepare a const type list
const typeList = ['text'] as const;

// Take the `type` as any
let type: any = message.type;

// Narrowing the `type`
if (typeList.includes(type)) {
    // Narrowing the `message`
    if (message.type === type) {
        // It's work
        message.text = message.text.trim();
    }
}
```