### PR TITLE
Error on missing BigInt in es2020

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10349,7 +10349,7 @@ namespace ts {
                 t.flags & TypeFlags.Intersection ? getApparentTypeOfIntersectionType(<IntersectionType>t) :
                 t.flags & TypeFlags.StringLike ? globalStringType :
                 t.flags & TypeFlags.NumberLike ? globalNumberType :
-                t.flags & TypeFlags.BigIntLike ? getGlobalBigIntType(/*reportErrors*/ languageVersion >= ScriptTarget.ESNext) :
+                t.flags & TypeFlags.BigIntLike ? getGlobalBigIntType(/*reportErrors*/ languageVersion >= ScriptTarget.ES2020) :
                 t.flags & TypeFlags.BooleanLike ? globalBooleanType :
                 t.flags & TypeFlags.ESSymbolLike ? getGlobalESSymbolType(/*reportErrors*/ languageVersion >= ScriptTarget.ES2015) :
                 t.flags & TypeFlags.NonPrimitive ? emptyObjectType :

--- a/tests/baselines/reference/bigintMissingES2019.js
+++ b/tests/baselines/reference/bigintMissingES2019.js
@@ -1,0 +1,13 @@
+//// [bigintMissingES2019.ts]
+declare function test<A, B extends A>(): void;
+
+test<{t?: string}, object>();
+test<{t?: string}, bigint>();
+
+// no error when bigint is used even when ES2020 lib is not present
+
+
+//// [bigintMissingES2019.js]
+test();
+test();
+// no error when bigint is used even when ES2020 lib is not present

--- a/tests/baselines/reference/bigintMissingES2019.symbols
+++ b/tests/baselines/reference/bigintMissingES2019.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/es2020/bigintMissingES2019.ts ===
+declare function test<A, B extends A>(): void;
+>test : Symbol(test, Decl(bigintMissingES2019.ts, 0, 0))
+>A : Symbol(A, Decl(bigintMissingES2019.ts, 0, 22))
+>B : Symbol(B, Decl(bigintMissingES2019.ts, 0, 24))
+>A : Symbol(A, Decl(bigintMissingES2019.ts, 0, 22))
+
+test<{t?: string}, object>();
+>test : Symbol(test, Decl(bigintMissingES2019.ts, 0, 0))
+>t : Symbol(t, Decl(bigintMissingES2019.ts, 2, 6))
+
+test<{t?: string}, bigint>();
+>test : Symbol(test, Decl(bigintMissingES2019.ts, 0, 0))
+>t : Symbol(t, Decl(bigintMissingES2019.ts, 3, 6))
+
+// no error when bigint is used even when ES2020 lib is not present
+

--- a/tests/baselines/reference/bigintMissingES2019.types
+++ b/tests/baselines/reference/bigintMissingES2019.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/es2020/bigintMissingES2019.ts ===
+declare function test<A, B extends A>(): void;
+>test : <A, B extends A>() => void
+
+test<{t?: string}, object>();
+>test<{t?: string}, object>() : void
+>test : <A, B extends A>() => void
+>t : string
+
+test<{t?: string}, bigint>();
+>test<{t?: string}, bigint>() : void
+>test : <A, B extends A>() => void
+>t : string
+
+// no error when bigint is used even when ES2020 lib is not present
+

--- a/tests/baselines/reference/bigintMissingES2020.errors.txt
+++ b/tests/baselines/reference/bigintMissingES2020.errors.txt
@@ -1,0 +1,12 @@
+error TS2318: Cannot find global type 'BigInt'.
+
+
+!!! error TS2318: Cannot find global type 'BigInt'.
+==== tests/cases/conformance/es2020/bigintMissingES2020.ts (0 errors) ====
+    declare function test<A, B extends A>(): void;
+    
+    test<{t?: string}, object>();
+    test<{t?: string}, bigint>();
+    
+    // should have global error when bigint is used but ES2020 lib is not present
+    

--- a/tests/baselines/reference/bigintMissingES2020.js
+++ b/tests/baselines/reference/bigintMissingES2020.js
@@ -1,0 +1,13 @@
+//// [bigintMissingES2020.ts]
+declare function test<A, B extends A>(): void;
+
+test<{t?: string}, object>();
+test<{t?: string}, bigint>();
+
+// should have global error when bigint is used but ES2020 lib is not present
+
+
+//// [bigintMissingES2020.js]
+test();
+test();
+// should have global error when bigint is used but ES2020 lib is not present

--- a/tests/baselines/reference/bigintMissingES2020.symbols
+++ b/tests/baselines/reference/bigintMissingES2020.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/es2020/bigintMissingES2020.ts ===
+declare function test<A, B extends A>(): void;
+>test : Symbol(test, Decl(bigintMissingES2020.ts, 0, 0))
+>A : Symbol(A, Decl(bigintMissingES2020.ts, 0, 22))
+>B : Symbol(B, Decl(bigintMissingES2020.ts, 0, 24))
+>A : Symbol(A, Decl(bigintMissingES2020.ts, 0, 22))
+
+test<{t?: string}, object>();
+>test : Symbol(test, Decl(bigintMissingES2020.ts, 0, 0))
+>t : Symbol(t, Decl(bigintMissingES2020.ts, 2, 6))
+
+test<{t?: string}, bigint>();
+>test : Symbol(test, Decl(bigintMissingES2020.ts, 0, 0))
+>t : Symbol(t, Decl(bigintMissingES2020.ts, 3, 6))
+
+// should have global error when bigint is used but ES2020 lib is not present
+

--- a/tests/baselines/reference/bigintMissingES2020.types
+++ b/tests/baselines/reference/bigintMissingES2020.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/es2020/bigintMissingES2020.ts ===
+declare function test<A, B extends A>(): void;
+>test : <A, B extends A>() => void
+
+test<{t?: string}, object>();
+>test<{t?: string}, object>() : void
+>test : <A, B extends A>() => void
+>t : string
+
+test<{t?: string}, bigint>();
+>test<{t?: string}, bigint>() : void
+>test : <A, B extends A>() => void
+>t : string
+
+// should have global error when bigint is used but ES2020 lib is not present
+

--- a/tests/baselines/reference/bigintMissingESNext.errors.txt
+++ b/tests/baselines/reference/bigintMissingESNext.errors.txt
@@ -1,0 +1,12 @@
+error TS2318: Cannot find global type 'BigInt'.
+
+
+!!! error TS2318: Cannot find global type 'BigInt'.
+==== tests/cases/conformance/es2020/bigintMissingESNext.ts (0 errors) ====
+    declare function test<A, B extends A>(): void;
+    
+    test<{t?: string}, object>();
+    test<{t?: string}, bigint>();
+    
+    // should have global error when bigint is used but ES2020 lib is not present
+    

--- a/tests/baselines/reference/bigintMissingESNext.js
+++ b/tests/baselines/reference/bigintMissingESNext.js
@@ -1,0 +1,13 @@
+//// [bigintMissingESNext.ts]
+declare function test<A, B extends A>(): void;
+
+test<{t?: string}, object>();
+test<{t?: string}, bigint>();
+
+// should have global error when bigint is used but ES2020 lib is not present
+
+
+//// [bigintMissingESNext.js]
+test();
+test();
+// should have global error when bigint is used but ES2020 lib is not present

--- a/tests/baselines/reference/bigintMissingESNext.symbols
+++ b/tests/baselines/reference/bigintMissingESNext.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/es2020/bigintMissingESNext.ts ===
+declare function test<A, B extends A>(): void;
+>test : Symbol(test, Decl(bigintMissingESNext.ts, 0, 0))
+>A : Symbol(A, Decl(bigintMissingESNext.ts, 0, 22))
+>B : Symbol(B, Decl(bigintMissingESNext.ts, 0, 24))
+>A : Symbol(A, Decl(bigintMissingESNext.ts, 0, 22))
+
+test<{t?: string}, object>();
+>test : Symbol(test, Decl(bigintMissingESNext.ts, 0, 0))
+>t : Symbol(t, Decl(bigintMissingESNext.ts, 2, 6))
+
+test<{t?: string}, bigint>();
+>test : Symbol(test, Decl(bigintMissingESNext.ts, 0, 0))
+>t : Symbol(t, Decl(bigintMissingESNext.ts, 3, 6))
+
+// should have global error when bigint is used but ES2020 lib is not present
+

--- a/tests/baselines/reference/bigintMissingESNext.types
+++ b/tests/baselines/reference/bigintMissingESNext.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/es2020/bigintMissingESNext.ts ===
+declare function test<A, B extends A>(): void;
+>test : <A, B extends A>() => void
+
+test<{t?: string}, object>();
+>test<{t?: string}, object>() : void
+>test : <A, B extends A>() => void
+>t : string
+
+test<{t?: string}, bigint>();
+>test<{t?: string}, bigint>() : void
+>test : <A, B extends A>() => void
+>t : string
+
+// should have global error when bigint is used but ES2020 lib is not present
+

--- a/tests/cases/conformance/es2020/bigintMissingES2019.ts
+++ b/tests/cases/conformance/es2020/bigintMissingES2019.ts
@@ -1,0 +1,8 @@
+// @target: es2019
+// @lib: dom,es2019
+declare function test<A, B extends A>(): void;
+
+test<{t?: string}, object>();
+test<{t?: string}, bigint>();
+
+// no error when bigint is used even when ES2020 lib is not present

--- a/tests/cases/conformance/es2020/bigintMissingES2020.ts
+++ b/tests/cases/conformance/es2020/bigintMissingES2020.ts
@@ -1,0 +1,8 @@
+// @target: es2020
+// @lib: dom,es2017
+declare function test<A, B extends A>(): void;
+
+test<{t?: string}, object>();
+test<{t?: string}, bigint>();
+
+// should have global error when bigint is used but ES2020 lib is not present

--- a/tests/cases/conformance/es2020/bigintMissingESNext.ts
+++ b/tests/cases/conformance/es2020/bigintMissingESNext.ts
@@ -1,0 +1,8 @@
+// @target: esnext
+// @lib: dom,es2017
+declare function test<A, B extends A>(): void;
+
+test<{t?: string}, object>();
+test<{t?: string}, bigint>();
+
+// should have global error when bigint is used but ES2020 lib is not present


### PR DESCRIPTION
Previously it was only an error in ESNext, but bigint is part of ES2020 so it should error there too.

I also added tests since there were none before.