### PR TITLE
Infer extracted local variable name from property name

### DIFF
--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -1009,7 +1009,9 @@ namespace ts.refactor.extractSymbol {
 
         // Make a unique name for the extracted variable
         const file = scope.getSourceFile();
-        const localNameText = getUniqueName(isClassLike(scope) ? "newProperty" : "newLocal", file);
+        const localNameText = isPropertyAccessExpression(node) && !isClassLike(scope) && !checker.resolveName(node.name.text, node, SymbolFlags.Value, /*excludeGlobals*/ false) && !isPrivateIdentifier(node.name) && !isKeyword(node.name.originalKeywordKind!)
+            ? node.name.text
+            : getUniqueName(isClassLike(scope) ? "newProperty" : "newLocal", file);
         const isJS = isInJSFile(scope);
 
         let variableType = isJS || !checker.isContextSensitive(node)

--- a/src/testRunner/unittests/services/extract/constants.ts
+++ b/src/testRunner/unittests/services/extract/constants.ts
@@ -279,6 +279,19 @@ switch (1) {
         break;
 }
 `);
+
+        testExtractConstant("extractConstant_PropertyName",
+            `[#|x.y|].z();`);
+
+        testExtractConstant("extractConstant_PropertyName_ExistingName",
+            `let y;
+[#|x.y|].z();`);
+
+        testExtractConstant("extractConstant_PropertyName_Keyword",
+            `[#|x.if|].z();`);
+
+        testExtractConstant("extractConstant_PropertyName_PrivateIdentifierKeyword",
+            `[#|this.#if|].z();`);
     });
 
     function testExtractConstant(caption: string, text: string) {

--- a/tests/baselines/reference/extractConstant/extractConstant_PropertyName.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_PropertyName.js
@@ -1,0 +1,5 @@
+// ==ORIGINAL==
+/*[#|*/x.y/*|]*/.z();
+// ==SCOPE::Extract to constant in enclosing scope==
+const y = x.y;
+/*RENAME*/y.z();

--- a/tests/baselines/reference/extractConstant/extractConstant_PropertyName.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_PropertyName.ts
@@ -1,0 +1,5 @@
+// ==ORIGINAL==
+/*[#|*/x.y/*|]*/.z();
+// ==SCOPE::Extract to constant in enclosing scope==
+const y = x.y;
+/*RENAME*/y.z();

--- a/tests/baselines/reference/extractConstant/extractConstant_PropertyName_ExistingName.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_PropertyName_ExistingName.js
@@ -1,0 +1,7 @@
+// ==ORIGINAL==
+let y;
+/*[#|*/x.y/*|]*/.z();
+// ==SCOPE::Extract to constant in enclosing scope==
+let y;
+const newLocal = x.y;
+/*RENAME*/newLocal.z();

--- a/tests/baselines/reference/extractConstant/extractConstant_PropertyName_ExistingName.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_PropertyName_ExistingName.ts
@@ -1,0 +1,7 @@
+// ==ORIGINAL==
+let y;
+/*[#|*/x.y/*|]*/.z();
+// ==SCOPE::Extract to constant in enclosing scope==
+let y;
+const newLocal = x.y;
+/*RENAME*/newLocal.z();

--- a/tests/baselines/reference/extractConstant/extractConstant_PropertyName_Keyword.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_PropertyName_Keyword.js
@@ -1,0 +1,5 @@
+// ==ORIGINAL==
+/*[#|*/x.if/*|]*/.z();
+// ==SCOPE::Extract to constant in enclosing scope==
+const newLocal = x.if;
+/*RENAME*/newLocal.z();

--- a/tests/baselines/reference/extractConstant/extractConstant_PropertyName_Keyword.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_PropertyName_Keyword.ts
@@ -1,0 +1,5 @@
+// ==ORIGINAL==
+/*[#|*/x.if/*|]*/.z();
+// ==SCOPE::Extract to constant in enclosing scope==
+const newLocal = x.if;
+/*RENAME*/newLocal.z();

--- a/tests/baselines/reference/extractConstant/extractConstant_PropertyName_PrivateIdentifierKeyword.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_PropertyName_PrivateIdentifierKeyword.js
@@ -1,0 +1,5 @@
+// ==ORIGINAL==
+/*[#|*/this.#if/*|]*/.z();
+// ==SCOPE::Extract to constant in enclosing scope==
+const newLocal = this.#if;
+/*RENAME*/newLocal.z();

--- a/tests/baselines/reference/extractConstant/extractConstant_PropertyName_PrivateIdentifierKeyword.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_PropertyName_PrivateIdentifierKeyword.ts
@@ -1,0 +1,5 @@
+// ==ORIGINAL==
+/*[#|*/this.#if/*|]*/.z();
+// ==SCOPE::Extract to constant in enclosing scope==
+const newLocal = this.#if;
+/*RENAME*/newLocal.z();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #37898

This PR makes TypeScript infer `newLocal` name from property name when performing an "Extract to constant in enclosing scope" refactoring on a `PropertyAccessExpression`.

![Kapture 2020-04-11 at 3 38 16](https://user-images.githubusercontent.com/193136/79021543-ffd21600-7ba5-11ea-80be-a220bd78c809.gif)
