### PR TITLE
Control flow for constructor initialized properties

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -659,7 +659,7 @@ namespace ts {
                 }
                 // We create a return control flow graph for IIFEs and constructors. For constructors
                 // we use the return control flow graph in strict property initialization checks.
-                currentReturnTarget = isIIFE || node.kind === SyntaxKind.Constructor ? createBranchLabel() : undefined;
+                currentReturnTarget = isIIFE || node.kind === SyntaxKind.Constructor || (isInJSFile && (node.kind === SyntaxKind.FunctionDeclaration || node.kind === SyntaxKind.FunctionExpression)) ? createBranchLabel() : undefined;
                 currentExceptionTarget = undefined;
                 currentBreakTarget = undefined;
                 currentContinueTarget = undefined;
@@ -680,8 +680,8 @@ namespace ts {
                 if (currentReturnTarget) {
                     addAntecedent(currentReturnTarget, currentFlow);
                     currentFlow = finishFlowLabel(currentReturnTarget);
-                    if (node.kind === SyntaxKind.Constructor) {
-                        (<ConstructorDeclaration>node).returnFlowNode = currentFlow;
+                    if (node.kind === SyntaxKind.Constructor || (isInJSFile && (node.kind === SyntaxKind.FunctionDeclaration || node.kind === SyntaxKind.FunctionExpression))) {
+                        (<FunctionLikeDeclaration>node).returnFlowNode = currentFlow;
                     }
                 }
                 if (!isIIFE) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7488,9 +7488,10 @@ namespace ts {
                 // We are in noImplicitAny mode and have a property declaration with no type annotation or initializer. Use
                 // control flow analysis of this.xxx assignments the constructor to determine the type of the property.
                 const constructor = findConstructorDeclaration(declaration.parent);
-                return constructor ? getFlowTypeInConstructor(declaration.symbol, constructor) :
+                const type = constructor ? getFlowTypeInConstructor(declaration.symbol, constructor) :
                     getModifierFlags(declaration) & ModifierFlags.Ambient ? getTypeOfPropertyInBaseClass(declaration.symbol) :
                     undefined;
+                return type && addOptionality(type, isOptional);
             }
 
             if (isJsxAttribute(declaration)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20150,7 +20150,7 @@ namespace ts {
                         if (isEmptyArrayAssignment(node)) {
                             return getEvolvingArrayType(neverType);
                         }
-                        const assignedType = getBaseTypeOfLiteralType(getInitialOrAssignedType(flow));
+                        const assignedType = getWidenedLiteralType(getInitialOrAssignedType(flow));
                         return isTypeAssignableTo(assignedType, declaredType) ? assignedType : anyArrayType;
                     }
                     if (declaredType.flags & TypeFlags.Union) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7529,9 +7529,11 @@ namespace ts {
         }
 
         function isAutoTypedProperty(symbol: Symbol) {
-            // A property is auto-typed in noImplicitAny mode when its declaration has no type annotation or initializer.
+            // A property is auto-typed when its declaration has no type annotation or initializer and we're in
+            // noImplicitAny mode or a .js file.
             const declaration = symbol.valueDeclaration;
-            return noImplicitAny && declaration && isPropertyDeclaration(declaration) && !declaration.type && !declaration.initializer;
+            return declaration && isPropertyDeclaration(declaration) && !getEffectiveTypeAnnotationNode(declaration) &&
+                !declaration.initializer && (noImplicitAny || isInJSFile(declaration));
         }
 
         function getDeclaringConstructor(symbol: Symbol) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7552,7 +7552,7 @@ namespace ts {
                 const containerObjectType = getJSContainerObjectType(symbol.valueDeclaration, symbol, container);
                 return containerObjectType || getWidenedLiteralType(checkExpressionCached(container));
             }
-            let type = undefined;
+            let type;
             let definedInConstructor = false;
             let definedInMethod = false;
             // We use control flow analysis to determine the type of the property if the property qualifies as a constructor

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7484,9 +7484,9 @@ namespace ts {
                 return addOptionality(type, isOptional);
             }
 
-            if (noImplicitAny && isPropertyDeclaration(declaration)) {
-                // We are in noImplicitAny mode and have a property declaration with no type annotation or initializer. Use
-                // control flow analysis of this.xxx assignments the constructor to determine the type of the property.
+            if (isPropertyDeclaration(declaration) && (noImplicitAny || isInJSFile(declaration))) {
+                // We have a property declaration with no type annotation or initializer, in noImplicitAny mode or a .js file.
+                // Use control flow analysis of this.xxx assignments the constructor to determine the type of the property.
                 const constructor = findConstructorDeclaration(declaration.parent);
                 const type = constructor ? getFlowTypeInConstructor(declaration.symbol, constructor) :
                     getModifierFlags(declaration) & ModifierFlags.Ambient ? getTypeOfPropertyInBaseClass(declaration.symbol) :

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4156,6 +4156,7 @@ namespace ts {
         deferralParent?: Type;              // Source union/intersection of a deferred type
         cjsExportMerged?: Symbol;           // Version of the symbol with all non export= exports merged with the export= target
         typeOnlyDeclaration?: TypeOnlyCompatibleAliasDeclaration | false; // First resolved alias declaration that makes the symbol only usable in type constructs
+        isPropertyDeclaredInConstructor?: boolean;  // Property declared through 'this.x = ...' assignment in constructor
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1107,6 +1107,7 @@ namespace ts {
         exclamationToken?: ExclamationToken;
         body?: Block | Expression;
         /* @internal */ endFlowNode?: FlowNode;
+        /* @internal */ returnFlowNode?: FlowNode;
     }
 
     export type FunctionLikeDeclaration =
@@ -1152,7 +1153,6 @@ namespace ts {
         kind: SyntaxKind.Constructor;
         parent: ClassLikeDeclaration;
         body?: FunctionBody;
-        /* @internal */ returnFlowNode?: FlowNode;
     }
 
     /** For when we encounter a semicolon in a class declaration. ES6 allows these as class elements. */
@@ -4156,7 +4156,8 @@ namespace ts {
         deferralParent?: Type;              // Source union/intersection of a deferred type
         cjsExportMerged?: Symbol;           // Version of the symbol with all non export= exports merged with the export= target
         typeOnlyDeclaration?: TypeOnlyCompatibleAliasDeclaration | false; // First resolved alias declaration that makes the symbol only usable in type constructs
-        isPropertyDeclaredInConstructor?: boolean;  // Property declared through 'this.x = ...' assignment in constructor
+        isConstructorDeclaredProperty?: boolean;  // Property declared through 'this.x = ...' assignment in constructor
+        typeOfPropertyInBaseClass?: Type;   // Type of constructor declared property in base class
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4157,7 +4157,6 @@ namespace ts {
         cjsExportMerged?: Symbol;           // Version of the symbol with all non export= exports merged with the export= target
         typeOnlyDeclaration?: TypeOnlyCompatibleAliasDeclaration | false; // First resolved alias declaration that makes the symbol only usable in type constructs
         isConstructorDeclaredProperty?: boolean;  // Property declared through 'this.x = ...' assignment in constructor
-        typeOfPropertyInBaseClass?: Type;   // Type of constructor declared property in base class
     }
 
     /* @internal */

--- a/tests/baselines/reference/checkExportsObjectAssignPrototypeProperty.types
+++ b/tests/baselines/reference/checkExportsObjectAssignPrototypeProperty.types
@@ -105,9 +105,9 @@ function Person(name) {
 
     this.name = name;
 >this.name = name : string
->this.name : string
+>this.name : any
 >this : this
->name : string
+>name : any
 >name : string
 }
 Person.prototype.describe = function () {

--- a/tests/baselines/reference/checkIndexConstraintOfJavascriptClassExpression.types
+++ b/tests/baselines/reference/checkIndexConstraintOfJavascriptClassExpression.types
@@ -23,9 +23,9 @@ someFunction(function(BaseClass) {
 
             this.foo = "bar";
 >this.foo = "bar" : "bar"
->this.foo : string
+>this.foo : any
 >this : this
->foo : string
+>foo : any
 >"bar" : "bar"
         }
         _render(error) {

--- a/tests/baselines/reference/checkJsFiles_noErrorLocation.types
+++ b/tests/baselines/reference/checkJsFiles_noErrorLocation.types
@@ -25,9 +25,9 @@ class B extends A {
 
     this.foo = () => 3;
 >this.foo = () => 3 : () => number
->this.foo : () => number
+>this.foo : any
 >this : this
->foo : () => number
+>foo : any
 >() => 3 : () => number
 >3 : 3
   }

--- a/tests/baselines/reference/checkSuperCallBeforeThisAccessing9.types
+++ b/tests/baselines/reference/checkSuperCallBeforeThisAccessing9.types
@@ -12,9 +12,9 @@ class Derived {
 
         this.x = 10;
 >this.x = 10 : 10
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >10 : 10
 
         var that = this;

--- a/tests/baselines/reference/classCanExtendConstructorFunction.types
+++ b/tests/baselines/reference/classCanExtendConstructorFunction.types
@@ -9,9 +9,9 @@ function Wagon(numberOxen) {
 
     this.numberOxen = numberOxen
 >this.numberOxen = numberOxen : number
->this.numberOxen : number
+>this.numberOxen : any
 >this : this
->numberOxen : number
+>numberOxen : any
 >numberOxen : number
 }
 /** @param {Wagon[]=} wagons */

--- a/tests/baselines/reference/classCanExtendConstructorFunction.types
+++ b/tests/baselines/reference/classCanExtendConstructorFunction.types
@@ -91,9 +91,9 @@ class Sql extends Wagon {
 
         this.foonly = 12
 >this.foonly = 12 : 12
->this.foonly : number
+>this.foonly : any
 >this : this
->foonly : number
+>foonly : any
 >12 : 12
     }
     /**

--- a/tests/baselines/reference/classExtendingAny.types
+++ b/tests/baselines/reference/classExtendingAny.types
@@ -67,9 +67,9 @@ class B extends Err {
 
         this.wat = 12
 >this.wat = 12 : 12
->this.wat : number
+>this.wat : any
 >this : this
->wat : number
+>wat : any
 >12 : 12
     }
     f() {

--- a/tests/baselines/reference/constructorFunctions.types
+++ b/tests/baselines/reference/constructorFunctions.types
@@ -143,9 +143,9 @@ function C6() {
 
   this.functions = [x => x, x => x + 1, x => x - 1]
 >this.functions = [x => x, x => x + 1, x => x - 1] : ((x: any) => any)[]
->this.functions : ((x: any) => any)[]
+>this.functions : any
 >this : this
->functions : ((x: any) => any)[]
+>functions : any
 >[x => x, x => x + 1, x => x - 1] : ((x: any) => any)[]
 >x => x : (x: any) => any
 >x : any

--- a/tests/baselines/reference/constructorFunctionsStrict.types
+++ b/tests/baselines/reference/constructorFunctionsStrict.types
@@ -85,10 +85,10 @@ var j = new A(2)
 
 k.x === j.x
 >k.x === j.x : boolean
->k.x : number
+>k.x : number | undefined
 >k : A
->x : number
->j.x : number
+>x : number | undefined
+>j.x : number | undefined
 >j : A
->x : number
+>x : number | undefined
 

--- a/tests/baselines/reference/exportNestedNamespaces.types
+++ b/tests/baselines/reference/exportNestedNamespaces.types
@@ -32,9 +32,9 @@ exports.Classic = class {
     constructor() {
         this.p = 1
 >this.p = 1 : 1
->this.p : number
+>this.p : any
 >this : this
->p : number
+>p : any
 >1 : 1
     }
 }

--- a/tests/baselines/reference/inferringClassMembersFromAssignments.types
+++ b/tests/baselines/reference/inferringClassMembersFromAssignments.types
@@ -11,24 +11,24 @@ class C {
 
             this.inConstructor = 0;
 >this.inConstructor = 0 : 0
->this.inConstructor : string | number
+>this.inConstructor : any
 >this : this
->inConstructor : string | number
+>inConstructor : any
 >0 : 0
         }
         else {
             this.inConstructor = "string"
 >this.inConstructor = "string" : "string"
->this.inConstructor : string | number
+>this.inConstructor : any
 >this : this
->inConstructor : string | number
+>inConstructor : any
 >"string" : "string"
         }
         this.inMultiple = 0;
 >this.inMultiple = 0 : 0
->this.inMultiple : number
+>this.inMultiple : any
 >this : this
->inMultiple : number
+>inMultiple : any
 >0 : 0
     }
     method() {

--- a/tests/baselines/reference/inferringClassMembersFromAssignments3.types
+++ b/tests/baselines/reference/inferringClassMembersFromAssignments3.types
@@ -5,9 +5,9 @@ class Base {
     constructor() {
         this.p = 1
 >this.p = 1 : 1
->this.p : number
+>this.p : any
 >this : this
->p : number
+>p : any
 >1 : 1
     }
 }

--- a/tests/baselines/reference/inferringClassMembersFromAssignments5.types
+++ b/tests/baselines/reference/inferringClassMembersFromAssignments5.types
@@ -25,9 +25,9 @@ class Derived extends Base {
         // should be OK, and p should have type number from this assignment
         this.p = 1
 >this.p = 1 : 1
->this.p : number
+>this.p : any
 >this : this
->p : number
+>p : any
 >1 : 1
     }
     test() {

--- a/tests/baselines/reference/jsDeclarationsClasses.types
+++ b/tests/baselines/reference/jsDeclarationsClasses.types
@@ -209,16 +209,16 @@ export class K {
     constructor() {
         this.p1 = 12;
 >this.p1 = 12 : 12
->this.p1 : number
+>this.p1 : any
 >this : this
->p1 : number
+>p1 : any
 >12 : 12
 
         this.p2 = "ok";
 >this.p2 = "ok" : "ok"
->this.p2 : string
+>this.p2 : any
 >this : this
->p2 : string
+>p2 : any
 >"ok" : "ok"
     }
 
@@ -243,9 +243,9 @@ export class M extends null {
     constructor() {
         this.prop = 12;
 >this.prop = 12 : 12
->this.prop : number
+>this.prop : any
 >this : this
->prop : number
+>prop : any
 >12 : 12
     }
 }
@@ -270,9 +270,9 @@ export class N extends L {
 
         this.another = param;
 >this.another = param : T
->this.another : T
+>this.another : any
 >this : this
->another : T
+>another : any
 >param : T
     }
 }
@@ -298,9 +298,9 @@ export class O extends N {
 
         this.another2 = param;
 >this.another2 = param : U
->this.another2 : U
+>this.another2 : any
 >this : this
->another2 : U
+>another2 : any
 >param : U
     }
 }

--- a/tests/baselines/reference/jsDeclarationsExportAssignedClassExpression.types
+++ b/tests/baselines/reference/jsDeclarationsExportAssignedClassExpression.types
@@ -15,9 +15,9 @@ module.exports = class Thing {
 
         this.t = 12 + p;
 >this.t = 12 + p : number
->this.t : number
+>this.t : any
 >this : this
->t : number
+>t : any
 >12 + p : number
 >12 : 12
 >p : number

--- a/tests/baselines/reference/jsDeclarationsExportAssignedClassExpressionAnonymous.types
+++ b/tests/baselines/reference/jsDeclarationsExportAssignedClassExpressionAnonymous.types
@@ -14,9 +14,9 @@ module.exports = class {
 
         this.t = 12 + p;
 >this.t = 12 + p : number
->this.t : number
+>this.t : any
 >this : this
->t : number
+>t : any
 >12 + p : number
 >12 : 12
 >p : number

--- a/tests/baselines/reference/jsDeclarationsExportAssignedClassExpressionAnonymousWithSub.types
+++ b/tests/baselines/reference/jsDeclarationsExportAssignedClassExpressionAnonymousWithSub.types
@@ -14,9 +14,9 @@ module.exports = class {
 
         this.t = 12 + p;
 >this.t = 12 + p : number
->this.t : number
+>this.t : any
 >this : this
->t : number
+>t : any
 >12 + p : number
 >12 : 12
 >p : number
@@ -34,9 +34,9 @@ module.exports.Sub = class {
     constructor() {
         this.instance = new module.exports(10);
 >this.instance = new module.exports(10) : import("tests/cases/conformance/jsdoc/declarations/index")
->this.instance : import("tests/cases/conformance/jsdoc/declarations/index")
+>this.instance : any
 >this : this
->instance : import("tests/cases/conformance/jsdoc/declarations/index")
+>instance : any
 >new module.exports(10) : import("tests/cases/conformance/jsdoc/declarations/index")
 >module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/index")
 >module : { "\"tests/cases/conformance/jsdoc/declarations/index\"": typeof import("tests/cases/conformance/jsdoc/declarations/index"); }

--- a/tests/baselines/reference/jsDeclarationsExportAssignedClassExpressionShadowing.types
+++ b/tests/baselines/reference/jsDeclarationsExportAssignedClassExpressionShadowing.types
@@ -25,9 +25,9 @@ module.exports = class Q {
     constructor() {
         this.x = new A();
 >this.x = new A() : A
->this.x : A
+>this.x : any
 >this : this
->x : A
+>x : any
 >new A() : A
 >A : typeof A
     }

--- a/tests/baselines/reference/jsDeclarationsExportAssignedConstructorFunction.types
+++ b/tests/baselines/reference/jsDeclarationsExportAssignedConstructorFunction.types
@@ -11,9 +11,9 @@ module.exports.MyClass = function() {
 
     this.x = 1
 >this.x = 1 : 1
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >1 : 1
 }
 module.exports.MyClass.prototype = {

--- a/tests/baselines/reference/jsDeclarationsExportAssignedVisibility.types
+++ b/tests/baselines/reference/jsDeclarationsExportAssignedVisibility.types
@@ -11,9 +11,9 @@ class Container {
     constructor() {
         this.usage = new Obj();
 >this.usage = new Obj() : import("tests/cases/conformance/jsdoc/declarations/obj")
->this.usage : import("tests/cases/conformance/jsdoc/declarations/obj")
+>this.usage : any
 >this : this
->usage : import("tests/cases/conformance/jsdoc/declarations/obj")
+>usage : any
 >new Obj() : import("tests/cases/conformance/jsdoc/declarations/obj")
 >Obj : typeof import("tests/cases/conformance/jsdoc/declarations/obj")
     }
@@ -38,9 +38,9 @@ module.exports = class Obj {
     constructor() {
         this.x = 12;
 >this.x = 12 : 12
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >12 : 12
     }
 }

--- a/tests/baselines/reference/jsDeclarationsTypedefAndImportTypes.types
+++ b/tests/baselines/reference/jsDeclarationsTypedefAndImportTypes.types
@@ -38,9 +38,9 @@ class Wrap {
 
         this.connItem = c.item;
 >this.connItem = c.item : number
->this.connItem : number
+>this.connItem : any
 >this : this
->connItem : number
+>connItem : any
 >c.item : number
 >c : import("tests/cases/conformance/jsdoc/declarations/conn")
 >item : number

--- a/tests/baselines/reference/jsFileClassPropertyType.types
+++ b/tests/baselines/reference/jsFileClassPropertyType.types
@@ -5,9 +5,9 @@ class C {
   constructor () {
       this.p = 0;
 >this.p = 0 : 0
->this.p : number
+>this.p : any
 >this : this
->p : number
+>p : any
 >0 : 0
   }
 }

--- a/tests/baselines/reference/jsFileClassPropertyType3.types
+++ b/tests/baselines/reference/jsFileClassPropertyType3.types
@@ -8,17 +8,17 @@ class C {
 
             this.p = null;
 >this.p = null : null
->this.p : number
+>this.p : any
 >this : this
->p : number
+>p : any
 >null : null
         }
         else {
             this.p = 0;
 >this.p = 0 : 0
->this.p : number
+>this.p : any
 >this : this
->p : number
+>p : any
 >0 : 0
         }
     }

--- a/tests/baselines/reference/jsFileClassSelfReferencedProperty.types
+++ b/tests/baselines/reference/jsFileClassSelfReferencedProperty.types
@@ -4,15 +4,15 @@ export class StackOverflowTest {
 
   constructor () {
     this.testStackOverflow = this.testStackOverflow.bind(this)
->this.testStackOverflow = this.testStackOverflow.bind(this) : any
+>this.testStackOverflow = this.testStackOverflow.bind(this) : error
 >this.testStackOverflow : any
 >this : this
 >testStackOverflow : any
->this.testStackOverflow.bind(this) : any
->this.testStackOverflow.bind : any
->this.testStackOverflow : any
+>this.testStackOverflow.bind(this) : error
+>this.testStackOverflow.bind : error
+>this.testStackOverflow : undefined
 >this : this
->testStackOverflow : any
+>testStackOverflow : undefined
 >bind : any
 >this : this
   }

--- a/tests/baselines/reference/jsObjectsMarkedAsOpenEnded.types
+++ b/tests/baselines/reference/jsObjectsMarkedAsOpenEnded.types
@@ -20,9 +20,9 @@ class C {
     constructor() {
         this.member = {};
 >this.member = {} : {}
->this.member : {}
+>this.member : any
 >this : this
->member : {}
+>member : any
 >{} : {}
 
         this.member.a = 0;

--- a/tests/baselines/reference/jsdocAccessibilityTags.types
+++ b/tests/baselines/reference/jsdocAccessibilityTags.types
@@ -52,9 +52,9 @@ class C {
          */
         this.priv2 = 1;
 >this.priv2 = 1 : 1
->this.priv2 : number
+>this.priv2 : any
 >this : this
->priv2 : number
+>priv2 : any
 >1 : 1
 
         /**
@@ -64,9 +64,9 @@ class C {
          */
         this.prot2 = 2;
 >this.prot2 = 2 : 2
->this.prot2 : number
+>this.prot2 : any
 >this : this
->prot2 : number
+>prot2 : any
 >2 : 2
 
         /**
@@ -76,9 +76,9 @@ class C {
          */
         this.pub2 = 3;
 >this.pub2 = 3 : 3
->this.pub2 : number
+>this.pub2 : any
 >this : this
->pub2 : number
+>pub2 : any
 >3 : 3
     }
     h() { return this.priv2 }

--- a/tests/baselines/reference/jsdocAugmentsMissingType.types
+++ b/tests/baselines/reference/jsdocAugmentsMissingType.types
@@ -2,9 +2,9 @@
 class A { constructor() { this.x = 0; } }
 >A : A
 >this.x = 0 : 0
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >0 : 0
 
 /** @augments */

--- a/tests/baselines/reference/jsdocAugments_noExtends.types
+++ b/tests/baselines/reference/jsdocAugments_noExtends.types
@@ -2,9 +2,9 @@
 class A { constructor() { this.x = 0; } }
 >A : A
 >this.x = 0 : 0
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >0 : 0
 
 /** @augments A */

--- a/tests/baselines/reference/jsdocFunctionType.types
+++ b/tests/baselines/reference/jsdocFunctionType.types
@@ -44,9 +44,9 @@ class C {
 
         this.length = n;
 >this.length = n : number
->this.length : number
+>this.length : any
 >this : this
->length : number
+>length : any
 >n : number
     }
 }

--- a/tests/baselines/reference/jsdocFunctionType.types
+++ b/tests/baselines/reference/jsdocFunctionType.types
@@ -92,9 +92,9 @@ function D(n) {
 
   this.length = n;
 >this.length = n : number
->this.length : number
+>this.length : any
 >this : this
->length : number
+>length : any
 >n : number
 }
 
@@ -151,9 +151,9 @@ var E = function(n) {
 
   this.not_length_on_purpose = n;
 >this.not_length_on_purpose = n : number
->this.not_length_on_purpose : number
+>this.not_length_on_purpose : any
 >this : this
->not_length_on_purpose : number
+>not_length_on_purpose : any
 >n : number
 
 };

--- a/tests/baselines/reference/jsdocImplements_missingType.types
+++ b/tests/baselines/reference/jsdocImplements_missingType.types
@@ -2,9 +2,9 @@
 class A { constructor() { this.x = 0; } }
 >A : A
 >this.x = 0 : 0
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >0 : 0
 
 /** @implements */

--- a/tests/baselines/reference/jsdocImplements_properties.types
+++ b/tests/baselines/reference/jsdocImplements_properties.types
@@ -2,9 +2,9 @@
 class A { constructor() { this.x = 0; } }
 >A : A
 >this.x = 0 : 0
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >0 : 0
 
 /** @implements A*/
@@ -26,9 +26,9 @@ class B3 {
 
     constructor() { this.x = 10 }
 >this.x = 10 : 10
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >10 : 10
 }
 

--- a/tests/baselines/reference/jsdocImportType.types
+++ b/tests/baselines/reference/jsdocImportType.types
@@ -45,9 +45,9 @@ class Chunk {
     constructor() {
         this.chunk = 1;
 >this.chunk = 1 : 1
->this.chunk : number
+>this.chunk : any
 >this : this
->chunk : number
+>chunk : any
 >1 : 1
     }
 }

--- a/tests/baselines/reference/jsdocImportType2.types
+++ b/tests/baselines/reference/jsdocImportType2.types
@@ -50,9 +50,9 @@ module.exports = class Chunk {
     constructor() {
         this.chunk = 1;
 >this.chunk = 1 : 1
->this.chunk : number
+>this.chunk : any
 >this : this
->chunk : number
+>chunk : any
 >1 : 1
     }
 }

--- a/tests/baselines/reference/jsdocReadonly.types
+++ b/tests/baselines/reference/jsdocReadonly.types
@@ -35,9 +35,9 @@ class LOL {
         /** @readonly ok */
         this.ka = 2
 >this.ka = 2 : 2
->this.ka : number
+>this.ka : any
 >this : this
->ka : number
+>ka : any
 >2 : 2
     }
 }

--- a/tests/baselines/reference/jsdocTemplateClass.types
+++ b/tests/baselines/reference/jsdocTemplateClass.types
@@ -14,9 +14,9 @@ class Foo {
 
         this.a = x
 >this.a = x : T
->this.a : T
+>this.a : any
 >this : this
->a : T
+>a : any
 >x : T
     }
     /**

--- a/tests/baselines/reference/jsdocTypeReferenceToImportOfClassExpression.types
+++ b/tests/baselines/reference/jsdocTypeReferenceToImportOfClassExpression.types
@@ -39,9 +39,9 @@ class MW {
 
     this.compiler = compiler;
 >this.compiler = compiler : import("tests/cases/conformance/jsdoc/MC")
->this.compiler : import("tests/cases/conformance/jsdoc/MC")
+>this.compiler : any
 >this : this
->compiler : import("tests/cases/conformance/jsdoc/MC")
+>compiler : any
 >compiler : import("tests/cases/conformance/jsdoc/MC")
   }
 }

--- a/tests/baselines/reference/jsdocTypeReferenceToImportOfFunctionExpression.types
+++ b/tests/baselines/reference/jsdocTypeReferenceToImportOfFunctionExpression.types
@@ -42,9 +42,9 @@ class MW {
 
     this.compiler = compiler;
 >this.compiler = compiler : typeof MC
->this.compiler : typeof MC
+>this.compiler : any
 >this : this
->compiler : typeof MC
+>compiler : any
 >compiler : typeof MC
   }
 }

--- a/tests/baselines/reference/jsdocTypeTagCast.types
+++ b/tests/baselines/reference/jsdocTypeTagCast.types
@@ -43,9 +43,9 @@ class SomeBase {
     constructor() {
         this.p = 42;
 >this.p = 42 : 42
->this.p : number
+>this.p : any
 >this : this
->p : number
+>p : any
 >42 : 42
     }
 }
@@ -60,9 +60,9 @@ class SomeDerived extends SomeBase {
 
         this.x = 42;
 >this.x = 42 : 42
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >42 : 42
     }
 }
@@ -72,9 +72,9 @@ class SomeOther {
     constructor() {
         this.q = 42;
 >this.q = 42 : 42
->this.q : number
+>this.q : any
 >this : this
->q : number
+>q : any
 >42 : 42
     }
 }

--- a/tests/baselines/reference/moduleExportAssignment6.types
+++ b/tests/baselines/reference/moduleExportAssignment6.types
@@ -8,16 +8,16 @@ class C {
 
         this.x = x
 >this.x = x : number
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >x : number
 
         this.exports = [x]
 >this.exports = [x] : number[]
->this.exports : number[]
+>this.exports : any
 >this : this
->exports : number[]
+>exports : any
 >[x] : number[]
 >x : number
     }

--- a/tests/baselines/reference/moduleExportNestedNamespaces.types
+++ b/tests/baselines/reference/moduleExportNestedNamespaces.types
@@ -39,9 +39,9 @@ module.exports.Classic = class {
     constructor() {
         this.p = 1
 >this.p = 1 : 1
->this.p : number
+>this.p : any
 >this : this
->p : number
+>p : any
 >1 : 1
     }
 }

--- a/tests/baselines/reference/propertiesOfGenericConstructorFunctions.types
+++ b/tests/baselines/reference/propertiesOfGenericConstructorFunctions.types
@@ -94,16 +94,16 @@ function Cp(t) {
 
     this.x = 1
 >this.x = 1 : 1
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >1 : 1
 
     this.y = t
 >this.y = t : T
->this.y : T
+>this.y : any
 >this : this
->y : T
+>y : any
 >t : T
 }
 Cp.prototype = {

--- a/tests/baselines/reference/returnTagTypeGuard.types
+++ b/tests/baselines/reference/returnTagTypeGuard.types
@@ -5,9 +5,9 @@ class Entry {
     constructor() {
         this.c = 1
 >this.c = 1 : 1
->this.c : number
+>this.c : any
 >this : this
->c : number
+>c : any
 >1 : 1
     }
     /**
@@ -28,9 +28,9 @@ class Group {
     constructor() {
         this.d = 'no'
 >this.d = 'no' : "no"
->this.d : string
+>this.d : any
 >this : this
->d : string
+>d : any
 >'no' : "no"
     }
     /**

--- a/tests/baselines/reference/thisPropertyAssignment.types
+++ b/tests/baselines/reference/thisPropertyAssignment.types
@@ -44,9 +44,9 @@ function F() {
 
   this.a = {};
 >this.a = {} : {}
->this.a : {}
+>this.a : any
 >this : this
->a : {}
+>a : any
 >{} : {}
 
   this.a.b = {};
@@ -60,7 +60,7 @@ function F() {
 
   this["b"] = {};
 >this["b"] = {} : {}
->this["b"] : {}
+>this["b"] : any
 >this : this
 >"b" : "b"
 >{} : {}

--- a/tests/baselines/reference/thisPropertyAssignmentCircular.symbols
+++ b/tests/baselines/reference/thisPropertyAssignmentCircular.symbols
@@ -44,8 +44,10 @@ function C() {
 >this.x : Symbol(C.x, Decl(thisPropertyAssignmentCircular.js, 13, 14), Decl(thisPropertyAssignmentCircular.js, 14, 15))
 >this : Symbol(C, Decl(thisPropertyAssignmentCircular.js, 10, 1))
 >x : Symbol(C.x, Decl(thisPropertyAssignmentCircular.js, 13, 14), Decl(thisPropertyAssignmentCircular.js, 14, 15))
+>this.x.toString : Symbol(Function.toString, Decl(lib.es5.d.ts, --, --))
 >this.x : Symbol(C.x, Decl(thisPropertyAssignmentCircular.js, 13, 14), Decl(thisPropertyAssignmentCircular.js, 14, 15))
 >this : Symbol(C, Decl(thisPropertyAssignmentCircular.js, 10, 1))
 >x : Symbol(C.x, Decl(thisPropertyAssignmentCircular.js, 13, 14), Decl(thisPropertyAssignmentCircular.js, 14, 15))
+>toString : Symbol(Function.toString, Decl(lib.es5.d.ts, --, --))
 }
 

--- a/tests/baselines/reference/thisPropertyAssignmentCircular.types
+++ b/tests/baselines/reference/thisPropertyAssignmentCircular.types
@@ -5,9 +5,9 @@ export class Foo {
     constructor() {
         this.foo = "Hello";
 >this.foo = "Hello" : "Hello"
->this.foo : string
+>this.foo : any
 >this : this
->foo : string
+>foo : any
 >"Hello" : "Hello"
     }
     slicey() {

--- a/tests/baselines/reference/thisPropertyAssignmentCircular.types
+++ b/tests/baselines/reference/thisPropertyAssignmentCircular.types
@@ -52,11 +52,11 @@ function C() {
 >this : this
 >x : any
 >function() { this.x.toString(); } : () => void
->this.x.toString() : any
->this.x.toString : any
->this.x : any
+>this.x.toString() : string
+>this.x.toString : () => string
+>this.x : () => void
 >this : this
->x : any
->toString : any
+>x : () => void
+>toString : () => string
 }
 

--- a/tests/baselines/reference/thisPropertyOverridesAccessors.types
+++ b/tests/baselines/reference/thisPropertyOverridesAccessors.types
@@ -23,9 +23,9 @@ class Bar extends Foo {
 
         this.p = 2
 >this.p = 2 : 2
->this.p : number
+>this.p : any
 >this : this
->p : number
+>p : any
 >2 : 2
     }
 }

--- a/tests/baselines/reference/thisTypeOfConstructorFunctions.types
+++ b/tests/baselines/reference/thisTypeOfConstructorFunctions.types
@@ -18,17 +18,17 @@ function Cp(t) {
 
     this.y = t
 >this.y = t : T
->this.y : T
+>this.y : any
 >this : this
->y : T
+>y : any
 >t : T
 
     /** @return {this} */
     this.m3 = () => this
 >this.m3 = () => this : () => this
->this.m3 : () => this
+>this.m3 : any
 >this : this
->m3 : () => this
+>m3 : any
 >() => this : () => this
 >this : this
 }
@@ -67,9 +67,9 @@ function Cpp(t) {
 
     this.y = t
 >this.y = t : T
->this.y : T
+>this.y : any
 >this : this
->y : T
+>y : any
 >t : T
 }
 /** @return {this} */

--- a/tests/baselines/reference/typeFromJSConstructor.errors.txt
+++ b/tests/baselines/reference/typeFromJSConstructor.errors.txt
@@ -1,12 +1,13 @@
 tests/cases/conformance/salsa/a.js(10,5): error TS7008: Member 'twices' implicitly has an 'any[]' type.
 tests/cases/conformance/salsa/a.js(14,5): error TS2322: Type '"hi"' is not assignable to type 'number'.
+tests/cases/conformance/salsa/a.js(17,5): error TS2322: Type 'undefined' is not assignable to type 'string'.
 tests/cases/conformance/salsa/a.js(21,5): error TS2322: Type 'false' is not assignable to type 'number'.
-tests/cases/conformance/salsa/a.js(24,5): error TS2322: Type 'null' is not assignable to type 'string | undefined'.
-tests/cases/conformance/salsa/a.js(25,5): error TS2322: Type 'false' is not assignable to type 'string | undefined'.
+tests/cases/conformance/salsa/a.js(24,5): error TS2322: Type 'null' is not assignable to type 'string'.
+tests/cases/conformance/salsa/a.js(25,5): error TS2322: Type 'false' is not assignable to type 'string'.
 tests/cases/conformance/salsa/a.js(26,5): error TS2531: Object is possibly 'null'.
 
 
-==== tests/cases/conformance/salsa/a.js (6 errors) ====
+==== tests/cases/conformance/salsa/a.js (7 errors) ====
     function Installer () {
         // arg: number
         this.arg = 0
@@ -28,6 +29,8 @@ tests/cases/conformance/salsa/a.js(26,5): error TS2531: Object is possibly 'null
         this.unknown = 'hi' // ok
         this.newProperty = 1 // ok: number | boolean
         this.twice = undefined // ok
+        ~~~~~~~~~~
+!!! error TS2322: Type 'undefined' is not assignable to type 'string'.
         this.twice = 'hi' // ok
     }
     Installer.prototype.second = function () {
@@ -38,10 +41,10 @@ tests/cases/conformance/salsa/a.js(26,5): error TS2531: Object is possibly 'null
         this.newProperty = false // ok
         this.twice = null // error
         ~~~~~~~~~~
-!!! error TS2322: Type 'null' is not assignable to type 'string | undefined'.
+!!! error TS2322: Type 'null' is not assignable to type 'string'.
         this.twice = false // error
         ~~~~~~~~~~
-!!! error TS2322: Type 'false' is not assignable to type 'string | undefined'.
+!!! error TS2322: Type 'false' is not assignable to type 'string'.
         this.twices.push(1) // error: Object is possibly null
         ~~~~~~~~~~~
 !!! error TS2531: Object is possibly 'null'.

--- a/tests/baselines/reference/typeFromJSConstructor.types
+++ b/tests/baselines/reference/typeFromJSConstructor.types
@@ -80,16 +80,16 @@ Installer.prototype.first = function () {
 
     this.twice = undefined // ok
 >this.twice = undefined : undefined
->this.twice : string | undefined
+>this.twice : string
 >this : this
->twice : string | undefined
+>twice : string
 >undefined : undefined
 
     this.twice = 'hi' // ok
 >this.twice = 'hi' : "hi"
->this.twice : string | undefined
+>this.twice : string
 >this : this
->twice : string | undefined
+>twice : string
 >'hi' : "hi"
 }
 Installer.prototype.second = function () {
@@ -124,16 +124,16 @@ Installer.prototype.second = function () {
 
     this.twice = null // error
 >this.twice = null : null
->this.twice : string | undefined
+>this.twice : string
 >this : this
->twice : string | undefined
+>twice : string
 >null : null
 
     this.twice = false // error
 >this.twice = false : false
->this.twice : string | undefined
+>this.twice : string
 >this : this
->twice : string | undefined
+>twice : string
 >false : false
 
     this.twices.push(1) // error: Object is possibly null

--- a/tests/baselines/reference/typeFromParamTagForFunction.types
+++ b/tests/baselines/reference/typeFromParamTagForFunction.types
@@ -50,9 +50,9 @@ exports.B = class {
     constructor() {
         this.x = 1;
 >this.x = 1 : 1
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >1 : 1
     }
 };
@@ -135,9 +135,9 @@ export class E {
     constructor() {
         this.x = 1;
 >this.x = 1 : 1
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >1 : 1
     }
 }
@@ -206,9 +206,9 @@ class H {
     constructor() {
         this.x = 1;
 >this.x = 1 : 1
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >1 : 1
     }
 }

--- a/tests/baselines/reference/typeFromPropertyAssignment15.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment15.types
@@ -13,9 +13,9 @@ Outer.Inner = class {
     constructor() {
         this.x = 1
 >this.x = 1 : 1
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >1 : 1
     }
     m() { }

--- a/tests/baselines/reference/typeFromPropertyAssignment2.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment2.types
@@ -20,9 +20,9 @@ Outer.Inner = class I {
     constructor() {
         this.x = 1
 >this.x = 1 : 1
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >1 : 1
     }
 }

--- a/tests/baselines/reference/typeFromPropertyAssignment23.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment23.types
@@ -5,9 +5,9 @@ class B {
     constructor () {
         this.n = 1
 >this.n = 1 : 1
->this.n : number
+>this.n : any
 >this : this
->n : number
+>n : any
 >1 : 1
     }
     foo() {

--- a/tests/baselines/reference/typeFromPropertyAssignment25.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment25.types
@@ -13,9 +13,9 @@ Common.I = class {
     constructor() {
         this.i = 1
 >this.i = 1 : 1
->this.i : number
+>this.i : any
 >this : this
->i : number
+>i : any
 >1 : 1
     }
 }
@@ -36,9 +36,9 @@ Common.O = class extends Common.I {
 
         this.o = 2
 >this.o = 2 : 2
->this.o : number
+>this.o : any
 >this : this
->o : number
+>o : any
 >2 : 2
     }
 }

--- a/tests/baselines/reference/typeFromPropertyAssignment26.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment26.types
@@ -13,9 +13,9 @@ UI.TreeElement = class {
     constructor() {
         this.treeOutline = 12
 >this.treeOutline = 12 : 12
->this.treeOutline : number
+>this.treeOutline : any
 >this : this
->treeOutline : number
+>treeOutline : any
 >12 : 12
     }
 };

--- a/tests/baselines/reference/typeFromPropertyAssignment28.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment28.types
@@ -3,9 +3,9 @@
 class C { constructor() { this.p = 1; } }
 >C : C
 >this.p = 1 : 1
->this.p : number
+>this.p : any
 >this : this
->p : number
+>p : any
 >1 : 1
 
 // Property assignment does nothing.

--- a/tests/baselines/reference/typeFromPropertyAssignment3.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment3.types
@@ -22,9 +22,9 @@ Outer.Inner = class I {
     constructor() {
         this.x = 1
 >this.x = 1 : 1
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
 >1 : 1
     }
 }

--- a/tests/baselines/reference/typeFromPropertyAssignment35.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment35.types
@@ -34,9 +34,9 @@ Emu.D = class {
     constructor() {
         this._model = 1
 >this._model = 1 : 1
->this._model : number
+>this._model : any
 >this : this
->_model : number
+>_model : any
 >1 : 1
     }
 }

--- a/tests/baselines/reference/typeFromPrototypeAssignment.types
+++ b/tests/baselines/reference/typeFromPrototypeAssignment.types
@@ -8,9 +8,9 @@ var Multimap = function() {
 
     this._map = {};
 >this._map = {} : {}
->this._map : {}
+>this._map : any
 >this : this
->_map : {}
+>_map : any
 >{} : {}
 
     this._map

--- a/tests/baselines/reference/typeFromPrototypeAssignment2.types
+++ b/tests/baselines/reference/typeFromPrototypeAssignment2.types
@@ -13,9 +13,9 @@
 
         this._map = {};
 >this._map = {} : {}
->this._map : {}
+>this._map : any
 >this : this
->_map : {}
+>_map : any
 >{} : {}
 
         this._map

--- a/tests/baselines/reference/varRequireFromJavascript.types
+++ b/tests/baselines/reference/varRequireFromJavascript.types
@@ -44,9 +44,9 @@ export class Crunch {
 
         this.n = n
 >this.n = n : number
->this.n : number
+>this.n : any
 >this : this
->n : number
+>n : any
 >n : number
     }
     m() {


### PR DESCRIPTION
With this PR we use control flow analysis of `this.xxx` assignments in constructors to determine the types of properties that have no type annotations or initializers.

* In `.ts` files we perform control flow analysis for properties declared with no type annotation or initializer when in `noImplicitAny` mode.
* In `.js` files we perform control flow analysis for properties declared with no JSDoc type annotation or initializer, and properties with no explicit declaration but at least one `this.xxx` assignment in the constructor.

In the following example, control flow analysis determines the type of `x` to be `string | number` based on the `this.x` assignments in the constructor:

```ts
// Compile with --noImplicitAny
class C {
    x;  // string | number
    constructor(b: boolean) {
        if (b) {
            this.x = 'hello';
        }
        else {
            this.x = 42;
        }
    }
}
```

In `.js` files we would previously determine the type of a property with no explicit declaration from local analysis of all `this.xxx` assignments seen in the constructor and methods of the class. This analysis is less precise than control flow analysis, but we still use it as a fallback. With the increased precision of control flow analysis we now correctly discover properties that are conditionally (as opposed to definitely) initialized in constructors. We're also able to handle assignments of values that depend on previous assignment to the same property, as well as other scenarios that previously were deemed circular.

The baseline changes are mostly because constructor declared properties are now considered to have type `any` when they are assignment targets in the constructor body. This an effect of how CFA auto-typing works.

Fixes #37900.