### PR TITLE
Fix instantiated check for imports

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -48,12 +48,15 @@ namespace ts {
                 }
                 break;
             // 3. non-exported import declarations
-            case SyntaxKind.ImportDeclaration:
             case SyntaxKind.ImportEqualsDeclaration:
-                if (!(hasModifier(node, ModifierFlags.Export))) {
-                    return ModuleInstanceState.NonInstantiated;
+                if (isExportedInBlock(node as ImportEqualsDeclaration)) {
+                    return ModuleInstanceState.Instantiated;
                 }
-                break;
+                // FALLTHROUGH
+            case SyntaxKind.ImportDeclaration:
+                return hasModifier(node, ModifierFlags.Export) ?
+                    ModuleInstanceState.Instantiated :
+                    ModuleInstanceState.NonInstantiated;
             // 4. Export alias declarations pointing at only uninstantiated modules or things uninstantiated modules contain
             case SyntaxKind.ExportDeclaration:
                 const exportDeclaration = node as ExportDeclaration;
@@ -104,6 +107,43 @@ namespace ts {
                 }
         }
         return ModuleInstanceState.Instantiated;
+    }
+
+    function isExportedInBlock(node: ImportEqualsDeclaration) {
+        const root = findAncestor(node, (n): n is ModuleDeclaration | SourceFile => isModuleDeclaration(n) || isSourceFile(n));
+        if (!root) {
+            return false;
+        }
+        else if (isSourceFile(root)) {
+            return isExportedInBlockWorker(node, root.statements);
+        }
+        else {
+            return root.body && isModuleBlock(root.body) && isExportedInBlockWorker(node, root.body.statements);
+        }
+    }
+
+    function isExportedInBlockWorker(node: ImportEqualsDeclaration, statements: readonly Statement[]): boolean {
+        for (const statement of statements) {
+            switch (statement.kind) {
+                case SyntaxKind.ModuleDeclaration:
+                    const decl = statement as ModuleDeclaration;
+                    return !!decl.body && isModuleBlock(decl.body) && isExportedInBlockWorker(node, decl.body.statements);
+                case SyntaxKind.Block:
+                    // recur on statements
+                    return isExportedInBlockWorker(node, (statement as Block).statements);
+                case SyntaxKind.ExportDeclaration:
+                    // check exportClause.elements
+                    if (isExportDeclaration(statement) && !statement.moduleSpecifier && statement.exportClause && isNamedExports(statement.exportClause)) {
+                        for (const spec of statement.exportClause.elements) {
+                            if (idText(node.name) === idText(spec.propertyName || spec.name)) {
+                                return true;
+                            }
+                        }
+                    }
+                    break;
+            }
+        }
+        return false;
     }
 
     function getModuleInstanceStateForAliasTarget(specifier: ExportSpecifier, visited: Map<ModuleInstanceState | undefined>) {

--- a/tests/baselines/reference/reexportedImportDeclarations.js
+++ b/tests/baselines/reference/reexportedImportDeclarations.js
@@ -1,0 +1,28 @@
+//// [reexportedImportDeclarations.ts]
+declare class C {
+    method(): any;
+}
+
+declare namespace ns1 {
+    export { C as A1 };
+}
+declare namespace ns2 {
+    import A2 = ns1.A1;
+    namespace ns21 {
+        export { A2 as A3 };
+    }
+}
+declare namespace ns3 {
+    import A4 = ns1.A1;
+    export { A4 as A5 };
+}
+
+export class C2 extends ns2.ns21.A3 {}
+export class C3 extends ns3.A5 {}
+
+
+//// [reexportedImportDeclarations.js]
+export class C2 extends ns2.ns21.A3 {
+}
+export class C3 extends ns3.A5 {
+}

--- a/tests/baselines/reference/reexportedImportDeclarations.symbols
+++ b/tests/baselines/reference/reexportedImportDeclarations.symbols
@@ -1,0 +1,58 @@
+=== tests/cases/conformance/internalModules/importDeclarations/reexportedImportDeclarations.ts ===
+declare class C {
+>C : Symbol(C, Decl(reexportedImportDeclarations.ts, 0, 0))
+
+    method(): any;
+>method : Symbol(C.method, Decl(reexportedImportDeclarations.ts, 0, 17))
+}
+
+declare namespace ns1 {
+>ns1 : Symbol(ns1, Decl(reexportedImportDeclarations.ts, 2, 1))
+
+    export { C as A1 };
+>C : Symbol(C, Decl(reexportedImportDeclarations.ts, 0, 0))
+>A1 : Symbol(A1, Decl(reexportedImportDeclarations.ts, 5, 12))
+}
+declare namespace ns2 {
+>ns2 : Symbol(ns2, Decl(reexportedImportDeclarations.ts, 6, 1))
+
+    import A2 = ns1.A1;
+>A2 : Symbol(A2, Decl(reexportedImportDeclarations.ts, 7, 23))
+>ns1 : Symbol(ns1, Decl(reexportedImportDeclarations.ts, 2, 1))
+>A1 : Symbol(ns1.A1, Decl(reexportedImportDeclarations.ts, 5, 12))
+
+    namespace ns21 {
+>ns21 : Symbol(ns21, Decl(reexportedImportDeclarations.ts, 8, 23))
+
+        export { A2 as A3 };
+>A2 : Symbol(A2, Decl(reexportedImportDeclarations.ts, 7, 23))
+>A3 : Symbol(A3, Decl(reexportedImportDeclarations.ts, 10, 16))
+    }
+}
+declare namespace ns3 {
+>ns3 : Symbol(ns3, Decl(reexportedImportDeclarations.ts, 12, 1))
+
+    import A4 = ns1.A1;
+>A4 : Symbol(A4, Decl(reexportedImportDeclarations.ts, 13, 23))
+>ns1 : Symbol(ns1, Decl(reexportedImportDeclarations.ts, 2, 1))
+>A1 : Symbol(ns1.A1, Decl(reexportedImportDeclarations.ts, 5, 12))
+
+    export { A4 as A5 };
+>A4 : Symbol(A4, Decl(reexportedImportDeclarations.ts, 13, 23))
+>A5 : Symbol(A5, Decl(reexportedImportDeclarations.ts, 15, 12))
+}
+
+export class C2 extends ns2.ns21.A3 {}
+>C2 : Symbol(C2, Decl(reexportedImportDeclarations.ts, 16, 1))
+>ns2.ns21.A3 : Symbol(ns2.ns21.A3, Decl(reexportedImportDeclarations.ts, 10, 16))
+>ns2.ns21 : Symbol(ns2.ns21, Decl(reexportedImportDeclarations.ts, 8, 23))
+>ns2 : Symbol(ns2, Decl(reexportedImportDeclarations.ts, 6, 1))
+>ns21 : Symbol(ns2.ns21, Decl(reexportedImportDeclarations.ts, 8, 23))
+>A3 : Symbol(ns2.ns21.A3, Decl(reexportedImportDeclarations.ts, 10, 16))
+
+export class C3 extends ns3.A5 {}
+>C3 : Symbol(C3, Decl(reexportedImportDeclarations.ts, 18, 38))
+>ns3.A5 : Symbol(ns3.A5, Decl(reexportedImportDeclarations.ts, 15, 12))
+>ns3 : Symbol(ns3, Decl(reexportedImportDeclarations.ts, 12, 1))
+>A5 : Symbol(ns3.A5, Decl(reexportedImportDeclarations.ts, 15, 12))
+

--- a/tests/baselines/reference/reexportedImportDeclarations.types
+++ b/tests/baselines/reference/reexportedImportDeclarations.types
@@ -1,0 +1,58 @@
+=== tests/cases/conformance/internalModules/importDeclarations/reexportedImportDeclarations.ts ===
+declare class C {
+>C : C
+
+    method(): any;
+>method : () => any
+}
+
+declare namespace ns1 {
+>ns1 : typeof ns1
+
+    export { C as A1 };
+>C : typeof C
+>A1 : typeof C
+}
+declare namespace ns2 {
+>ns2 : typeof ns2
+
+    import A2 = ns1.A1;
+>A2 : typeof A2
+>ns1 : typeof ns1
+>A1 : A2
+
+    namespace ns21 {
+>ns21 : typeof ns21
+
+        export { A2 as A3 };
+>A2 : typeof A2
+>A3 : typeof A2
+    }
+}
+declare namespace ns3 {
+>ns3 : typeof ns3
+
+    import A4 = ns1.A1;
+>A4 : typeof A4
+>ns1 : typeof ns1
+>A1 : A4
+
+    export { A4 as A5 };
+>A4 : typeof A4
+>A5 : typeof A4
+}
+
+export class C2 extends ns2.ns21.A3 {}
+>C2 : C2
+>ns2.ns21.A3 : C
+>ns2.ns21 : typeof ns2.ns21
+>ns2 : typeof ns2
+>ns21 : typeof ns2.ns21
+>A3 : typeof C
+
+export class C3 extends ns3.A5 {}
+>C3 : C3
+>ns3.A5 : C
+>ns3 : typeof ns3
+>A5 : typeof C
+

--- a/tests/cases/conformance/internalModules/importDeclarations/reexportedImportDeclarations.ts
+++ b/tests/cases/conformance/internalModules/importDeclarations/reexportedImportDeclarations.ts
@@ -1,0 +1,21 @@
+// @target: es2015
+declare class C {
+    method(): any;
+}
+
+declare namespace ns1 {
+    export { C as A1 };
+}
+declare namespace ns2 {
+    import A2 = ns1.A1;
+    namespace ns21 {
+        export { A2 as A3 };
+    }
+}
+declare namespace ns3 {
+    import A4 = ns1.A1;
+    export { A4 as A5 };
+}
+
+export class C2 extends ns2.ns21.A3 {}
+export class C3 extends ns3.A5 {}


### PR DESCRIPTION
Currently, the instantiated check for namespaces assumes that an `import` that doesn't use the `export import` syntax is uninstantiated. This is not correct when the import is exported.

This PR searchs siblings and descendants for exports of the symbol bound by the import.

This is less efficient. I'm thinking about how to improve that.

Fixes #35385