### PR TITLE
Handle non literal computed name when trying to get the name for object literal property name in json object

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7192,10 +7192,6 @@ namespace ts {
             return symbol && getSymbolLinks(symbol).type || getTypeForVariableLikeDeclaration(node, /*includeOptionality*/ false);
         }
 
-        function isComputedNonLiteralName(name: PropertyName): boolean {
-            return name.kind === SyntaxKind.ComputedPropertyName && !isStringOrNumericLiteralLike(name.expression);
-        }
-
         function getRestType(source: Type, properties: PropertyName[], symbol: Symbol | undefined): Type {
             source = filterType(source, t => !(t.flags & TypeFlags.Nullable));
             if (source.flags & TypeFlags.Never) {

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1721,7 +1721,7 @@ namespace ts {
                     errors.push(createDiagnosticForNodeInSourceFile(sourceFile, element.name, Diagnostics.String_literal_with_double_quotes_expected));
                 }
 
-                const textOfKey = getTextOfPropertyName(element.name);
+                const textOfKey = isComputedNonLiteralName(element.name) ? undefined : getTextOfPropertyName(element.name);
                 const keyText = textOfKey && unescapeLeadingUnderscores(textOfKey);
                 const option = keyText && knownOptions ? knownOptions.get(keyText) : undefined;
                 if (keyText && extraKeyDiagnostics && !option) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -876,6 +876,10 @@ namespace ts {
         return info.declaration ? declarationNameToString(info.declaration.parameters[0].name) : undefined;
     }
 
+    export function isComputedNonLiteralName(name: PropertyName): boolean {
+        return name.kind === SyntaxKind.ComputedPropertyName && !isStringOrNumericLiteralLike(name.expression);
+    }
+
     export function getTextOfPropertyName(name: PropertyName | NoSubstitutionTemplateLiteral): __String {
         switch (name.kind) {
             case SyntaxKind.Identifier:

--- a/tests/baselines/reference/requireOfJsonFileWithComputedPropertyName.errors.txt
+++ b/tests/baselines/reference/requireOfJsonFileWithComputedPropertyName.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/compiler/b.json(2,5): error TS1327: String literal with double quotes expected.
+
+
+==== tests/cases/compiler/file1.ts (0 errors) ====
+    import b1 = require('./b.json');
+    let x = b1;
+    import b2 = require('./b.json');
+    if (x) {
+        x = b2;
+    }
+    
+==== tests/cases/compiler/b.json (1 errors) ====
+    {
+        [a]: 10
+        ~~~
+!!! error TS1327: String literal with double quotes expected.
+    }

--- a/tests/baselines/reference/requireOfJsonFileWithComputedPropertyName.js
+++ b/tests/baselines/reference/requireOfJsonFileWithComputedPropertyName.js
@@ -1,0 +1,29 @@
+//// [tests/cases/compiler/requireOfJsonFileWithComputedPropertyName.ts] ////
+
+//// [file1.ts]
+import b1 = require('./b.json');
+let x = b1;
+import b2 = require('./b.json');
+if (x) {
+    x = b2;
+}
+
+//// [b.json]
+{
+    [a]: 10
+}
+
+//// [b.json]
+var _a;
+_a = {},
+    _a[a] = 10,
+    _a;
+//// [file1.js]
+"use strict";
+exports.__esModule = true;
+var b1 = require("./b.json");
+var x = b1;
+var b2 = require("./b.json");
+if (x) {
+    x = b2;
+}

--- a/tests/baselines/reference/requireOfJsonFileWithComputedPropertyName.symbols
+++ b/tests/baselines/reference/requireOfJsonFileWithComputedPropertyName.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/file1.ts ===
+import b1 = require('./b.json');
+>b1 : Symbol(b1, Decl(file1.ts, 0, 0))
+
+let x = b1;
+>x : Symbol(x, Decl(file1.ts, 1, 3))
+>b1 : Symbol(b1, Decl(file1.ts, 0, 0))
+
+import b2 = require('./b.json');
+>b2 : Symbol(b2, Decl(file1.ts, 1, 11))
+
+if (x) {
+>x : Symbol(x, Decl(file1.ts, 1, 3))
+
+    x = b2;
+>x : Symbol(x, Decl(file1.ts, 1, 3))
+>b2 : Symbol(b2, Decl(file1.ts, 1, 11))
+}
+
+=== tests/cases/compiler/b.json ===
+{
+    [a]: 10
+>[a] : Symbol([a], Decl(b.json, 0, 1))
+}

--- a/tests/baselines/reference/requireOfJsonFileWithComputedPropertyName.types
+++ b/tests/baselines/reference/requireOfJsonFileWithComputedPropertyName.types
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/file1.ts ===
+import b1 = require('./b.json');
+>b1 : { [x: number]: number; }
+
+let x = b1;
+>x : { [x: number]: number; }
+>b1 : { [x: number]: number; }
+
+import b2 = require('./b.json');
+>b2 : { [x: number]: number; }
+
+if (x) {
+>x : { [x: number]: number; }
+
+    x = b2;
+>x = b2 : { [x: number]: number; }
+>x : { [x: number]: number; }
+>b2 : { [x: number]: number; }
+}
+
+=== tests/cases/compiler/b.json ===
+{
+>{    [a]: 10} : { [x: number]: number; }
+
+    [a]: 10
+>[a] : number
+>a : any
+>10 : 10
+}

--- a/tests/cases/compiler/requireOfJsonFileWithComputedPropertyName.ts
+++ b/tests/cases/compiler/requireOfJsonFileWithComputedPropertyName.ts
@@ -1,0 +1,15 @@
+// @outdir: out/
+// @resolveJsonModule: true
+
+// @Filename: file1.ts
+import b1 = require('./b.json');
+let x = b1;
+import b2 = require('./b.json');
+if (x) {
+    x = b2;
+}
+
+// @Filename: b.json
+{
+    [a]: 10
+}


### PR DESCRIPTION
Fixes #37984
