### PR TITLE
we can return value from void function

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1143,7 +1143,7 @@ obj[Symbol.toStringTag] = "test";   // Use of well-known symbol
 
 ### <a name="3.2.5"/>3.2.5 The Void Type
 
-The Void type, referenced by the `void` keyword, represents the absence of a value and is used as the return type of functions with no return value.
+The Void type, referenced by the `void` keyword, represents the absence of a value and is used as the return type of functions which doesn't have to return value.
 
 The only possible values for the Void type are `null` and `undefined`. The Void type is a subtype of the Any type and a supertype of the Null and Undefined types, but otherwise Void is unrelated to all other types.
 


### PR DESCRIPTION
We do not have to return a value from void typed function but we can.

```
//Example 1----------------------
type func = ()=>void;
let f1: func;
f1=function(){
  return 'TypeScript';
}

//Example 2---------------------
abstract class Base{
    abstract sayHello(): void;
}

class Child extends Base{
    sayHello() {
        return 123;
    }
}
```

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
