### PR TITLE
Navto covers all projects

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2784,7 +2784,7 @@ namespace ts.server.protocol {
     /**
      * Arguments for navto request message.
      */
-    export interface NavtoRequestArgs extends FileRequestArgs {
+    export interface NavtoRequestArgs {
         /**
          * Search term to navigate to from current location; term can
          * be '.*' or an identifier prefix.
@@ -2794,6 +2794,10 @@ namespace ts.server.protocol {
          *  Optional limit on the number of items to return.
          */
         maxResultCount?: number;
+        /**
+         * The file for the request (absolute pathname required).
+         */
+        file?: string;
         /**
          * Optional flag to indicate we want results for just the current file
          * or the entire project.
@@ -2809,7 +2813,7 @@ namespace ts.server.protocol {
      * match the search term given in argument 'searchTerm'.  The
      * context for the search is given by the named file.
      */
-    export interface NavtoRequest extends FileRequest {
+    export interface NavtoRequest extends Request {
         command: CommandTypes.Navto;
         arguments: NavtoRequestArgs;
     }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1307,8 +1307,8 @@ namespace ts.server {
         private getProjects(args: protocol.FileRequestArgs, getScriptInfoEnsuringProjectsUptoDate?: boolean, ignoreNoProjectError?: boolean): Projects {
             let projects: readonly Project[] | undefined;
             let symLinkedProjects: MultiMap<Project> | undefined;
-            if (args.projectFileName) { // manually specified tsconfig, not sure anybody does this (but be sure to note it in the fix)
-                const project = this.getProject(args.projectFileName); // and we only get here when currentFileOnly is off
+            if (args.projectFileName) {
+                const project = this.getProject(args.projectFileName);
                 if (project) {
                     projects = [project];
                 }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -423,7 +423,7 @@ namespace ts.server {
         let toDo: ProjectAndLocation<TLocation>[] | undefined;
         const seenProjects = createMap<true>();
         forEachProjectInProjects(projects, initialLocation && initialLocation.fileName, (project, path) => {
-            // TLocation shoud be either `DocumentPosition` or `undefined`. Since `initialLocation` is `TLocation` this cast should be valid.
+            // TLocation should be either `DocumentPosition` or `undefined`. Since `initialLocation` is `TLocation` this cast should be valid.
             const location = (initialLocation ? { fileName: path, pos: initialLocation.pos } : undefined) as TLocation;
             toDo = callbackProjectAndLocation(project, location, projectService, toDo, seenProjects, cb);
         });
@@ -447,6 +447,13 @@ namespace ts.server {
                     }
                 });
             }
+        }
+        else {
+            projectService.forEachEnabledProject(project => {
+                if (!addToSeen(seenProjects, project)) return;
+                projectService.loadAncestorProjectTree(seenProjects);
+                toDo = callbackProjectAndLocation(project, undefined as TLocation, projectService, toDo, seenProjects, cb);
+            });
         }
 
         while (toDo && toDo.length) {

--- a/src/testRunner/unittests/tsserver/declarationFileMaps.ts
+++ b/src/testRunner/unittests/tsserver/declarationFileMaps.ts
@@ -63,7 +63,7 @@ namespace ts.projectSystem {
         };
         const aDts: File = {
             path: "/a/bin/a.d.ts",
-            // Need to mangle the sourceMappingURL part or it breaks the build
+            // ${""} is needed to mangle the sourceMappingURL part or it breaks the build
             content: `export declare function fnA(): void;\nexport interface IfaceA {\n}\nexport declare const instanceA: IfaceA;\n//# source${""}MappingURL=a.d.ts.map`,
         };
 
@@ -86,7 +86,7 @@ namespace ts.projectSystem {
             content: JSON.stringify(bDtsMapContent),
         };
         const bDts: File = {
-            // Need to mangle the sourceMappingURL part or it breaks the build
+            // ${""} is need to mangle the sourceMappingURL part so it doesn't break the build
             path: "/b/bin/b.d.ts",
             content: `export declare function fnB(): void;\n//# source${""}MappingURL=b.d.ts.map`,
         };
@@ -114,7 +114,7 @@ namespace ts.projectSystem {
             })
         };
 
-        function makeSampleProjects(addUserTsConfig?: boolean) {
+        function makeSampleProjects(addUserTsConfig?: boolean, keepAllFiles?: boolean) {
             const host = createServerHost([aTs, aTsconfig, aDtsMap, aDts, bTsconfig, bTs, bDtsMap, bDts, ...(addUserTsConfig ? [userTsForConfigProject, userTsconfig] : [userTs]), dummyFile]);
             const session = createSession(host);
 
@@ -122,7 +122,9 @@ namespace ts.projectSystem {
             checkDeclarationFiles(bTs, session, [bDtsMap, bDts]);
 
             // Testing what happens if we delete the original sources.
-            host.deleteFile(bTs.path);
+            if (!keepAllFiles) {
+                host.deleteFile(bTs.path);
+            }
 
             openFilesForSession([userTs], session);
             const service = session.getProjectService();
@@ -320,6 +322,46 @@ namespace ts.projectSystem {
             ]);
 
             verifyATsConfigOriginalProject(session);
+        });
+
+        it("navigateToAll", () => {
+            const session = makeSampleProjects(/*addUserTsConfig*/ true, /*keepAllFiles*/ true);
+            const response = executeSessionRequest<protocol.NavtoRequest, protocol.NavtoResponse>(session, CommandNames.Navto, { file: undefined, searchValue: "fn" });
+            assert.deepEqual<readonly protocol.NavtoItem[] | undefined>(response, [
+                {
+                    ...protocolFileSpanFromSubstring({
+                        file: bTs,
+                        text: "export function fnB() {}"
+                    }),
+                    name: "fnB",
+                    matchKind: "prefix",
+                    isCaseSensitive: true,
+                    kind: ScriptElementKind.functionElement,
+                    kindModifiers: "export",
+                },
+                {
+                    ...protocolFileSpanFromSubstring({
+                        file: aTs,
+                        text: "export function fnA() {}"
+                    }),
+                    name: "fnA",
+                    matchKind: "prefix",
+                    isCaseSensitive: true,
+                    kind: ScriptElementKind.functionElement,
+                    kindModifiers: "export",
+                },
+                {
+                    ...protocolFileSpanFromSubstring({
+                        file: userTs,
+                        text: "export function fnUser() { a.fnA(); b.fnB(); a.instanceA; }"
+                    }),
+                    name: "fnUser",
+                    matchKind: "prefix",
+                    isCaseSensitive: true,
+                    kind: ScriptElementKind.functionElement,
+                    kindModifiers: "export",
+                }
+            ]);
         });
 
         const referenceATs = (aTs: File): protocol.ReferencesResponseItem => makeReferenceItem({

--- a/src/testRunner/unittests/tsserver/declarationFileMaps.ts
+++ b/src/testRunner/unittests/tsserver/declarationFileMaps.ts
@@ -324,7 +324,7 @@ namespace ts.projectSystem {
             verifyATsConfigOriginalProject(session);
         });
 
-        it("navigateToAll", () => {
+        it("navigateToAll -- when neither file nor project is specified", () => {
             const session = makeSampleProjects(/*addUserTsConfig*/ true, /*keepAllFiles*/ true);
             const response = executeSessionRequest<protocol.NavtoRequest, protocol.NavtoResponse>(session, CommandNames.Navto, { file: undefined, searchValue: "fn" });
             assert.deepEqual<readonly protocol.NavtoItem[] | undefined>(response, [
@@ -356,6 +356,24 @@ namespace ts.projectSystem {
                         text: "export function fnUser() { a.fnA(); b.fnB(); a.instanceA; }"
                     }),
                     name: "fnUser",
+                    matchKind: "prefix",
+                    isCaseSensitive: true,
+                    kind: ScriptElementKind.functionElement,
+                    kindModifiers: "export",
+                }
+            ]);
+        });
+
+        it("navigateToAll -- when file is not specified but project is", () => {
+            const session = makeSampleProjects(/*addUserTsConfig*/ true, /*keepAllFiles*/ true);
+            const response = executeSessionRequest<protocol.NavtoRequest, protocol.NavtoResponse>(session, CommandNames.Navto, { projectFileName: bTsconfig.path, file: undefined, searchValue: "fn" });
+            assert.deepEqual<readonly protocol.NavtoItem[] | undefined>(response, [
+                {
+                    ...protocolFileSpanFromSubstring({
+                        file: bTs,
+                        text: "export function fnB() {}"
+                    }),
+                    name: "fnB",
                     matchKind: "prefix",
                     isCaseSensitive: true,
                     kind: ScriptElementKind.functionElement,

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8319,7 +8319,7 @@ declare namespace ts.server.protocol {
     /**
      * Arguments for navto request message.
      */
-    interface NavtoRequestArgs extends FileRequestArgs {
+    interface NavtoRequestArgs {
         /**
          * Search term to navigate to from current location; term can
          * be '.*' or an identifier prefix.
@@ -8329,6 +8329,10 @@ declare namespace ts.server.protocol {
          *  Optional limit on the number of items to return.
          */
         maxResultCount?: number;
+        /**
+         * The file for the request (absolute pathname required).
+         */
+        file?: string;
         /**
          * Optional flag to indicate we want results for just the current file
          * or the entire project.
@@ -8342,7 +8346,7 @@ declare namespace ts.server.protocol {
      * match the search term given in argument 'searchTerm'.  The
      * context for the search is given by the named file.
      */
-    interface NavtoRequest extends FileRequest {
+    interface NavtoRequest extends Request {
         command: CommandTypes.Navto;
         arguments: NavtoRequestArgs;
     }


### PR DESCRIPTION
With this PR, when navto is called without a file, it returns matches from all projects. Currently it only returns matches from the current project and its dependencies.

I had to change the protocol interface for this, and I'm not sure I did that in the right way. I'm also not sure what tests to write for this feature, beyond the basic one I have.

Fixes #2530
