### PR TITLE
Fix doc comment template on assignment expressions

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -363,6 +363,8 @@ namespace ts.JsDoc {
                 // want to give back a JSDoc template for the 'b' or 'c' in 'namespace a.b.c { }'.
                 return commentOwner.parent.kind === SyntaxKind.ModuleDeclaration ? undefined : { commentOwner };
 
+            case SyntaxKind.ExpressionStatement:
+                return getCommentOwnerInfoWorker((commentOwner as ExpressionStatement).expression);
             case SyntaxKind.BinaryExpression: {
                 const be = commentOwner as BinaryExpression;
                 if (getAssignmentDeclarationKind(be) === AssignmentDeclarationKind.None) {

--- a/tests/cases/fourslash/docCommentTemplateExportAssignmentJS.ts
+++ b/tests/cases/fourslash/docCommentTemplateExportAssignmentJS.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: index.js
+//// /** /**/ */
+//// exports.foo = (a) => {};
+
+
+verify.docCommentTemplateAt("", 8,
+`/**
+ * 
+ * @param {any} a
+ */`);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

The trick is including the initial `/** */` characters in the fourslash content, as that more accurately represents the state of the file when VS Code sends the request. Without that, the token at the request position would be `exports`, giving you the opportunity to walk up the parse tree through `BinaryExpression`, which was already accounted for. But if you start inside an empty JSDoc comment, you only walk through `JSDocComment` -> `ExpressionStatement` -> `SourceFile`.

Fixes #30848
