### PR TITLE
Propagate nonInferrableType in &&, || and ?? operators

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28332,15 +28332,18 @@ namespace ts {
                 case SyntaxKind.InKeyword:
                     return checkInExpression(left, right, leftType, rightType);
                 case SyntaxKind.AmpersandAmpersandToken:
-                    return getTypeFacts(leftType) & TypeFacts.Truthy ?
+                    return leftType === nonInferrableType || rightType === nonInferrableType ? nonInferrableType :
+                        getTypeFacts(leftType) & TypeFacts.Truthy ?
                         getUnionType([extractDefinitelyFalsyTypes(strictNullChecks ? leftType : getBaseTypeOfLiteralType(rightType)), rightType]) :
                         leftType;
                 case SyntaxKind.BarBarToken:
-                    return getTypeFacts(leftType) & TypeFacts.Falsy ?
+                    return leftType === nonInferrableType || rightType === nonInferrableType ? nonInferrableType :
+                        getTypeFacts(leftType) & TypeFacts.Falsy && leftType !== nonInferrableType ?
                         getUnionType([removeDefinitelyFalsyTypes(leftType), rightType], UnionReduction.Subtype) :
                         leftType;
                 case SyntaxKind.QuestionQuestionToken:
-                    return getTypeFacts(leftType) & TypeFacts.EQUndefinedOrNull ?
+                    return leftType === nonInferrableType || rightType === nonInferrableType ? nonInferrableType :
+                        getTypeFacts(leftType) & TypeFacts.EQUndefinedOrNull && leftType !== nonInferrableType ?
                         getUnionType([getNonNullableType(leftType), rightType], UnionReduction.Subtype) :
                         leftType;
                 case SyntaxKind.EqualsToken:

--- a/tests/baselines/reference/propagateNonInferrableType.js
+++ b/tests/baselines/reference/propagateNonInferrableType.js
@@ -1,0 +1,10 @@
+//// [propagateNonInferrableType.ts]
+declare function resolver<T>(): () => void;
+declare function wrapResolver<T>(resolverFunction: () => void): void;
+
+wrapResolver(resolver() || []);
+
+
+//// [propagateNonInferrableType.js]
+"use strict";
+wrapResolver(resolver() || []);

--- a/tests/baselines/reference/propagateNonInferrableType.symbols
+++ b/tests/baselines/reference/propagateNonInferrableType.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/propagateNonInferrableType.ts ===
+declare function resolver<T>(): () => void;
+>resolver : Symbol(resolver, Decl(propagateNonInferrableType.ts, 0, 0))
+>T : Symbol(T, Decl(propagateNonInferrableType.ts, 0, 26))
+
+declare function wrapResolver<T>(resolverFunction: () => void): void;
+>wrapResolver : Symbol(wrapResolver, Decl(propagateNonInferrableType.ts, 0, 43))
+>T : Symbol(T, Decl(propagateNonInferrableType.ts, 1, 30))
+>resolverFunction : Symbol(resolverFunction, Decl(propagateNonInferrableType.ts, 1, 33))
+
+wrapResolver(resolver() || []);
+>wrapResolver : Symbol(wrapResolver, Decl(propagateNonInferrableType.ts, 0, 43))
+>resolver : Symbol(resolver, Decl(propagateNonInferrableType.ts, 0, 0))
+

--- a/tests/baselines/reference/propagateNonInferrableType.types
+++ b/tests/baselines/reference/propagateNonInferrableType.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/propagateNonInferrableType.ts ===
+declare function resolver<T>(): () => void;
+>resolver : <T>() => () => void
+
+declare function wrapResolver<T>(resolverFunction: () => void): void;
+>wrapResolver : <T>(resolverFunction: () => void) => void
+>resolverFunction : () => void
+
+wrapResolver(resolver() || []);
+>wrapResolver(resolver() || []) : void
+>wrapResolver : <T>(resolverFunction: () => void) => void
+>resolver() || [] : () => void
+>resolver() : () => void
+>resolver : <T>() => () => void
+>[] : never[]
+

--- a/tests/cases/compiler/propagateNonInferrableType.ts
+++ b/tests/cases/compiler/propagateNonInferrableType.ts
@@ -1,0 +1,6 @@
+// @strict: true
+
+declare function resolver<T>(): () => void;
+declare function wrapResolver<T>(resolverFunction: () => void): void;
+
+wrapResolver(resolver() || []);


### PR DESCRIPTION
Fixes #37974.