### PR TITLE
allow consecutive newlines in jsdoc tag comments

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7440,11 +7440,9 @@ namespace ts {
                     loop: while (true) {
                         switch (tok) {
                             case SyntaxKind.NewLineTrivia:
-                                if (state >= JSDocState.SawAsterisk) {
-                                    state = JSDocState.BeginningOfLine;
-                                    // don't use pushComment here because we want to keep the margin unchanged
-                                    comments.push(scanner.getTokenText());
-                                }
+                                state = JSDocState.BeginningOfLine;
+                                // don't use pushComment here because we want to keep the margin unchanged
+                                comments.push(scanner.getTokenText());
                                 indent = 0;
                                 break;
                             case SyntaxKind.AtToken:

--- a/src/testRunner/unittests/jsDocParsing.ts
+++ b/src/testRunner/unittests/jsDocParsing.ts
@@ -321,6 +321,12 @@ namespace ts {
  * @author John Doe <john.doe@example.com>
  * @author John Doe <john.doe@example.com> unexpected comment
  */`);
+
+                parsesCorrectly("consecutive newline tokens",
+                    `/**
+ * @example
+ * Some\n\n * text\r\n * with newlines.
+ */`);
             });
         });
         describe("getFirstToken", () => {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.consecutive newline tokens.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.consecutive newline tokens.json
@@ -1,0 +1,31 @@
+{
+    "kind": "JSDocComment",
+    "pos": 0,
+    "end": 55,
+    "flags": "JSDoc",
+    "modifierFlagsCache": 0,
+    "transformFlags": 0,
+    "tags": {
+        "0": {
+            "kind": "JSDocTag",
+            "pos": 7,
+            "end": 19,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 8,
+                "end": 15,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "example"
+            },
+            "comment": "Some\n\ntext\r\nwith newlines."
+        },
+        "length": 1,
+        "pos": 7,
+        "end": 19,
+        "hasTrailingComma": false,
+        "transformFlags": 0
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] There is an associated issue in the `Backlog` milestone (**required**)
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `gulp runtests` locally
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #35511

The parser for JSDoc tag comments currently skips successive `NewLineTrivia` tokens. 
In files using CRLF line endings, this leads to only `\r` being retained in the node, which can cause issues for tooling.
This PR removes that restriction, such that all `NewLineTrivia` tokens are persisted in the node.
