### PR TITLE
fix(38080): Add outlining spans for 'type' declarations

### DIFF
--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -199,6 +199,7 @@ namespace ts.OutliningElementsCollector {
             case SyntaxKind.InterfaceDeclaration:
             case SyntaxKind.EnumDeclaration:
             case SyntaxKind.CaseBlock:
+            case SyntaxKind.TypeLiteral:
                 return spanForNode(n);
             case SyntaxKind.CaseClause:
             case SyntaxKind.DefaultClause:

--- a/tests/cases/fourslash/getOutliningForTypeLiteral.ts
+++ b/tests/cases/fourslash/getOutliningForTypeLiteral.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts"/>
+
+////type A =[| {
+////    a: number;
+////}|]
+////
+////type B =[| {
+////   a:[| {
+////       a1:[| {
+////           a2:[| {
+////               x: number;
+////               y: number;
+////           }|]
+////       }|]
+////   }|],
+////   b:[| {
+////       x: number;
+////   }|],
+////   c:[| {
+////       x: number;
+////   }|]
+////}|]
+
+verify.outliningSpansInCurrentFile(test.ranges(), "code");


### PR DESCRIPTION
Fixes #38080