### PR TITLE
Skip comparing optional property flag when comparing against discriminant properties

### DIFF
--- a/tests/baselines/reference/unionRelationshipCheckPasses.js
+++ b/tests/baselines/reference/unionRelationshipCheckPasses.js
@@ -1,0 +1,7 @@
+//// [unionRelationshipCheckPasses.ts]
+const item: { foo?: undefined } | { foo: number } = null as any as { foo?: number | undefined };
+
+
+//// [unionRelationshipCheckPasses.js]
+"use strict";
+var item = null;

--- a/tests/baselines/reference/unionRelationshipCheckPasses.symbols
+++ b/tests/baselines/reference/unionRelationshipCheckPasses.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/unionRelationshipCheckPasses.ts ===
+const item: { foo?: undefined } | { foo: number } = null as any as { foo?: number | undefined };
+>item : Symbol(item, Decl(unionRelationshipCheckPasses.ts, 0, 5))
+>foo : Symbol(foo, Decl(unionRelationshipCheckPasses.ts, 0, 13))
+>foo : Symbol(foo, Decl(unionRelationshipCheckPasses.ts, 0, 35))
+>foo : Symbol(foo, Decl(unionRelationshipCheckPasses.ts, 0, 68))
+

--- a/tests/baselines/reference/unionRelationshipCheckPasses.types
+++ b/tests/baselines/reference/unionRelationshipCheckPasses.types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/unionRelationshipCheckPasses.ts ===
+const item: { foo?: undefined } | { foo: number } = null as any as { foo?: number | undefined };
+>item : { foo?: undefined; } | { foo: number; }
+>foo : undefined
+>foo : number
+>null as any as { foo?: number | undefined } : { foo?: number | undefined; }
+>null as any : any
+>null : null
+>foo : number | undefined
+

--- a/tests/cases/compiler/unionRelationshipCheckPasses.ts
+++ b/tests/cases/compiler/unionRelationshipCheckPasses.ts
@@ -1,0 +1,2 @@
+// @strict: true
+const item: { foo?: undefined } | { foo: number } = null as any as { foo?: number | undefined };


### PR DESCRIPTION
When `strictNullChecks` is on. When that's the case, `{x: string | undefined}` and `{x?: string | undefined}` should now both match `{x: string} | {x?: undefined}` and `{x: string} | {x: undefined}`. (Since an optional `undefined` is the same as an `undefined` field in everything except what we require be written in declarations).

Fixes #35204
