### PR TITLE
Filter undefined only in binding patterns in parameters w/initialiser

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7306,7 +7306,7 @@ namespace ts {
                 parentType = getNonNullableType(parentType);
             }
             // Filter `undefined` from the type we check against if the parent has an initializer (which handles the `undefined` case implicitly)
-            else if (strictNullChecks && pattern.parent.initializer) {
+            else if (strictNullChecks && pattern.parent.initializer && isParameter(pattern.parent)) {
                 parentType = getTypeWithFacts(parentType, TypeFacts.NEUndefined);
             }
 

--- a/tests/baselines/reference/contextualTypeForInitalizedVariablesFiltersUndefined.errors.txt
+++ b/tests/baselines/reference/contextualTypeForInitalizedVariablesFiltersUndefined.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/contextualTypeForInitalizedVariablesFiltersUndefined.ts(7,9): error TS2339: Property 's' does not exist on type '{ s: string; } | undefined'.
+
+
+==== tests/cases/compiler/contextualTypeForInitalizedVariablesFiltersUndefined.ts (1 errors) ====
+    const fInferred = ({ a = 0 } = {}) => a;
+    // const fInferred: ({ a }?: { a?: number; }) => number
+    
+    const fAnnotated: typeof fInferred = ({ a = 0 } = {}) => a;
+    
+    declare var t: { s: string } | undefined;
+    const { s } = t;
+            ~
+!!! error TS2339: Property 's' does not exist on type '{ s: string; } | undefined'.
+    

--- a/tests/baselines/reference/contextualTypeForInitalizedVariablesFiltersUndefined.js
+++ b/tests/baselines/reference/contextualTypeForInitalizedVariablesFiltersUndefined.js
@@ -4,6 +4,10 @@ const fInferred = ({ a = 0 } = {}) => a;
 
 const fAnnotated: typeof fInferred = ({ a = 0 } = {}) => a;
 
+declare var t: { s: string } | undefined;
+const { s } = t;
+
+
 //// [contextualTypeForInitalizedVariablesFiltersUndefined.js]
 "use strict";
 var fInferred = function (_a) {
@@ -15,3 +19,4 @@ var fAnnotated = function (_a) {
     var _b = (_a === void 0 ? {} : _a).a, a = _b === void 0 ? 0 : _b;
     return a;
 };
+var s = t.s;

--- a/tests/baselines/reference/contextualTypeForInitalizedVariablesFiltersUndefined.symbols
+++ b/tests/baselines/reference/contextualTypeForInitalizedVariablesFiltersUndefined.symbols
@@ -12,3 +12,11 @@ const fAnnotated: typeof fInferred = ({ a = 0 } = {}) => a;
 >a : Symbol(a, Decl(contextualTypeForInitalizedVariablesFiltersUndefined.ts, 3, 39))
 >a : Symbol(a, Decl(contextualTypeForInitalizedVariablesFiltersUndefined.ts, 3, 39))
 
+declare var t: { s: string } | undefined;
+>t : Symbol(t, Decl(contextualTypeForInitalizedVariablesFiltersUndefined.ts, 5, 11))
+>s : Symbol(s, Decl(contextualTypeForInitalizedVariablesFiltersUndefined.ts, 5, 16))
+
+const { s } = t;
+>s : Symbol(s, Decl(contextualTypeForInitalizedVariablesFiltersUndefined.ts, 6, 7))
+>t : Symbol(t, Decl(contextualTypeForInitalizedVariablesFiltersUndefined.ts, 5, 11))
+

--- a/tests/baselines/reference/contextualTypeForInitalizedVariablesFiltersUndefined.types
+++ b/tests/baselines/reference/contextualTypeForInitalizedVariablesFiltersUndefined.types
@@ -18,3 +18,11 @@ const fAnnotated: typeof fInferred = ({ a = 0 } = {}) => a;
 >{} : {}
 >a : number
 
+declare var t: { s: string } | undefined;
+>t : { s: string; } | undefined
+>s : string
+
+const { s } = t;
+>s : any
+>t : { s: string; } | undefined
+

--- a/tests/cases/compiler/contextualTypeForInitalizedVariablesFiltersUndefined.ts
+++ b/tests/cases/compiler/contextualTypeForInitalizedVariablesFiltersUndefined.ts
@@ -3,3 +3,6 @@ const fInferred = ({ a = 0 } = {}) => a;
 // const fInferred: ({ a }?: { a?: number; }) => number
 
 const fAnnotated: typeof fInferred = ({ a = 0 } = {}) => a;
+
+declare var t: { s: string } | undefined;
+const { s } = t;


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/pull/37309 removes undefined from the type of any binding pattern whose parent has an initialiser. But this is only correct when the initialiser is for a parameter. Here's a counter-example:

```ts
declare let x: { s: string } | undefined;
const { s } = x;
```

This PR removes undefined from the type of a binding pattern only when
the binding pattern's parent is a parameter. This fixes the regression
from 3.8. However, it's still not the ideal fix; we should be able to
use control flow to solve this problem. Consider:

```ts
const { s }: { s: string } | undefined = { s: 'hi' }
declare function f({ s }: { s: string } | undefined = { s: 'hi' }): void
```

Neither line should have an error, but the first does in 3.8 and after
this change.

Fixes #38110