### PR TITLE
Fix temp variable scoping in async generators

### DIFF
--- a/src/compiler/transformers/es2018.ts
+++ b/src/compiler/transformers/es2018.ts
@@ -1115,7 +1115,7 @@ namespace ts {
         context.requestEmitHelper(asyncGeneratorHelper);
 
         // Mark this node as originally an async function
-        (generatorFunc.emitNode || (generatorFunc.emitNode = {} as EmitNode)).flags |= EmitFlags.AsyncFunctionBody;
+        (generatorFunc.emitNode || (generatorFunc.emitNode = {} as EmitNode)).flags |= EmitFlags.AsyncFunctionBody | EmitFlags.ReuseTempVariableScope;
 
         return createCall(
             getUnscopedHelperName("__asyncGenerator"),

--- a/tests/baselines/reference/nullishCoalescingOperatorInAsyncGenerator(target=es2015).js
+++ b/tests/baselines/reference/nullishCoalescingOperatorInAsyncGenerator(target=es2015).js
@@ -1,0 +1,21 @@
+//// [nullishCoalescingOperatorInAsyncGenerator.ts]
+// https://github.com/microsoft/TypeScript/issues/37686
+async function* f(a: { b?: number }) {
+    let c = a.b ?? 10;
+    while (c) {
+        yield c--;
+    }
+}
+
+
+//// [nullishCoalescingOperatorInAsyncGenerator.js]
+// https://github.com/microsoft/TypeScript/issues/37686
+function f(a) {
+    var _a;
+    return __asyncGenerator(this, arguments, function* f_1() {
+        let c = (_a = a.b) !== null && _a !== void 0 ? _a : 10;
+        while (c) {
+            yield yield __await(c--);
+        }
+    });
+}

--- a/tests/baselines/reference/nullishCoalescingOperatorInAsyncGenerator(target=es5).js
+++ b/tests/baselines/reference/nullishCoalescingOperatorInAsyncGenerator(target=es5).js
@@ -1,0 +1,33 @@
+//// [nullishCoalescingOperatorInAsyncGenerator.ts]
+// https://github.com/microsoft/TypeScript/issues/37686
+async function* f(a: { b?: number }) {
+    let c = a.b ?? 10;
+    while (c) {
+        yield c--;
+    }
+}
+
+
+//// [nullishCoalescingOperatorInAsyncGenerator.js]
+// https://github.com/microsoft/TypeScript/issues/37686
+function f(a) {
+    var _a;
+    return __asyncGenerator(this, arguments, function f_1() {
+        var c;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    c = (_a = a.b) !== null && _a !== void 0 ? _a : 10;
+                    _b.label = 1;
+                case 1:
+                    if (!c) return [3 /*break*/, 4];
+                    return [4 /*yield*/, __await(c--)];
+                case 2: return [4 /*yield*/, _b.sent()];
+                case 3:
+                    _b.sent();
+                    return [3 /*break*/, 1];
+                case 4: return [2 /*return*/];
+            }
+        });
+    });
+}

--- a/tests/baselines/reference/nullishCoalescingOperatorInAsyncGenerator(target=esnext).js
+++ b/tests/baselines/reference/nullishCoalescingOperatorInAsyncGenerator(target=esnext).js
@@ -1,0 +1,18 @@
+//// [nullishCoalescingOperatorInAsyncGenerator.ts]
+// https://github.com/microsoft/TypeScript/issues/37686
+async function* f(a: { b?: number }) {
+    let c = a.b ?? 10;
+    while (c) {
+        yield c--;
+    }
+}
+
+
+//// [nullishCoalescingOperatorInAsyncGenerator.js]
+// https://github.com/microsoft/TypeScript/issues/37686
+async function* f(a) {
+    let c = a.b ?? 10;
+    while (c) {
+        yield c--;
+    }
+}

--- a/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperatorInAsyncGenerator.ts
+++ b/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperatorInAsyncGenerator.ts
@@ -1,0 +1,12 @@
+// @target: esnext,es2015,es5
+// @lib: esnext
+// @noEmitHelpers: true
+// @noTypesAndSymbols: true
+
+// https://github.com/microsoft/TypeScript/issues/37686
+async function* f(a: { b?: number }) {
+    let c = a.b ?? 10;
+    while (c) {
+        yield c--;
+    }
+}


### PR DESCRIPTION
Fixes a bug where we were generating temporary variables in a downlevel async generator that collided with temporary variables from prior transformations. This was happening because we were treating the function in `asyncGenerator(this, arguments, function () { ... })` as a temporary variable scope, however we should not reset temporary variables in this scope.

Fixes #37686
Fixes #37418
Supersedes #37484