### PR TITLE
Have the `ChangeTracker` filter out edits that are no-ops

### DIFF
--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -37,14 +37,7 @@ namespace ts.OrganizeImports {
             organizeImportsWorker(ambientModuleExportDecls, coalesceExports);
         }
 
-        const calculatedChanges = changeTracker.getChanges();
-        return calculatedChanges.filter(fileTextChanges => {
-            const file = Debug.checkDefined(program.getSourceFile(fileTextChanges.fileName));
-            return fileTextChanges.textChanges.every(textChange => {
-                const span = textChange.span;
-                return file.text.substr(span.start, span.length) !== textChange.newText;
-            });
-        });
+        return changeTracker.getChanges();
 
         function organizeImportsWorker<T extends ImportDeclaration | ExportDeclaration>(
             oldImportDecls: readonly T[],

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -37,7 +37,14 @@ namespace ts.OrganizeImports {
             organizeImportsWorker(ambientModuleExportDecls, coalesceExports);
         }
 
-        return changeTracker.getChanges();
+        const calculatedChanges = changeTracker.getChanges();
+        return calculatedChanges.filter(fileTextChanges => {
+            const file = Debug.checkDefined(program.getSourceFile(fileTextChanges.fileName));
+            return fileTextChanges.textChanges.every(textChange => {
+                const span = textChange.span;
+                return file.text.substr(span.start, span.length) !== textChange.newText;
+            });
+        });
 
         function organizeImportsWorker<T extends ImportDeclaration | ExportDeclaration>(
             oldImportDecls: readonly T[],

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -873,7 +873,7 @@ namespace ts.textChanges {
 
     namespace changesToText {
         export function getTextChangesFromChanges(changes: readonly Change[], newLineCharacter: string, formatContext: formatting.FormatContext, validate: ValidateNonFormattedText | undefined): FileTextChanges[] {
-            return group(changes, c => c.sourceFile.path).map(changesInFile => {
+            return mapDefined(group(changes, c => c.sourceFile.path), changesInFile => {
                 const sourceFile = changesInFile[0].sourceFile;
                 // order changes by start position
                 // If the start position is the same, put the shorter range first, since an empty range (x, x) may precede (x, y) but not vice-versa.
@@ -883,9 +883,22 @@ namespace ts.textChanges {
                     Debug.assert(normalized[i].range.end <= normalized[i + 1].range.pos, "Changes overlap", () =>
                         `${JSON.stringify(normalized[i].range)} and ${JSON.stringify(normalized[i + 1].range)}`);
                 }
-                const textChanges = normalized.map(c =>
+                const naiveTextChanges = normalized.map(c =>
                     createTextChange(createTextSpanFromRange(c.range), computeNewText(c, sourceFile, newLineCharacter, formatContext, validate)));
-                return { fileName: sourceFile.fileName, textChanges };
+
+                // Only return changes that will actually have an impact on the file.
+                const textChanges = naiveTextChanges.filter(({ span, newText }) => {
+                    // The new text occupies a different amount of space from the old text.
+                    // It has to impact the file, so we'll keep it.
+                    if (span.length !== newText.length) {
+                        return true;
+                    }
+
+                    // The text differs, so keep it.
+                    return sourceFile.text.indexOf(newText, span.start) !== span.start;
+                });
+
+                return textChanges.length > 0 ? { fileName: sourceFile.fileName, textChanges } : undefined;
             });
         }
 

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -895,7 +895,7 @@ namespace ts.textChanges {
                     }
 
                     // The text differs, so keep it.
-                    return sourceFile.text.indexOf(newText, span.start) !== span.start;
+                    return !stringContainsAt(sourceFile.text, newText, span.start);
                 });
 
                 return textChanges.length > 0 ? { fileName: sourceFile.fileName, textChanges } : undefined;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2818,6 +2818,35 @@ namespace ts {
         return symbol.name;
     }
 
+    /**
+     * Useful to check whether a string contains another string at a specific index
+     * without allocating another string or traversing the entire contents of the outer string.
+     *
+     * This function is useful in place of either of the following:
+     *
+     * ```ts
+     * // Allocates
+     * haystack.substr(startIndex, startIndex + needle.length) === needle
+     *
+     * // Full traversal
+     * haystack.indexOf(needle, startIndex) === startIndex
+     * ```
+     *
+     * @param haystack The string that potentially contains `needle`.
+     * @param needle The string whose content might sit within `haystack`.
+     * @param startIndex The index within `haystack` to start searching for `needle`.
+     */
+    export function stringContainsAt(haystack: string, needle: string, startIndex: number) {
+        const needleLength = needle.length;
+        if (needleLength + startIndex > haystack.length) {
+            return false;
+        }
+        for (let i = 0; i < needleLength; i++) {
+            if (needle.charCodeAt(i) !== haystack.charCodeAt(i + startIndex)) return false;
+        }
+        return true;
+    }
+
     export function startsWithUnderscore(name: string): boolean {
         return name.charCodeAt(0) === CharacterCodes._;
     }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2826,7 +2826,7 @@ namespace ts {
      *
      * ```ts
      * // Allocates
-     * haystack.substr(startIndex, startIndex + needle.length) === needle
+     * haystack.substr(startIndex, needle.length) === needle
      *
      * // Full traversal
      * haystack.indexOf(needle, startIndex) === startIndex

--- a/src/testRunner/unittests/services/organizeImports.ts
+++ b/src/testRunner/unittests/services/organizeImports.ts
@@ -285,6 +285,7 @@ namespace ts {
             });
         });
 
+
         describe("Baselines", () => {
 
             const libFile = {
@@ -321,6 +322,16 @@ export const Other = 1;
                 const testFile = {
                     path: "/a.ts",
                     content: "declare module '*';",
+                };
+                const languageService = makeLanguageService(testFile);
+                const changes = languageService.organizeImports({ type: "file", fileName: testFile.path }, testFormatSettings, emptyOptions);
+                assert.isEmpty(changes);
+            });
+
+            it("doesn't return any changes when the text would be identical", () => {
+                const testFile = {
+                    path: "/a.ts",
+                    content: `import { f } from 'foo';\nf();`
                 };
                 const languageService = makeLanguageService(testFile);
                 const changes = languageService.organizeImports({ type: "file", fileName: testFile.path }, testFormatSettings, emptyOptions);
@@ -366,6 +377,16 @@ D();
                 },
                 libFile);
 
+                it("doesn't return any changes when the text would be identical", () => {
+                    const testFile = {
+                        path: "/a.ts",
+                        content: `import { f } from 'foo';\nf();`
+                    };
+                    const languageService = makeLanguageService(testFile);
+                    const changes = languageService.organizeImports({ type: "file", fileName: testFile.path }, testFormatSettings, emptyOptions);
+                    assert.isEmpty(changes);
+                });
+
             testOrganizeImports("Unused_All",
                 {
                     path: "/test.ts",
@@ -377,14 +398,17 @@ import D from "lib";
                 },
                 libFile);
 
-            testOrganizeImports("Unused_Empty",
-                {
+            it("Unused_Empty", () => {
+                const testFile = {
                     path: "/test.ts",
                     content: `
 import { } from "lib";
 `,
-                },
-                libFile);
+                };
+                const languageService = makeLanguageService(testFile);
+                const changes = languageService.organizeImports({ type: "file", fileName: testFile.path }, testFormatSettings, emptyOptions);
+                assert.isEmpty(changes);
+            });
 
             testOrganizeImports("Unused_false_positive_module_augmentation",
                 {
@@ -414,25 +438,33 @@ declare module 'caseless' {
         test(name: KeyType): boolean;
     }
 }`
-                });
+            });
 
-            testOrganizeImports("Unused_false_positive_shorthand_assignment",
-                {
+            it("Unused_false_positive_shorthand_assignment", () => {
+                const testFile = {
                     path: "/test.ts",
                     content: `
 import { x } from "a";
 const o = { x };
 `
-                });
+                };
+                const languageService = makeLanguageService(testFile);
+                const changes = languageService.organizeImports({ type: "file", fileName: testFile.path }, testFormatSettings, emptyOptions);
+                assert.isEmpty(changes);
+            });
 
-            testOrganizeImports("Unused_false_positive_export_shorthand",
-                {
+            it("Unused_false_positive_export_shorthand", () => {
+                const testFile = {
                     path: "/test.ts",
                     content: `
 import { x } from "a";
 export { x };
 `
-                });
+                };
+                const languageService = makeLanguageService(testFile);
+                const changes = languageService.organizeImports({ type: "file", fileName: testFile.path }, testFormatSettings, emptyOptions);
+                assert.isEmpty(changes);
+            });
 
             testOrganizeImports("MoveToTop",
                 {


### PR DESCRIPTION
Fixes #22912