### PR TITLE
Fix `updateBinary` `operator` parameter

### DIFF
--- a/src/compiler/factoryPublic.ts
+++ b/src/compiler/factoryPublic.ts
@@ -1412,9 +1412,11 @@ namespace ts {
     }
 
     export function updateBinary(node: BinaryExpression, left: Expression, right: Expression, operator?: BinaryOperator | BinaryOperatorToken) {
+        const nextOperator = operator ?? node.operatorToken;
         return node.left !== left
             || node.right !== right
-            ? updateNode(createBinary(left, operator || node.operatorToken, right), node)
+            || node.operatorToken !== nextOperator
+            ? updateNode(createBinary(left, nextOperator, right), node)
             : node;
     }
 

--- a/src/compiler/factoryPublic.ts
+++ b/src/compiler/factoryPublic.ts
@@ -1411,12 +1411,11 @@ namespace ts {
         return node;
     }
 
-    export function updateBinary(node: BinaryExpression, left: Expression, right: Expression, operator?: BinaryOperator | BinaryOperatorToken) {
-        const nextOperator = operator ?? node.operatorToken;
+    export function updateBinary(node: BinaryExpression, left: Expression, right: Expression, operator: BinaryOperator | BinaryOperatorToken = node.operatorToken) {
         return node.left !== left
             || node.right !== right
-            || node.operatorToken !== nextOperator
-            ? updateNode(createBinary(left, nextOperator, right), node)
+            || node.operatorToken !== operator
+            ? updateNode(createBinary(left, operator, right), node)
             : node;
     }
 


### PR DESCRIPTION
There is an issue in `updateBinary` where attempting to update `operator` without updating `left` or `right` results in a silent no-op.

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

I ran into this bug while writing a transform hook which decomposes `foo += 1` into `foo = foo + 1` (as part of a larger process where such a rewrite would be useful).

As far as I can tell there is not currently any test coverage that hits this function or those in the same mutation family, so there's no tests to update without building out more test infrastructure.