### PR TITLE
Special-case export assigned namespaces in getSpecifierForModuleSymbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3456,10 +3456,14 @@ namespace ts {
             return mapDefined(candidates, candidate => getAliasForSymbolInContainer(candidate, symbol) ? candidate : undefined);
 
             function fileSymbolIfFileSymbolExportEqualsContainer(d: Declaration) {
-                const fileSymbol = getExternalModuleContainer(d);
-                const exported = fileSymbol && fileSymbol.exports && fileSymbol.exports.get(InternalSymbolName.ExportEquals);
-                return exported && container && getSymbolIfSameReference(exported, container) ? fileSymbol : undefined;
+                return container && getFileSymbolIfFileSymbolExportEqualsContainer(d, container);
             }
+        }
+
+        function getFileSymbolIfFileSymbolExportEqualsContainer(d: Declaration, container: Symbol) {
+            const fileSymbol = getExternalModuleContainer(d);
+            const exported = fileSymbol && fileSymbol.exports && fileSymbol.exports.get(InternalSymbolName.ExportEquals);
+            return exported && getSymbolIfSameReference(exported, container) ? fileSymbol : undefined;
         }
 
         function getAliasForSymbolInContainer(container: Symbol, symbol: Symbol) {
@@ -5077,7 +5081,13 @@ namespace ts {
             }
 
             function getSpecifierForModuleSymbol(symbol: Symbol, context: NodeBuilderContext) {
-                const file = getDeclarationOfKind<SourceFile>(symbol, SyntaxKind.SourceFile);
+                let file = getDeclarationOfKind<SourceFile>(symbol, SyntaxKind.SourceFile);
+                if (!file) {
+                    const equivalentFileSymbol = firstDefined(symbol.declarations, d => getFileSymbolIfFileSymbolExportEqualsContainer(d, symbol));
+                    if (equivalentFileSymbol) {
+                        file = getDeclarationOfKind<SourceFile>(equivalentFileSymbol, SyntaxKind.SourceFile);
+                    }
+                }
                 if (file && file.moduleName !== undefined) {
                     // Use the amd name if it is available
                     return file.moduleName;

--- a/tests/baselines/reference/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.js
+++ b/tests/baselines/reference/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.js
@@ -1,0 +1,82 @@
+//// [tests/cases/compiler/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.ts] ////
+
+//// [index.d.ts]
+export = React;
+
+declare namespace React {
+    export type Component<T = any, U = {}, V = {}> = { x: T, y: U, z: V };
+    export interface DOMAttributes<T> { }
+}
+//// [index.d.ts]
+import {
+    Component
+} from 'react'
+export {};
+
+declare module 'react' {
+    interface DOMAttributes<T> {
+        css?: any
+    }
+}
+
+//// [get-comp.ts]
+import {Component} from 'react';
+
+export function getComp(): Component {
+    return {} as any as Component
+}
+//// [inferred-comp-export.ts]
+import { getComp } from "./get-comp";
+
+// this shouldn't need any triple-slash references - it should have a direct import to `react` and that's it
+// This issue (#35343) _only_ reproduces in the test harness when the file in question is in a subfolder
+export const obj = {
+    comp: getComp()
+}
+//// [some-other-file.ts]
+export * from '@emotion/core';
+
+
+//// [get-comp.js]
+"use strict";
+exports.__esModule = true;
+exports.getComp = void 0;
+function getComp() {
+    return {};
+}
+exports.getComp = getComp;
+//// [inferred-comp-export.js]
+"use strict";
+exports.__esModule = true;
+exports.obj = void 0;
+var get_comp_1 = require("./get-comp");
+// this shouldn't need any triple-slash references - it should have a direct import to `react` and that's it
+// This issue (#35343) _only_ reproduces in the test harness when the file in question is in a subfolder
+exports.obj = {
+    comp: get_comp_1.getComp()
+};
+//// [some-other-file.js]
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+}
+exports.__esModule = true;
+__exportStar(require("@emotion/core"), exports);
+
+
+//// [get-comp.d.ts]
+import { Component } from 'react';
+export declare function getComp(): Component;
+//// [inferred-comp-export.d.ts]
+export declare const obj: {
+    comp: import("react").Component<any, {}, {}>;
+};
+//// [some-other-file.d.ts]
+export * from '@emotion/core';

--- a/tests/baselines/reference/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.symbols
+++ b/tests/baselines/reference/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.symbols
@@ -1,0 +1,71 @@
+=== tests/cases/compiler/node_modules/@types/react/index.d.ts ===
+export = React;
+>React : Symbol(React, Decl(index.d.ts, 0, 15), Decl(index.d.ts, 3, 10))
+
+declare namespace React {
+>React : Symbol(React, Decl(index.d.ts, 0, 15), Decl(index.d.ts, 3, 10))
+
+    export type Component<T = any, U = {}, V = {}> = { x: T, y: U, z: V };
+>Component : Symbol(Component, Decl(index.d.ts, 2, 25))
+>T : Symbol(T, Decl(index.d.ts, 3, 26))
+>U : Symbol(U, Decl(index.d.ts, 3, 34))
+>V : Symbol(V, Decl(index.d.ts, 3, 42))
+>x : Symbol(x, Decl(index.d.ts, 3, 54))
+>T : Symbol(T, Decl(index.d.ts, 3, 26))
+>y : Symbol(y, Decl(index.d.ts, 3, 60))
+>U : Symbol(U, Decl(index.d.ts, 3, 34))
+>z : Symbol(z, Decl(index.d.ts, 3, 66))
+>V : Symbol(V, Decl(index.d.ts, 3, 42))
+
+    export interface DOMAttributes<T> { }
+>DOMAttributes : Symbol(DOMAttributes, Decl(index.d.ts, 3, 74), Decl(index.d.ts, 5, 24))
+>T : Symbol(T, Decl(index.d.ts, 4, 35), Decl(index.d.ts, 6, 28))
+}
+=== tests/cases/compiler/node_modules/@emotion/core/index.d.ts ===
+import {
+    Component
+>Component : Symbol(Component, Decl(index.d.ts, 0, 8))
+
+} from 'react'
+export {};
+
+declare module 'react' {
+>'react' : Symbol(React, Decl(index.d.ts, 0, 15), Decl(index.d.ts, 3, 10))
+
+    interface DOMAttributes<T> {
+>DOMAttributes : Symbol(DOMAttributes, Decl(index.d.ts, 3, 74), Decl(index.d.ts, 5, 24))
+>T : Symbol(T, Decl(index.d.ts, 4, 35), Decl(index.d.ts, 6, 28))
+
+        css?: any
+>css : Symbol(DOMAttributes.css, Decl(index.d.ts, 6, 32))
+    }
+}
+
+=== tests/cases/compiler/src/get-comp.ts ===
+import {Component} from 'react';
+>Component : Symbol(Component, Decl(get-comp.ts, 0, 8))
+
+export function getComp(): Component {
+>getComp : Symbol(getComp, Decl(get-comp.ts, 0, 32))
+>Component : Symbol(Component, Decl(get-comp.ts, 0, 8))
+
+    return {} as any as Component
+>Component : Symbol(Component, Decl(get-comp.ts, 0, 8))
+}
+=== tests/cases/compiler/src/inferred-comp-export.ts ===
+import { getComp } from "./get-comp";
+>getComp : Symbol(getComp, Decl(inferred-comp-export.ts, 0, 8))
+
+// this shouldn't need any triple-slash references - it should have a direct import to `react` and that's it
+// This issue (#35343) _only_ reproduces in the test harness when the file in question is in a subfolder
+export const obj = {
+>obj : Symbol(obj, Decl(inferred-comp-export.ts, 4, 12))
+
+    comp: getComp()
+>comp : Symbol(comp, Decl(inferred-comp-export.ts, 4, 20))
+>getComp : Symbol(getComp, Decl(inferred-comp-export.ts, 0, 8))
+}
+=== tests/cases/compiler/src/some-other-file.ts ===
+export * from '@emotion/core';
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.types
+++ b/tests/baselines/reference/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.types
@@ -1,0 +1,61 @@
+=== tests/cases/compiler/node_modules/@types/react/index.d.ts ===
+export = React;
+>React : any
+
+declare namespace React {
+    export type Component<T = any, U = {}, V = {}> = { x: T, y: U, z: V };
+>Component : Component<T, U, V>
+>x : T
+>y : U
+>z : V
+
+    export interface DOMAttributes<T> { }
+}
+=== tests/cases/compiler/node_modules/@emotion/core/index.d.ts ===
+import {
+    Component
+>Component : any
+
+} from 'react'
+export {};
+
+declare module 'react' {
+>'react' : error
+
+    interface DOMAttributes<T> {
+        css?: any
+>css : any
+    }
+}
+
+=== tests/cases/compiler/src/get-comp.ts ===
+import {Component} from 'react';
+>Component : any
+
+export function getComp(): Component {
+>getComp : () => Component
+
+    return {} as any as Component
+>{} as any as Component : Component<any, {}, {}>
+>{} as any : any
+>{} : {}
+}
+=== tests/cases/compiler/src/inferred-comp-export.ts ===
+import { getComp } from "./get-comp";
+>getComp : () => import("tests/cases/compiler/node_modules/@types/react/index").Component<any, {}, {}>
+
+// this shouldn't need any triple-slash references - it should have a direct import to `react` and that's it
+// This issue (#35343) _only_ reproduces in the test harness when the file in question is in a subfolder
+export const obj = {
+>obj : { comp: import("tests/cases/compiler/node_modules/@types/react/index").Component<any, {}, {}>; }
+>{    comp: getComp()} : { comp: import("tests/cases/compiler/node_modules/@types/react/index").Component<any, {}, {}>; }
+
+    comp: getComp()
+>comp : import("tests/cases/compiler/node_modules/@types/react/index").Component<any, {}, {}>
+>getComp() : import("tests/cases/compiler/node_modules/@types/react/index").Component<any, {}, {}>
+>getComp : () => import("tests/cases/compiler/node_modules/@types/react/index").Component<any, {}, {}>
+}
+=== tests/cases/compiler/src/some-other-file.ts ===
+export * from '@emotion/core';
+No type information for this code.
+No type information for this code.

--- a/tests/cases/compiler/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.ts
+++ b/tests/cases/compiler/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.ts
@@ -1,0 +1,36 @@
+// @declaration: true
+// @filename: node_modules/@types/react/index.d.ts
+export = React;
+
+declare namespace React {
+    export type Component<T = any, U = {}, V = {}> = { x: T, y: U, z: V };
+    export interface DOMAttributes<T> { }
+}
+// @filename: node_modules/@emotion/core/index.d.ts
+import {
+    Component
+} from 'react'
+export {};
+
+declare module 'react' {
+    interface DOMAttributes<T> {
+        css?: any
+    }
+}
+
+// @filename: src/get-comp.ts
+import {Component} from 'react';
+
+export function getComp(): Component {
+    return {} as any as Component
+}
+// @filename: src/inferred-comp-export.ts
+import { getComp } from "./get-comp";
+
+// this shouldn't need any triple-slash references - it should have a direct import to `react` and that's it
+// This issue (#35343) _only_ reproduces in the test harness when the file in question is in a subfolder
+export const obj = {
+    comp: getComp()
+}
+// @filename: src/some-other-file.ts
+export * from '@emotion/core';


### PR DESCRIPTION
so they behave like their containing module symbol.

Fixes #35343

One could argue that the compiler is operating as expected, emitting a reference to `@emotion/core` - it doesn't know if including it is critical to the correct evaluation of the type in the produced type reference (it just knows you're referencing a module declared in multiple places). _However_, we do _not_ usually produce extra references like this when the module in question is originally declared as a normal module, only as an ambient external module. In the case of the original issue, because we looked up the `namespace React` symbol in generating the module symbol chain, we found no `SourceFile` for the module, so we fell back to looking up ambient declarations and including type references to point at them (like the augmentation provided by `@emotion/core`). By recognizing the `export =`'d namespace as equivalent to the containing module itself (as we do in symbol chain container calculations), we can prevent that fallback behavior.