### PR TITLE
Fix truthiness call check for this-property access

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -31843,7 +31843,9 @@ namespace ts {
                         let childExpression = childNode.parent;
                         while (testedExpression && childExpression) {
 
-                            if (isIdentifier(testedExpression) && isIdentifier(childExpression)) {
+                            if (isIdentifier(testedExpression) && isIdentifier(childExpression) ||
+                                testedExpression.kind === SyntaxKind.ThisKeyword && childExpression.kind === SyntaxKind.ThisKeyword
+                            ) {
                                 return getSymbolAtLocation(testedExpression) === getSymbolAtLocation(childExpression);
                             }
 

--- a/tests/baselines/reference/truthinessCallExpressionCoercion1.errors.txt
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion1.errors.txt
@@ -80,6 +80,11 @@ tests/cases/compiler/truthinessCallExpressionCoercion1.ts(61,9): error TS2774: T
     
             // ok
             this.maybeIsUser ? console.log('this.maybeIsUser') : undefined;
+    
+            // ok
+            if (this.isUser) {
+                this.isUser();
+            }
         }
     }
     

--- a/tests/baselines/reference/truthinessCallExpressionCoercion1.js
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion1.js
@@ -63,6 +63,11 @@ class Foo {
 
         // ok
         this.maybeIsUser ? console.log('this.maybeIsUser') : undefined;
+
+        // ok
+        if (this.isUser) {
+            this.isUser();
+        }
     }
 }
 
@@ -117,6 +122,10 @@ var Foo = /** @class */ (function () {
         this.isUser ? console.log('this.isUser') : undefined;
         // ok
         this.maybeIsUser ? console.log('this.maybeIsUser') : undefined;
+        // ok
+        if (this.isUser) {
+            this.isUser();
+        }
     };
     return Foo;
 }());

--- a/tests/baselines/reference/truthinessCallExpressionCoercion1.symbols
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion1.symbols
@@ -170,6 +170,18 @@ class Foo {
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >undefined : Symbol(undefined)
+
+        // ok
+        if (this.isUser) {
+>this.isUser : Symbol(Foo.isUser, Decl(truthinessCallExpressionCoercion1.ts, 52, 32))
+>this : Symbol(Foo, Decl(truthinessCallExpressionCoercion1.ts, 49, 1))
+>isUser : Symbol(Foo.isUser, Decl(truthinessCallExpressionCoercion1.ts, 52, 32))
+
+            this.isUser();
+>this.isUser : Symbol(Foo.isUser, Decl(truthinessCallExpressionCoercion1.ts, 52, 32))
+>this : Symbol(Foo, Decl(truthinessCallExpressionCoercion1.ts, 49, 1))
+>isUser : Symbol(Foo.isUser, Decl(truthinessCallExpressionCoercion1.ts, 52, 32))
+        }
     }
 }
 

--- a/tests/baselines/reference/truthinessCallExpressionCoercion1.types
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion1.types
@@ -223,6 +223,19 @@ class Foo {
 >log : (...data: any[]) => void
 >'this.maybeIsUser' : "this.maybeIsUser"
 >undefined : undefined
+
+        // ok
+        if (this.isUser) {
+>this.isUser : () => boolean
+>this : this
+>isUser : () => boolean
+
+            this.isUser();
+>this.isUser() : boolean
+>this.isUser : () => boolean
+>this : this
+>isUser : () => boolean
+        }
     }
 }
 

--- a/tests/cases/compiler/truthinessCallExpressionCoercion1.ts
+++ b/tests/cases/compiler/truthinessCallExpressionCoercion1.ts
@@ -64,5 +64,10 @@ class Foo {
 
         // ok
         this.maybeIsUser ? console.log('this.maybeIsUser') : undefined;
+
+        // ok
+        if (this.isUser) {
+            this.isUser();
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #38161

Caught by the age-old `this`-is-not-an-identifier gotcha
