### PR TITLE
Revert #37106

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20555,7 +20555,7 @@ namespace ts {
             }
 
             function narrowByInKeyword(type: Type, literal: LiteralExpression, assumeTrue: boolean) {
-                if (type.flags & (TypeFlags.Union | TypeFlags.Object | TypeFlags.Intersection) || isThisTypeParameter(type)) {
+                if (type.flags & (TypeFlags.Union | TypeFlags.Object) || isThisTypeParameter(type)) {
                     const propName = escapeLeadingUnderscores(literal.text);
                     return filterType(type, t => isTypePresencePossible(t, propName, assumeTrue));
                 }

--- a/tests/baselines/reference/inKeywordTypeguard.errors.txt
+++ b/tests/baselines/reference/inKeywordTypeguard.errors.txt
@@ -19,9 +19,10 @@ tests/cases/compiler/inKeywordTypeguard.ts(74,32): error TS2339: Property 'a' do
 tests/cases/compiler/inKeywordTypeguard.ts(82,39): error TS2339: Property 'b' does not exist on type 'A'.
 tests/cases/compiler/inKeywordTypeguard.ts(84,39): error TS2339: Property 'a' does not exist on type 'B'.
 tests/cases/compiler/inKeywordTypeguard.ts(94,26): error TS2339: Property 'a' does not exist on type 'never'.
+tests/cases/compiler/inKeywordTypeguard.ts(103,13): error TS2322: Type '{ a: string; } & { b: string; }' is not assignable to type 'never'.
 
 
-==== tests/cases/compiler/inKeywordTypeguard.ts (17 errors) ====
+==== tests/cases/compiler/inKeywordTypeguard.ts (18 errors) ====
     class A { a: string; }
     class B { b: string; }
     
@@ -163,6 +164,8 @@ tests/cases/compiler/inKeywordTypeguard.ts(94,26): error TS2339: Property 'a' do
             let s: string = x.a;
         } else {
             let n: never = x;
+                ~
+!!! error TS2322: Type '{ a: string; } & { b: string; }' is not assignable to type 'never'.
         }
     }
     

--- a/tests/baselines/reference/inKeywordTypeguard.types
+++ b/tests/baselines/reference/inKeywordTypeguard.types
@@ -318,7 +318,7 @@ function positiveIntersectionTest(x: { a: string } & { b: string }) {
     } else {
         let n: never = x;
 >n : never
->x : never
+>x : { a: string; } & { b: string; }
     }
 }
 


### PR DESCRIPTION
Reverts #37106 due to unanticipated breaks in some public codebases

Brings #38162 into compliance for 3.9. We'll bring this back up for 4.0 with the optionality/undefined changes needed to avoid a break