### PR TITLE
Add outlining spans for the Tuple type

### DIFF
--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -200,6 +200,8 @@ namespace ts.OutliningElementsCollector {
             case SyntaxKind.EnumDeclaration:
             case SyntaxKind.CaseBlock:
                 return spanForNode(n);
+            case SyntaxKind.TupleType:
+                return spanForNode(n, /*autoCollapse*/ false, /*useFullStart*/ !isTupleTypeNode(n.parent), SyntaxKind.OpenBracketToken);
             case SyntaxKind.CaseClause:
             case SyntaxKind.DefaultClause:
                 return spanForNodeArray((n as CaseClause | DefaultClause).statements);

--- a/tests/cases/fourslash/getOutliningForTupleType.ts
+++ b/tests/cases/fourslash/getOutliningForTupleType.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts"/>
+
+////type A =[| [
+////    number,
+////    number,
+////    number
+////]|]
+////
+////type B =[| [
+////    [|[
+////        [|[
+////            number,
+////            number,
+////            number
+////        ]|]
+////    ]|]
+////]|]
+
+verify.outliningSpansInCurrentFile(test.ranges(), "code");


### PR DESCRIPTION
```ts
type Foo = [
    number,
    number
]
```