### PR TITLE
Handle undefined in indent helper

### DIFF
--- a/src/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/typingsInstaller/nodeTypingsInstaller.ts
@@ -246,7 +246,7 @@ namespace ts.server.typingsInstaller {
     const installer = new NodeTypingsInstaller(globalTypingsCacheLocation!, typingSafeListLocation!, typesMapLocation!, npmLocation, validateDefaultNpmLocation, /*throttleLimit*/5, log); // TODO: GH#18217
     installer.listen();
 
-    function indent(newline: string, str: string): string {
+    function indent(newline: string, str: string | undefined): string {
         return str && str.length
             ? `${newline}    ` + str.replace(/\r?\n/, `${newline}    `)
             : "";

--- a/src/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/typingsInstaller/nodeTypingsInstaller.ts
@@ -247,6 +247,8 @@ namespace ts.server.typingsInstaller {
     installer.listen();
 
     function indent(newline: string, str: string): string {
-        return `${newline}    ` + str.replace(/\r?\n/, `${newline}    `);
+        return str && str.length
+            ? `${newline}    ` + str.replace(/\r?\n/, `${newline}    `)
+            : "";
     }
 }


### PR DESCRIPTION
Telemetry shows that it's called with undefined (probably `stderr` in an error scenario?).