### PR TITLE
fix(37877): Export default child items not included in 'navtree'

### DIFF
--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -307,7 +307,18 @@ namespace ts.NavigationBar {
                 addNodeWithRecursiveChild(node, getInteriorModule(<ModuleDeclaration>node).body);
                 break;
 
-            case SyntaxKind.ExportAssignment:
+            case SyntaxKind.ExportAssignment: {
+                const expression = (<ExportAssignment>node).expression;
+                if (isObjectLiteralExpression(expression)) {
+                    startNode(node);
+                    addChildrenRecursively(expression);
+                    endNode();
+                }
+                else {
+                    addLeafNode(node);
+                }
+                break;
+            }
             case SyntaxKind.ExportSpecifier:
             case SyntaxKind.ImportEqualsDeclaration:
             case SyntaxKind.IndexSignature:

--- a/tests/cases/fourslash/navigationItemsExportDefaultExpression.ts
+++ b/tests/cases/fourslash/navigationItemsExportDefaultExpression.ts
@@ -5,6 +5,13 @@
 //// export default () => ""
 //// export default abc;
 //// export default class AB {}
+//// export default {
+////     a: 1,
+////     b: 1,
+////     c: {
+////         d: 1
+////     }
+//// }
 
 verify.navigationTree({
   "text": '"navigationItemsExportDefaultExpression"',
@@ -19,6 +26,31 @@ verify.navigationTree({
       "text": "default",
       "kind": "function",
       "kindModifiers": "export"
+    },
+    {
+      "text": "default",
+      "kind": "const",
+      "kindModifiers": "export",
+      "childItems": [
+        {
+          "text": "a",
+          "kind": "property"
+        },
+        {
+          "text": "b",
+          "kind": "property"
+        },
+        {
+          "text": "c",
+          "kind": "property",
+          "childItems": [
+            {
+              "text": "d",
+              "kind": "property"
+            }
+          ]
+        }
+      ]
     },
     {
       "text": "AB",

--- a/tests/cases/fourslash/navigationItemsExportEqualsExpression.ts
+++ b/tests/cases/fourslash/navigationItemsExportEqualsExpression.ts
@@ -6,6 +6,13 @@
 //// export = function () {}
 //// export = () => ""
 //// export = class AB {}
+//// export = {
+////     a: 1,
+////     b: 1,
+////     c: {
+////         d: 1
+////     }
+//// }
 
 verify.navigationTree({
   "text": '"navigationItemsExportEqualsExpression"',
@@ -25,6 +32,31 @@ verify.navigationTree({
       "text": "export=",
       "kind": "class",
       "kindModifiers": "export"
+    },
+    {
+      "text": "export=",
+      "kind": "const",
+      "kindModifiers": "export",
+      "childItems": [
+        {
+          "text": "a",
+          "kind": "property"
+        },
+        {
+          "text": "b",
+          "kind": "property"
+        },
+        {
+          "text": "c",
+          "kind": "property",
+          "childItems": [
+            {
+              "text": "d",
+              "kind": "property"
+            }
+          ]
+        }
+      ]
     },
     {
       "text": "abc",


### PR DESCRIPTION
Fixes #37877