### PR TITLE
Typeguard-friendly Array#every

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -1139,6 +1139,15 @@ interface ReadonlyArray<T> {
      */
     every(callbackfn: (value: T, index: number, array: readonly T[]) => unknown, thisArg?: any): boolean;
     /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param callbackfn A function that accepts up to three arguments. The every method calls
+     * the callbackfn function for each element in the array until the callbackfn returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every<TValue extends T>(callbackfn: (value: T, index: number, array: readonly T[]) => value is TValue, thisArg?: any): this is readonly TValue[];
+    /**
      * Determines whether the specified callback function returns true for any element of an array.
      * @param callbackfn A function that accepts up to three arguments. The some method calls
      * the callbackfn function for each element in the array until the callbackfn returns a value
@@ -1308,6 +1317,15 @@ interface Array<T> {
      * If thisArg is omitted, undefined is used as the this value.
      */
     every(callbackfn: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param callbackfn A function that accepts up to three arguments. The every method calls
+     * the callbackfn function for each element in the array until the callbackfn returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every<TValue extends T>(callbackfn: (value: T, index: number, array: T[]) => value is TValue, thisArg?: any): this is TValue[];
     /**
      * Determines whether the specified callback function returns true for any element of an array.
      * @param callbackfn A function that accepts up to three arguments. The some method calls

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1119,6 +1119,15 @@ interface ReadonlyArray<T> {
      */
     every(callbackfn: (value: T, index: number, array: readonly T[]) => unknown, thisArg?: any): boolean;
     /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param callbackfn A function that accepts up to three arguments. The every method calls
+     * the callbackfn function for each element in the array until the callbackfn returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every<TValue extends T>(callbackfn: (value: T, index: number, array: readonly T[]) => value is TValue, thisArg?: any): this is readonly TValue[];
+    /**
      * Determines whether the specified callback function returns true for any element of an array.
      * @param callbackfn A function that accepts up to three arguments. The some method calls
      * the callbackfn function for each element in the array until the callbackfn returns a value
@@ -1288,6 +1297,15 @@ interface Array<T> {
      * If thisArg is omitted, undefined is used as the this value.
      */
     every(callbackfn: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param callbackfn A function that accepts up to three arguments. The every method calls
+     * the callbackfn function for each element in the array until the callbackfn returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every<TValue extends T>(callbackfn: (value: T, index: number, array: T[]) => value is TValue, thisArg?: any): this is TValue[];
     /**
      * Determines whether the specified callback function returns true for any element of an array.
      * @param callbackfn A function that accepts up to three arguments. The some method calls


### PR DESCRIPTION
~Fixes #~ I'm not aware of any issue

This PR tries to address the following. However, it may not play well with mutations.

```ts
function is_number(v: unknown): v is number {
  return typeof v === "number";
}

function weird_sum(collection: Array<string | number>) {
  if (collection.every(is_number)) {
    // currently, typescript raises an error here
    const sum: number = collection.reduce((acc, v) => acc + v);
    return sum;
  }
  return 0;
}

weird_sum([5, "abc", 42]);
```

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change
