### PR TITLE
Improve assert message in binder

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2977,15 +2977,15 @@ namespace ts {
                 //    util.property = function ...
                 bindExportsPropertyAssignment(node as BindableStaticPropertyAssignmentExpression);
             }
+            else if (hasDynamicName(node)) {
+                bindAnonymousDeclaration(node, SymbolFlags.Property | SymbolFlags.Assignment, InternalSymbolName.Computed);
+                const sym = bindPotentiallyMissingNamespaces(parentSymbol, node.left.expression, isTopLevelNamespaceAssignment(node.left), /*isPrototype*/ false, /*containerIsClass*/ false);
+                addLateBoundAssignmentDeclarationToSymbol(node, sym);
+            }
             else {
-                if (hasDynamicName(node)) {
-                    bindAnonymousDeclaration(node, SymbolFlags.Property | SymbolFlags.Assignment, InternalSymbolName.Computed);
-                    const sym = bindPotentiallyMissingNamespaces(parentSymbol, node.left.expression, isTopLevelNamespaceAssignment(node.left), /*isPrototype*/ false, /*containerIsClass*/ false);
-                    addLateBoundAssignmentDeclarationToSymbol(node, sym);
-                }
-                else {
-                    bindStaticPropertyAssignment(cast(node.left, isBindableStaticAccessExpression));
-                }
+                if (!isBindableStaticAccessExpression(node.left))
+                    return Debug.fail(`Invalid cast. The supplied value ${getTextOfNode(node.left)} was not a BindableStaticAccessExpression.`);
+                bindStaticPropertyAssignment(node.left as BindableStaticAccessExpression);
             }
         }
 

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2983,8 +2983,9 @@ namespace ts {
                 addLateBoundAssignmentDeclarationToSymbol(node, sym);
             }
             else {
-                if (!isBindableStaticAccessExpression(node.left))
+                if (!isBindableStaticAccessExpression(node.left)) {
                     return Debug.fail(`Invalid cast. The supplied value ${getTextOfNode(node.left)} was not a BindableStaticAccessExpression.`);
+                }
                 bindStaticPropertyAssignment(node.left as BindableStaticAccessExpression);
             }
         }

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2983,10 +2983,7 @@ namespace ts {
                 addLateBoundAssignmentDeclarationToSymbol(node, sym);
             }
             else {
-                if (!isBindableStaticAccessExpression(node.left)) {
-                    return Debug.fail(`Invalid cast. The supplied value ${getTextOfNode(node.left)} was not a BindableStaticAccessExpression.`);
-                }
-                bindStaticPropertyAssignment(node.left as BindableStaticAccessExpression);
+                bindStaticPropertyAssignment(cast(node.left, isBindableStaticNameExpression));
             }
         }
 
@@ -2994,7 +2991,8 @@ namespace ts {
          * For nodes like `x.y = z`, declare a member 'y' on 'x' if x is a function (or IIFE) or class or {}, or not declared.
          * Also works for expression statements preceded by JSDoc, like / ** @type number * / x.y;
          */
-        function bindStaticPropertyAssignment(node: BindableStaticAccessExpression) {
+        function bindStaticPropertyAssignment(node: BindableStaticNameExpression) {
+            Debug.assert(!isIdentifier(node));
             node.expression.parent = node;
             bindPropertyAssignment(node.expression, node, /*isPrototypeProperty*/ false, /*containerIsClass*/ false);
         }


### PR DESCRIPTION
Looking at the code, I don't think the assert can ever fire, but it clearly does, or did in the past. This will make it easier for people to create a repro for #37633.
