### PR TITLE
Fix crash on duplicate default exports

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -413,7 +413,7 @@ namespace ts {
         function declareSymbol(symbolTable: SymbolTable, parent: Symbol | undefined, node: Declaration, includes: SymbolFlags, excludes: SymbolFlags, isReplaceableByMethod?: boolean): Symbol {
             Debug.assert(!hasDynamicName(node));
 
-            const isDefaultExport = hasModifier(node, ModifierFlags.Default);
+            const isDefaultExport = hasModifier(node, ModifierFlags.Default) || isExportSpecifier(node) && node.name.escapedText === "default";
 
             // The exported symbol for an export default function/class node is always named "default"
             const name = isDefaultExport && parent ? InternalSymbolName.Default : getDeclarationName(node);

--- a/tests/baselines/reference/exportDefaultDuplicateCrash.errors.txt
+++ b/tests/baselines/reference/exportDefaultDuplicateCrash.errors.txt
@@ -1,0 +1,34 @@
+tests/cases/compiler/exportDefaultDuplicateCrash.ts(3,1): error TS2323: Cannot redeclare exported variable 'default'.
+tests/cases/compiler/exportDefaultDuplicateCrash.ts(3,1): error TS2528: A module cannot have multiple default exports.
+tests/cases/compiler/exportDefaultDuplicateCrash.ts(4,10): error TS2323: Cannot redeclare exported variable 'default'.
+tests/cases/compiler/exportDefaultDuplicateCrash.ts(4,10): error TS2528: A module cannot have multiple default exports.
+tests/cases/compiler/exportDefaultDuplicateCrash.ts(4,25): error TS2307: Cannot find module './hi' or its corresponding type declarations.
+tests/cases/compiler/exportDefaultDuplicateCrash.ts(5,16): error TS2528: A module cannot have multiple default exports.
+tests/cases/compiler/exportDefaultDuplicateCrash.ts(5,31): error TS2307: Cannot find module './hi' or its corresponding type declarations.
+
+
+==== tests/cases/compiler/exportDefaultDuplicateCrash.ts (7 errors) ====
+    // #38214
+    
+    export default function () { }
+    ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'default'.
+    ~~~~~~
+!!! error TS2528: A module cannot have multiple default exports.
+!!! related TS2753 tests/cases/compiler/exportDefaultDuplicateCrash.ts:5:16: Another export default is here.
+    export { default } from './hi'
+             ~~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'default'.
+             ~~~~~~~
+!!! error TS2528: A module cannot have multiple default exports.
+!!! related TS6204 tests/cases/compiler/exportDefaultDuplicateCrash.ts:5:16: and here.
+                            ~~~~~~
+!!! error TS2307: Cannot find module './hi' or its corresponding type declarations.
+    export { aa as default } from './hi'
+                   ~~~~~~~
+!!! error TS2528: A module cannot have multiple default exports.
+!!! related TS2752 tests/cases/compiler/exportDefaultDuplicateCrash.ts:3:1: The first export default is here.
+!!! related TS2752 tests/cases/compiler/exportDefaultDuplicateCrash.ts:4:10: The first export default is here.
+                                  ~~~~~~
+!!! error TS2307: Cannot find module './hi' or its corresponding type declarations.
+    

--- a/tests/baselines/reference/exportDefaultDuplicateCrash.js
+++ b/tests/baselines/reference/exportDefaultDuplicateCrash.js
@@ -1,0 +1,25 @@
+//// [exportDefaultDuplicateCrash.ts]
+// #38214
+
+export default function () { }
+export { default } from './hi'
+export { aa as default } from './hi'
+
+
+//// [exportDefaultDuplicateCrash.js]
+"use strict";
+// #38214
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+exports.__esModule = true;
+function default_1() { }
+exports["default"] = default_1;
+var hi_1 = require("./hi");
+__createBinding(exports, hi_1, "default");
+var hi_2 = require("./hi");
+__createBinding(exports, hi_2, "aa", "default");

--- a/tests/cases/compiler/exportDefaultDuplicateCrash.ts
+++ b/tests/cases/compiler/exportDefaultDuplicateCrash.ts
@@ -1,0 +1,7 @@
+// @noTypesAndSymbols: true
+
+// #38214
+
+export default function () { }
+export { default } from './hi'
+export { aa as default } from './hi'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #38214 
