### PR TITLE
Update return type Object.keys(o)

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -302,7 +302,7 @@ interface ObjectConstructor {
      * Returns the names of the enumerable string properties and methods of an object.
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
-    keys(o: {}): string[];
+    keys(o: {}): (keyof typeof o)[];
 
     /**
      * Returns true if the values are the same value, false otherwise.


### PR DESCRIPTION
Object.keys(o) does not return an array of strings, but an array of keys o.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
