### PR TITLE
Stop an infinite loop when using an exported JSDoc function as a type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13305,7 +13305,9 @@ namespace ts {
                     links.resolvedSymbol = unknownSymbol;
                     return links.resolvedType = errorType;
                 }
-                const targetMeaning = node.isTypeOf ? SymbolFlags.Value : node.flags & NodeFlags.JSDoc ? SymbolFlags.Value | SymbolFlags.Type : SymbolFlags.Type;
+                const targetMeaning = node.isTypeOf || isJSDocTypeExpression(node.parent) ? SymbolFlags.Value
+                                                       : node.flags & NodeFlags.JSDoc ? SymbolFlags.Value | SymbolFlags.Type
+                                                                                   : SymbolFlags.Type;
                 // TODO: Future work: support unions/generics/whatever via a deferred import-type
                 const innerModuleSymbol = resolveExternalModuleName(node, node.argument.literal);
                 if (!innerModuleSymbol) {

--- a/tests/baselines/reference/jsDocImplicitTypeOfForValueImport.symbols
+++ b/tests/baselines/reference/jsDocImplicitTypeOfForValueImport.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/lib/index.js ===
+// 36830
+//
+
+/** @type {import('../folder/index').zzz} */
+export function xxx() {
+>xxx : Symbol(xxx, Decl(index.js, 0, 0))
+
+  return null;
+}
+
+=== tests/cases/compiler/folder/index.d.ts ===
+export function zzz(): string;
+>zzz : Symbol(zzz, Decl(index.d.ts, 0, 0))
+

--- a/tests/baselines/reference/jsdocImportTypeReferenceToClassAlias.symbols
+++ b/tests/baselines/reference/jsdocImportTypeReferenceToClassAlias.symbols
@@ -21,8 +21,6 @@ function demo(c) {
 >c : Symbol(c, Decl(test.js, 2, 14))
 
     c.s
->c.s : Symbol(C.s, Decl(mod1.js, 0, 9))
 >c : Symbol(c, Decl(test.js, 2, 14))
->s : Symbol(C.s, Decl(mod1.js, 0, 9))
 }
 

--- a/tests/baselines/reference/jsdocImportTypeReferenceToClassAlias.types
+++ b/tests/baselines/reference/jsdocImportTypeReferenceToClassAlias.types
@@ -19,11 +19,11 @@ module.exports.C = C
 /** @param {X} c */
 function demo(c) {
 >demo : (c: X) => void
->c : C
+>c : typeof C
 
     c.s
->c.s : () => void
->c : C
->s : () => void
+>c.s : any
+>c : typeof C
+>s : any
 }
 

--- a/tests/cases/compiler/jsDocImplicitTypeOfForValueImport.ts
+++ b/tests/cases/compiler/jsDocImplicitTypeOfForValueImport.ts
@@ -1,0 +1,14 @@
+// 36830
+//
+// @allowJs: true
+// @noEmit: true
+// @checkJs: true
+
+// @filename: lib/index.js
+/** @type {import('../folder/index').zzz} */
+export function xxx() {
+  return null;
+}
+
+// @filename: folder/index.d.ts
+export function zzz(): string;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -28,7 +28,7 @@
 
 //---------------------------------------
 // For API editors:
-// When editting this file, and only while editing this file, enable the reference comments
+// When editing this file, and only while editing this file, enable the reference comments
 // and comment out the declarations in this section to get proper type information.
 // Undo these changes before compiling/committing/editing any other fourslash tests.
 // The test suite will likely crash if you try 'jake runtests' with reference comments enabled.


### PR DESCRIPTION
Fixes #36830

In JS we want to support treating values as types in a bunch of positions, the code in https://github.com/microsoft/TypeScript/pull/35057 added the ability for this to work in classes but it was over-reaching and also getting called when you have a function. This caused an infinite loop as the type lookup was the same object and not something which could differ in the way an instance vs the 'class' (e.g. the static stuff) could differ. 