### PR TITLE
Fix regression in name resolution in parameter

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1889,7 +1889,9 @@ namespace ts {
                             lastLocation === (location as BindingElement).name && isBindingPattern(lastLocation))) {
                             const root = getRootDeclaration(location);
                             if (root.kind === SyntaxKind.Parameter) {
-                                associatedDeclarationForContainingInitializerOrBindingName = location as BindingElement;
+                                if (!associatedDeclarationForContainingInitializerOrBindingName) {
+                                    associatedDeclarationForContainingInitializerOrBindingName = location as BindingElement;
+                                }
                             }
                         }
                         break;

--- a/tests/cases/conformance/functions/parameterInitializersBackwardReferencing.ts
+++ b/tests/cases/conformance/functions/parameterInitializersBackwardReferencing.ts
@@ -1,0 +1,13 @@
+// @target: es5, es2015, esnext
+// @noEmit: true
+// @noTypesAndSymbols: true
+
+// https://github.com/microsoft/TypeScript/issues/38243
+
+function test0({ a = 0, b = a } = {}) {
+    return { a, b };
+}
+
+function test1({ c: { a = 0, b = a } = {} } = {}) {
+    return { a, b };
+}


### PR DESCRIPTION
This ensures we don't overwrite `associatedDeclarationForContainingInitializerOrBindingName` in `resolveNameHelper` so we can be sure we have the correct associated declaration.

Fixes #38243
