### PR TITLE
Exclude arrays and tuples from full intersection property check

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15874,7 +15874,7 @@ namespace ts {
                 // recursive intersections that are structurally similar but not exactly identical. See #37854.
                 if (result && !inPropertyCheck && (
                     target.flags & TypeFlags.Intersection && (isPerformingExcessPropertyChecks || isPerformingCommonPropertyChecks) ||
-                    isNonGenericObjectType(target) && source.flags & TypeFlags.Intersection && getApparentType(source).flags & TypeFlags.StructuredType && !some((<IntersectionType>source).types, t => !!(getObjectFlags(t) & ObjectFlags.NonInferrableType)))) {
+                    isNonGenericObjectType(target) && !isArrayType(target) && !isTupleType(target) && source.flags & TypeFlags.Intersection && getApparentType(source).flags & TypeFlags.StructuredType && !some((<IntersectionType>source).types, t => !!(getObjectFlags(t) & ObjectFlags.NonInferrableType)))) {
                     inPropertyCheck = true;
                     result &= recursiveTypeRelatedTo(source, target, reportErrors, IntersectionState.PropertyCheck);
                     inPropertyCheck = false;

--- a/tests/baselines/reference/intersectionsAndOptionalProperties.errors.txt
+++ b/tests/baselines/reference/intersectionsAndOptionalProperties.errors.txt
@@ -47,3 +47,8 @@ tests/cases/compiler/intersectionsAndOptionalProperties.ts(20,5): error TS2322: 
 !!! error TS2322: Type 'null' is not assignable to type 'number | undefined'.
     }
     
+    // Repro from #38348
+    
+    const yy: number[] & [number, ...number[]] = [1];
+    const xx: [number, ...number[]] = yy;
+    

--- a/tests/baselines/reference/intersectionsAndOptionalProperties.js
+++ b/tests/baselines/reference/intersectionsAndOptionalProperties.js
@@ -21,6 +21,11 @@ function foo(v: From) {
     x.field = v.field; // Error
 }
 
+// Repro from #38348
+
+const yy: number[] & [number, ...number[]] = [1];
+const xx: [number, ...number[]] = yy;
+
 
 //// [intersectionsAndOptionalProperties.js]
 "use strict";
@@ -31,3 +36,6 @@ function foo(v) {
     x = v; // Error
     x.field = v.field; // Error
 }
+// Repro from #38348
+var yy = [1];
+var xx = yy;

--- a/tests/baselines/reference/intersectionsAndOptionalProperties.symbols
+++ b/tests/baselines/reference/intersectionsAndOptionalProperties.symbols
@@ -62,3 +62,12 @@ function foo(v: From) {
 >field : Symbol(field, Decl(intersectionsAndOptionalProperties.ts, 14, 14))
 }
 
+// Repro from #38348
+
+const yy: number[] & [number, ...number[]] = [1];
+>yy : Symbol(yy, Decl(intersectionsAndOptionalProperties.ts, 24, 5))
+
+const xx: [number, ...number[]] = yy;
+>xx : Symbol(xx, Decl(intersectionsAndOptionalProperties.ts, 25, 5))
+>yy : Symbol(yy, Decl(intersectionsAndOptionalProperties.ts, 24, 5))
+

--- a/tests/baselines/reference/intersectionsAndOptionalProperties.types
+++ b/tests/baselines/reference/intersectionsAndOptionalProperties.types
@@ -63,3 +63,14 @@ function foo(v: From) {
 >field : null
 }
 
+// Repro from #38348
+
+const yy: number[] & [number, ...number[]] = [1];
+>yy : number[] & [number, ...number[]]
+>[1] : [number]
+>1 : 1
+
+const xx: [number, ...number[]] = yy;
+>xx : [number, ...number[]]
+>yy : number[] & [number, ...number[]]
+

--- a/tests/cases/compiler/intersectionsAndOptionalProperties.ts
+++ b/tests/cases/compiler/intersectionsAndOptionalProperties.ts
@@ -21,3 +21,8 @@ function foo(v: From) {
     x = v;  // Error
     x.field = v.field; // Error
 }
+
+// Repro from #38348
+
+const yy: number[] & [number, ...number[]] = [1];
+const xx: [number, ...number[]] = yy;


### PR DESCRIPTION
With this PR we exclude array and tuple types from the extra check introduced in #37195.

Fixes #38348.