### PR TITLE
Fix for jsdoc modifiers on constructor params

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -50,7 +50,7 @@ namespace ts {
             // 3. non-exported import declarations
             case SyntaxKind.ImportDeclaration:
             case SyntaxKind.ImportEqualsDeclaration:
-                if (!(hasModifier(node, ModifierFlags.Export))) {
+                if (!(hasSyntacticModifier(node, ModifierFlags.Export))) {
                     return ModuleInstanceState.NonInstantiated;
                 }
                 break;
@@ -413,7 +413,7 @@ namespace ts {
         function declareSymbol(symbolTable: SymbolTable, parent: Symbol | undefined, node: Declaration, includes: SymbolFlags, excludes: SymbolFlags, isReplaceableByMethod?: boolean): Symbol {
             Debug.assert(!hasDynamicName(node));
 
-            const isDefaultExport = hasModifier(node, ModifierFlags.Default) || isExportSpecifier(node) && node.name.escapedText === "default";
+            const isDefaultExport = hasSyntacticModifier(node, ModifierFlags.Default) || isExportSpecifier(node) && node.name.escapedText === "default";
 
             // The exported symbol for an export default function/class node is always named "default"
             const name = isDefaultExport && parent ? InternalSymbolName.Default : getDeclarationName(node);
@@ -508,7 +508,7 @@ namespace ts {
                         }
 
                         const relatedInformation: DiagnosticRelatedInformation[] = [];
-                        if (isTypeAliasDeclaration(node) && nodeIsMissing(node.type) && hasModifier(node, ModifierFlags.Export) && symbol.flags & (SymbolFlags.Alias | SymbolFlags.Type | SymbolFlags.Namespace)) {
+                        if (isTypeAliasDeclaration(node) && nodeIsMissing(node.type) && hasSyntacticModifier(node, ModifierFlags.Export) && symbol.flags & (SymbolFlags.Alias | SymbolFlags.Type | SymbolFlags.Namespace)) {
                             // export type T; - may have meant export type { T }?
                             relatedInformation.push(createDiagnosticForNode(node, Diagnostics.Did_you_mean_0, `export type { ${unescapeLeadingUnderscores(node.name.escapedText)} }`));
                         }
@@ -572,7 +572,7 @@ namespace ts {
                 //       and should never be merged directly with other augmentation, and the latter case would be possible if automatic merge is allowed.
                 if (isJSDocTypeAlias(node)) Debug.assert(isInJSFile(node)); // We shouldn't add symbols for JSDoc nodes if not in a JS file.
                 if ((!isAmbientModule(node) && (hasExportModifier || container.flags & NodeFlags.ExportContext)) || isJSDocTypeAlias(node)) {
-                    if (!container.locals || (hasModifier(node, ModifierFlags.Default) && !getDeclarationName(node))) {
+                    if (!container.locals || (hasSyntacticModifier(node, ModifierFlags.Default) && !getDeclarationName(node))) {
                         return declareSymbol(container.symbol.exports!, container.symbol, node, symbolFlags, symbolExcludes); // No local symbol for an unnamed default!
                     }
                     const exportKind = symbolFlags & SymbolFlags.Value ? SymbolFlags.ExportValue : 0;
@@ -637,7 +637,7 @@ namespace ts {
                 const saveExceptionTarget = currentExceptionTarget;
                 const saveActiveLabelList = activeLabelList;
                 const saveHasExplicitReturn = hasExplicitReturn;
-                const isIIFE = containerFlags & ContainerFlags.IsFunctionExpression && !hasModifier(node, ModifierFlags.Async) &&
+                const isIIFE = containerFlags & ContainerFlags.IsFunctionExpression && !hasSyntacticModifier(node, ModifierFlags.Async) &&
                     !(<FunctionLikeDeclaration>node).asteriskToken && !!getImmediatelyInvokedFunctionExpression(node);
                 // A non-async, non-generator IIFE is considered part of the containing control flow. Return statements behave
                 // similarly to break statements that exit to a label just past the statement body.
@@ -1906,7 +1906,7 @@ namespace ts {
         }
 
         function declareClassMember(node: Declaration, symbolFlags: SymbolFlags, symbolExcludes: SymbolFlags) {
-            return hasModifier(node, ModifierFlags.Static)
+            return hasSyntacticModifier(node, ModifierFlags.Static)
                 ? declareSymbol(container.symbol.exports!, container.symbol, node, symbolFlags, symbolExcludes)
                 : declareSymbol(container.symbol.members!, container.symbol, node, symbolFlags, symbolExcludes);
         }
@@ -1936,7 +1936,7 @@ namespace ts {
         function bindModuleDeclaration(node: ModuleDeclaration) {
             setExportContextFlag(node);
             if (isAmbientModule(node)) {
-                if (hasModifier(node, ModifierFlags.Export)) {
+                if (hasSyntacticModifier(node, ModifierFlags.Export)) {
                     errorOnFirstToken(node, Diagnostics.export_modifier_cannot_be_applied_to_ambient_modules_and_module_augmentations_since_they_are_always_visible);
                 }
                 if (isModuleAugmentationExternal(node)) {
@@ -2869,7 +2869,7 @@ namespace ts {
                     // this.foo assignment in a JavaScript class
                     // Bind this property to the containing class
                     const containingClass = thisContainer.parent;
-                    const symbolTable = hasModifier(thisContainer, ModifierFlags.Static) ? containingClass.symbol.exports! : containingClass.symbol.members!;
+                    const symbolTable = hasSyntacticModifier(thisContainer, ModifierFlags.Static) ? containingClass.symbol.exports! : containingClass.symbol.members!;
                     if (hasDynamicName(node)) {
                         bindDynamicallyNamedThisPropertyAssignment(node, containingClass.symbol);
                     }
@@ -3403,7 +3403,7 @@ namespace ts {
             case SyntaxKind.ModuleDeclaration:
                 return getModuleInstanceState(s as ModuleDeclaration) !== ModuleInstanceState.Instantiated;
             case SyntaxKind.EnumDeclaration:
-                return hasModifier(s, ModifierFlags.Const);
+                return hasSyntacticModifier(s, ModifierFlags.Const);
             default:
                 return false;
         }
@@ -3637,7 +3637,7 @@ namespace ts {
         }
 
         // If a parameter has an accessibility modifier, then it is TypeScript syntax.
-        if (hasModifier(node, ModifierFlags.ParameterPropertyModifier)) {
+        if (hasSyntacticModifier(node, ModifierFlags.ParameterPropertyModifier)) {
             transformFlags |= TransformFlags.AssertTypeScript | TransformFlags.ContainsTypeScriptClassSyntax;
         }
 
@@ -3676,7 +3676,7 @@ namespace ts {
     function computeClassDeclaration(node: ClassDeclaration, subtreeFlags: TransformFlags) {
         let transformFlags: TransformFlags;
 
-        if (hasModifier(node, ModifierFlags.Ambient)) {
+        if (hasSyntacticModifier(node, ModifierFlags.Ambient)) {
             // An ambient declaration is TypeScript syntax.
             transformFlags = TransformFlags.AssertTypeScript;
         }
@@ -3767,7 +3767,7 @@ namespace ts {
         let transformFlags = subtreeFlags;
 
         // TypeScript-specific modifiers and overloads are TypeScript syntax
-        if (hasModifier(node, ModifierFlags.TypeScriptModifier)
+        if (hasSyntacticModifier(node, ModifierFlags.TypeScriptModifier)
             || !node.body) {
             transformFlags |= TransformFlags.AssertTypeScript;
         }
@@ -3788,7 +3788,7 @@ namespace ts {
         // Decorators, TypeScript-specific modifiers, type parameters, type annotations, and
         // overloads are TypeScript syntax.
         if (node.decorators
-            || hasModifier(node, ModifierFlags.TypeScriptModifier)
+            || hasSyntacticModifier(node, ModifierFlags.TypeScriptModifier)
             || node.typeParameters
             || node.type
             || !node.body
@@ -3802,7 +3802,7 @@ namespace ts {
         }
 
         // An async method declaration is ES2017 syntax.
-        if (hasModifier(node, ModifierFlags.Async)) {
+        if (hasSyntacticModifier(node, ModifierFlags.Async)) {
             transformFlags |= node.asteriskToken ? TransformFlags.AssertES2018 : TransformFlags.AssertES2017;
         }
 
@@ -3820,7 +3820,7 @@ namespace ts {
         // Decorators, TypeScript-specific modifiers, type annotations, and overloads are
         // TypeScript syntax.
         if (node.decorators
-            || hasModifier(node, ModifierFlags.TypeScriptModifier)
+            || hasSyntacticModifier(node, ModifierFlags.TypeScriptModifier)
             || node.type
             || !node.body) {
             transformFlags |= TransformFlags.AssertTypeScript;
@@ -3839,7 +3839,7 @@ namespace ts {
         let transformFlags = subtreeFlags | TransformFlags.ContainsClassFields;
 
         // Decorators, TypeScript-specific modifiers, and type annotations are TypeScript syntax.
-        if (some(node.decorators) || hasModifier(node, ModifierFlags.TypeScriptModifier) || node.type || node.questionToken || node.exclamationToken) {
+        if (some(node.decorators) || hasSyntacticModifier(node, ModifierFlags.TypeScriptModifier) || node.type || node.questionToken || node.exclamationToken) {
             transformFlags |= TransformFlags.AssertTypeScript;
         }
 
@@ -3854,7 +3854,7 @@ namespace ts {
 
     function computeFunctionDeclaration(node: FunctionDeclaration, subtreeFlags: TransformFlags) {
         let transformFlags: TransformFlags;
-        const modifierFlags = getModifierFlags(node);
+        const modifierFlags = getSyntacticModifierFlags(node);
         const body = node.body;
 
         if (!body || (modifierFlags & ModifierFlags.Ambient)) {
@@ -3902,14 +3902,14 @@ namespace ts {
 
         // TypeScript-specific modifiers, type parameters, and type annotations are TypeScript
         // syntax.
-        if (hasModifier(node, ModifierFlags.TypeScriptModifier)
+        if (hasSyntacticModifier(node, ModifierFlags.TypeScriptModifier)
             || node.typeParameters
             || node.type) {
             transformFlags |= TransformFlags.AssertTypeScript;
         }
 
         // An async function expression is ES2017 syntax.
-        if (hasModifier(node, ModifierFlags.Async)) {
+        if (hasSyntacticModifier(node, ModifierFlags.Async)) {
             transformFlags |= node.asteriskToken ? TransformFlags.AssertES2018 : TransformFlags.AssertES2017;
         }
 
@@ -3935,14 +3935,14 @@ namespace ts {
 
         // TypeScript-specific modifiers, type parameters, and type annotations are TypeScript
         // syntax.
-        if (hasModifier(node, ModifierFlags.TypeScriptModifier)
+        if (hasSyntacticModifier(node, ModifierFlags.TypeScriptModifier)
             || node.typeParameters
             || node.type) {
             transformFlags |= TransformFlags.AssertTypeScript;
         }
 
         // An async arrow function is ES2017 syntax.
-        if (hasModifier(node, ModifierFlags.Async)) {
+        if (hasSyntacticModifier(node, ModifierFlags.Async)) {
             transformFlags |= TransformFlags.AssertES2017;
         }
 
@@ -4016,7 +4016,7 @@ namespace ts {
         const declarationListTransformFlags = node.declarationList.transformFlags;
 
         // An ambient declaration is TypeScript syntax.
-        if (hasModifier(node, ModifierFlags.Ambient)) {
+        if (hasSyntacticModifier(node, ModifierFlags.Ambient)) {
             transformFlags = TransformFlags.AssertTypeScript;
         }
         else {
@@ -4064,7 +4064,7 @@ namespace ts {
 
     function computeModuleDeclaration(node: ModuleDeclaration, subtreeFlags: TransformFlags) {
         let transformFlags = TransformFlags.AssertTypeScript;
-        const modifierFlags = getModifierFlags(node);
+        const modifierFlags = getSyntacticModifierFlags(node);
 
         if ((modifierFlags & ModifierFlags.Ambient) === 0) {
             transformFlags |= subtreeFlags;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37561,7 +37561,14 @@ namespace ts {
                     return grammarErrorOnNode(node.type, Diagnostics._0_expected, tokenToString(SyntaxKind.SymbolKeyword));
                 }
 
-                const parent = walkUpParenthesizedTypes(node.parent);
+                let parent = walkUpParenthesizedTypes(node.parent);
+                if (isInJSFile(parent) && isJSDocTypeExpression(parent)) {
+                    parent = parent.parent;
+                    if (isJSDocTypeTag(parent)) {
+                        // walk up past JSDoc comment node
+                        parent = parent.parent.parent;
+                    }
+                }
                 switch (parent.kind) {
                     case SyntaxKind.VariableDeclaration:
                         const decl = parent as VariableDeclaration;
@@ -37578,7 +37585,7 @@ namespace ts {
 
                     case SyntaxKind.PropertyDeclaration:
                         if (!hasSyntacticModifier(parent, ModifierFlags.Static) ||
-                            !hasSyntacticModifier(parent, ModifierFlags.Readonly)) {
+                            !hasEffectiveModifier(parent, ModifierFlags.Readonly)) {
                             return grammarErrorOnNode((<PropertyDeclaration>parent).name, Diagnostics.A_property_of_a_class_whose_type_is_a_unique_symbol_type_must_be_both_static_and_readonly);
                         }
                         break;

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -376,7 +376,7 @@ namespace ts {
                     Object.defineProperties(ctor.prototype, {
                         __debugKind: { get(this: Node) { return formatSyntaxKind(this.kind); } },
                         __debugNodeFlags: { get(this: Node) { return formatNodeFlags(this.flags); } },
-                        __debugModifierFlags: { get(this: Node) { return formatModifierFlags(getModifierFlagsNoCache(this)); } },
+                        __debugModifierFlags: { get(this: Node) { return formatModifierFlags(getEffectiveModifierFlagsNoCache(this)); } },
                         __debugTransformFlags: { get(this: Node) { return formatTransformFlags(this.transformFlags); } },
                         __debugIsParseTreeNode: { get(this: Node) { return isParseTreeNode(this); } },
                         __debugEmitFlags: { get(this: Node) { return formatEmitFlags(getEmitFlags(this)); } },

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -751,7 +751,7 @@ namespace ts {
      * @param allowSourceMaps A value indicating whether source maps may be emitted for the name.
      */
     export function getExternalModuleOrNamespaceExportName(ns: Identifier | undefined, node: Declaration, allowComments?: boolean, allowSourceMaps?: boolean): Identifier | PropertyAccessExpression {
-        if (ns && hasModifier(node, ModifierFlags.Export)) {
+        if (ns && hasSyntacticModifier(node, ModifierFlags.Export)) {
             return getNamespaceMemberName(ns, getName(node), allowComments, allowSourceMaps);
         }
         return getExportName(node, allowComments, allowSourceMaps);

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2145,7 +2145,7 @@ namespace ts {
                     }
                 }
                 else if (isModuleDeclaration(node)) {
-                    if (isAmbientModule(node) && (inAmbientModule || hasModifier(node, ModifierFlags.Ambient) || file.isDeclarationFile)) {
+                    if (isAmbientModule(node) && (inAmbientModule || hasSyntacticModifier(node, ModifierFlags.Ambient) || file.isDeclarationFile)) {
                         const nameText = getTextOfIdentifierOrLiteral(node.name);
                         // Ambient module declarations can be interpreted as augmentations for some existing external modules.
                         // This will happen in two cases:

--- a/src/compiler/transformers/declarations/diagnostics.ts
+++ b/src/compiler/transformers/declarations/diagnostics.ts
@@ -71,7 +71,7 @@ namespace ts {
         }
 
         function getAccessorNameVisibilityDiagnosticMessage(symbolAccessibilityResult: SymbolAccessibilityResult) {
-            if (hasModifier(node, ModifierFlags.Static)) {
+            if (hasSyntacticModifier(node, ModifierFlags.Static)) {
                 return symbolAccessibilityResult.errorModuleName ?
                     symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
                         Diagnostics.Public_static_property_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
@@ -102,7 +102,7 @@ namespace ts {
         }
 
         function getMethodNameVisibilityDiagnosticMessage(symbolAccessibilityResult: SymbolAccessibilityResult) {
-            if (hasModifier(node, ModifierFlags.Static)) {
+            if (hasSyntacticModifier(node, ModifierFlags.Static)) {
                 return symbolAccessibilityResult.errorModuleName ?
                     symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
                         Diagnostics.Public_static_method_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
@@ -135,7 +135,7 @@ namespace ts {
             return getReturnTypeVisibilityError;
         }
         else if (isParameter(node)) {
-            if (isParameterPropertyDeclaration(node, node.parent) && hasModifier(node.parent, ModifierFlags.Private)) {
+            if (isParameterPropertyDeclaration(node, node.parent) && hasSyntacticModifier(node.parent, ModifierFlags.Private)) {
                 return getVariableDeclarationTypeVisibilityError;
             }
             return getParameterDeclarationTypeVisibilityError;
@@ -167,9 +167,9 @@ namespace ts {
             // This check is to ensure we don't report error on constructor parameter property as that error would be reported during parameter emit
             // The only exception here is if the constructor was marked as private. we are not emitting the constructor parameters at all.
             else if (node.kind === SyntaxKind.PropertyDeclaration || node.kind === SyntaxKind.PropertyAccessExpression || node.kind === SyntaxKind.PropertySignature ||
-                (node.kind === SyntaxKind.Parameter && hasModifier(node.parent, ModifierFlags.Private))) {
+                (node.kind === SyntaxKind.Parameter && hasSyntacticModifier(node.parent, ModifierFlags.Private))) {
                 // TODO(jfreeman): Deal with computed properties in error reporting.
-                if (hasModifier(node, ModifierFlags.Static)) {
+                if (hasSyntacticModifier(node, ModifierFlags.Static)) {
                     return symbolAccessibilityResult.errorModuleName ?
                         symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
                             Diagnostics.Public_static_property_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
@@ -206,7 +206,7 @@ namespace ts {
             if (node.kind === SyntaxKind.SetAccessor) {
                 // Getters can infer the return type from the returned expression, but setters cannot, so the
                 // "_from_external_module_1_but_cannot_be_named" case cannot occur.
-                if (hasModifier(node, ModifierFlags.Static)) {
+                if (hasSyntacticModifier(node, ModifierFlags.Static)) {
                     diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
                         Diagnostics.Parameter_type_of_public_static_setter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2 :
                         Diagnostics.Parameter_type_of_public_static_setter_0_from_exported_class_has_or_is_using_private_name_1;
@@ -218,7 +218,7 @@ namespace ts {
                 }
             }
             else {
-                if (hasModifier(node, ModifierFlags.Static)) {
+                if (hasSyntacticModifier(node, ModifierFlags.Static)) {
                     diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
                         symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
                             Diagnostics.Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
@@ -266,7 +266,7 @@ namespace ts {
 
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.MethodSignature:
-                    if (hasModifier(node, ModifierFlags.Static)) {
+                    if (hasSyntacticModifier(node, ModifierFlags.Static)) {
                         diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
                             symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
                                 Diagnostics.Return_type_of_public_static_method_from_exported_class_has_or_is_using_name_0_from_external_module_1_but_cannot_be_named :
@@ -345,7 +345,7 @@ namespace ts {
 
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.MethodSignature:
-                    if (hasModifier(node.parent, ModifierFlags.Static)) {
+                    if (hasEffectiveModifier(node.parent, ModifierFlags.Static)) {
                         return symbolAccessibilityResult.errorModuleName ?
                             symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
                                 Diagnostics.Parameter_0_of_public_static_method_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
@@ -413,7 +413,7 @@ namespace ts {
 
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.MethodSignature:
-                    if (hasModifier(node.parent, ModifierFlags.Static)) {
+                    if (hasEffectiveModifier(node.parent, ModifierFlags.Static)) {
                         diagnosticMessage = Diagnostics.Type_parameter_0_of_public_static_method_from_exported_class_has_or_is_using_private_name_1;
                     }
                     else if (node.parent.parent.kind === SyntaxKind.ClassDeclaration) {

--- a/src/compiler/transformers/declarations/diagnostics.ts
+++ b/src/compiler/transformers/declarations/diagnostics.ts
@@ -345,7 +345,7 @@ namespace ts {
 
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.MethodSignature:
-                    if (hasEffectiveModifier(node.parent, ModifierFlags.Static)) {
+                    if (hasSyntacticModifier(node.parent, ModifierFlags.Static)) {
                         return symbolAccessibilityResult.errorModuleName ?
                             symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
                                 Diagnostics.Parameter_0_of_public_static_method_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
@@ -413,7 +413,7 @@ namespace ts {
 
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.MethodSignature:
-                    if (hasEffectiveModifier(node.parent, ModifierFlags.Static)) {
+                    if (hasSyntacticModifier(node.parent, ModifierFlags.Static)) {
                         diagnosticMessage = Diagnostics.Type_parameter_0_of_public_static_method_from_exported_class_has_or_is_using_private_name_1;
                     }
                     else if (node.parent.parent.kind === SyntaxKind.ClassDeclaration) {

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -681,8 +681,8 @@ namespace ts {
             statements.push(statement);
 
             // Add an `export default` statement for default exports (for `--target es5 --module es6`)
-            if (hasModifier(node, ModifierFlags.Export)) {
-                const exportStatement = hasModifier(node, ModifierFlags.Default)
+            if (hasSyntacticModifier(node, ModifierFlags.Export)) {
+                const exportStatement = hasSyntacticModifier(node, ModifierFlags.Default)
                     ? createExportDefault(getLocalName(node))
                     : createExternalModuleExport(getLocalName(node));
 
@@ -1804,7 +1804,7 @@ namespace ts {
         function transformFunctionLikeToExpression(node: FunctionLikeDeclaration, location: TextRange | undefined, name: Identifier | undefined, container: Node | undefined): FunctionExpression {
             const savedConvertedLoopState = convertedLoopState;
             convertedLoopState = undefined;
-            const ancestorFacts = container && isClassLike(container) && !hasModifier(node, ModifierFlags.Static)
+            const ancestorFacts = container && isClassLike(container) && !hasSyntacticModifier(node, ModifierFlags.Static)
                 ? enterSubtree(HierarchyFacts.FunctionExcludes, HierarchyFacts.FunctionIncludes | HierarchyFacts.NonStaticClassElement)
                 : enterSubtree(HierarchyFacts.FunctionExcludes, HierarchyFacts.FunctionIncludes);
             const parameters = visitParameterList(node.parameters, visitor, context);
@@ -2011,7 +2011,7 @@ namespace ts {
         }
 
         function visitVariableStatement(node: VariableStatement): Statement | undefined {
-            const ancestorFacts = enterSubtree(HierarchyFacts.None, hasModifier(node, ModifierFlags.Export) ? HierarchyFacts.ExportedVariableStatement : HierarchyFacts.None);
+            const ancestorFacts = enterSubtree(HierarchyFacts.None, hasSyntacticModifier(node, ModifierFlags.Export) ? HierarchyFacts.ExportedVariableStatement : HierarchyFacts.None);
             let updated: Statement | undefined;
             if (convertedLoopState && (node.declarationList.flags & NodeFlags.BlockScoped) === 0 && !isVariableStatementOfTypeScriptClassWrapper(node)) {
                 // we are inside a converted loop - hoist variable declarations
@@ -4257,7 +4257,7 @@ namespace ts {
         }
 
         function getClassMemberPrefix(node: ClassExpression | ClassDeclaration, member: ClassElement) {
-            return hasModifier(member, ModifierFlags.Static)
+            return hasSyntacticModifier(member, ModifierFlags.Static)
                 ? getInternalName(node)
                 : createPropertyAccess(getInternalName(node), "prototype");
         }

--- a/src/compiler/transformers/es2018.ts
+++ b/src/compiler/transformers/es2018.ts
@@ -486,7 +486,7 @@ namespace ts {
         }
 
         function visitVariableStatement(node: VariableStatement): VisitResult<VariableStatement> {
-            if (hasModifier(node, ModifierFlags.Export)) {
+            if (hasSyntacticModifier(node, ModifierFlags.Export)) {
                 const savedExportedVariableStatement = exportedVariableStatement;
                 exportedVariableStatement = true;
                 const visited = visitEachChild(node, visitor, context);

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -895,7 +895,7 @@ namespace ts {
 
             let statements: Statement[] | undefined;
             if (moduleKind !== ModuleKind.AMD) {
-                if (hasModifier(node, ModifierFlags.Export)) {
+                if (hasSyntacticModifier(node, ModifierFlags.Export)) {
                     statements = append(statements,
                         setOriginalNode(
                             setTextRange(
@@ -934,7 +934,7 @@ namespace ts {
                 }
             }
             else {
-                if (hasModifier(node, ModifierFlags.Export)) {
+                if (hasSyntacticModifier(node, ModifierFlags.Export)) {
                     statements = append(statements,
                         setOriginalNode(
                             setTextRange(
@@ -1095,7 +1095,7 @@ namespace ts {
          */
         function visitFunctionDeclaration(node: FunctionDeclaration): VisitResult<Statement> {
             let statements: Statement[] | undefined;
-            if (hasModifier(node, ModifierFlags.Export)) {
+            if (hasSyntacticModifier(node, ModifierFlags.Export)) {
                 statements = append(statements,
                     setOriginalNode(
                         setTextRange(
@@ -1138,7 +1138,7 @@ namespace ts {
          */
         function visitClassDeclaration(node: ClassDeclaration): VisitResult<Statement> {
             let statements: Statement[] | undefined;
-            if (hasModifier(node, ModifierFlags.Export)) {
+            if (hasSyntacticModifier(node, ModifierFlags.Export)) {
                 statements = append(statements,
                     setOriginalNode(
                         setTextRange(
@@ -1182,7 +1182,7 @@ namespace ts {
             let variables: VariableDeclaration[] | undefined;
             let expressions: Expression[] | undefined;
 
-            if (hasModifier(node, ModifierFlags.Export)) {
+            if (hasSyntacticModifier(node, ModifierFlags.Export)) {
                 let modifiers: NodeArray<Modifier> | undefined;
 
                 // If we're exporting these variables, then these just become assignments to 'exports.x'.
@@ -1442,8 +1442,8 @@ namespace ts {
                 return statements;
             }
 
-            if (hasModifier(decl, ModifierFlags.Export)) {
-                const exportName = hasModifier(decl, ModifierFlags.Default) ? createIdentifier("default") : getDeclarationName(decl);
+            if (hasSyntacticModifier(decl, ModifierFlags.Export)) {
+                const exportName = hasSyntacticModifier(decl, ModifierFlags.Default) ? createIdentifier("default") : getDeclarationName(decl);
                 statements = appendExportStatement(statements, exportName, getLocalName(decl), /*location*/ decl);
             }
 

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -693,7 +693,7 @@ namespace ts {
          * @param node The node to visit.
          */
         function visitFunctionDeclaration(node: FunctionDeclaration): VisitResult<Statement> {
-            if (hasModifier(node, ModifierFlags.Export)) {
+            if (hasSyntacticModifier(node, ModifierFlags.Export)) {
                 hoistedStatements = append(hoistedStatements,
                     updateFunctionDeclaration(
                         node,
@@ -780,7 +780,7 @@ namespace ts {
             }
 
             let expressions: Expression[] | undefined;
-            const isExportedDeclaration = hasModifier(node, ModifierFlags.Export);
+            const isExportedDeclaration = hasSyntacticModifier(node, ModifierFlags.Export);
             const isMarkedDeclaration = hasAssociatedEndOfDeclarationMarker(node);
             for (const variable of node.declarationList.declarations) {
                 if (variable.initializer) {
@@ -911,7 +911,7 @@ namespace ts {
             // statement until we visit this declaration's `EndOfDeclarationMarker`.
             if (hasAssociatedEndOfDeclarationMarker(node) && node.original!.kind === SyntaxKind.VariableStatement) {
                 const id = getOriginalNodeId(node);
-                const isExportedDeclaration = hasModifier(node.original!, ModifierFlags.Export);
+                const isExportedDeclaration = hasSyntacticModifier(node.original!, ModifierFlags.Export);
                 deferredExports[id] = appendExportsOfVariableStatement(deferredExports[id], <VariableStatement>node.original, isExportedDeclaration);
             }
 
@@ -1087,8 +1087,8 @@ namespace ts {
             }
 
             let excludeName: string | undefined;
-            if (hasModifier(decl, ModifierFlags.Export)) {
-                const exportName = hasModifier(decl, ModifierFlags.Default) ? createLiteral("default") : decl.name!;
+            if (hasSyntacticModifier(decl, ModifierFlags.Export)) {
+                const exportName = hasSyntacticModifier(decl, ModifierFlags.Default) ? createLiteral("default") : decl.name!;
                 statements = appendExportStatement(statements, exportName, getLocalName(decl));
                 excludeName = getTextOfIdentifierOrLiteral(exportName);
             }

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -166,7 +166,7 @@ namespace ts {
 
                 case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.FunctionDeclaration:
-                    if (hasModifier(node, ModifierFlags.Ambient)) {
+                    if (hasSyntacticModifier(node, ModifierFlags.Ambient)) {
                         break;
                     }
 
@@ -178,7 +178,7 @@ namespace ts {
                         // These nodes should always have names unless they are default-exports;
                         // however, class declaration parsing allows for undefined names, so syntactically invalid
                         // programs may also have an undefined name.
-                        Debug.assert(node.kind === SyntaxKind.ClassDeclaration || hasModifier(node, ModifierFlags.Default));
+                        Debug.assert(node.kind === SyntaxKind.ClassDeclaration || hasSyntacticModifier(node, ModifierFlags.Default));
                     }
                     if (isClassDeclaration(node)) {
                         // XXX: should probably also cover interfaces and type aliases that can have type variables?
@@ -287,7 +287,7 @@ namespace ts {
                 // do not emit ES6 imports and exports since they are illegal inside a namespace
                 return undefined;
             }
-            else if (node.transformFlags & TransformFlags.ContainsTypeScript || hasModifier(node, ModifierFlags.Export)) {
+            else if (node.transformFlags & TransformFlags.ContainsTypeScript || hasSyntacticModifier(node, ModifierFlags.Export)) {
                 return visitTypeScript(node);
             }
 
@@ -349,7 +349,7 @@ namespace ts {
          * @param node The node to visit.
          */
         function visitTypeScript(node: Node): VisitResult<Node> {
-            if (isStatement(node) && hasModifier(node, ModifierFlags.Ambient)) {
+            if (isStatement(node) && hasSyntacticModifier(node, ModifierFlags.Ambient)) {
                 // TypeScript ambient declarations are elided, but some comments may be preserved.
                 // See the implementation of `getLeadingComments` in comments.ts for more details.
                 return createNotEmittedStatement(node);
@@ -610,7 +610,7 @@ namespace ts {
         }
 
         function visitClassDeclaration(node: ClassDeclaration): VisitResult<Statement> {
-            if (!isClassLikeDeclarationWithTypeScriptSyntax(node) && !(currentNamespace && hasModifier(node, ModifierFlags.Export))) {
+            if (!isClassLikeDeclarationWithTypeScriptSyntax(node) && !(currentNamespace && hasSyntacticModifier(node, ModifierFlags.Export))) {
                 return visitEachChild(node, visitor, context);
             }
 
@@ -966,7 +966,7 @@ namespace ts {
          */
         function isDecoratedClassElement(member: ClassElement, isStatic: boolean, parent: ClassLikeDeclaration) {
             return nodeOrChildIsDecorated(member, parent)
-                && isStatic === hasModifier(member, ModifierFlags.Static);
+                && isStatic === hasSyntacticModifier(member, ModifierFlags.Static);
         }
 
         /**
@@ -2045,7 +2045,7 @@ namespace ts {
          * @param node The declaration node.
          */
         function shouldEmitAccessorDeclaration(node: AccessorDeclaration) {
-            return !(nodeIsMissing(node.body) && hasModifier(node, ModifierFlags.Abstract));
+            return !(nodeIsMissing(node.body) && hasSyntacticModifier(node, ModifierFlags.Abstract));
         }
 
         function visitGetAccessor(node: GetAccessorDeclaration) {
@@ -2352,7 +2352,7 @@ namespace ts {
             const containerName = getNamespaceContainerName(node);
 
             // `exportName` is the expression used within this node's container for any exported references.
-            const exportName = hasModifier(node, ModifierFlags.Export)
+            const exportName = hasSyntacticModifier(node, ModifierFlags.Export)
                 ? getExternalModuleOrNamespaceExportName(currentNamespaceContainerName, node, /*allowComments*/ false, /*allowSourceMaps*/ true)
                 : getLocalName(node, /*allowComments*/ false, /*allowSourceMaps*/ true);
 
@@ -2653,7 +2653,7 @@ namespace ts {
             const containerName = getNamespaceContainerName(node);
 
             // `exportName` is the expression used within this node's container for any exported references.
-            const exportName = hasModifier(node, ModifierFlags.Export)
+            const exportName = hasSyntacticModifier(node, ModifierFlags.Export)
                 ? getExternalModuleOrNamespaceExportName(currentNamespaceContainerName, node, /*allowComments*/ false, /*allowSourceMaps*/ true)
                 : getLocalName(node, /*allowComments*/ false, /*allowSourceMaps*/ true);
 
@@ -3039,7 +3039,7 @@ namespace ts {
          * @param node The node to test.
          */
         function isExportOfNamespace(node: Node) {
-            return currentNamespace !== undefined && hasModifier(node, ModifierFlags.Export);
+            return currentNamespace !== undefined && hasSyntacticModifier(node, ModifierFlags.Export);
         }
 
         /**
@@ -3048,7 +3048,7 @@ namespace ts {
          * @param node The node to test.
          */
         function isExternalModuleExport(node: Node) {
-            return currentNamespace === undefined && hasModifier(node, ModifierFlags.Export);
+            return currentNamespace === undefined && hasSyntacticModifier(node, ModifierFlags.Export);
         }
 
         /**
@@ -3058,7 +3058,7 @@ namespace ts {
          */
         function isNamedExternalModuleExport(node: Node) {
             return isExternalModuleExport(node)
-                && !hasModifier(node, ModifierFlags.Default);
+                && !hasSyntacticModifier(node, ModifierFlags.Default);
         }
 
         /**
@@ -3068,7 +3068,7 @@ namespace ts {
          */
         function isDefaultExternalModuleExport(node: Node) {
             return isExternalModuleExport(node)
-                && hasModifier(node, ModifierFlags.Default);
+                && hasSyntacticModifier(node, ModifierFlags.Default);
         }
 
         /**
@@ -3147,7 +3147,7 @@ namespace ts {
         }
 
         function getClassMemberPrefix(node: ClassExpression | ClassDeclaration, member: ClassElement) {
-            return hasModifier(member, ModifierFlags.Static)
+            return hasSyntacticModifier(member, ModifierFlags.Static)
                 ? getDeclarationName(node)
                 : getClassPrototype(node);
         }

--- a/src/compiler/transformers/utilities.ts
+++ b/src/compiler/transformers/utilities.ts
@@ -143,7 +143,7 @@ namespace ts {
                     break;
 
                 case SyntaxKind.VariableStatement:
-                    if (hasModifier(node, ModifierFlags.Export)) {
+                    if (hasSyntacticModifier(node, ModifierFlags.Export)) {
                         for (const decl of (<VariableStatement>node).declarationList.declarations) {
                             exportedNames = collectExportedVariableInfo(decl, uniqueExports, exportedNames);
                         }
@@ -151,8 +151,8 @@ namespace ts {
                     break;
 
                 case SyntaxKind.FunctionDeclaration:
-                    if (hasModifier(node, ModifierFlags.Export)) {
-                        if (hasModifier(node, ModifierFlags.Default)) {
+                    if (hasSyntacticModifier(node, ModifierFlags.Export)) {
+                        if (hasSyntacticModifier(node, ModifierFlags.Default)) {
                             // export default function() { }
                             if (!hasExportDefault) {
                                 multiMapSparseArrayAdd(exportedBindings, getOriginalNodeId(node), getDeclarationName(<FunctionDeclaration>node));
@@ -172,8 +172,8 @@ namespace ts {
                     break;
 
                 case SyntaxKind.ClassDeclaration:
-                    if (hasModifier(node, ModifierFlags.Export)) {
-                        if (hasModifier(node, ModifierFlags.Default)) {
+                    if (hasSyntacticModifier(node, ModifierFlags.Export)) {
+                        if (hasSyntacticModifier(node, ModifierFlags.Default)) {
                             // export default class { }
                             if (!hasExportDefault) {
                                 multiMapSparseArrayAdd(exportedBindings, getOriginalNodeId(node), getDeclarationName(<ClassDeclaration>node));

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -609,6 +609,7 @@ namespace ts {
         Async =              1 << 8,  // Property/Method/Function
         Default =            1 << 9,  // Function/Class (export default declaration)
         Const =              1 << 11, // Const enum
+        HasComputedJSDocModifiers = 1 << 12, // Indiciates the computed modifier flags include modifiers from JSDoc.
         HasComputedFlags =   1 << 29, // Modifier flags have been computed
 
         AccessibilityModifier = Public | Private | Protected,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -609,7 +609,7 @@ namespace ts {
         Async =              1 << 8,  // Property/Method/Function
         Default =            1 << 9,  // Function/Class (export default declaration)
         Const =              1 << 11, // Const enum
-        HasComputedJSDocModifiers = 1 << 12, // Indiciates the computed modifier flags include modifiers from JSDoc.
+        HasComputedJSDocModifiers = 1 << 12, // Indicates the computed modifier flags include modifiers from JSDoc.
         HasComputedFlags =   1 << 29, // Modifier flags have been computed
 
         AccessibilityModifier = Public | Private | Protected,

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -684,7 +684,7 @@ namespace ts {
     function aggregateTransformFlagsForSubtree(node: Node): TransformFlags {
         // We do not transform ambient declarations or types, so there is no need to
         // recursively aggregate transform flags.
-        if (hasModifier(node, ModifierFlags.Ambient) || (isTypeNode(node) && node.kind !== SyntaxKind.ExpressionWithTypeArguments)) {
+        if (hasSyntacticModifier(node, ModifierFlags.Ambient) || (isTypeNode(node) && node.kind !== SyntaxKind.ExpressionWithTypeArguments)) {
             return TransformFlags.None;
         }
 

--- a/src/services/breakpoints.ts
+++ b/src/services/breakpoints.ts
@@ -392,7 +392,7 @@ namespace ts.BreakpointResolver {
                 // Breakpoint is possible in variableDeclaration only if there is initialization
                 // or its declaration from 'for of'
                 if (variableDeclaration.initializer ||
-                    hasModifier(variableDeclaration, ModifierFlags.Export) ||
+                    hasSyntacticModifier(variableDeclaration, ModifierFlags.Export) ||
                     parent.parent.kind === SyntaxKind.ForOfStatement) {
                     return textSpanFromVariableDeclaration(variableDeclaration);
                 }
@@ -410,7 +410,7 @@ namespace ts.BreakpointResolver {
             function canHaveSpanInParameterDeclaration(parameter: ParameterDeclaration): boolean {
                 // Breakpoint is possible on parameter only if it has initializer, is a rest parameter, or has public or private modifier
                 return !!parameter.initializer || parameter.dotDotDotToken !== undefined ||
-                    hasModifier(parameter, ModifierFlags.Public | ModifierFlags.Private);
+                    hasSyntacticModifier(parameter, ModifierFlags.Public | ModifierFlags.Private);
             }
 
             function spanInParameterDeclaration(parameter: ParameterDeclaration): TextSpan | undefined {
@@ -437,7 +437,7 @@ namespace ts.BreakpointResolver {
             }
 
             function canFunctionHaveSpanInWholeDeclaration(functionDeclaration: FunctionLikeDeclaration) {
-                return hasModifier(functionDeclaration, ModifierFlags.Export) ||
+                return hasSyntacticModifier(functionDeclaration, ModifierFlags.Export) ||
                     (functionDeclaration.parent.kind === SyntaxKind.ClassDeclaration && functionDeclaration.kind !== SyntaxKind.Constructor);
             }
 

--- a/src/services/callHierarchy.ts
+++ b/src/services/callHierarchy.ts
@@ -410,7 +410,7 @@ namespace ts.CallHierarchy {
     }
 
     function collectCallSitesOfModuleDeclaration(node: ModuleDeclaration, collect: (node: Node | undefined) => void) {
-        if (!hasModifier(node, ModifierFlags.Ambient) && node.body && isModuleBlock(node.body)) {
+        if (!hasSyntacticModifier(node, ModifierFlags.Ambient) && node.body && isModuleBlock(node.body)) {
             forEach(node.body.statements, collect);
         }
     }

--- a/src/services/codefixes/addMissingAsync.ts
+++ b/src/services/codefixes/addMissingAsync.ts
@@ -53,7 +53,7 @@ namespace ts.codefix {
         }
         fixedDeclarations?.set(getNodeId(insertionSite).toString(), true);
         const cloneWithModifier = getSynthesizedDeepClone(insertionSite, /*includeTrivia*/ true);
-        cloneWithModifier.modifiers = createNodeArray(createModifiersFromModifierFlags(getModifierFlags(insertionSite) | ModifierFlags.Async));
+        cloneWithModifier.modifiers = createNodeArray(createModifiersFromModifierFlags(getSyntacticModifierFlags(insertionSite) | ModifierFlags.Async));
         cloneWithModifier.modifierFlagsCache = 0;
         changeTracker.replaceNode(
             sourceFile,

--- a/src/services/codefixes/addMissingAwait.ts
+++ b/src/services/codefixes/addMissingAwait.ts
@@ -148,7 +148,7 @@ namespace ts.codefix {
                 declaration.type ||
                 !declaration.initializer ||
                 variableStatement.getSourceFile() !== sourceFile ||
-                hasModifier(variableStatement, ModifierFlags.Export) ||
+                hasSyntacticModifier(variableStatement, ModifierFlags.Export) ||
                 !variableName ||
                 !isInsideAwaitableBody(declaration.initializer)) {
                 isCompleteFix = false;

--- a/src/services/codefixes/convertToMappedObjectType.ts
+++ b/src/services/codefixes/convertToMappedObjectType.ts
@@ -42,7 +42,7 @@ namespace ts.codefix {
         const parameter = first(indexSignature.parameters);
         const mappedTypeParameter = createTypeParameterDeclaration(cast(parameter.name, isIdentifier), parameter.type);
         const mappedIntersectionType = createMappedTypeNode(
-            hasReadonlyModifier(indexSignature) ? createModifier(SyntaxKind.ReadonlyKeyword) : undefined,
+            hasEffectiveReadonlyModifier(indexSignature) ? createModifier(SyntaxKind.ReadonlyKeyword) : undefined,
             mappedTypeParameter,
             indexSignature.questionToken,
             indexSignature.type);

--- a/src/services/codefixes/fixClassDoesntImplementInheritedAbstractMember.ts
+++ b/src/services/codefixes/fixClassDoesntImplementInheritedAbstractMember.ts
@@ -49,7 +49,7 @@ namespace ts.codefix {
     function symbolPointsToNonPrivateAndAbstractMember(symbol: Symbol): boolean {
         // See `codeFixClassExtendAbstractProtectedProperty.ts` in https://github.com/Microsoft/TypeScript/pull/11547/files
         // (now named `codeFixClassExtendAbstractPrivateProperty.ts`)
-        const flags = getModifierFlags(first(symbol.getDeclarations()!));
+        const flags = getSyntacticModifierFlags(first(symbol.getDeclarations()!));
         return !(flags & ModifierFlags.Private) && !!(flags & ModifierFlags.Abstract);
     }
 }

--- a/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
+++ b/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
@@ -34,7 +34,7 @@ namespace ts.codefix {
     }
 
     function symbolPointsToNonPrivateMember(symbol: Symbol) {
-        return !symbol.valueDeclaration || !(getModifierFlags(symbol.valueDeclaration) & ModifierFlags.Private);
+        return !symbol.valueDeclaration || !(getSyntacticModifierFlags(symbol.valueDeclaration) & ModifierFlags.Private);
     }
 
     function addMissingDeclarations(

--- a/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
+++ b/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
@@ -34,7 +34,7 @@ namespace ts.codefix {
     }
 
     function symbolPointsToNonPrivateMember(symbol: Symbol) {
-        return !symbol.valueDeclaration || !(getSyntacticModifierFlags(symbol.valueDeclaration) & ModifierFlags.Private);
+        return !symbol.valueDeclaration || !(getEffectiveModifierFlags(symbol.valueDeclaration) & ModifierFlags.Private);
     }
 
     function addMissingDeclarations(

--- a/src/services/codefixes/fixStrictClassInitialization.ts
+++ b/src/services/codefixes/fixStrictClassInitialization.ts
@@ -120,7 +120,7 @@ namespace ts.codefix {
         }
         else if (type.isClass()) {
             const classDeclaration = getClassLikeDeclarationOfSymbol(type.symbol);
-            if (!classDeclaration || hasModifier(classDeclaration, ModifierFlags.Abstract)) return undefined;
+            if (!classDeclaration || hasSyntacticModifier(classDeclaration, ModifierFlags.Abstract)) return undefined;
 
             const constructorDeclaration = getFirstConstructorWithBody(classDeclaration);
             if (constructorDeclaration && constructorDeclaration.parameters.length) return undefined;

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -40,7 +40,7 @@ namespace ts.codefix {
         const scriptTarget = getEmitScriptTarget(context.program.getCompilerOptions());
         const declaration = declarations[0];
         const name = getSynthesizedDeepClone(getNameOfDeclaration(declaration), /*includeTrivia*/ false) as PropertyName;
-        const visibilityModifier = createVisibilityModifier(getModifierFlags(declaration));
+        const visibilityModifier = createVisibilityModifier(getSyntacticModifierFlags(declaration));
         const modifiers = visibilityModifier ? createNodeArray([visibilityModifier]) : undefined;
         const type = checker.getWidenedType(checker.getTypeOfSymbolAtLocation(symbol, enclosingDeclaration));
         const optional = !!(symbol.flags & SymbolFlags.Optional);

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -40,7 +40,7 @@ namespace ts.codefix {
         const scriptTarget = getEmitScriptTarget(context.program.getCompilerOptions());
         const declaration = declarations[0];
         const name = getSynthesizedDeepClone(getNameOfDeclaration(declaration), /*includeTrivia*/ false) as PropertyName;
-        const visibilityModifier = createVisibilityModifier(getSyntacticModifierFlags(declaration));
+        const visibilityModifier = createVisibilityModifier(getEffectiveModifierFlags(declaration));
         const modifiers = visibilityModifier ? createNodeArray([visibilityModifier]) : undefined;
         const type = checker.getWidenedType(checker.getTypeOfSymbolAtLocation(symbol, enclosingDeclaration));
         const optional = !!(symbol.flags & SymbolFlags.Optional);

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1990,7 +1990,7 @@ namespace ts.Completions {
             if (!isClassLike(decl)) return GlobalsSearch.Success;
 
             const classElement = contextToken.kind === SyntaxKind.SemicolonToken ? contextToken.parent.parent : contextToken.parent;
-            let classElementModifierFlags = isClassElement(classElement) ? getModifierFlags(classElement) : ModifierFlags.None;
+            let classElementModifierFlags = isClassElement(classElement) ? getEffectiveModifierFlags(classElement) : ModifierFlags.None;
             // If this is context token is not something we are editing now, consider if this would lead to be modifier
             if (contextToken.kind === SyntaxKind.Identifier && !isCurrentlyEditingNode(contextToken)) {
                 switch (contextToken.getText()) {
@@ -2409,12 +2409,12 @@ namespace ts.Completions {
                 }
 
                 // Dont filter member even if the name matches if it is declared private in the list
-                if (hasModifier(m, ModifierFlags.Private)) {
+                if (hasEffectiveModifier(m, ModifierFlags.Private)) {
                     continue;
                 }
 
                 // do not filter it out if the static presence doesnt match
-                if (hasModifier(m, ModifierFlags.Static) !== !!(currentClassElementModifierFlags & ModifierFlags.Static)) {
+                if (hasEffectiveModifier(m, ModifierFlags.Static) !== !!(currentClassElementModifierFlags & ModifierFlags.Static)) {
                     continue;
                 }
 

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -102,7 +102,7 @@ namespace ts.FindAllReferences {
             ((isImportOrExportSpecifier(node.parent) || isBindingElement(node.parent))
                 && node.parent.propertyName === node) ||
             // Is default export
-            (node.kind === SyntaxKind.DefaultKeyword && hasModifier(node.parent, ModifierFlags.ExportDefault))) {
+            (node.kind === SyntaxKind.DefaultKeyword && hasSyntacticModifier(node.parent, ModifierFlags.ExportDefault))) {
             return getContextNode(node.parent);
         }
 
@@ -1146,7 +1146,7 @@ namespace ts.FindAllReferences {
 
             // If this is private property or method, the scope is the containing class
             if (flags & (SymbolFlags.Property | SymbolFlags.Method)) {
-                const privateDeclaration = find(declarations, d => hasModifier(d, ModifierFlags.Private) || isPrivateIdentifierPropertyDeclaration(d));
+                const privateDeclaration = find(declarations, d => hasEffectiveModifier(d, ModifierFlags.Private) || isPrivateIdentifierPropertyDeclaration(d));
                 if (privateDeclaration) {
                     return getAncestor(privateDeclaration, SyntaxKind.ClassDeclaration);
                 }
@@ -1561,7 +1561,7 @@ namespace ts.FindAllReferences {
             Debug.assert(classLike.name === referenceLocation);
             const addRef = state.referenceAdder(search.symbol);
             for (const member of classLike.members) {
-                if (!(isMethodOrAccessor(member) && hasModifier(member, ModifierFlags.Static))) {
+                if (!(isMethodOrAccessor(member) && hasSyntacticModifier(member, ModifierFlags.Static))) {
                     continue;
                 }
                 if (member.body) {
@@ -1776,7 +1776,7 @@ namespace ts.FindAllReferences {
                 case SyntaxKind.Constructor:
                 case SyntaxKind.GetAccessor:
                 case SyntaxKind.SetAccessor:
-                    staticFlag &= getModifierFlags(searchSpaceNode);
+                    staticFlag &= getSyntacticModifierFlags(searchSpaceNode);
                     searchSpaceNode = searchSpaceNode.parent; // re-assign to be the owning class
                     break;
                 default:
@@ -1794,7 +1794,7 @@ namespace ts.FindAllReferences {
                 // If we have a 'super' container, we must have an enclosing class.
                 // Now make sure the owning class is the same as the search-space
                 // and has the same static qualifier as the original 'super's owner.
-                return container && (ModifierFlags.Static & getModifierFlags(container)) === staticFlag && container.parent.symbol === searchSpaceNode.symbol ? nodeEntry(node) : undefined;
+                return container && (ModifierFlags.Static & getSyntacticModifierFlags(container)) === staticFlag && container.parent.symbol === searchSpaceNode.symbol ? nodeEntry(node) : undefined;
             });
 
             return [{ definition: { type: DefinitionKind.Symbol, symbol: searchSpaceNode.symbol }, references }];
@@ -1822,7 +1822,7 @@ namespace ts.FindAllReferences {
                 case SyntaxKind.Constructor:
                 case SyntaxKind.GetAccessor:
                 case SyntaxKind.SetAccessor:
-                    staticFlag &= getModifierFlags(searchSpaceNode);
+                    staticFlag &= getSyntacticModifierFlags(searchSpaceNode);
                     searchSpaceNode = searchSpaceNode.parent; // re-assign to be the owning class
                     break;
                 case SyntaxKind.SourceFile:
@@ -1857,7 +1857,7 @@ namespace ts.FindAllReferences {
                         case SyntaxKind.ClassDeclaration:
                             // Make sure the container belongs to the same class
                             // and has the appropriate static modifier from the original container.
-                            return container.parent && searchSpaceNode.symbol === container.parent.symbol && (getModifierFlags(container) & ModifierFlags.Static) === staticFlag;
+                            return container.parent && searchSpaceNode.symbol === container.parent.symbol && (getSyntacticModifierFlags(container) & ModifierFlags.Static) === staticFlag;
                         case SyntaxKind.SourceFile:
                             return container.kind === SyntaxKind.SourceFile && !isExternalModule(<SourceFile>container) && !isParameterName(node);
                     }

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -103,7 +103,7 @@ namespace ts.FindAllReferences {
                             break; // TODO: GH#23879
 
                         case SyntaxKind.ImportEqualsDeclaration:
-                            handleNamespaceImport(direct, direct.name, hasModifier(direct, ModifierFlags.Export), /*alreadyAddedDirect*/ false);
+                            handleNamespaceImport(direct, direct.name, hasSyntacticModifier(direct, ModifierFlags.Export), /*alreadyAddedDirect*/ false);
                             break;
 
                         case SyntaxKind.ImportDeclaration:
@@ -463,7 +463,7 @@ namespace ts.FindAllReferences {
             }
             else {
                 const exportNode = getExportNode(parent, node);
-                if (exportNode && hasModifier(exportNode, ModifierFlags.Export)) {
+                if (exportNode && hasSyntacticModifier(exportNode, ModifierFlags.Export)) {
                     if (isImportEqualsDeclaration(exportNode) && exportNode.moduleReference === node) {
                         // We're at `Y` in `export import X = Y`. This is not the exported symbol, the left-hand-side is. So treat this as an import statement.
                         if (comingFromExport) {
@@ -553,7 +553,7 @@ namespace ts.FindAllReferences {
 
         // Not meant for use with export specifiers or export assignment.
         function getExportKindForDeclaration(node: Node): ExportKind {
-            return hasModifier(node, ModifierFlags.Default) ? ExportKind.Default : ExportKind.Named;
+            return hasSyntacticModifier(node, ModifierFlags.Default) ? ExportKind.Default : ExportKind.Named;
         }
     }
 

--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -590,7 +590,7 @@ namespace ts.NavigationBar {
             case SyntaxKind.MethodDeclaration:
             case SyntaxKind.GetAccessor:
             case SyntaxKind.SetAccessor:
-                return hasModifier(a, ModifierFlags.Static) === hasModifier(b, ModifierFlags.Static);
+                return hasSyntacticModifier(a, ModifierFlags.Static) === hasSyntacticModifier(b, ModifierFlags.Static);
             case SyntaxKind.ModuleDeclaration:
                 return areSameModule(<ModuleDeclaration>a, <ModuleDeclaration>b);
             default:
@@ -690,7 +690,7 @@ namespace ts.NavigationBar {
             case SyntaxKind.FunctionExpression:
             case SyntaxKind.ClassDeclaration:
             case SyntaxKind.ClassExpression:
-                if (getModifierFlags(node) & ModifierFlags.Default) {
+                if (getSyntacticModifierFlags(node) & ModifierFlags.Default) {
                     return "default";
                 }
                 // We may get a string with newlines or other whitespace in the case of an object dereference
@@ -883,7 +883,7 @@ namespace ts.NavigationBar {
             return nodeText(parent.name);
         }
         // Default exports are named "default"
-        else if (getModifierFlags(node) & ModifierFlags.Default) {
+        else if (getSyntacticModifierFlags(node) & ModifierFlags.Default) {
             return "default";
         }
         else if (isClassLike(node)) {

--- a/src/services/refactors/convertExport.ts
+++ b/src/services/refactors/convertExport.ts
@@ -38,7 +38,7 @@ namespace ts.refactor {
 
         const exportingModuleSymbol = isSourceFile(exportNode.parent) ? exportNode.parent.symbol : exportNode.parent.parent.symbol;
 
-        const flags = getModifierFlags(exportNode);
+        const flags = getSyntacticModifierFlags(exportNode);
         const wasDefault = !!(flags & ModifierFlags.Default);
         // If source file already has a default export, don't offer refactor.
         if (!(flags & ModifierFlags.Export) || !wasDefault && exportingModuleSymbol.exports!.has(InternalSymbolName.Default)) {

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -309,7 +309,7 @@ namespace ts.refactor.extractSymbol {
             let current: Node = nodeToCheck;
             while (current !== containingClass) {
                 if (current.kind === SyntaxKind.PropertyDeclaration) {
-                    if (hasModifier(current, ModifierFlags.Static)) {
+                    if (hasSyntacticModifier(current, ModifierFlags.Static)) {
                         rangeFacts |= RangeFacts.InStaticRegion;
                     }
                     break;
@@ -322,7 +322,7 @@ namespace ts.refactor.extractSymbol {
                     break;
                 }
                 else if (current.kind === SyntaxKind.MethodDeclaration) {
-                    if (hasModifier(current, ModifierFlags.Static)) {
+                    if (hasSyntacticModifier(current, ModifierFlags.Static)) {
                         rangeFacts |= RangeFacts.InStaticRegion;
                     }
                 }
@@ -375,7 +375,7 @@ namespace ts.refactor.extractSymbol {
 
                 if (isDeclaration(node)) {
                     const declaringNode = (node.kind === SyntaxKind.VariableDeclaration) ? node.parent.parent : node;
-                    if (hasModifier(declaringNode, ModifierFlags.Export)) {
+                    if (hasSyntacticModifier(declaringNode, ModifierFlags.Export)) {
                         // TODO: GH#18217 Silly to use `errors ||` since it's definitely not defined (see top of `visit`)
                         // Also, if we're only pushing one error, just use `let error: Diagnostic | undefined`!
                         // Also TODO: GH#19956
@@ -1584,7 +1584,7 @@ namespace ts.refactor.extractSymbol {
                     hasWrite = true;
                     if (value.symbol.flags & SymbolFlags.ClassMember &&
                         value.symbol.valueDeclaration &&
-                        hasModifier(value.symbol.valueDeclaration, ModifierFlags.Readonly)) {
+                        hasEffectiveModifier(value.symbol.valueDeclaration, ModifierFlags.Readonly)) {
                         readonlyClassPropertyWrite = value.symbol.valueDeclaration;
                     }
                 }

--- a/src/services/refactors/generateGetAccessorAndSetAccessor.ts
+++ b/src/services/refactors/generateGetAccessorAndSetAccessor.ts
@@ -52,7 +52,7 @@ namespace ts.refactor.generateGetAccessorAndSetAccessor {
 
         const isInClassLike = isClassLike(container);
         // avoid Readonly modifier because it will convert to get accessor
-        const modifierFlags = getModifierFlags(declaration) & ~ModifierFlags.Readonly;
+        const modifierFlags = getEffectiveModifierFlags(declaration) & ~ModifierFlags.Readonly;
         const accessorModifiers = isInClassLike
             ? !modifierFlags || modifierFlags & ModifierFlags.Private
                 ? getModifiers(isJS, isStatic, SyntaxKind.PublicKeyword)
@@ -121,7 +121,7 @@ namespace ts.refactor.generateGetAccessorAndSetAccessor {
         // make sure declaration have AccessibilityModifier or Static Modifier or Readonly Modifier
         const meaning = ModifierFlags.AccessibilityModifier | ModifierFlags.Static | ModifierFlags.Readonly;
         if (!declaration || !nodeOverlapsWithStartEnd(declaration.name, file, startPosition, endPosition!) // TODO: GH#18217
-            || !isConvertibleName(declaration.name) || (getModifierFlags(declaration) | meaning) !== meaning) return undefined;
+            || !isConvertibleName(declaration.name) || (getEffectiveModifierFlags(declaration) | meaning) !== meaning) return undefined;
 
         const name = declaration.name.text;
         const startWithUnderscore = startsWithUnderscore(name);
@@ -129,7 +129,7 @@ namespace ts.refactor.generateGetAccessorAndSetAccessor {
         const accessorName = createPropertyName(startWithUnderscore ? getUniqueName(name.substring(1), file) : name, declaration.name);
         return {
             isStatic: hasStaticModifier(declaration),
-            isReadonly: hasReadonlyModifier(declaration),
+            isReadonly: hasEffectiveReadonlyModifier(declaration),
             type: getTypeAnnotationNode(declaration),
             container: declaration.kind === SyntaxKind.Parameter ? declaration.parent.parent : declaration.parent,
             originalName: (<AcceptedNameType>declaration.name).text,

--- a/src/services/refactors/moveToNewFile.ts
+++ b/src/services/refactors/moveToNewFile.ts
@@ -84,7 +84,7 @@ namespace ts.refactor {
             case SyntaxKind.ImportDeclaration:
                 return true;
             case SyntaxKind.ImportEqualsDeclaration:
-                return !hasModifier(node, ModifierFlags.Export);
+                return !hasSyntacticModifier(node, ModifierFlags.Export);
             case SyntaxKind.VariableStatement:
                 return (node as VariableStatement).declarationList.declarations.every(d => !!d.initializer && isRequireCall(d.initializer, /*checkArgumentIsStringLiteralLike*/ true));
             default:
@@ -420,7 +420,7 @@ namespace ts.refactor {
                 if (markSeenTop(top)) {
                     addExportToChanges(oldFile, top, changes, useEs6ModuleSyntax);
                 }
-                if (hasModifier(decl, ModifierFlags.Default)) {
+                if (hasSyntacticModifier(decl, ModifierFlags.Default)) {
                     oldFileDefault = name;
                 }
                 else {
@@ -737,7 +737,7 @@ namespace ts.refactor {
 
     function isExported(sourceFile: SourceFile, decl: TopLevelDeclarationStatement, useEs6Exports: boolean): boolean {
         if (useEs6Exports) {
-            return !isExpressionStatement(decl) && hasModifier(decl, ModifierFlags.Export);
+            return !isExpressionStatement(decl) && hasSyntacticModifier(decl, ModifierFlags.Export);
         }
         else {
             return getNamesToExportInCommonJS(decl).some(name => sourceFile.symbol.exports!.has(escapeLeadingUnderscores(name)));

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -763,7 +763,7 @@ namespace ts {
 
                     case SyntaxKind.Parameter:
                         // Only consider parameter properties
-                        if (!hasModifier(node, ModifierFlags.ParameterPropertyModifier)) {
+                        if (!hasSyntacticModifier(node, ModifierFlags.ParameterPropertyModifier)) {
                             break;
                         }
                         // falls through

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -389,7 +389,7 @@ namespace ts.SymbolDisplay {
                     if (declarationName) {
                         const isExternalModuleDeclaration =
                             isModuleWithStringLiteralName(resolvedNode) &&
-                            hasModifier(resolvedNode, ModifierFlags.Ambient);
+                            hasSyntacticModifier(resolvedNode, ModifierFlags.Ambient);
                         const shouldUseAliasName = symbol.name !== "default" && !isExternalModuleDeclaration;
                         const resolvedInfo = getSymbolDisplayPartsDocumentationAndSymbolKind(
                             typeChecker,

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -407,7 +407,7 @@ namespace ts {
             case SyntaxKind.Constructor: return ScriptElementKind.constructorImplementationElement;
             case SyntaxKind.TypeParameter: return ScriptElementKind.typeParameterElement;
             case SyntaxKind.EnumMember: return ScriptElementKind.enumMemberElement;
-            case SyntaxKind.Parameter: return hasModifier(node, ModifierFlags.ParameterPropertyModifier) ? ScriptElementKind.memberVariableElement : ScriptElementKind.parameterElement;
+            case SyntaxKind.Parameter: return hasSyntacticModifier(node, ModifierFlags.ParameterPropertyModifier) ? ScriptElementKind.memberVariableElement : ScriptElementKind.parameterElement;
             case SyntaxKind.ImportEqualsDeclaration:
             case SyntaxKind.ImportSpecifier:
             case SyntaxKind.ExportSpecifier:

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -482,6 +482,7 @@ declare namespace ts {
         Async = 256,
         Default = 512,
         Const = 2048,
+        HasComputedJSDocModifiers = 4096,
         HasComputedFlags = 536870912,
         AccessibilityModifier = 28,
         ParameterPropertyModifier = 92,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -482,6 +482,7 @@ declare namespace ts {
         Async = 256,
         Default = 512,
         Const = 2048,
+        HasComputedJSDocModifiers = 4096,
         HasComputedFlags = 536870912,
         AccessibilityModifier = 28,
         ParameterPropertyModifier = 92,

--- a/tests/baselines/reference/jsdocAccessibilityTagsDeclarations.js
+++ b/tests/baselines/reference/jsdocAccessibilityTagsDeclarations.js
@@ -31,6 +31,11 @@ class Private {
     set p(value) { this.c = value }
 }
 
+// https://github.com/microsoft/TypeScript/issues/38401
+class C {
+    constructor(/** @public */ x, /** @protected */ y, /** @private */ z) {
+    }
+}
 
 //// [foo.js]
 class Protected {
@@ -63,6 +68,11 @@ class Private {
     /** @private */
     set p(value) { this.c = value; }
 }
+// https://github.com/microsoft/TypeScript/issues/38401
+class C {
+    constructor(/** @public */ x, /** @protected */ y, /** @private */ z) {
+    }
+}
 
 
 //// [foo.d.ts]
@@ -89,4 +99,7 @@ declare class Private {
     private set p(arg);
     /** @private */
     private get p();
+}
+declare class C {
+    constructor(x: any, y: any, z: any);
 }

--- a/tests/baselines/reference/jsdocAccessibilityTagsDeclarations.symbols
+++ b/tests/baselines/reference/jsdocAccessibilityTagsDeclarations.symbols
@@ -79,3 +79,13 @@ class Private {
 >value : Symbol(value, Decl(jsdocAccessibilityTagDeclarations.js, 29, 10))
 }
 
+// https://github.com/microsoft/TypeScript/issues/38401
+class C {
+>C : Symbol(C, Decl(jsdocAccessibilityTagDeclarations.js, 30, 1))
+
+    constructor(/** @public */ x, /** @protected */ y, /** @private */ z) {
+>x : Symbol(x, Decl(jsdocAccessibilityTagDeclarations.js, 34, 16))
+>y : Symbol(y, Decl(jsdocAccessibilityTagDeclarations.js, 34, 33))
+>z : Symbol(z, Decl(jsdocAccessibilityTagDeclarations.js, 34, 54))
+    }
+}

--- a/tests/baselines/reference/jsdocAccessibilityTagsDeclarations.types
+++ b/tests/baselines/reference/jsdocAccessibilityTagsDeclarations.types
@@ -83,3 +83,13 @@ class Private {
 >value : any
 }
 
+// https://github.com/microsoft/TypeScript/issues/38401
+class C {
+>C : C
+
+    constructor(/** @public */ x, /** @protected */ y, /** @private */ z) {
+>x : any
+>y : any
+>z : any
+    }
+}

--- a/tests/baselines/reference/jsdocReadonlyDeclarations.js
+++ b/tests/baselines/reference/jsdocReadonlyDeclarations.js
@@ -19,6 +19,10 @@ function F() {
     this.z = 1
 }
 
+// https://github.com/microsoft/TypeScript/issues/38401
+class D {
+    constructor(/** @readonly */ x) {}
+}
 
 //// [foo.js]
 class C {
@@ -39,6 +43,10 @@ function F() {
     /** @readonly */
     this.z = 1;
 }
+// https://github.com/microsoft/TypeScript/issues/38401
+class D {
+    constructor(/** @readonly */ x) { }
+}
 
 
 //// [foo.d.ts]
@@ -57,4 +65,7 @@ declare class C {
      * @type {number}
      */
     readonly y: number;
+}
+declare class D {
+    constructor(x: any);
 }

--- a/tests/baselines/reference/jsdocReadonlyDeclarations.symbols
+++ b/tests/baselines/reference/jsdocReadonlyDeclarations.symbols
@@ -40,3 +40,10 @@ function F() {
 >z : Symbol(F.z, Decl(jsdocReadonlyDeclarations.js, 15, 14))
 }
 
+// https://github.com/microsoft/TypeScript/issues/38401
+class D {
+>D : Symbol(D, Decl(jsdocReadonlyDeclarations.js, 18, 1))
+
+    constructor(/** @readonly */ x) {}
+>x : Symbol(x, Decl(jsdocReadonlyDeclarations.js, 22, 16))
+}

--- a/tests/baselines/reference/jsdocReadonlyDeclarations.types
+++ b/tests/baselines/reference/jsdocReadonlyDeclarations.types
@@ -48,3 +48,10 @@ function F() {
 >1 : 1
 }
 
+// https://github.com/microsoft/TypeScript/issues/38401
+class D {
+>D : D
+
+    constructor(/** @readonly */ x) {}
+>x : any
+}

--- a/tests/baselines/reference/uniqueSymbolsDeclarationsInJs.js
+++ b/tests/baselines/reference/uniqueSymbolsDeclarationsInJs.js
@@ -1,0 +1,76 @@
+//// [uniqueSymbolsDeclarationsInJs.js]
+// classes
+class C {
+    /**
+     * @readonly
+     */
+    static readonlyStaticCall = Symbol();
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonlyStaticType;
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonlyStaticTypeAndCall = Symbol();
+    static readwriteStaticCall = Symbol();
+
+    /**
+     * @readonly
+     */
+    readonlyCall = Symbol();
+    readwriteCall = Symbol();
+}
+
+
+//// [uniqueSymbolsDeclarationsInJs-out.js]
+// classes
+let C = /** @class */ (() => {
+    class C {
+        constructor() {
+            /**
+             * @readonly
+             */
+            this.readonlyCall = Symbol();
+            this.readwriteCall = Symbol();
+        }
+    }
+    /**
+     * @readonly
+     */
+    C.readonlyStaticCall = Symbol();
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    C.readonlyStaticTypeAndCall = Symbol();
+    C.readwriteStaticCall = Symbol();
+    return C;
+})();
+
+
+//// [uniqueSymbolsDeclarationsInJs-out.d.ts]
+declare class C {
+    /**
+     * @readonly
+     */
+    static readonly readonlyStaticCall: unique symbol;
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonly readonlyStaticType: unique symbol;
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonly readonlyStaticTypeAndCall: unique symbol;
+    static readwriteStaticCall: symbol;
+    /**
+     * @readonly
+     */
+    readonly readonlyCall: symbol;
+    readwriteCall: symbol;
+}

--- a/tests/baselines/reference/uniqueSymbolsDeclarationsInJs.symbols
+++ b/tests/baselines/reference/uniqueSymbolsDeclarationsInJs.symbols
@@ -1,0 +1,43 @@
+=== tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJs.js ===
+// classes
+class C {
+>C : Symbol(C, Decl(uniqueSymbolsDeclarationsInJs.js, 0, 0))
+
+    /**
+     * @readonly
+     */
+    static readonlyStaticCall = Symbol();
+>readonlyStaticCall : Symbol(C.readonlyStaticCall, Decl(uniqueSymbolsDeclarationsInJs.js, 1, 9))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonlyStaticType;
+>readonlyStaticType : Symbol(C.readonlyStaticType, Decl(uniqueSymbolsDeclarationsInJs.js, 5, 41))
+
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonlyStaticTypeAndCall = Symbol();
+>readonlyStaticTypeAndCall : Symbol(C.readonlyStaticTypeAndCall, Decl(uniqueSymbolsDeclarationsInJs.js, 10, 30))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+
+    static readwriteStaticCall = Symbol();
+>readwriteStaticCall : Symbol(C.readwriteStaticCall, Decl(uniqueSymbolsDeclarationsInJs.js, 15, 48))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+
+    /**
+     * @readonly
+     */
+    readonlyCall = Symbol();
+>readonlyCall : Symbol(C.readonlyCall, Decl(uniqueSymbolsDeclarationsInJs.js, 16, 42))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+
+    readwriteCall = Symbol();
+>readwriteCall : Symbol(C.readwriteCall, Decl(uniqueSymbolsDeclarationsInJs.js, 21, 28))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+}
+

--- a/tests/baselines/reference/uniqueSymbolsDeclarationsInJs.types
+++ b/tests/baselines/reference/uniqueSymbolsDeclarationsInJs.types
@@ -1,0 +1,48 @@
+=== tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJs.js ===
+// classes
+class C {
+>C : C
+
+    /**
+     * @readonly
+     */
+    static readonlyStaticCall = Symbol();
+>readonlyStaticCall : unique symbol
+>Symbol() : unique symbol
+>Symbol : SymbolConstructor
+
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonlyStaticType;
+>readonlyStaticType : symbol
+
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonlyStaticTypeAndCall = Symbol();
+>readonlyStaticTypeAndCall : symbol
+>Symbol() : unique symbol
+>Symbol : SymbolConstructor
+
+    static readwriteStaticCall = Symbol();
+>readwriteStaticCall : symbol
+>Symbol() : symbol
+>Symbol : SymbolConstructor
+
+    /**
+     * @readonly
+     */
+    readonlyCall = Symbol();
+>readonlyCall : symbol
+>Symbol() : symbol
+>Symbol : SymbolConstructor
+
+    readwriteCall = Symbol();
+>readwriteCall : symbol
+>Symbol() : symbol
+>Symbol : SymbolConstructor
+}
+

--- a/tests/baselines/reference/uniqueSymbolsDeclarationsInJsErrors.errors.txt
+++ b/tests/baselines/reference/uniqueSymbolsDeclarationsInJsErrors.errors.txt
@@ -1,0 +1,24 @@
+tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.js(5,12): error TS1331: A property of a class whose type is a 'unique symbol' type must be both 'static' and 'readonly'.
+tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.js(14,12): error TS1331: A property of a class whose type is a 'unique symbol' type must be both 'static' and 'readonly'.
+
+
+==== tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.js (2 errors) ====
+    class C {
+        /**
+         * @type {unique symbol}
+         */
+        static readwriteStaticType;
+               ~~~~~~~~~~~~~~~~~~~
+!!! error TS1331: A property of a class whose type is a 'unique symbol' type must be both 'static' and 'readonly'.
+        /**
+         * @type {unique symbol}
+         * @readonly
+         */
+        static readonlyType;
+        /**
+         * @type {unique symbol}
+         */
+        static readwriteType;
+               ~~~~~~~~~~~~~
+!!! error TS1331: A property of a class whose type is a 'unique symbol' type must be both 'static' and 'readonly'.
+    }

--- a/tests/baselines/reference/uniqueSymbolsDeclarationsInJsErrors.js
+++ b/tests/baselines/reference/uniqueSymbolsDeclarationsInJsErrors.js
@@ -1,0 +1,38 @@
+//// [uniqueSymbolsDeclarationsInJsErrors.js]
+class C {
+    /**
+     * @type {unique symbol}
+     */
+    static readwriteStaticType;
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonlyType;
+    /**
+     * @type {unique symbol}
+     */
+    static readwriteType;
+}
+
+//// [uniqueSymbolsDeclarationsInJsErrors-out.js]
+class C {
+}
+
+
+//// [uniqueSymbolsDeclarationsInJsErrors-out.d.ts]
+declare class C {
+    /**
+     * @type {unique symbol}
+     */
+    static readwriteStaticType: unique symbol;
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonly readonlyType: unique symbol;
+    /**
+     * @type {unique symbol}
+     */
+    static readwriteType: unique symbol;
+}

--- a/tests/baselines/reference/uniqueSymbolsDeclarationsInJsErrors.symbols
+++ b/tests/baselines/reference/uniqueSymbolsDeclarationsInJsErrors.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.js ===
+class C {
+>C : Symbol(C, Decl(uniqueSymbolsDeclarationsInJsErrors.js, 0, 0))
+
+    /**
+     * @type {unique symbol}
+     */
+    static readwriteStaticType;
+>readwriteStaticType : Symbol(C.readwriteStaticType, Decl(uniqueSymbolsDeclarationsInJsErrors.js, 0, 9))
+
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonlyType;
+>readonlyType : Symbol(C.readonlyType, Decl(uniqueSymbolsDeclarationsInJsErrors.js, 4, 31))
+
+    /**
+     * @type {unique symbol}
+     */
+    static readwriteType;
+>readwriteType : Symbol(C.readwriteType, Decl(uniqueSymbolsDeclarationsInJsErrors.js, 9, 24))
+}

--- a/tests/baselines/reference/uniqueSymbolsDeclarationsInJsErrors.types
+++ b/tests/baselines/reference/uniqueSymbolsDeclarationsInJsErrors.types
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.js ===
+class C {
+>C : C
+
+    /**
+     * @type {unique symbol}
+     */
+    static readwriteStaticType;
+>readwriteStaticType : symbol
+
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonlyType;
+>readonlyType : symbol
+
+    /**
+     * @type {unique symbol}
+     */
+    static readwriteType;
+>readwriteType : symbol
+}

--- a/tests/cases/conformance/jsdoc/jsdocAccessibilityTagsDeclarations.ts
+++ b/tests/cases/conformance/jsdoc/jsdocAccessibilityTagsDeclarations.ts
@@ -35,3 +35,9 @@ class Private {
     /** @private */
     set p(value) { this.c = value }
 }
+
+// https://github.com/microsoft/TypeScript/issues/38401
+class C {
+    constructor(/** @public */ x, /** @protected */ y, /** @private */ z) {
+    }
+}

--- a/tests/cases/conformance/jsdoc/jsdocReadonlyDeclarations.ts
+++ b/tests/cases/conformance/jsdoc/jsdocReadonlyDeclarations.ts
@@ -23,3 +23,8 @@ function F() {
     /** @readonly */
     this.z = 1
 }
+
+// https://github.com/microsoft/TypeScript/issues/38401
+class D {
+    constructor(/** @readonly */ x) {}
+}

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJs.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJs.ts
@@ -1,0 +1,32 @@
+// @target: esnext
+// @lib: esnext
+// @declaration: true
+// @allowJs: true
+// @checkJs: true
+// @filename: uniqueSymbolsDeclarationsInJs.js
+// @out: uniqueSymbolsDeclarationsInJs-out.js
+
+// classes
+class C {
+    /**
+     * @readonly
+     */
+    static readonlyStaticCall = Symbol();
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonlyStaticType;
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonlyStaticTypeAndCall = Symbol();
+    static readwriteStaticCall = Symbol();
+
+    /**
+     * @readonly
+     */
+    readonlyCall = Symbol();
+    readwriteCall = Symbol();
+}

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.ts
@@ -1,0 +1,23 @@
+// @target: esnext
+// @lib: esnext
+// @declaration: true
+// @allowJs: true
+// @checkJs: true
+// @filename: uniqueSymbolsDeclarationsInJsErrors.js
+// @out: uniqueSymbolsDeclarationsInJsErrors-out.js
+
+class C {
+    /**
+     * @type {unique symbol}
+     */
+    static readwriteStaticType;
+    /**
+     * @type {unique symbol}
+     * @readonly
+     */
+    static readonlyType;
+    /**
+     * @type {unique symbol}
+     */
+    static readwriteType;
+}


### PR DESCRIPTION
When we added support for `@public`, `@private`, `@protected`, `@readonly` JSDoc-style modifiers, we inadvertently treated such modifiers on constructor properties as if they were TypeScript "parameter property modifiers", resulting in comments in a JS source file affecting JS emit.

This PR splits the various "modifier"-related functions into "syntactic" and "effective" forms, where "syntactic" modifiers are derived from syntax, and "effective" modifiers including both the syntactic modifiers as well as modifiers derived from "jsdoc" comments.

Fixes #38401

/cc @DanielRosenwasser, @RyanCavanaugh in case we decide to take this for 3.9.