### PR TITLE
Address false positive cases for return value codefix

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3568,9 +3568,9 @@ namespace ts {
         /* @internal */ createAnonymousType(symbol: Symbol | undefined, members: SymbolTable, callSignatures: Signature[], constructSignatures: Signature[], stringIndexInfo: IndexInfo | undefined, numberIndexInfo: IndexInfo | undefined): Type;
         /* @internal */ createSignature(
             declaration: SignatureDeclaration,
-            typeParameters: TypeParameter[] | undefined,
+            typeParameters: readonly TypeParameter[] | undefined,
             thisParameter: Symbol | undefined,
-            parameters: Symbol[],
+            parameters: readonly Symbol[],
             resolvedReturnType: Type,
             typePredicate: TypePredicate | undefined,
             minArgumentCount: number,

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction11.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction11.ts
@@ -6,7 +6,7 @@
 
 // should not change type if it's incorrectly set
 verify.codeFix({
-    index: 2,
+    index: 0,
     description: "Add async modifier to containing function",
     newFileContent:
 `const f: string = async () => {

--- a/tests/cases/fourslash/codeFixCorrectReturnValue27.ts
+++ b/tests/cases/fourslash/codeFixCorrectReturnValue27.ts
@@ -1,0 +1,5 @@
+/// <reference path='fourslash.ts' />
+
+//// const a: ((() => number) | (() => undefined)) = () => { "" }
+
+verify.not.codeFixAvailable();


### PR DESCRIPTION
In #26434 we added a code fix that can insert a `return` statement in places where it is missing, however the code fix has a step that is intended to verify that the resulting return expression will be correctly assignable. Unfortunately, this code fix attempts to type check a purely synthetic AST with no `original` pointer set, which results in the call to `checker.getTypeAtLocation` essentially returning `any`. This results in false-positives for code fixes that should not be valid.

This changes the code fix to instead leverage the `checker.createSignature` and `checker.createAnonymousType` functions to synthesize the expected type for comparison.

