### PR TITLE
Fix some JSDoc factory function return types

### DIFF
--- a/src/compiler/factoryPublic.ts
+++ b/src/compiler/factoryPublic.ts
@@ -2592,23 +2592,23 @@ namespace ts {
     }
 
     export function createJSDocAuthorTag(comment?: string) {
-        return createJSDocTag(SyntaxKind.JSDocAuthorTag, "author", comment);
+        return createJSDocTag<JSDocAuthorTag>(SyntaxKind.JSDocAuthorTag, "author", comment);
     }
 
     export function createJSDocPublicTag() {
-        return createJSDocTag(SyntaxKind.JSDocPublicTag, "public");
+        return createJSDocTag<JSDocPublicTag>(SyntaxKind.JSDocPublicTag, "public");
     }
 
     export function createJSDocPrivateTag() {
-        return createJSDocTag(SyntaxKind.JSDocPrivateTag, "private");
+        return createJSDocTag<JSDocPrivateTag>(SyntaxKind.JSDocPrivateTag, "private");
     }
 
     export function createJSDocProtectedTag() {
-        return createJSDocTag(SyntaxKind.JSDocProtectedTag, "protected");
+        return createJSDocTag<JSDocProtectedTag>(SyntaxKind.JSDocProtectedTag, "protected");
     }
 
     export function createJSDocReadonlyTag() {
-        return createJSDocTag(SyntaxKind.JSDocReadonlyTag, "readonly");
+        return createJSDocTag<JSDocReadonlyTag>(SyntaxKind.JSDocReadonlyTag, "readonly");
     }
 
     export function appendJSDocToContainer(node: JSDocContainer, jsdoc: JSDoc) {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4268,11 +4268,11 @@ declare namespace ts {
     function createJSDocParameterTag(typeExpression: JSDocTypeExpression | undefined, name: EntityName, isNameFirst: boolean, isBracketed: boolean, comment?: string): JSDocParameterTag;
     function createJSDocTypeLiteral(jsDocPropertyTags?: readonly JSDocPropertyLikeTag[], isArrayType?: boolean): JSDocTypeLiteral;
     function createJSDocImplementsTag(classExpression: JSDocImplementsTag["class"], comment?: string): JSDocImplementsTag;
-    function createJSDocAuthorTag(comment?: string): JSDocTag;
-    function createJSDocPublicTag(): JSDocTag;
-    function createJSDocPrivateTag(): JSDocTag;
-    function createJSDocProtectedTag(): JSDocTag;
-    function createJSDocReadonlyTag(): JSDocTag;
+    function createJSDocAuthorTag(comment?: string): JSDocAuthorTag;
+    function createJSDocPublicTag(): JSDocPublicTag;
+    function createJSDocPrivateTag(): JSDocPrivateTag;
+    function createJSDocProtectedTag(): JSDocProtectedTag;
+    function createJSDocReadonlyTag(): JSDocReadonlyTag;
     function appendJSDocToContainer(node: JSDocContainer, jsdoc: JSDoc): JSDocContainer;
     function createJsxElement(openingElement: JsxOpeningElement, children: readonly JsxChild[], closingElement: JsxClosingElement): JsxElement;
     function updateJsxElement(node: JsxElement, openingElement: JsxOpeningElement, children: readonly JsxChild[], closingElement: JsxClosingElement): JsxElement;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4268,11 +4268,11 @@ declare namespace ts {
     function createJSDocParameterTag(typeExpression: JSDocTypeExpression | undefined, name: EntityName, isNameFirst: boolean, isBracketed: boolean, comment?: string): JSDocParameterTag;
     function createJSDocTypeLiteral(jsDocPropertyTags?: readonly JSDocPropertyLikeTag[], isArrayType?: boolean): JSDocTypeLiteral;
     function createJSDocImplementsTag(classExpression: JSDocImplementsTag["class"], comment?: string): JSDocImplementsTag;
-    function createJSDocAuthorTag(comment?: string): JSDocTag;
-    function createJSDocPublicTag(): JSDocTag;
-    function createJSDocPrivateTag(): JSDocTag;
-    function createJSDocProtectedTag(): JSDocTag;
-    function createJSDocReadonlyTag(): JSDocTag;
+    function createJSDocAuthorTag(comment?: string): JSDocAuthorTag;
+    function createJSDocPublicTag(): JSDocPublicTag;
+    function createJSDocPrivateTag(): JSDocPrivateTag;
+    function createJSDocProtectedTag(): JSDocProtectedTag;
+    function createJSDocReadonlyTag(): JSDocReadonlyTag;
     function appendJSDocToContainer(node: JSDocContainer, jsdoc: JSDoc): JSDocContainer;
     function createJsxElement(openingElement: JsxOpeningElement, children: readonly JsxChild[], closingElement: JsxClosingElement): JsxElement;
     function updateJsxElement(node: JsxElement, openingElement: JsxOpeningElement, children: readonly JsxChild[], closingElement: JsxClosingElement): JsxElement;


### PR DESCRIPTION
Small PR that fixes some of the return types on the JS doc factory functions (didn't bother opening an issue because it's so small).
