### PR TITLE
Fix argument to require() must be a string literal

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1256,7 +1256,8 @@ namespace ts {
                 require: (baseDir, moduleName) => {
                     try {
                         const modulePath = resolveJSModule(moduleName, baseDir, nodeSystem);
-                        return { module: require(modulePath), modulePath, error: undefined };
+                        // eslint-disable-next-line no-eval
+                        return { module: eval("module.require")(modulePath), modulePath, error: undefined };
                     }
                     catch (error) {
                         return { module: undefined, modulePath: undefined, error };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes Webpack warn that require argument should be string