### PR TITLE
Fix crash in JS declaration emit

### DIFF
--- a/tests/baselines/reference/jsDeclarationsClassLikeHeuristic.errors.txt
+++ b/tests/baselines/reference/jsDeclarationsClassLikeHeuristic.errors.txt
@@ -1,0 +1,10 @@
+tests/cases/conformance/jsdoc/declarations/index.js(4,3): error TS2339: Property 'prototype' does not exist on type '{}'.
+
+
+==== tests/cases/conformance/jsdoc/declarations/index.js (1 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/35801
+    let A;
+    A = {};
+    A.prototype.b = {};
+      ~~~~~~~~~
+!!! error TS2339: Property 'prototype' does not exist on type '{}'.

--- a/tests/baselines/reference/jsDeclarationsClassLikeHeuristic.js
+++ b/tests/baselines/reference/jsDeclarationsClassLikeHeuristic.js
@@ -1,0 +1,15 @@
+//// [index.js]
+// https://github.com/microsoft/TypeScript/issues/35801
+let A;
+A = {};
+A.prototype.b = {};
+
+//// [index.js]
+// https://github.com/microsoft/TypeScript/issues/35801
+var A;
+A = {};
+A.prototype.b = {};
+
+
+//// [index.d.ts]
+declare let A: any;

--- a/tests/baselines/reference/jsDeclarationsClassLikeHeuristic.js
+++ b/tests/baselines/reference/jsDeclarationsClassLikeHeuristic.js
@@ -12,4 +12,7 @@ A.prototype.b = {};
 
 
 //// [index.d.ts]
-declare let A: any;
+declare class A {
+    private constructor();
+    b: {};
+}

--- a/tests/baselines/reference/jsDeclarationsClassLikeHeuristic.symbols
+++ b/tests/baselines/reference/jsDeclarationsClassLikeHeuristic.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/jsdoc/declarations/index.js ===
+// https://github.com/microsoft/TypeScript/issues/35801
+let A;
+>A : Symbol(A, Decl(index.js, 1, 3))
+
+A = {};
+>A : Symbol(A, Decl(index.js, 1, 3))
+
+A.prototype.b = {};
+>A.prototype : Symbol(A.b, Decl(index.js, 2, 7))
+>A : Symbol(A, Decl(index.js, 1, 3))
+>b : Symbol(A.b, Decl(index.js, 2, 7))
+

--- a/tests/baselines/reference/jsDeclarationsClassLikeHeuristic.types
+++ b/tests/baselines/reference/jsDeclarationsClassLikeHeuristic.types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/jsdoc/declarations/index.js ===
+// https://github.com/microsoft/TypeScript/issues/35801
+let A;
+>A : any
+
+A = {};
+>A = {} : {}
+>A : any
+>{} : {}
+
+A.prototype.b = {};
+>A.prototype.b = {} : {}
+>A.prototype.b : any
+>A.prototype : any
+>A : {}
+>prototype : any
+>b : any
+>{} : {}
+

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassLikeHeuristic.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassLikeHeuristic.ts
@@ -1,0 +1,10 @@
+// @allowJs: true
+// @checkJs: true
+// @target: es5
+// @outDir: ./out
+// @declaration: true
+// @filename: index.js
+// https://github.com/microsoft/TypeScript/issues/35801
+let A;
+A = {};
+A.prototype.b = {};


### PR DESCRIPTION
Our binder has a heuristic that detects `X.prototype.y` assignment in a JS file and treats `X` as a class, even if `X` isn't constructible. That results in a crash in JS declaration emit. This adds a check to ensure that the symbol for `X` actually has valid signatures.

Fixes #36273
