### PR TITLE
Remove resolveUntypedCall from checkJsxSelfClosingElementDeferred

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23378,7 +23378,6 @@ namespace ts {
 
         function checkJsxSelfClosingElementDeferred(node: JsxSelfClosingElement) {
             checkJsxOpeningLikeElementOrOpeningFragment(node);
-            resolveUntypedCall(node); // ensure type arguments and parameters are typechecked, even if there is an arity error
         }
 
         function checkJsxSelfClosingElement(node: JsxSelfClosingElement, _checkMode: CheckMode | undefined): Type {


### PR DESCRIPTION
This doesn't cause any tests to fail; I'll see whether it causes user tests to fail.

This call is responsible for a 5% slowdown or so in ant-design, which is a generic react library with big types. So it's not too surprising that any additional checking is quite slow.

Fixes, or at least addresses, #38477

From discussion with @weswigham:

1. This check was not technically needed in #36744 to replace the previous checks.
2. But is definitely something we *should* be doing.

Additionally, I'd say:

3. It's scary that we don't have any tests anywhere that notice this check disappearing.