### PR TITLE
Fix top-level await parsing (#38483)

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4150,8 +4150,15 @@ namespace ts {
                     return true;
                 }
 
+                // This handles cases like `await (async () => {})()`
+                // One drawback of this implementation is that we cannot use this form in top-level
+                // if there is an "await" identifier as we cannot differentiate this two cases
+                const isCallLike = () => {
+                    return (nextToken() === SyntaxKind.OpenParenToken && !identifiers.has("await")) && !scanner.hasPrecedingLineBreak();
+                };
+
                 // here we are using similar heuristics as 'isYieldExpression'
-                return lookAhead(nextTokenIsIdentifierOrKeywordOrLiteralOnSameLine);
+                return lookAhead(isCallLike) || lookAhead(nextTokenIsIdentifierOrKeywordOrLiteralOnSameLine);
             }
 
             return false;

--- a/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).errors.txt
+++ b/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).errors.txt
@@ -1,9 +1,13 @@
 tests/cases/conformance/externalModules/topLevelAwait.ts(2,1): error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'esnext' or 'system', and the 'target' option is set to 'es2017' or higher.
+tests/cases/conformance/externalModules/topLevelAwait.ts(4,1): error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'esnext' or 'system', and the 'target' option is set to 'es2017' or higher.
 
 
-==== tests/cases/conformance/externalModules/topLevelAwait.ts (1 errors) ====
+==== tests/cases/conformance/externalModules/topLevelAwait.ts (2 errors) ====
     export const x = 1;
     await x;
     ~~~~~
 !!! error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'esnext' or 'system', and the 'target' option is set to 'es2017' or higher.
     
+    await (async () => {})();
+    ~~~~~
+!!! error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'esnext' or 'system', and the 'target' option is set to 'es2017' or higher.

--- a/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).js
@@ -2,7 +2,18 @@
 export const x = 1;
 await x;
 
+await (async () => {})();
 
 //// [topLevelAwait.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 export const x = 1;
 await x;
+await (() => __awaiter(void 0, void 0, void 0, function* () { }))();

--- a/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).symbols
+++ b/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).symbols
@@ -5,3 +5,4 @@ export const x = 1;
 await x;
 >x : Symbol(x, Decl(topLevelAwait.ts, 0, 12))
 
+await (async () => {})();

--- a/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).types
+++ b/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).types
@@ -7,3 +7,9 @@ await x;
 >await x : 1
 >x : 1
 
+await (async () => {})();
+>await (async () => {})() : void
+>(async () => {})() : Promise<void>
+>(async () => {}) : () => Promise<void>
+>async () => {} : () => Promise<void>
+

--- a/tests/baselines/reference/topLevelAwait(module=esnext,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait(module=esnext,target=es2017).js
@@ -2,7 +2,9 @@
 export const x = 1;
 await x;
 
+await (async () => {})();
 
 //// [topLevelAwait.js]
 export const x = 1;
 await x;
+await (async () => { })();

--- a/tests/baselines/reference/topLevelAwait(module=esnext,target=es2017).symbols
+++ b/tests/baselines/reference/topLevelAwait(module=esnext,target=es2017).symbols
@@ -5,3 +5,4 @@ export const x = 1;
 await x;
 >x : Symbol(x, Decl(topLevelAwait.ts, 0, 12))
 
+await (async () => {})();

--- a/tests/baselines/reference/topLevelAwait(module=esnext,target=es2017).types
+++ b/tests/baselines/reference/topLevelAwait(module=esnext,target=es2017).types
@@ -7,3 +7,9 @@ await x;
 >await x : 1
 >x : 1
 
+await (async () => {})();
+>await (async () => {})() : void
+>(async () => {})() : Promise<void>
+>(async () => {}) : () => Promise<void>
+>async () => {} : () => Promise<void>
+

--- a/tests/baselines/reference/topLevelAwait(module=system,target=es2015).errors.txt
+++ b/tests/baselines/reference/topLevelAwait(module=system,target=es2015).errors.txt
@@ -1,9 +1,13 @@
 tests/cases/conformance/externalModules/topLevelAwait.ts(2,1): error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'esnext' or 'system', and the 'target' option is set to 'es2017' or higher.
+tests/cases/conformance/externalModules/topLevelAwait.ts(4,1): error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'esnext' or 'system', and the 'target' option is set to 'es2017' or higher.
 
 
-==== tests/cases/conformance/externalModules/topLevelAwait.ts (1 errors) ====
+==== tests/cases/conformance/externalModules/topLevelAwait.ts (2 errors) ====
     export const x = 1;
     await x;
     ~~~~~
 !!! error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'esnext' or 'system', and the 'target' option is set to 'es2017' or higher.
     
+    await (async () => {})();
+    ~~~~~
+!!! error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'esnext' or 'system', and the 'target' option is set to 'es2017' or higher.

--- a/tests/baselines/reference/topLevelAwait(module=system,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait(module=system,target=es2015).js
@@ -2,10 +2,20 @@
 export const x = 1;
 await x;
 
+await (async () => {})();
 
 //// [topLevelAwait.js]
 System.register([], function (exports_1, context_1) {
     "use strict";
+    var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+        function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
     var x;
     var __moduleName = context_1 && context_1.id;
     return {
@@ -13,6 +23,7 @@ System.register([], function (exports_1, context_1) {
         execute: async function () {
             exports_1("x", x = 1);
             await x;
+            await (() => __awaiter(void 0, void 0, void 0, function* () { }))();
         }
     };
 });

--- a/tests/baselines/reference/topLevelAwait(module=system,target=es2015).symbols
+++ b/tests/baselines/reference/topLevelAwait(module=system,target=es2015).symbols
@@ -5,3 +5,4 @@ export const x = 1;
 await x;
 >x : Symbol(x, Decl(topLevelAwait.ts, 0, 12))
 
+await (async () => {})();

--- a/tests/baselines/reference/topLevelAwait(module=system,target=es2015).types
+++ b/tests/baselines/reference/topLevelAwait(module=system,target=es2015).types
@@ -7,3 +7,9 @@ await x;
 >await x : 1
 >x : 1
 
+await (async () => {})();
+>await (async () => {})() : void
+>(async () => {})() : Promise<void>
+>(async () => {}) : () => Promise<void>
+>async () => {} : () => Promise<void>
+

--- a/tests/baselines/reference/topLevelAwait(module=system,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait(module=system,target=es2017).js
@@ -2,6 +2,7 @@
 export const x = 1;
 await x;
 
+await (async () => {})();
 
 //// [topLevelAwait.js]
 System.register([], function (exports_1, context_1) {
@@ -13,6 +14,7 @@ System.register([], function (exports_1, context_1) {
         execute: async function () {
             exports_1("x", x = 1);
             await x;
+            await (async () => { })();
         }
     };
 });

--- a/tests/baselines/reference/topLevelAwait(module=system,target=es2017).symbols
+++ b/tests/baselines/reference/topLevelAwait(module=system,target=es2017).symbols
@@ -5,3 +5,4 @@ export const x = 1;
 await x;
 >x : Symbol(x, Decl(topLevelAwait.ts, 0, 12))
 
+await (async () => {})();

--- a/tests/baselines/reference/topLevelAwait(module=system,target=es2017).types
+++ b/tests/baselines/reference/topLevelAwait(module=system,target=es2017).types
@@ -7,3 +7,9 @@ await x;
 >await x : 1
 >x : 1
 
+await (async () => {})();
+>await (async () => {})() : void
+>(async () => {})() : Promise<void>
+>(async () => {}) : () => Promise<void>
+>async () => {} : () => Promise<void>
+

--- a/tests/cases/conformance/externalModules/topLevelAwait.ts
+++ b/tests/cases/conformance/externalModules/topLevelAwait.ts
@@ -2,3 +2,5 @@
 // @module: esnext,system
 export const x = 1;
 await x;
+
+await (async () => {})();


### PR DESCRIPTION
The previous implementation wasn't able to handle case like `await (async () => {})` outside of "async" functions.

One problem is that the syntax can be exactly the same for two usecases:

**Use case 1**
```typescript
await (async () => {})()
```
An await expression on the self-calling async function

**Use case 2**
```typescript
function await(fn) {
  return () => {};
}
await (async () => {})(); // equivalent to: await((async () => {})())
```
A call to the function returned by a call to the "await" user defined function with the `async () => {}` argument.

---

We have no way to know which case we want to handle. This pull request handles ***Use case 2*** first. If there is some identifier named "await" defined, we make this statement a function call, otherwise, we make it an await expression.

I can update this PR if someone has a better idea to handle this ambiguous case.

Fixes #38483