### PR TITLE
Detailed Intl.DateTimeFormatOptions types

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4277,20 +4277,34 @@ declare namespace Intl {
         supportedLocalesOf(locales: string | string[], options?: NumberFormatOptions): string[];
     };
 
+    type DateFormatNumericVerbosity = "numeric" | "2-digit";
+    type DateFormatNameVerbosity = "long" | "short" | "narrow";
+
     interface DateTimeFormatOptions {
-        localeMatcher?: string;
-        weekday?: string;
-        era?: string;
-        year?: string;
-        month?: string;
-        day?: string;
-        hour?: string;
-        minute?: string;
-        second?: string;
-        timeZoneName?: string;
-        formatMatcher?: string;
+        /** output examples – numeric: "2020", 2-digit: "20" */
+        year?: DateFormatNumericVerbosity;
+        /** output examples – numeric: "3", 2-digit: "03", long: "March", short: "Mar", narrow: "M" */
+        month?: DateFormatNumericVerbosity | DateFormatNameVerbosity;
+        /** output examples – numeric: "2", 2-digit: "02" */
+        day?: DateFormatNumericVerbosity;
+        /** output examples – numeric: "2", 2-digit: "02" */
+        hour?: DateFormatNumericVerbosity;
+        /** output examples – numeric: "2", 2-digit: "02" */
+        minute?: DateFormatNumericVerbosity;
+        /** output examples – numeric: "2", 2-digit: "02" */
+        second?: DateFormatNumericVerbosity;
+        /** output examples – long: "Thursday", short: "Thu", narrow: "T" */
+        weekday?: DateFormatNameVerbosity;
+        /** output examples – long: "Anno Domini", short: "AD", narrow "A" */
+        era?: DateFormatNameVerbosity;
+        /** set to `true` to force 12-hour am/pm "dayPeriod" values, or `false` to force 24-hour time without */
         hour12?: boolean;
+        /** output examples – long: "Pacific Daylight Time", short: "PDT" */
+        timeZoneName?: "long" | "short";
+        /** set to the timezone name you want to render date and time for, e g "UTC", "Europe/Rome" */
         timeZone?: string;
+        localeMatcher?: "best fit" | "lookup";
+        formatMatcher?: "best fit" | "basic";
     }
 
     interface ResolvedDateTimeFormatOptions {

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4277,26 +4277,23 @@ declare namespace Intl {
         supportedLocalesOf(locales: string | string[], options?: NumberFormatOptions): string[];
     };
 
-    type DateFormatNumericVerbosity = "numeric" | "2-digit";
-    type DateFormatNameVerbosity = "long" | "short" | "narrow";
-
     interface DateTimeFormatOptions {
         /** output examples – numeric: "2020", 2-digit: "20" */
-        year?: DateFormatNumericVerbosity;
+        year?: "numeric" | "2-digit";
         /** output examples – numeric: "3", 2-digit: "03", long: "March", short: "Mar", narrow: "M" */
-        month?: DateFormatNumericVerbosity | DateFormatNameVerbosity;
+        month?: "numeric" | "2-digit" | "long" | "short" | "narrow";
         /** output examples – numeric: "2", 2-digit: "02" */
-        day?: DateFormatNumericVerbosity;
+        day?: "numeric" | "2-digit";
         /** output examples – numeric: "2", 2-digit: "02" */
-        hour?: DateFormatNumericVerbosity;
+        hour?: "numeric" | "2-digit";
         /** output examples – numeric: "2", 2-digit: "02" */
-        minute?: DateFormatNumericVerbosity;
+        minute?: "numeric" | "2-digit";
         /** output examples – numeric: "2", 2-digit: "02" */
-        second?: DateFormatNumericVerbosity;
+        second?: "numeric" | "2-digit";
         /** output examples – long: "Thursday", short: "Thu", narrow: "T" */
-        weekday?: DateFormatNameVerbosity;
+        weekday?: "long" | "short" | "narrow";
         /** output examples – long: "Anno Domini", short: "AD", narrow "A" */
-        era?: DateFormatNameVerbosity;
+        era?: "long" | "short" | "narrow";
         /** set to `true` to force 12-hour am/pm "dayPeriod" values, or `false` to force 24-hour time without */
         hour12?: boolean;
         /** output examples – long: "Pacific Daylight Time", short: "PDT" */


### PR DESCRIPTION
Fixes #35865: Missing specific types in DateTimeFormatOptions.

This narrows the type info for `Intl.DateTimeFormatOptions` to legal inputs.

Existing code passing options satisfying the former (overly-lax) types in shipping typescript (and which browsers would thus throw a run-time `RangeError` exception for), will now be flagged as typescript compile-time errors, instead.