### PR TITLE
Perform intersection reduction before and after getApparentType

### DIFF
--- a/tests/baselines/reference/intersectionReduction.errors.txt
+++ b/tests/baselines/reference/intersectionReduction.errors.txt
@@ -121,3 +121,35 @@ tests/cases/conformance/types/intersection/intersectionReduction.ts(81,1): error
     const f3 = (t: Container<"a"> | (Container<"b"> & { dataB: boolean } & Container<"a">)): Container<"a"> => t;
     const f4 = (t: number | (Container<"b"> & { dataB: boolean } & Container<"a">)): number => t;
     
+    // Repro from #38549
+    
+    interface A2 {
+        kind: "A";
+        a: number;
+    }
+    
+    interface B2 {
+        kind: "B";
+        b: number;
+    }
+    
+    declare const shouldBeB: (A2 | B2) & B2;
+    const b: B2 = shouldBeB; // works
+    
+    function inGeneric<T extends A2 | B2>(alsoShouldBeB: T & B2) {
+        const b: B2 = alsoShouldBeB;
+    }
+    
+    // Repro from #38542
+    
+    interface ABI {
+        kind: 'a' | 'b';
+    }
+    
+    declare class CA { kind: 'a'; a: string; x: number };
+    declare class CB { kind: 'b'; b: string; y: number };
+    
+    function bar<T extends CA | CB>(x: T & CA) {
+        let ab: ABI = x;
+    }
+    

--- a/tests/baselines/reference/intersectionReduction.js
+++ b/tests/baselines/reference/intersectionReduction.js
@@ -108,6 +108,38 @@ const f2 = (t: Container<"a"> | (Container<"b"> & Container<"c">)): Container<"a
 const f3 = (t: Container<"a"> | (Container<"b"> & { dataB: boolean } & Container<"a">)): Container<"a"> => t;
 const f4 = (t: number | (Container<"b"> & { dataB: boolean } & Container<"a">)): number => t;
 
+// Repro from #38549
+
+interface A2 {
+    kind: "A";
+    a: number;
+}
+
+interface B2 {
+    kind: "B";
+    b: number;
+}
+
+declare const shouldBeB: (A2 | B2) & B2;
+const b: B2 = shouldBeB; // works
+
+function inGeneric<T extends A2 | B2>(alsoShouldBeB: T & B2) {
+    const b: B2 = alsoShouldBeB;
+}
+
+// Repro from #38542
+
+interface ABI {
+    kind: 'a' | 'b';
+}
+
+declare class CA { kind: 'a'; a: string; x: number };
+declare class CB { kind: 'b'; b: string; y: number };
+
+function bar<T extends CA | CB>(x: T & CA) {
+    let ab: ABI = x;
+}
+
 
 //// [intersectionReduction.js]
 ab.kind; // Error
@@ -128,3 +160,12 @@ var f1 = function (t) { return t; };
 var f2 = function (t) { return t; };
 var f3 = function (t) { return t; };
 var f4 = function (t) { return t; };
+var b = shouldBeB; // works
+function inGeneric(alsoShouldBeB) {
+    var b = alsoShouldBeB;
+}
+;
+;
+function bar(x) {
+    var ab = x;
+}

--- a/tests/baselines/reference/intersectionReduction.symbols
+++ b/tests/baselines/reference/intersectionReduction.symbols
@@ -373,3 +373,87 @@ const f4 = (t: number | (Container<"b"> & { dataB: boolean } & Container<"a">)):
 >Container : Symbol(Container, Decl(intersectionReduction.ts, 99, 44))
 >t : Symbol(t, Decl(intersectionReduction.ts, 107, 12))
 
+// Repro from #38549
+
+interface A2 {
+>A2 : Symbol(A2, Decl(intersectionReduction.ts, 107, 93))
+
+    kind: "A";
+>kind : Symbol(A2.kind, Decl(intersectionReduction.ts, 111, 14))
+
+    a: number;
+>a : Symbol(A2.a, Decl(intersectionReduction.ts, 112, 14))
+}
+
+interface B2 {
+>B2 : Symbol(B2, Decl(intersectionReduction.ts, 114, 1))
+
+    kind: "B";
+>kind : Symbol(B2.kind, Decl(intersectionReduction.ts, 116, 14))
+
+    b: number;
+>b : Symbol(B2.b, Decl(intersectionReduction.ts, 117, 14))
+}
+
+declare const shouldBeB: (A2 | B2) & B2;
+>shouldBeB : Symbol(shouldBeB, Decl(intersectionReduction.ts, 121, 13))
+>A2 : Symbol(A2, Decl(intersectionReduction.ts, 107, 93))
+>B2 : Symbol(B2, Decl(intersectionReduction.ts, 114, 1))
+>B2 : Symbol(B2, Decl(intersectionReduction.ts, 114, 1))
+
+const b: B2 = shouldBeB; // works
+>b : Symbol(b, Decl(intersectionReduction.ts, 122, 5))
+>B2 : Symbol(B2, Decl(intersectionReduction.ts, 114, 1))
+>shouldBeB : Symbol(shouldBeB, Decl(intersectionReduction.ts, 121, 13))
+
+function inGeneric<T extends A2 | B2>(alsoShouldBeB: T & B2) {
+>inGeneric : Symbol(inGeneric, Decl(intersectionReduction.ts, 122, 24))
+>T : Symbol(T, Decl(intersectionReduction.ts, 124, 19))
+>A2 : Symbol(A2, Decl(intersectionReduction.ts, 107, 93))
+>B2 : Symbol(B2, Decl(intersectionReduction.ts, 114, 1))
+>alsoShouldBeB : Symbol(alsoShouldBeB, Decl(intersectionReduction.ts, 124, 38))
+>T : Symbol(T, Decl(intersectionReduction.ts, 124, 19))
+>B2 : Symbol(B2, Decl(intersectionReduction.ts, 114, 1))
+
+    const b: B2 = alsoShouldBeB;
+>b : Symbol(b, Decl(intersectionReduction.ts, 125, 9))
+>B2 : Symbol(B2, Decl(intersectionReduction.ts, 114, 1))
+>alsoShouldBeB : Symbol(alsoShouldBeB, Decl(intersectionReduction.ts, 124, 38))
+}
+
+// Repro from #38542
+
+interface ABI {
+>ABI : Symbol(ABI, Decl(intersectionReduction.ts, 126, 1))
+
+    kind: 'a' | 'b';
+>kind : Symbol(ABI.kind, Decl(intersectionReduction.ts, 130, 15))
+}
+
+declare class CA { kind: 'a'; a: string; x: number };
+>CA : Symbol(CA, Decl(intersectionReduction.ts, 132, 1))
+>kind : Symbol(CA.kind, Decl(intersectionReduction.ts, 134, 18))
+>a : Symbol(CA.a, Decl(intersectionReduction.ts, 134, 29))
+>x : Symbol(CA.x, Decl(intersectionReduction.ts, 134, 40))
+
+declare class CB { kind: 'b'; b: string; y: number };
+>CB : Symbol(CB, Decl(intersectionReduction.ts, 134, 53))
+>kind : Symbol(CB.kind, Decl(intersectionReduction.ts, 135, 18))
+>b : Symbol(CB.b, Decl(intersectionReduction.ts, 135, 29))
+>y : Symbol(CB.y, Decl(intersectionReduction.ts, 135, 40))
+
+function bar<T extends CA | CB>(x: T & CA) {
+>bar : Symbol(bar, Decl(intersectionReduction.ts, 135, 53))
+>T : Symbol(T, Decl(intersectionReduction.ts, 137, 13))
+>CA : Symbol(CA, Decl(intersectionReduction.ts, 132, 1))
+>CB : Symbol(CB, Decl(intersectionReduction.ts, 134, 53))
+>x : Symbol(x, Decl(intersectionReduction.ts, 137, 32))
+>T : Symbol(T, Decl(intersectionReduction.ts, 137, 13))
+>CA : Symbol(CA, Decl(intersectionReduction.ts, 132, 1))
+
+    let ab: ABI = x;
+>ab : Symbol(ab, Decl(intersectionReduction.ts, 138, 7))
+>ABI : Symbol(ABI, Decl(intersectionReduction.ts, 126, 1))
+>x : Symbol(x, Decl(intersectionReduction.ts, 137, 32))
+}
+

--- a/tests/baselines/reference/intersectionReduction.types
+++ b/tests/baselines/reference/intersectionReduction.types
@@ -315,3 +315,65 @@ const f4 = (t: number | (Container<"b"> & { dataB: boolean } & Container<"a">)):
 >dataB : boolean
 >t : number
 
+// Repro from #38549
+
+interface A2 {
+    kind: "A";
+>kind : "A"
+
+    a: number;
+>a : number
+}
+
+interface B2 {
+    kind: "B";
+>kind : "B"
+
+    b: number;
+>b : number
+}
+
+declare const shouldBeB: (A2 | B2) & B2;
+>shouldBeB : B2
+
+const b: B2 = shouldBeB; // works
+>b : B2
+>shouldBeB : B2
+
+function inGeneric<T extends A2 | B2>(alsoShouldBeB: T & B2) {
+>inGeneric : <T extends A2 | B2>(alsoShouldBeB: T & B2) => void
+>alsoShouldBeB : T & B2
+
+    const b: B2 = alsoShouldBeB;
+>b : B2
+>alsoShouldBeB : T & B2
+}
+
+// Repro from #38542
+
+interface ABI {
+    kind: 'a' | 'b';
+>kind : "a" | "b"
+}
+
+declare class CA { kind: 'a'; a: string; x: number };
+>CA : CA
+>kind : "a"
+>a : string
+>x : number
+
+declare class CB { kind: 'b'; b: string; y: number };
+>CB : CB
+>kind : "b"
+>b : string
+>y : number
+
+function bar<T extends CA | CB>(x: T & CA) {
+>bar : <T extends CA | CB>(x: T & CA) => void
+>x : T & CA
+
+    let ab: ABI = x;
+>ab : ABI
+>x : T & CA
+}
+

--- a/tests/cases/conformance/types/intersection/intersectionReduction.ts
+++ b/tests/cases/conformance/types/intersection/intersectionReduction.ts
@@ -108,3 +108,35 @@ type Container<Type extends string> = {
 const f2 = (t: Container<"a"> | (Container<"b"> & Container<"c">)): Container<"a"> => t;
 const f3 = (t: Container<"a"> | (Container<"b"> & { dataB: boolean } & Container<"a">)): Container<"a"> => t;
 const f4 = (t: number | (Container<"b"> & { dataB: boolean } & Container<"a">)): number => t;
+
+// Repro from #38549
+
+interface A2 {
+    kind: "A";
+    a: number;
+}
+
+interface B2 {
+    kind: "B";
+    b: number;
+}
+
+declare const shouldBeB: (A2 | B2) & B2;
+const b: B2 = shouldBeB; // works
+
+function inGeneric<T extends A2 | B2>(alsoShouldBeB: T & B2) {
+    const b: B2 = alsoShouldBeB;
+}
+
+// Repro from #38542
+
+interface ABI {
+    kind: 'a' | 'b';
+}
+
+declare class CA { kind: 'a'; a: string; x: number };
+declare class CB { kind: 'b'; b: string; y: number };
+
+function bar<T extends CA | CB>(x: T & CA) {
+    let ab: ABI = x;
+}


### PR DESCRIPTION
Fixes #38542.
Fixes #38549.