### PR TITLE
fix wrapping classes when targeting ESNext

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -23,10 +23,10 @@ namespace ts {
         IsNamedExternalExport = 1 << 4,
         IsDefaultExternalExport = 1 << 5,
         IsDerivedClass = 1 << 6,
+        UseImmediatelyInvokedFunctionExpression = 1 << 7,
 
         HasAnyDecorators = HasConstructorDecorators | HasMemberDecorators,
         NeedsName = HasStaticInitializedProperties | HasMemberDecorators,
-        UseImmediatelyInvokedFunctionExpression = HasAnyDecorators | HasStaticInitializedProperties,
         IsExported = IsExportOfNamespace | IsDefaultExternalExport | IsNamedExternalExport,
     }
 
@@ -595,6 +595,10 @@ namespace ts {
             if (isExportOfNamespace(node)) facts |= ClassFacts.IsExportOfNamespace;
             else if (isDefaultExternalModuleExport(node)) facts |= ClassFacts.IsDefaultExternalExport;
             else if (isNamedExternalModuleExport(node)) facts |= ClassFacts.IsNamedExternalExport;
+            if (facts & ClassFacts.HasAnyDecorators) facts |= ClassFacts.UseImmediatelyInvokedFunctionExpression;
+            if (facts & ClassFacts.HasStaticInitializedProperties) {
+                if (languageVersion < ScriptTarget.ESNext || !compilerOptions.useDefineForClassFields) facts |= ClassFacts.UseImmediatelyInvokedFunctionExpression;
+            }
             return facts;
         }
 

--- a/tests/baselines/reference/thisInClassBodyStaticESNext.js
+++ b/tests/baselines/reference/thisInClassBodyStaticESNext.js
@@ -11,13 +11,10 @@ class Foo {
 
 //// [thisInClassBodyStaticESNext.js]
 // all are allowed with es-compliant class field emit
-let Foo = /** @class */ (() => {
-    class Foo {
-        x = this;
-        static t = this;
-        static at = () => this;
-        static ft = function () { return this; };
-        static mt() { return this; }
-    }
-    return Foo;
-})();
+class Foo {
+    x = this;
+    static t = this;
+    static at = () => this;
+    static ft = function () { return this; };
+    static mt() { return this; }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
This conforms to the behavior present in the class fields transformer: https://github.com/microsoft/TypeScript/blob/c1f676dd3f1337286bd99d3d189bc59c930b703d/src/compiler/transformers/classFields.ts#L70-L75

Fixes #38528
