### PR TITLE
Fix regression organize imports duplicates comments

### DIFF
--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -76,7 +76,7 @@ namespace ts.OrganizeImports {
 
             // Delete any subsequent imports.
             for (let i = 1; i < oldImportDecls.length; i++) {
-                changeTracker.delete(sourceFile, oldImportDecls[i]);
+                changeTracker.deleteNode(sourceFile, oldImportDecls[i]);
             }
         }
     }

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -286,6 +286,12 @@ namespace ts.textChanges {
             this.deletedNodes.push({ sourceFile, node });
         }
 
+        public deleteNode(sourceFile: SourceFile, node: Node, options: ConfigurableStartEnd = { leadingTriviaOption: LeadingTriviaOption.IncludeAll }): void {
+            const startPosition = getAdjustedStartPosition(sourceFile, node, options);
+            const endPosition = getAdjustedEndPosition(sourceFile, node, options);
+            this.deleteRange(sourceFile, { pos: startPosition, end: endPosition });
+        }
+
         public deleteModifier(sourceFile: SourceFile, modifier: Modifier): void {
             this.deleteRange(sourceFile, { pos: modifier.getStart(sourceFile), end: skipTrivia(sourceFile.text, modifier.end, /*stopAfterLineBreak*/ true) });
         }

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -287,9 +287,7 @@ namespace ts.textChanges {
         }
 
         public deleteNode(sourceFile: SourceFile, node: Node, options: ConfigurableStartEnd = { leadingTriviaOption: LeadingTriviaOption.IncludeAll }): void {
-            const startPosition = getAdjustedStartPosition(sourceFile, node, options);
-            const endPosition = getAdjustedEndPosition(sourceFile, node, options);
-            this.deleteRange(sourceFile, { pos: startPosition, end: endPosition });
+            this.deleteRange(sourceFile, getAdjustedRange(sourceFile, node, node, options));
         }
 
         public deleteModifier(sourceFile: SourceFile, modifier: Modifier): void {

--- a/src/testRunner/unittests/services/organizeImports.ts
+++ b/src/testRunner/unittests/services/organizeImports.ts
@@ -591,6 +591,22 @@ import "lib1";
                 },
                 { path: "/lib1.ts", content: "" },
                 { path: "/lib2.ts", content: "" });
+            
+                testOrganizeImports("SortComments",
+                {
+                    path: "/test.ts",
+                    content: `
+// Header
+import "lib3";
+// Comment2
+import "lib2";
+// Comment1
+import "lib1";
+`,
+                },
+                { path: "/lib1.ts", content: "" },
+                { path: "/lib2.ts", content: "" },
+                { path: "/lib3.ts", content: "" });
 
             testOrganizeImports("AmbientModule",
                 {

--- a/src/testRunner/unittests/services/organizeImports.ts
+++ b/src/testRunner/unittests/services/organizeImports.ts
@@ -591,7 +591,7 @@ import "lib1";
                 },
                 { path: "/lib1.ts", content: "" },
                 { path: "/lib2.ts", content: "" });
-            
+
                 testOrganizeImports("SortComments",
                 {
                     path: "/test.ts",

--- a/tests/baselines/reference/organizeImports/SortComments.ts
+++ b/tests/baselines/reference/organizeImports/SortComments.ts
@@ -1,0 +1,17 @@
+// ==ORIGINAL==
+
+// Header
+import "lib3";
+// Comment2
+import "lib2";
+// Comment1
+import "lib1";
+
+// ==ORGANIZED==
+
+// Header
+// Comment1
+import "lib1";
+// Comment2
+import "lib2";
+import "lib3";


### PR DESCRIPTION
Fixes #38507 

#37467 started preserving comments when deleting unused declarations. When organize imports creates a sorted list of imports, it deletes the old imports in the same way. This caused us to start duplicating comments when organizing imports.
