### PR TITLE
Introduces new flag for optimization hints

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -987,6 +987,13 @@ namespace ts {
             description: Diagnostics.Resolve_keyof_to_string_valued_property_names_only_no_numbers_or_symbols,
         },
         {
+          name: "addOptimizationHints",
+          type: "boolean",
+          affectsEmit: true,
+          category: Diagnostics.Advanced_Options,
+          description: Diagnostics.Resolve_keyof_to_string_valued_property_names_only_no_numbers_or_symbols,
+        },
+        {
             // A list of plugins to load in the language service
             name: "plugins",
             type: "list",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4400,6 +4400,10 @@
         "category": "Error",
         "code": 6233
     },
+    "Emit code hints for optimizers and minifiers.": {
+      "category": "Message",
+      "code": 6234
+    },
 
     "Projects to reference": {
         "category": "Message",

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -23,10 +23,10 @@ namespace ts {
         IsNamedExternalExport = 1 << 4,
         IsDefaultExternalExport = 1 << 5,
         IsDerivedClass = 1 << 6,
+        UseImmediatelyInvokedFunctionExpression = 1 << 7,
 
         HasAnyDecorators = HasConstructorDecorators | HasMemberDecorators,
         NeedsName = HasStaticInitializedProperties | HasMemberDecorators,
-        UseImmediatelyInvokedFunctionExpression = HasAnyDecorators | HasStaticInitializedProperties,
         IsExported = IsExportOfNamespace | IsDefaultExternalExport | IsNamedExternalExport,
     }
 
@@ -595,6 +595,11 @@ namespace ts {
             if (isExportOfNamespace(node)) facts |= ClassFacts.IsExportOfNamespace;
             else if (isDefaultExternalModuleExport(node)) facts |= ClassFacts.IsDefaultExternalExport;
             else if (isNamedExternalModuleExport(node)) facts |= ClassFacts.IsNamedExternalExport;
+            if (facts & ClassFacts.HasAnyDecorators) facts |= ClassFacts.UseImmediatelyInvokedFunctionExpression;
+            if (facts & ClassFacts.HasStaticInitializedProperties) {
+                if (languageVersion < ScriptTarget.ESNext) facts |= ClassFacts.UseImmediatelyInvokedFunctionExpression;
+                else if (languageVersion === ScriptTarget.ESNext && !compilerOptions.useDefineForClassFields) facts |= ClassFacts.UseImmediatelyInvokedFunctionExpression;
+            }
             return facts;
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5133,6 +5133,7 @@ namespace ts {
     export type CompilerOptionsValue = string | number | boolean | (string | number)[] | string[] | MapLike<string[]> | PluginImport[] | ProjectReference[] | null | undefined;
 
     export interface CompilerOptions {
+        addOptimizationHints?: boolean;
         /*@internal*/ all?: boolean;
         allowJs?: boolean;
         /*@internal*/ allowNonTsExtensions?: boolean;

--- a/tests/baselines/reference/addOptimizationHints.errors.txt
+++ b/tests/baselines/reference/addOptimizationHints.errors.txt
@@ -1,0 +1,23 @@
+tests/cases/compiler/addOptimizationHints.ts(13,2): error TS2304: Cannot find name 'decorate'.
+
+
+==== tests/cases/compiler/addOptimizationHints.ts (1 errors) ====
+    class HasNoStatics {
+      value: unknown;
+      method() {}
+    }
+    
+    class HasStatic {
+      static value = 0;
+      static someMethod() {}
+    
+      method() {}
+    }
+    
+    @decorate
+     ~~~~~~~~
+!!! error TS2304: Cannot find name 'decorate'.
+    class HasDecorator {
+      method() {}
+    }
+    

--- a/tests/baselines/reference/addOptimizationHints.js
+++ b/tests/baselines/reference/addOptimizationHints.js
@@ -1,0 +1,40 @@
+//// [addOptimizationHints.ts]
+class HasNoStatics {
+  value: unknown;
+  method() {}
+}
+
+class HasStatic {
+  static value = 0;
+  static someMethod() {}
+
+  method() {}
+}
+
+@decorate
+class HasDecorator {
+  method() {}
+}
+
+
+//// [addOptimizationHints.js]
+class HasNoStatics {
+    method() { }
+}
+let HasStatic = /** @class */ (() => {
+    class HasStatic {
+        static someMethod() { }
+        method() { }
+    }
+    HasStatic.value = 0;
+    return HasStatic;
+})();
+let HasDecorator = /** @class */ (() => {
+    let HasDecorator = class HasDecorator {
+        method() { }
+    };
+    HasDecorator = __decorate([
+        decorate
+    ], HasDecorator);
+    return HasDecorator;
+})();

--- a/tests/baselines/reference/addOptimizationHints.symbols
+++ b/tests/baselines/reference/addOptimizationHints.symbols
@@ -1,0 +1,32 @@
+=== tests/cases/compiler/addOptimizationHints.ts ===
+class HasNoStatics {
+>HasNoStatics : Symbol(HasNoStatics, Decl(addOptimizationHints.ts, 0, 0))
+
+  value: unknown;
+>value : Symbol(HasNoStatics.value, Decl(addOptimizationHints.ts, 0, 20))
+
+  method() {}
+>method : Symbol(HasNoStatics.method, Decl(addOptimizationHints.ts, 1, 17))
+}
+
+class HasStatic {
+>HasStatic : Symbol(HasStatic, Decl(addOptimizationHints.ts, 3, 1))
+
+  static value = 0;
+>value : Symbol(HasStatic.value, Decl(addOptimizationHints.ts, 5, 17))
+
+  static someMethod() {}
+>someMethod : Symbol(HasStatic.someMethod, Decl(addOptimizationHints.ts, 6, 19))
+
+  method() {}
+>method : Symbol(HasStatic.method, Decl(addOptimizationHints.ts, 7, 24))
+}
+
+@decorate
+class HasDecorator {
+>HasDecorator : Symbol(HasDecorator, Decl(addOptimizationHints.ts, 10, 1))
+
+  method() {}
+>method : Symbol(HasDecorator.method, Decl(addOptimizationHints.ts, 13, 20))
+}
+

--- a/tests/baselines/reference/addOptimizationHints.types
+++ b/tests/baselines/reference/addOptimizationHints.types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/addOptimizationHints.ts ===
+class HasNoStatics {
+>HasNoStatics : HasNoStatics
+
+  value: unknown;
+>value : unknown
+
+  method() {}
+>method : () => void
+}
+
+class HasStatic {
+>HasStatic : HasStatic
+
+  static value = 0;
+>value : number
+>0 : 0
+
+  static someMethod() {}
+>someMethod : () => void
+
+  method() {}
+>method : () => void
+}
+
+@decorate
+>decorate : any
+
+class HasDecorator {
+>HasDecorator : HasDecorator
+
+  method() {}
+>method : () => void
+}
+

--- a/tests/baselines/reference/addOptimizationHintsFalse.errors.txt
+++ b/tests/baselines/reference/addOptimizationHintsFalse.errors.txt
@@ -1,0 +1,23 @@
+tests/cases/compiler/addOptimizationHintsFalse.ts(13,2): error TS2304: Cannot find name 'decorate'.
+
+
+==== tests/cases/compiler/addOptimizationHintsFalse.ts (1 errors) ====
+    class HasNoStatics {
+      value: unknown;
+      method() {}
+    }
+    
+    class HasStatic {
+      static value = 0;
+      static someMethod() {}
+    
+      method() {}
+    }
+    
+    @decorate
+     ~~~~~~~~
+!!! error TS2304: Cannot find name 'decorate'.
+    class HasDecorator {
+      method() {}
+    }
+    

--- a/tests/baselines/reference/addOptimizationHintsFalse.js
+++ b/tests/baselines/reference/addOptimizationHintsFalse.js
@@ -1,0 +1,34 @@
+//// [addOptimizationHintsFalse.ts]
+class HasNoStatics {
+  value: unknown;
+  method() {}
+}
+
+class HasStatic {
+  static value = 0;
+  static someMethod() {}
+
+  method() {}
+}
+
+@decorate
+class HasDecorator {
+  method() {}
+}
+
+
+//// [addOptimizationHintsFalse.js]
+class HasNoStatics {
+    method() { }
+}
+class HasStatic {
+    static someMethod() { }
+    method() { }
+}
+HasStatic.value = 0;
+let HasDecorator = class HasDecorator {
+    method() { }
+};
+HasDecorator = __decorate([
+    decorate
+], HasDecorator);

--- a/tests/baselines/reference/addOptimizationHintsFalse.symbols
+++ b/tests/baselines/reference/addOptimizationHintsFalse.symbols
@@ -1,0 +1,32 @@
+=== tests/cases/compiler/addOptimizationHintsFalse.ts ===
+class HasNoStatics {
+>HasNoStatics : Symbol(HasNoStatics, Decl(addOptimizationHintsFalse.ts, 0, 0))
+
+  value: unknown;
+>value : Symbol(HasNoStatics.value, Decl(addOptimizationHintsFalse.ts, 0, 20))
+
+  method() {}
+>method : Symbol(HasNoStatics.method, Decl(addOptimizationHintsFalse.ts, 1, 17))
+}
+
+class HasStatic {
+>HasStatic : Symbol(HasStatic, Decl(addOptimizationHintsFalse.ts, 3, 1))
+
+  static value = 0;
+>value : Symbol(HasStatic.value, Decl(addOptimizationHintsFalse.ts, 5, 17))
+
+  static someMethod() {}
+>someMethod : Symbol(HasStatic.someMethod, Decl(addOptimizationHintsFalse.ts, 6, 19))
+
+  method() {}
+>method : Symbol(HasStatic.method, Decl(addOptimizationHintsFalse.ts, 7, 24))
+}
+
+@decorate
+class HasDecorator {
+>HasDecorator : Symbol(HasDecorator, Decl(addOptimizationHintsFalse.ts, 10, 1))
+
+  method() {}
+>method : Symbol(HasDecorator.method, Decl(addOptimizationHintsFalse.ts, 13, 20))
+}
+

--- a/tests/baselines/reference/addOptimizationHintsFalse.types
+++ b/tests/baselines/reference/addOptimizationHintsFalse.types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/addOptimizationHintsFalse.ts ===
+class HasNoStatics {
+>HasNoStatics : HasNoStatics
+
+  value: unknown;
+>value : unknown
+
+  method() {}
+>method : () => void
+}
+
+class HasStatic {
+>HasStatic : HasStatic
+
+  static value = 0;
+>value : number
+>0 : 0
+
+  static someMethod() {}
+>someMethod : () => void
+
+  method() {}
+>method : () => void
+}
+
+@decorate
+>decorate : any
+
+class HasDecorator {
+>HasDecorator : HasDecorator
+
+  method() {}
+>method : () => void
+}
+

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2651,6 +2651,7 @@ declare namespace ts {
     }
     export type CompilerOptionsValue = string | number | boolean | (string | number)[] | string[] | MapLike<string[]> | PluginImport[] | ProjectReference[] | null | undefined;
     export interface CompilerOptions {
+        addOptimizationHints?: boolean;
         allowJs?: boolean;
         allowSyntheticDefaultImports?: boolean;
         allowUmdGlobalAccess?: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2651,6 +2651,7 @@ declare namespace ts {
     }
     export type CompilerOptionsValue = string | number | boolean | (string | number)[] | string[] | MapLike<string[]> | PluginImport[] | ProjectReference[] | null | undefined;
     export interface CompilerOptions {
+        addOptimizationHints?: boolean;
         allowJs?: boolean;
         allowSyntheticDefaultImports?: boolean;
         allowUmdGlobalAccess?: boolean;

--- a/tests/baselines/reference/showConfig/Shows tsconfig for single option/addOptimizationHints/tsconfig.json
+++ b/tests/baselines/reference/showConfig/Shows tsconfig for single option/addOptimizationHints/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "addOptimizationHints": true
+    }
+}

--- a/tests/baselines/reference/thisInClassBodyStaticESNext.js
+++ b/tests/baselines/reference/thisInClassBodyStaticESNext.js
@@ -11,13 +11,10 @@ class Foo {
 
 //// [thisInClassBodyStaticESNext.js]
 // all are allowed with es-compliant class field emit
-let Foo = /** @class */ (() => {
-    class Foo {
-        x = this;
-        static t = this;
-        static at = () => this;
-        static ft = function () { return this; };
-        static mt() { return this; }
-    }
-    return Foo;
-})();
+class Foo {
+    x = this;
+    static t = this;
+    static at = () => this;
+    static ft = function () { return this; };
+    static mt() { return this; }
+}

--- a/tests/cases/compiler/addOptimizationHints.ts
+++ b/tests/cases/compiler/addOptimizationHints.ts
@@ -1,0 +1,20 @@
+// @target: ES2015
+// @experimentalDecorators: true
+// @noemithelpers: true
+// @addOptimizationHints: true
+class HasNoStatics {
+  value: unknown;
+  method() {}
+}
+
+class HasStatic {
+  static value = 0;
+  static someMethod() {}
+
+  method() {}
+}
+
+@decorate
+class HasDecorator {
+  method() {}
+}

--- a/tests/cases/compiler/addOptimizationHintsFalse.ts
+++ b/tests/cases/compiler/addOptimizationHintsFalse.ts
@@ -1,0 +1,20 @@
+// @target: ES2015
+// @experimentalDecorators: true
+// @noemithelpers: true
+// @addOptimizationHints: false
+class HasNoStatics {
+  value: unknown;
+  method() {}
+}
+
+class HasStatic {
+  static value = 0;
+  static someMethod() {}
+
+  method() {}
+}
+
+@decorate
+class HasDecorator {
+  method() {}
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #38374

This is an implementation of the `addOptimizationHints` compiler flag suggested in #38374. The intent of this feature is to allow must users to receive the benefits of the `/** @class */` and IIFE wrapper introduced by #32011, while being able to opt-out if needed. In our case, opting out is helpful because we have an optimization toolchain that attempts to understand and decompose classes rather than treating them as an opaque value.

This is based on PR #38566 to include that bug fix.

As far as the name goes, I am not tied to `addOptimizationHints` at all, it's just an example. I am very open to changing the name, description, and default value for this compiler option. Also if I missed some places new compiler options need to be introduced or documented please point them out 😄
