### PR TITLE
No contextual types from circular mapped type properties

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22469,6 +22469,10 @@ namespace ts {
             }
         }
 
+        function isCircularMappedProperty(symbol: Symbol) {
+            return !!(getCheckFlags(symbol) & CheckFlags.Mapped && !(<MappedSymbol>symbol).type && findResolutionCycleStartIndex(symbol, TypeSystemPropertyName.Type) >= 0);
+        }
+
         function getTypeOfPropertyOfContextualType(type: Type, name: __String) {
             return mapType(type, t => {
                 if (isGenericMappedType(t)) {
@@ -22482,7 +22486,7 @@ namespace ts {
                 else if (t.flags & TypeFlags.StructuredType) {
                     const prop = getPropertyOfType(t, name);
                     if (prop) {
-                        return getTypeOfSymbol(prop);
+                        return isCircularMappedProperty(prop) ? undefined : getTypeOfSymbol(prop);
                     }
                     if (isTupleType(t)) {
                         const restType = getRestTypeOfTupleType(t);

--- a/tests/baselines/reference/circularContextualMappedType.js
+++ b/tests/baselines/reference/circularContextualMappedType.js
@@ -1,0 +1,32 @@
+//// [circularContextualMappedType.ts]
+type Func<T> = () => T;
+
+type Mapped<T> = { [K in keyof T]: Func<T[K]> };
+
+declare function reproduce(options: number): void;
+declare function reproduce<T>(options: Mapped<T>): T
+
+reproduce({
+  name:   () => { return 123 }
+});
+
+reproduce({
+  name() { return 123 }
+});
+
+reproduce({
+  name: function () { return 123 }
+});
+
+
+//// [circularContextualMappedType.js]
+"use strict";
+reproduce({
+    name: function () { return 123; }
+});
+reproduce({
+    name: function () { return 123; }
+});
+reproduce({
+    name: function () { return 123; }
+});

--- a/tests/baselines/reference/circularContextualMappedType.symbols
+++ b/tests/baselines/reference/circularContextualMappedType.symbols
@@ -1,0 +1,51 @@
+=== tests/cases/compiler/circularContextualMappedType.ts ===
+type Func<T> = () => T;
+>Func : Symbol(Func, Decl(circularContextualMappedType.ts, 0, 0))
+>T : Symbol(T, Decl(circularContextualMappedType.ts, 0, 10))
+>T : Symbol(T, Decl(circularContextualMappedType.ts, 0, 10))
+
+type Mapped<T> = { [K in keyof T]: Func<T[K]> };
+>Mapped : Symbol(Mapped, Decl(circularContextualMappedType.ts, 0, 23))
+>T : Symbol(T, Decl(circularContextualMappedType.ts, 2, 12))
+>K : Symbol(K, Decl(circularContextualMappedType.ts, 2, 20))
+>T : Symbol(T, Decl(circularContextualMappedType.ts, 2, 12))
+>Func : Symbol(Func, Decl(circularContextualMappedType.ts, 0, 0))
+>T : Symbol(T, Decl(circularContextualMappedType.ts, 2, 12))
+>K : Symbol(K, Decl(circularContextualMappedType.ts, 2, 20))
+
+declare function reproduce(options: number): void;
+>reproduce : Symbol(reproduce, Decl(circularContextualMappedType.ts, 2, 48), Decl(circularContextualMappedType.ts, 4, 50))
+>options : Symbol(options, Decl(circularContextualMappedType.ts, 4, 27))
+
+declare function reproduce<T>(options: Mapped<T>): T
+>reproduce : Symbol(reproduce, Decl(circularContextualMappedType.ts, 2, 48), Decl(circularContextualMappedType.ts, 4, 50))
+>T : Symbol(T, Decl(circularContextualMappedType.ts, 5, 27))
+>options : Symbol(options, Decl(circularContextualMappedType.ts, 5, 30))
+>Mapped : Symbol(Mapped, Decl(circularContextualMappedType.ts, 0, 23))
+>T : Symbol(T, Decl(circularContextualMappedType.ts, 5, 27))
+>T : Symbol(T, Decl(circularContextualMappedType.ts, 5, 27))
+
+reproduce({
+>reproduce : Symbol(reproduce, Decl(circularContextualMappedType.ts, 2, 48), Decl(circularContextualMappedType.ts, 4, 50))
+
+  name:   () => { return 123 }
+>name : Symbol(name, Decl(circularContextualMappedType.ts, 7, 11))
+
+});
+
+reproduce({
+>reproduce : Symbol(reproduce, Decl(circularContextualMappedType.ts, 2, 48), Decl(circularContextualMappedType.ts, 4, 50))
+
+  name() { return 123 }
+>name : Symbol(name, Decl(circularContextualMappedType.ts, 11, 11))
+
+});
+
+reproduce({
+>reproduce : Symbol(reproduce, Decl(circularContextualMappedType.ts, 2, 48), Decl(circularContextualMappedType.ts, 4, 50))
+
+  name: function () { return 123 }
+>name : Symbol(name, Decl(circularContextualMappedType.ts, 15, 11))
+
+});
+

--- a/tests/baselines/reference/circularContextualMappedType.types
+++ b/tests/baselines/reference/circularContextualMappedType.types
@@ -1,0 +1,50 @@
+=== tests/cases/compiler/circularContextualMappedType.ts ===
+type Func<T> = () => T;
+>Func : Func<T>
+
+type Mapped<T> = { [K in keyof T]: Func<T[K]> };
+>Mapped : Mapped<T>
+
+declare function reproduce(options: number): void;
+>reproduce : { (options: number): void; <T>(options: Mapped<T>): T; }
+>options : number
+
+declare function reproduce<T>(options: Mapped<T>): T
+>reproduce : { (options: number): void; <T>(options: Mapped<T>): T; }
+>options : Mapped<T>
+
+reproduce({
+>reproduce({  name:   () => { return 123 }}) : { name: number; }
+>reproduce : { (options: number): void; <T>(options: Mapped<T>): T; }
+>{  name:   () => { return 123 }} : { name: () => number; }
+
+  name:   () => { return 123 }
+>name : () => number
+>() => { return 123 } : () => number
+>123 : 123
+
+});
+
+reproduce({
+>reproduce({  name() { return 123 }}) : { name: number; }
+>reproduce : { (options: number): void; <T>(options: Mapped<T>): T; }
+>{  name() { return 123 }} : { name(): number; }
+
+  name() { return 123 }
+>name : () => number
+>123 : 123
+
+});
+
+reproduce({
+>reproduce({  name: function () { return 123 }}) : { name: number; }
+>reproduce : { (options: number): void; <T>(options: Mapped<T>): T; }
+>{  name: function () { return 123 }} : { name: () => number; }
+
+  name: function () { return 123 }
+>name : () => number
+>function () { return 123 } : () => number
+>123 : 123
+
+});
+

--- a/tests/cases/compiler/circularContextualMappedType.ts
+++ b/tests/cases/compiler/circularContextualMappedType.ts
@@ -1,0 +1,20 @@
+// @strict: true
+
+type Func<T> = () => T;
+
+type Mapped<T> = { [K in keyof T]: Func<T[K]> };
+
+declare function reproduce(options: number): void;
+declare function reproduce<T>(options: Mapped<T>): T
+
+reproduce({
+  name:   () => { return 123 }
+});
+
+reproduce({
+  name() { return 123 }
+});
+
+reproduce({
+  name: function () { return 123 }
+});


### PR DESCRIPTION
With this PR we no longer attempt to produce contextual types from mapped type properties that are circular. Specifically, in `getTypeOfPropertyOfContextualType` we now check if the property originates in mapped type and if resolution of the type of the property would cause a circularity. If so, instead of resolving the type (which would produce a circularity error) we simply return `undefined` to indicate that there is no contextual type.

I have added the simplified repro from #38279 to the tests, plus I have manually verified that each of the complex repros in that issue no longer error.

Fixes #38279.