### PR TITLE
fix(33233): Code Folding on es5 object functions does not work (getOutliningSpans)

### DIFF
--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -42,6 +42,10 @@ namespace ts.OutliningElementsCollector {
                 addOutliningForLeadingCommentsForNode(n.parent.parent.parent, sourceFile, cancellationToken, out);
             }
 
+            if (isFunctionLike(n) && isBinaryExpression(n.parent) && isPropertyAccessExpression(n.parent.left)) {
+                addOutliningForLeadingCommentsForNode(n.parent.left, sourceFile, cancellationToken, out);
+            }
+
             const span = getOutliningSpanForNode(n, sourceFile);
             if (span) out.push(span);
 

--- a/tests/cases/fourslash/getOutliningForBlockComments.ts
+++ b/tests/cases/fourslash/getOutliningForBlockComments.ts
@@ -110,6 +110,26 @@
 //// const sum2 = (y, z) =>[| {
 ////     return y + z;
 //// }|];
+////
+////function Foo()[| {
+////   [|/**
+////     * Description
+////     *
+////     * @param {string} param
+////     * @returns
+////     */|]
+////    this.method = function (param)[| {
+////    }|]
+////
+////   [|/**
+////     * Description
+////     *
+////     * @param {string} param
+////     * @returns
+////     */|]
+////    function method(param)[| {
+////    }|]
+////}|]
 
 verify.outliningSpansInCurrentFile(test.ranges());
 

--- a/tests/cases/fourslash/getOutliningForSingleLineComments.ts
+++ b/tests/cases/fourslash/getOutliningForSingleLineComments.ts
@@ -72,6 +72,18 @@
 ////// One single line comment should not be collapsed
 ////class WithOneSingleLineComment[| {
 ////}|]
+////
+////function Foo()[| {
+////   [|// comment 1
+////     // comment 2|]
+////    this.method = function (param)[| {
+////    }|]
+////
+////   [|// comment 1
+////     // comment 2|]
+////    function method(param)[| {
+////    }|]
+////}|]
 
 verify.outliningSpansInCurrentFile(test.ranges());
 


### PR DESCRIPTION
Fixes #33233
