### PR TITLE
Remove mentions of runtests-browser in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,19 +139,6 @@ gulp runtests --tests=2dArrays
 
 ## Debugging the tests
 
-To debug the tests, invoke the `runtests-browser` task from gulp.
-You will probably only want to debug one test at a time:
-
-```Shell
-gulp runtests-browser --tests=2dArrays
-```
-
-You can specify which browser to use for debugging. Currently, Chrome and IE are supported:
-
-```Shell
-gulp runtests-browser --tests=2dArrays --browser=chrome
-```
-
 You can debug with VS Code or Node instead with `gulp runtests --inspect=true`:
 
 ```Shell


### PR DESCRIPTION
The gulp tasks were removed in #30054, but the contributing
guidelines weren't updated accordingly.
