### PR TITLE
Fix debug command for Node debugging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,10 +152,10 @@ You can specify which browser to use for debugging. Currently, Chrome and IE are
 gulp runtests-browser --tests=2dArrays --browser=chrome
 ```
 
-You can debug with VS Code or Node instead with `gulp runtests --inspect=true`:
+You can debug with VS Code or Node instead with `gulp runtests --inspect`:
 
 ```Shell
-gulp runtests --tests=2dArrays --inspect=true
+gulp runtests --tests=2dArrays --inspect
 ```
 
 You can also use the [provided VS Code launch configuration](./.vscode/launch.template.json) to launch a debug session for an open test file. Rename the file 'launch.json', open the test file of interest, and launch the debugger from the debug panel (or press F5).


### PR DESCRIPTION
If you would run with `--inspect=true`, the following error would be thrown:

```
[12:08:13] > node --inspect-brk=true TypeScript/node_modules/mocha/bin/_mocha -R scripts/failed-tests -O "reporter=mocha-fivemat-progress-reporter" -g "implementsJSDocReferencesDeclarationEmit" --colors -t 0 built/local/run.js
Unable to resolve "true": unknown node or service
```