### PR TITLE
Intersection check for empty object type shouldn't cause circularities

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15308,7 +15308,9 @@ namespace ts {
         }
 
         function isEmptyAnonymousObjectType(type: Type) {
-            return !!(getObjectFlags(type) & ObjectFlags.Anonymous) && isEmptyObjectType(type);
+            return !!(getObjectFlags(type) & ObjectFlags.Anonymous && (
+                (<ResolvedType>type).members && isEmptyResolvedType(<ResolvedType>type) ||
+                type.symbol && type.symbol.flags & SymbolFlags.TypeLiteral && getMembersOfSymbol(type.symbol).size === 0));
         }
 
         function isStringIndexSignatureOnlyType(type: Type): boolean {

--- a/tests/baselines/reference/intersectionsAndEmptyObjects.js
+++ b/tests/baselines/reference/intersectionsAndEmptyObjects.js
@@ -76,6 +76,11 @@ var myChoicesAndEmpty: choices<IMyChoiceList & {}>;
 var unknownChoices: choices<IUnknownChoiceList>;
 var unknownChoicesAndEmpty: choices<IUnknownChoiceList & {}>;
 
+// Repro from #38672
+
+type Foo1 = { x: string } & { [x: number]: Foo1 };
+type Foo2 = { x: string } & { [K in number]: Foo2 };
+
 
 //// [intersectionsAndEmptyObjects.js]
 // Empty object type literals are removed from intersections types

--- a/tests/baselines/reference/intersectionsAndEmptyObjects.symbols
+++ b/tests/baselines/reference/intersectionsAndEmptyObjects.symbols
@@ -246,3 +246,17 @@ var unknownChoicesAndEmpty: choices<IUnknownChoiceList & {}>;
 >choices : Symbol(choices, Decl(intersectionsAndEmptyObjects.ts, 51, 19))
 >IUnknownChoiceList : Symbol(IUnknownChoiceList, Decl(intersectionsAndEmptyObjects.ts, 64, 2))
 
+// Repro from #38672
+
+type Foo1 = { x: string } & { [x: number]: Foo1 };
+>Foo1 : Symbol(Foo1, Decl(intersectionsAndEmptyObjects.ts, 75, 61))
+>x : Symbol(x, Decl(intersectionsAndEmptyObjects.ts, 79, 13))
+>x : Symbol(x, Decl(intersectionsAndEmptyObjects.ts, 79, 31))
+>Foo1 : Symbol(Foo1, Decl(intersectionsAndEmptyObjects.ts, 75, 61))
+
+type Foo2 = { x: string } & { [K in number]: Foo2 };
+>Foo2 : Symbol(Foo2, Decl(intersectionsAndEmptyObjects.ts, 79, 50))
+>x : Symbol(x, Decl(intersectionsAndEmptyObjects.ts, 80, 13))
+>K : Symbol(K, Decl(intersectionsAndEmptyObjects.ts, 80, 31))
+>Foo2 : Symbol(Foo2, Decl(intersectionsAndEmptyObjects.ts, 79, 50))
+

--- a/tests/baselines/reference/intersectionsAndEmptyObjects.types
+++ b/tests/baselines/reference/intersectionsAndEmptyObjects.types
@@ -206,3 +206,14 @@ var unknownChoices: choices<IUnknownChoiceList>;
 var unknownChoicesAndEmpty: choices<IUnknownChoiceList & {}>;
 >unknownChoicesAndEmpty : { shoes: boolean; food: boolean; }
 
+// Repro from #38672
+
+type Foo1 = { x: string } & { [x: number]: Foo1 };
+>Foo1 : Foo1
+>x : string
+>x : number
+
+type Foo2 = { x: string } & { [K in number]: Foo2 };
+>Foo2 : Foo2
+>x : string
+

--- a/tests/cases/conformance/types/intersection/intersectionsAndEmptyObjects.ts
+++ b/tests/cases/conformance/types/intersection/intersectionsAndEmptyObjects.ts
@@ -76,3 +76,8 @@ var myChoicesAndEmpty: choices<IMyChoiceList & {}>;
 
 var unknownChoices: choices<IUnknownChoiceList>;
 var unknownChoicesAndEmpty: choices<IUnknownChoiceList & {}>;
+
+// Repro from #38672
+
+type Foo1 = { x: string } & { [x: number]: Foo1 };
+type Foo2 = { x: string } & { [K in number]: Foo2 };


### PR DESCRIPTION
Fixes #38672.