### PR TITLE
fix(38682): The latest build 4.0.0-dev.20200520 breaks @typescript-eslint/parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "source-map-support": "latest",
         "through2": "latest",
         "travis-fold": "latest",
-        "typescript": "next",
+        "typescript": "^3.9.3",
         "vinyl": "latest",
         "vinyl-sourcemaps-apply": "latest",
         "xml2js": "^0.4.19"


### PR DESCRIPTION
Fixes #38682
