### PR TITLE
Fix two tests

### DIFF
--- a/tests/cases/fourslash/codeFixCorrectReturnValue13.ts
+++ b/tests/cases/fourslash/codeFixCorrectReturnValue13.ts
@@ -12,7 +12,3 @@ verify.codeFixAvailable([
     { description: ts.Diagnostics.Remove_braces_from_arrow_function_body.message },
     { description: ts.Diagnostics.Remove_unused_label.message }
 ]);
-
-interface A {
-    bar: string
-}

--- a/tests/cases/fourslash/docCommentTemplateInSingleLineComment.ts
+++ b/tests/cases/fourslash/docCommentTemplateInSingleLineComment.ts
@@ -3,7 +3,7 @@
 // @Filename: justAComment.ts
 //// // We want to check off-by-one errors in assessing the end of the comment, so we check twice,
 //// // first with a trailing space and then without.
-//// // /*0*/
+//// // /*0*/ 
 //// // /*1*/
 //// // We also want to check EOF handling at the end of a comment
 //// // /*2*/


### PR DESCRIPTION
* `docCommentTemplateInSingleLineComment`: Accidentally dropped space, fixes #38651

* `codeFixCorrectReturnValue13`: Bogus test code copied
