### PR TITLE
fix(38722): Incorrect error message for use-before-declaration on const enum in `preserveConstEnums`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2287,7 +2287,7 @@ namespace ts {
                 else {
                     Debug.assert(!!(result.flags & SymbolFlags.ConstEnum));
                     if (compilerOptions.preserveConstEnums) {
-                        diagnosticMessage = error(errorLocation, Diagnostics.Class_0_used_before_its_declaration, declarationName);
+                        diagnosticMessage = error(errorLocation, Diagnostics.Enum_0_used_before_its_declaration, declarationName);
                     }
                 }
 

--- a/tests/baselines/reference/blockScopedEnumVariablesUseBeforeDef_preserve.errors.txt
+++ b/tests/baselines/reference/blockScopedEnumVariablesUseBeforeDef_preserve.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/blockScopedEnumVariablesUseBeforeDef_preserve.ts(2,12): error TS2450: Enum 'E' used before its declaration.
-tests/cases/compiler/blockScopedEnumVariablesUseBeforeDef_preserve.ts(7,12): error TS2449: Class 'E' used before its declaration.
+tests/cases/compiler/blockScopedEnumVariablesUseBeforeDef_preserve.ts(7,12): error TS2450: Enum 'E' used before its declaration.
 
 
 ==== tests/cases/compiler/blockScopedEnumVariablesUseBeforeDef_preserve.ts (2 errors) ====
@@ -14,7 +14,7 @@ tests/cases/compiler/blockScopedEnumVariablesUseBeforeDef_preserve.ts(7,12): err
     function foo2() {
         return E.A
                ~
-!!! error TS2449: Class 'E' used before its declaration.
+!!! error TS2450: Enum 'E' used before its declaration.
 !!! related TS2728 tests/cases/compiler/blockScopedEnumVariablesUseBeforeDef_preserve.ts:8:16: 'E' is declared here.
         const enum E { A }
     }


### PR DESCRIPTION
Fixes #38722