### PR TITLE
feat: suppress error 1208 (All files must be modules) when the file is empty

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3113,7 +3113,9 @@ namespace ts {
                     createDiagnosticForOptionName(Diagnostics.Option_isolatedModules_can_only_be_used_when_either_option_module_is_provided_or_option_target_is_ES2015_or_higher, "isolatedModules", "target");
                 }
 
-                const firstNonExternalModuleSourceFile = find(files, f => !isExternalModule(f) && !isSourceFileJS(f) && !f.isDeclarationFile && f.scriptKind !== ScriptKind.JSON);
+                const firstNonExternalModuleSourceFile = find(files,
+                    f => !isExternalModule(f) && !isSourceFileJS(f) && !f.isDeclarationFile && f.scriptKind !== ScriptKind.JSON && f.statements.length !== 0
+                );
                 if (firstNonExternalModuleSourceFile) {
                     const span = getErrorSpanForNode(firstNonExternalModuleSourceFile, firstNonExternalModuleSourceFile);
                     programDiagnostics.add(createFileDiagnostic(firstNonExternalModuleSourceFile, span.start, span.length, Diagnostics.All_files_must_be_modules_when_the_isolatedModules_flag_is_provided));

--- a/tests/baselines/reference/isolatedModulesInEmptyFile.js
+++ b/tests/baselines/reference/isolatedModulesInEmptyFile.js
@@ -1,0 +1,8 @@
+//// [file.ts]
+// this is an empty file
+// therefore it's safe and helpful to suppress the ts1208 error
+
+
+//// [file.js]
+// this is an empty file
+// therefore it's safe and helpful to suppress the ts1208 error

--- a/tests/baselines/reference/isolatedModulesInEmptyFile.symbols
+++ b/tests/baselines/reference/isolatedModulesInEmptyFile.symbols
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/file.ts ===
+// this is an empty file
+No type information for this code.// therefore it's safe and helpful to suppress the ts1208 error
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/isolatedModulesInEmptyFile.types
+++ b/tests/baselines/reference/isolatedModulesInEmptyFile.types
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/file.ts ===
+// this is an empty file
+No type information for this code.// therefore it's safe and helpful to suppress the ts1208 error
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/isolatedModulesInEmptyFiles.errors.txt
+++ b/tests/baselines/reference/isolatedModulesInEmptyFiles.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/file2.ts(2,1): error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
+
+
+==== tests/cases/compiler/file.ts (0 errors) ====
+    // Should not error in this file
+    
+==== tests/cases/compiler/file2.ts (1 errors) ====
+    // but this file
+    var a = 1
+    ~~~
+!!! error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
+    

--- a/tests/baselines/reference/isolatedModulesInEmptyFiles.js
+++ b/tests/baselines/reference/isolatedModulesInEmptyFiles.js
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/isolatedModulesInEmptyFiles.ts] ////
+
+//// [file.ts]
+// Should not error in this file
+
+//// [file2.ts]
+// but this file
+var a = 1
+
+
+//// [file.js]
+// Should not error in this file
+//// [file2.js]
+// but this file
+var a = 1;

--- a/tests/baselines/reference/isolatedModulesInEmptyFiles.symbols
+++ b/tests/baselines/reference/isolatedModulesInEmptyFiles.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/file.ts ===
+// Should not error in this file
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/file2.ts ===
+// but this file
+var a = 1
+>a : Symbol(a, Decl(file2.ts, 1, 3))
+

--- a/tests/baselines/reference/isolatedModulesInEmptyFiles.types
+++ b/tests/baselines/reference/isolatedModulesInEmptyFiles.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/file.ts ===
+// Should not error in this file
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/file2.ts ===
+// but this file
+var a = 1
+>a : number
+>1 : 1
+

--- a/tests/cases/compiler/isolatedModulesInEmptyFile.ts
+++ b/tests/cases/compiler/isolatedModulesInEmptyFile.ts
@@ -1,0 +1,7 @@
+// @isolatedModules: true
+// @target: esnext
+// @module: esnext
+
+// @filename: file.ts
+// this is an empty file
+// therefore it's safe and helpful to suppress the ts1208 error

--- a/tests/cases/compiler/isolatedModulesInEmptyFiles.ts
+++ b/tests/cases/compiler/isolatedModulesInEmptyFiles.ts
@@ -1,0 +1,10 @@
+// @isolatedModules: true
+// @target: esnext
+// @module: esnext
+
+// @filename: file.ts
+// Should not error in this file
+
+// @filename: file2.ts
+// but this file
+var a = 1


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

In the daily coding, if I create a new file in with `isolatedModule` is on, TypeScript will warn me instantly "All files must be modules" even I just created them and not writing anything yet.

Screenshot for this change:
![image](https://user-images.githubusercontent.com/5390719/82819903-cb0aeb80-9ed3-11ea-8de8-3dad6716ef4c.png)

