### PR TITLE
Report base primitive sources against boolean targets

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16130,6 +16130,7 @@ namespace ts {
 
                 if (isLiteralType(source) && !typeCouldHaveTopLevelSingletonTypes(target)) {
                     generalizedSource = getBaseTypeOfLiteralType(source);
+                    Debug.assert(!isTypeAssignableTo(generalizedSource, target), "generalized source shouldn't be assignable");
                     generalizedSourceType = getTypeNameForErrorDisplay(generalizedSource);
                 }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17833,6 +17833,13 @@ namespace ts {
         }
 
         function typeCouldHaveTopLevelSingletonTypes(type: Type): boolean {
+            // Okay, yes, 'boolean' is a union of 'true | false', but that's not useful
+            // in error reporting scenarios. If you need to use this function but that detail matters,
+            // feel free to add a flag.
+            if (type.flags & TypeFlags.Boolean) {
+                return false;
+            }
+
             if (type.flags & TypeFlags.UnionOrIntersection) {
                 return !!forEach((type as IntersectionType).types, typeCouldHaveTopLevelSingletonTypes);
             }

--- a/tests/baselines/reference/conditionalExpression1.errors.txt
+++ b/tests/baselines/reference/conditionalExpression1.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/conditionalExpression1.ts(1,5): error TS2322: Type '1 | ""' is not assignable to type 'boolean'.
-  Type '1' is not assignable to type 'boolean'.
+tests/cases/compiler/conditionalExpression1.ts(1,5): error TS2322: Type 'string | number' is not assignable to type 'boolean'.
+  Type 'number' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/compiler/conditionalExpression1.ts (1 errors) ====
     var x: boolean = (true ? 1 : ""); // should be an error
         ~
-!!! error TS2322: Type '1 | ""' is not assignable to type 'boolean'.
-!!! error TS2322:   Type '1' is not assignable to type 'boolean'.
+!!! error TS2322: Type 'string | number' is not assignable to type 'boolean'.
+!!! error TS2322:   Type 'number' is not assignable to type 'boolean'.

--- a/tests/baselines/reference/for-of46.errors.txt
+++ b/tests/baselines/reference/for-of46.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/es6/for-ofStatements/for-of46.ts(3,7): error TS2322: Type 'boolean' is not assignable to type 'string'.
-tests/cases/conformance/es6/for-ofStatements/for-of46.ts(3,18): error TS2322: Type '""' is not assignable to type 'boolean'.
+tests/cases/conformance/es6/for-ofStatements/for-of46.ts(3,18): error TS2322: Type 'string' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/es6/for-ofStatements/for-of46.ts (2 errors) ====
@@ -9,7 +9,7 @@ tests/cases/conformance/es6/for-ofStatements/for-of46.ts(3,18): error TS2322: Ty
           ~
 !!! error TS2322: Type 'boolean' is not assignable to type 'string'.
                      ~
-!!! error TS2322: Type '""' is not assignable to type 'boolean'.
+!!! error TS2322: Type 'string' is not assignable to type 'boolean'.
         k;
         v;
     }

--- a/tests/baselines/reference/generatorExplicitReturnType.errors.txt
+++ b/tests/baselines/reference/generatorExplicitReturnType.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/generators/generatorExplicitReturnType.ts(2,5): error TS2322: Type 'undefined' is not assignable to type 'number'.
 tests/cases/conformance/generators/generatorExplicitReturnType.ts(3,11): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/generators/generatorExplicitReturnType.ts(4,11): error TS2322: Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/generators/generatorExplicitReturnType.ts(5,5): error TS2322: Type '10' is not assignable to type 'boolean'.
+tests/cases/conformance/generators/generatorExplicitReturnType.ts(5,5): error TS2322: Type 'number' is not assignable to type 'boolean'.
 tests/cases/conformance/generators/generatorExplicitReturnType.ts(16,11): error TS2322: Type 'symbol' is not assignable to type 'number'.
 
 
@@ -18,7 +18,7 @@ tests/cases/conformance/generators/generatorExplicitReturnType.ts(16,11): error 
 !!! error TS2322: Type 'string' is not assignable to type 'number'.
         return 10; // error
         ~~~~~~~~~~
-!!! error TS2322: Type '10' is not assignable to type 'boolean'.
+!!! error TS2322: Type 'number' is not assignable to type 'boolean'.
     }
     
     function* g2(): Generator<number, boolean, string> {

--- a/tests/baselines/reference/jsdocInTypeScript.errors.txt
+++ b/tests/baselines/reference/jsdocInTypeScript.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/jsdocInTypeScript.ts(16,23): error TS2304: Cannot find name 'MyType'.
 tests/cases/compiler/jsdocInTypeScript.ts(23,33): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
-tests/cases/compiler/jsdocInTypeScript.ts(25,3): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+tests/cases/compiler/jsdocInTypeScript.ts(25,3): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 tests/cases/compiler/jsdocInTypeScript.ts(25,15): error TS2339: Property 'length' does not exist on type 'number'.
 tests/cases/compiler/jsdocInTypeScript.ts(30,3): error TS2339: Property 'x' does not exist on type '{}'.
 tests/cases/compiler/jsdocInTypeScript.ts(42,12): error TS2503: Cannot find namespace 'N'.
@@ -37,7 +37,7 @@ tests/cases/compiler/jsdocInTypeScript.ts(42,12): error TS2503: Cannot find name
     // Should fail, because it takes a boolean and returns a number
     f(1); f(true).length;
       ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
                   ~~~~~~
 !!! error TS2339: Property 'length' does not exist on type 'number'.
     

--- a/tests/baselines/reference/jsdocIndexSignature.errors.txt
+++ b/tests/baselines/reference/jsdocIndexSignature.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsdoc/indices.js(9,5): error TS2322: Type '1' is not assignable to type 'boolean'.
+tests/cases/conformance/jsdoc/indices.js(9,5): error TS2322: Type 'number' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/jsdoc/indices.js (1 errors) ====
@@ -12,7 +12,7 @@ tests/cases/conformance/jsdoc/indices.js(9,5): error TS2322: Type '1' is not ass
     function f(o) {
         o.foo = 1; // error
         ~~~~~
-!!! error TS2322: Type '1' is not assignable to type 'boolean'.
+!!! error TS2322: Type 'number' is not assignable to type 'boolean'.
         o.bar = false; // ok
     }
     

--- a/tests/baselines/reference/jsdocPrivateName1.errors.txt
+++ b/tests/baselines/reference/jsdocPrivateName1.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsdoc/jsdocPrivateName1.js(3,5): error TS2322: Type '3' is not assignable to type 'boolean'.
+tests/cases/conformance/jsdoc/jsdocPrivateName1.js(3,5): error TS2322: Type 'number' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/jsdoc/jsdocPrivateName1.js (1 errors) ====
@@ -6,6 +6,6 @@ tests/cases/conformance/jsdoc/jsdocPrivateName1.js(3,5): error TS2322: Type '3' 
         /** @type {boolean} some number value */
         #foo = 3 // Error because not assignable to boolean
         ~~~~
-!!! error TS2322: Type '3' is not assignable to type 'boolean'.
+!!! error TS2322: Type 'number' is not assignable to type 'boolean'.
     }
     

--- a/tests/baselines/reference/matchReturnTypeInAllBranches.errors.txt
+++ b/tests/baselines/reference/matchReturnTypeInAllBranches.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/matchReturnTypeInAllBranches.ts(30,13): error TS2322: Type '12345' is not assignable to type 'boolean'.
+tests/cases/compiler/matchReturnTypeInAllBranches.ts(30,13): error TS2322: Type 'number' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/compiler/matchReturnTypeInAllBranches.ts (1 errors) ====
@@ -33,7 +33,7 @@ tests/cases/compiler/matchReturnTypeInAllBranches.ts(30,13): error TS2322: Type 
             {
                 return 12345;
                 ~~~~~~~~~~~~~
-!!! error TS2322: Type '12345' is not assignable to type 'boolean'.
+!!! error TS2322: Type 'number' is not assignable to type 'boolean'.
             }
         }
     }

--- a/tests/baselines/reference/parser15.4.4.14-9-2.errors.txt
+++ b/tests/baselines/reference/parser15.4.4.14-9-2.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts(16,42): error TS2345: Argument of type '"0"' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts(16,42): error TS2345: Argument of type 'string' is not assignable to parameter of type 'boolean'.
 tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts(17,17): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts(18,17): error TS2345: Argument of type '0' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts(19,17): error TS2345: Argument of type '0' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts(20,17): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts(18,17): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts(19,17): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts(20,17): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts(25,1): error TS2304: Cannot find name 'runTestCase'.
 
 
@@ -24,19 +24,19 @@ tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts(25,1): error T
       var _float = -(4/3);
       var a = new Array(false,undefined,null,"0",obj,-1.3333333333333, "str",-0,true,+0, one, 1,0, false, _float, -(4/3));
                                              ~~~
-!!! error TS2345: Argument of type '"0"' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'boolean'.
       if (a.indexOf(-(4/3)) === 14 &&      // a[14]=_float===-(4/3)
                     ~~~~~~
 !!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
           a.indexOf(0) === 7      &&       // a[7] = +0, 0===+0
                     ~
-!!! error TS2345: Argument of type '0' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
           a.indexOf(-0) === 7      &&     // a[7] = +0, -0===+0
                     ~~
-!!! error TS2345: Argument of type '0' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
           a.indexOf(1) === 10 )            // a[10] =one=== 1
                     ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
       {
         return true;
       }

--- a/tests/baselines/reference/readonlyTupleAndArrayElaboration.errors.txt
+++ b/tests/baselines/reference/readonlyTupleAndArrayElaboration.errors.txt
@@ -25,12 +25,12 @@ tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(45,7): error TS2322: Ty
 tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(48,7): error TS2322: Type 'number[]' is not assignable to type 'boolean[]'.
   Type 'number' is not assignable to type 'boolean'.
 tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(51,7): error TS2322: Type 'readonly [1]' is not assignable to type 'readonly boolean[]'.
-  Type '1' is not assignable to type 'boolean'.
+  Type 'number' is not assignable to type 'boolean'.
 tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(54,7): error TS4104: The type 'readonly [1]' is 'readonly' and cannot be assigned to the mutable type 'number[]'.
 tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(57,7): error TS2322: Type '[1]' is not assignable to type 'readonly boolean[]'.
-  Type '1' is not assignable to type 'boolean'.
+  Type 'number' is not assignable to type 'boolean'.
 tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(60,7): error TS2322: Type '[1]' is not assignable to type 'boolean[]'.
-  Type '1' is not assignable to type 'boolean'.
+  Type 'number' is not assignable to type 'boolean'.
 tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(63,7): error TS2322: Type 'readonly number[]' is not assignable to type 'readonly [1]'.
   Target requires 1 element(s) but source may have fewer.
 tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(66,7): error TS4104: The type 'readonly number[]' is 'readonly' and cannot be assigned to the mutable type '[1]'.
@@ -134,7 +134,7 @@ tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(72,7): error TS2322: Ty
     const ta2: readonly boolean[] = ta1;
           ~~~
 !!! error TS2322: Type 'readonly [1]' is not assignable to type 'readonly boolean[]'.
-!!! error TS2322:   Type '1' is not assignable to type 'boolean'.
+!!! error TS2322:   Type 'number' is not assignable to type 'boolean'.
     
     const ta3: readonly [1] = [1];
     const ta4: number[] = ta3;
@@ -145,13 +145,13 @@ tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(72,7): error TS2322: Ty
     const ta6: readonly boolean[] = ta5;
           ~~~
 !!! error TS2322: Type '[1]' is not assignable to type 'readonly boolean[]'.
-!!! error TS2322:   Type '1' is not assignable to type 'boolean'.
+!!! error TS2322:   Type 'number' is not assignable to type 'boolean'.
     
     const ta7: [1] = [1];
     const ta8: boolean[] = ta7;
           ~~~
 !!! error TS2322: Type '[1]' is not assignable to type 'boolean[]'.
-!!! error TS2322:   Type '1' is not assignable to type 'boolean'.
+!!! error TS2322:   Type 'number' is not assignable to type 'boolean'.
     
     const at1: readonly number[] = [1];
     const at2: readonly [1] = at1;

--- a/tests/baselines/reference/restParameterWithBindingPattern3.errors.txt
+++ b/tests/baselines/reference/restParameterWithBindingPattern3.errors.txt
@@ -3,7 +3,7 @@ tests/cases/compiler/restParameterWithBindingPattern3.ts(1,23): error TS2322: Ty
 tests/cases/compiler/restParameterWithBindingPattern3.ts(3,23): error TS1186: A rest element cannot have an initializer.
 tests/cases/compiler/restParameterWithBindingPattern3.ts(5,30): error TS2493: Tuple type '[boolean, string, number]' of length '3' has no element at index '3'.
 tests/cases/compiler/restParameterWithBindingPattern3.ts(7,23): error TS2493: Tuple type '[boolean, string, number]' of length '3' has no element at index '3'.
-tests/cases/compiler/restParameterWithBindingPattern3.ts(9,19): error TS2322: Type '1' is not assignable to type 'boolean'.
+tests/cases/compiler/restParameterWithBindingPattern3.ts(9,19): error TS2322: Type 'number' is not assignable to type 'boolean'.
 tests/cases/compiler/restParameterWithBindingPattern3.ts(9,29): error TS2322: Type 'boolean' is not assignable to type 'string'.
 tests/cases/compiler/restParameterWithBindingPattern3.ts(9,48): error TS2566: A rest element cannot have a property name.
 
@@ -29,7 +29,7 @@ tests/cases/compiler/restParameterWithBindingPattern3.ts(9,48): error TS2566: A 
     
     function e(...{0: a = 1, 1: b = true, ...rest: rest}: [boolean, string, number]) { }
                       ~
-!!! error TS2322: Type '1' is not assignable to type 'boolean'.
+!!! error TS2322: Type 'number' is not assignable to type 'boolean'.
                                 ~
 !!! error TS2322: Type 'boolean' is not assignable to type 'string'.
                                                    ~~~~

--- a/tests/baselines/reference/taggedTemplateStringsWithIncompatibleTypedTags.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithIncompatibleTypedTags.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts(14,9): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts(18,9): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts(22,9): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts(24,25): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts(26,9): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts(26,46): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts(28,57): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts(14,9): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts(18,9): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts(22,9): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts(24,25): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts(26,9): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts(26,46): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts(28,57): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 
 
 ==== tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTags.ts (7 errors) ====
@@ -23,33 +23,33 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTyped
     
     f `abc${1}def${2}ghi`;
             ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
     
     f `abc`.member
     
     f `abc${1}def${2}ghi`.member;
             ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
     
     f `abc`["member"];
     
     f `abc${1}def${2}ghi`["member"];
             ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
     
     f `abc`[0].member `abc${1}def${2}ghi`;
                             ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
     
     f `abc${1}def${2}ghi`["member"].member `abc${1}def${2}ghi`;
             ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
                                                  ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
     
     f `abc${ true }def${ true }ghi`["member"].member `abc${ 1 }def${ 2 }ghi`;
                                                             ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
     
     f.thisIsNotATag(`abc`);
     

--- a/tests/baselines/reference/taggedTemplateStringsWithIncompatibleTypedTagsES6.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithIncompatibleTypedTagsES6.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts(14,9): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts(18,9): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts(22,9): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts(24,25): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts(26,9): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts(26,46): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts(28,57): error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts(14,9): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts(18,9): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts(22,9): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts(24,25): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts(26,9): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts(26,46): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts(28,57): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 
 
 ==== tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTypedTagsES6.ts (7 errors) ====
@@ -23,33 +23,33 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithIncompatibleTyped
     
     f `abc${1}def${2}ghi`;
             ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
     
     f `abc`.member
     
     f `abc${1}def${2}ghi`.member;
             ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
     
     f `abc`["member"];
     
     f `abc${1}def${2}ghi`["member"];
             ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
     
     f `abc`[0].member `abc${1}def${2}ghi`;
                             ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
     
     f `abc${1}def${2}ghi`["member"].member `abc${1}def${2}ghi`;
             ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
                                                  ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
     
     f `abc${ true }def${ true }ghi`["member"].member `abc${ 1 }def${ 2 }ghi`;
                                                             ~
-!!! error TS2345: Argument of type '1' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
     
     f.thisIsNotATag(`abc`);
     

--- a/tests/baselines/reference/typeGuardFunctionErrors.errors.txt
+++ b/tests/baselines/reference/typeGuardFunctionErrors.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(1,7): error TS2300: Duplicate identifier 'A'.
-tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(14,5): error TS2322: Type '""' is not assignable to type 'boolean'.
+tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(14,5): error TS2322: Type 'string' is not assignable to type 'boolean'.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(17,55): error TS2749: 'x' refers to a value, but is being used as a type here. Did you mean 'typeof x'?
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(17,57): error TS1144: '{' or ';' expected.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(17,60): error TS1005: ';' expected.
@@ -86,7 +86,7 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(166,54
     function hasANonBooleanReturnStatement(x): x is A {
         return '';
         ~~~~~~~~~~
-!!! error TS2322: Type '""' is not assignable to type 'boolean'.
+!!! error TS2322: Type 'string' is not assignable to type 'boolean'.
     }
     
     function hasTypeGuardTypeInsideTypeGuardType(x): x is x is A {

--- a/tests/baselines/reference/variadicTuples1.errors.txt
+++ b/tests/baselines/reference/variadicTuples1.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/types/tuple/variadicTuples1.ts(6,48): error TS1256: A rest element must be last in a tuple type.
 tests/cases/conformance/types/tuple/variadicTuples1.ts(52,5): error TS2555: Expected at least 3 arguments, but got 2.
-tests/cases/conformance/types/tuple/variadicTuples1.ts(53,17): error TS2345: Argument of type '45' is not assignable to parameter of type 'boolean'.
+tests/cases/conformance/types/tuple/variadicTuples1.ts(53,17): error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
 tests/cases/conformance/types/tuple/variadicTuples1.ts(131,9): error TS2344: Type 'V' does not satisfy the constraint 'unknown[]'.
   The type 'readonly unknown[]' is 'readonly' and cannot be assigned to the mutable type 'unknown[]'.
 tests/cases/conformance/types/tuple/variadicTuples1.ts(149,5): error TS2322: Type '[string, ...unknown[]]' is not assignable to type '[string, ...T]'.
@@ -104,7 +104,7 @@ tests/cases/conformance/types/tuple/variadicTuples1.ts(342,19): error TS2322: Ty
 !!! related TS6210 tests/cases/conformance/types/tuple/variadicTuples1.ts:45:45: An argument for 'c' was not provided.
         foo1(...t1, 45);  // Error
                     ~~
-!!! error TS2345: Argument of type '45' is not assignable to parameter of type 'boolean'.
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'boolean'.
     }
     
     declare function foo3<T extends unknown[]>(x: number, ...args: [...T, number]): T;


### PR DESCRIPTION
Expands @JoshuaKGoldberg's #38049 to special-case the bare `boolean` type.