### PR TITLE
Convert HTML tags in doc-comments into markdown

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -434,48 +434,48 @@ interface String {
     startsWith(searchString: string, position?: number): boolean;
 
     /**
-     * Returns an <a> HTML anchor element and sets the name attribute to the text value
+     * Returns an `<a>` HTML anchor element and sets the name attribute to the text value
      * @param name
      */
     anchor(name: string): string;
 
-    /** Returns a <big> HTML element */
+    /** Returns a `<big>` HTML element */
     big(): string;
 
-    /** Returns a <blink> HTML element */
+    /** Returns a `<blink>` HTML element */
     blink(): string;
 
-    /** Returns a <b> HTML element */
+    /** Returns a `<b>` HTML element */
     bold(): string;
 
-    /** Returns a <tt> HTML element */
+    /** Returns a `<tt>` HTML element */
     fixed(): string;
 
-    /** Returns a <font> HTML element and sets the color attribute value */
+    /** Returns a `<font>` HTML element and sets the color attribute value */
     fontcolor(color: string): string;
 
-    /** Returns a <font> HTML element and sets the size attribute value */
+    /** Returns a `<font>` HTML element and sets the size attribute value */
     fontsize(size: number): string;
 
-    /** Returns a <font> HTML element and sets the size attribute value */
+    /** Returns a `<font>` HTML element and sets the size attribute value */
     fontsize(size: string): string;
 
-    /** Returns an <i> HTML element */
+    /** Returns an `<i>` HTML element */
     italics(): string;
 
-    /** Returns an <a> HTML element and sets the href attribute value */
+    /** Returns an `<a>` HTML element and sets the href attribute value */
     link(url: string): string;
 
-    /** Returns a <small> HTML element */
+    /** Returns a `<small>` HTML element */
     small(): string;
 
-    /** Returns a <strike> HTML element */
+    /** Returns a `<strike>` HTML element */
     strike(): string;
 
-    /** Returns a <sub> HTML element */
+    /** Returns a `<sub>` HTML element */
     sub(): string;
 
-    /** Returns a <sup> HTML element */
+    /** Returns a `<sup>` HTML element */
     sup(): string;
 }
 


### PR DESCRIPTION
HTML tags in doc-comments don't get parsed properly by tools like TypeDoc,
once it encounters an open HTML tag like `<b>` in the comments, all the subsequent
doc-comments become bold in the generated docs.

![Annotation 2020-05-27 210559](https://user-images.githubusercontent.com/17353112/83061840-eb66b180-a05d-11ea-8c6c-d3caa701598a.png)


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #38812
