### PR TITLE
fix(38815): Extract to function crash

### DIFF
--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -405,6 +405,20 @@ namespace ts.refactor.extractSymbol {
                             rangeFacts |= RangeFacts.UsesThis;
                         }
                         break;
+                    case SyntaxKind.ArrowFunction:
+                        // check if arrow function uses this
+                        forEachChild(node, function check(n) {
+                            if (isThis(n)) {
+                                rangeFacts |= RangeFacts.UsesThis;
+                            }
+                            else if (isClassLike(n) || (isFunctionLike(n) && !isArrowFunction(n))) {
+                                return false;
+                            }
+                            else {
+                                forEachChild(n, check);
+                            }
+                        });
+                        // falls through
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.FunctionDeclaration:
                         if (isSourceFile(node.parent) && node.parent.externalModuleIndicator === undefined) {
@@ -418,7 +432,7 @@ namespace ts.refactor.extractSymbol {
                     case SyntaxKind.Constructor:
                     case SyntaxKind.GetAccessor:
                     case SyntaxKind.SetAccessor:
-                        // do not dive into functions (except arrow functions) or classes
+                        // do not dive into functions or classes
                         return false;
                 }
 

--- a/tests/cases/fourslash/extract-method40.ts
+++ b/tests/cases/fourslash/extract-method40.ts
@@ -1,0 +1,23 @@
+/// <reference path='fourslash.ts' />
+
+////const foo = /*start*/{
+////    a: 1,
+////    b: () => { return 1; }
+////}/*end*/
+
+goTo.select("start", "end");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "function_scope_0",
+    actionDescription: "Extract to function in global scope",
+    newContent:
+`const foo = /*RENAME*/newFunction()
+
+function newFunction() {
+    return {
+        a: 1,
+        b: () => { return 1; }
+    };
+}
+`
+});

--- a/tests/cases/fourslash/extract-method41.ts
+++ b/tests/cases/fourslash/extract-method41.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+////function bar(fn: () => void) {}
+////
+////class Foo {
+////    x: number;
+////    foo() {
+////        /*start*/bar(() => {
+////            () => {
+////                () => {
+////                     this.x;
+////                }
+////            }
+////        });/*end*/
+////    }
+////}
+
+goTo.select("start", "end");
+verify.refactorAvailable("Extract Symbol", "function_scope_1");
+verify.not.refactorAvailable("Extract Symbol", "function_scope_2");


### PR DESCRIPTION
Fixes #38815

In https://github.com/microsoft/TypeScript/pull/38107 to skip global function refactoring (when arrow function uses `this`, [extract-method38.ts](https://github.com/microsoft/TypeScript/blob/master/tests/cases/fourslash/extract-method38.ts), [extract-method39.ts](https://github.com/microsoft/TypeScript/blob/master/tests/cases/fourslash/extract-method39.ts)), I added checking arrow function, to find `this` usage., It caused that during checking arrow function body, service finds `return` and marks as used too. I changed that, to find only `this` in arrow function, and skip dive into further checking. If there is a much better way to do that, I would be grateful if you could please point me out about it.

cc @andrewbranch 