### PR TITLE
Make isEntityNameVisible duplicate the node builder logic to always consider type parameters as visible if they are the resolution result

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4064,6 +4064,9 @@ namespace ts {
 
             const firstIdentifier = getFirstIdentifier(entityName);
             const symbol = resolveName(enclosingDeclaration, firstIdentifier.escapedText, meaning, /*nodeNotFoundErrorMessage*/ undefined, /*nameArg*/ undefined, /*isUse*/ false);
+            if (symbol && symbol.flags & SymbolFlags.TypeParameter && meaning & SymbolFlags.Type) {
+                return { accessibility: SymbolAccessibility.Accessible };
+            }
 
             // Verify if the symbol is accessible
             return (symbol && hasVisibleDeclarations(symbol, /*shouldComputeAliasToMakeVisible*/ true)) || {

--- a/tests/baselines/reference/declarationEmitTypeParamMergedWithPrivate.js
+++ b/tests/baselines/reference/declarationEmitTypeParamMergedWithPrivate.js
@@ -1,0 +1,27 @@
+//// [declarationEmitTypeParamMergedWithPrivate.ts]
+export class Test<T> {
+    private get T(): T {
+        throw "";
+    }
+
+    public test(): T {
+        return null as any;
+    }
+}
+
+//// [declarationEmitTypeParamMergedWithPrivate.js]
+export class Test {
+    get T() {
+        throw "";
+    }
+    test() {
+        return null;
+    }
+}
+
+
+//// [declarationEmitTypeParamMergedWithPrivate.d.ts]
+export declare class Test<T> {
+    private get T();
+    test(): T;
+}

--- a/tests/baselines/reference/declarationEmitTypeParamMergedWithPrivate.symbols
+++ b/tests/baselines/reference/declarationEmitTypeParamMergedWithPrivate.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/declarationEmitTypeParamMergedWithPrivate.ts ===
+export class Test<T> {
+>Test : Symbol(Test, Decl(declarationEmitTypeParamMergedWithPrivate.ts, 0, 0))
+>T : Symbol(T, Decl(declarationEmitTypeParamMergedWithPrivate.ts, 0, 18), Decl(declarationEmitTypeParamMergedWithPrivate.ts, 0, 22))
+
+    private get T(): T {
+>T : Symbol(T, Decl(declarationEmitTypeParamMergedWithPrivate.ts, 0, 18), Decl(declarationEmitTypeParamMergedWithPrivate.ts, 0, 22))
+>T : Symbol(T, Decl(declarationEmitTypeParamMergedWithPrivate.ts, 0, 18), Decl(declarationEmitTypeParamMergedWithPrivate.ts, 0, 22))
+
+        throw "";
+    }
+
+    public test(): T {
+>test : Symbol(Test.test, Decl(declarationEmitTypeParamMergedWithPrivate.ts, 3, 5))
+>T : Symbol(T, Decl(declarationEmitTypeParamMergedWithPrivate.ts, 0, 18), Decl(declarationEmitTypeParamMergedWithPrivate.ts, 0, 22))
+
+        return null as any;
+    }
+}

--- a/tests/baselines/reference/declarationEmitTypeParamMergedWithPrivate.types
+++ b/tests/baselines/reference/declarationEmitTypeParamMergedWithPrivate.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/declarationEmitTypeParamMergedWithPrivate.ts ===
+export class Test<T> {
+>Test : Test<T>
+
+    private get T(): T {
+>T : T
+
+        throw "";
+>"" : ""
+    }
+
+    public test(): T {
+>test : () => T
+
+        return null as any;
+>null as any : any
+>null : null
+    }
+}

--- a/tests/cases/compiler/declarationEmitTypeParamMergedWithPrivate.ts
+++ b/tests/cases/compiler/declarationEmitTypeParamMergedWithPrivate.ts
@@ -1,0 +1,11 @@
+// @declaration: true
+// @target: es6
+export class Test<T> {
+    private get T(): T {
+        throw "";
+    }
+
+    public test(): T {
+        return null as any;
+    }
+}


### PR DESCRIPTION
Fixes #38345
