### PR TITLE
`getSymbolDisplayPartsDocumentationAndSymbolKind`: use actual `symbol…

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -379,7 +379,8 @@ namespace ts.SymbolDisplay {
                 }
             }
         }
-        if (symbolFlags & SymbolFlags.Alias) {
+        // don't use symbolFlags since getAliasedSymbol requires the flag on the symbol itself
+        if (symbol.flags & SymbolFlags.Alias) {
             prefixNextMeaning();
             if (!hasAddedSymbolInfo) {
                 const resolvedSymbol = typeChecker.getAliasedSymbol(symbol);

--- a/tests/cases/fourslash/quickInfoJSExport.ts
+++ b/tests/cases/fourslash/quickInfoJSExport.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts" />
+
+// GH #35347
+
+// @Filename: a.js
+// @allowJs: true
+//// /**
+////  * @enum {string}
+////  */
+//// const testString = {
+////     one: "1",
+////     two: "2"
+//// };
+////
+//// export { test/**/String };
+
+verify.quickInfoAt("",
+`type testString = string
+(alias) type testString = any
+(alias) const testString: {
+    one: string;
+    two: string;
+}
+export testString`);


### PR DESCRIPTION
….flags` for `getAliasedSymbol`

Fixes #35347.
