### PR TITLE
Improved HTMLFormControlsCollection definition

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -6707,7 +6707,7 @@ interface HTMLFormControlsCollection extends HTMLCollectionBase {
      * 
      * If there are multiple matching items, then a RadioNodeList object containing all those elements is returned.
      */
-    namedItem(name: string): RadioNodeList | Element | null;
+    namedItem(name: string): RadioNodeList | HTMLButtonElement | HTMLFieldSetElement | HTMLInputElement | HTMLObjectElement | HTMLOutputElement | HTMLSelectElement | HTMLTextAreaElement | null;
 }
 
 declare var HTMLFormControlsCollection: {
@@ -12403,7 +12403,7 @@ declare var RTCTrackEvent: {
     new(type: string, eventInitDict: RTCTrackEventInit): RTCTrackEvent;
 };
 
-interface RadioNodeList extends NodeList {
+interface RadioNodeList extends NodeListOf<HTMLButtonElement | HTMLFieldSetElement | HTMLInputElement | HTMLObjectElement | HTMLOutputElement | HTMLSelectElement | HTMLTextAreaElement> {
     value: string;
 }
 


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/elements), `HTMLFormControlsCollection` will only contain a very specific set of element types.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #39003
