### PR TITLE
fix(a11y): make ISSUE_TEMPLATE/Bug_report.md more accessible for folks with screen readers

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-<!-- 🚨 STOP 🚨 𝗦𝗧𝗢𝗣 🚨 𝑺𝑻𝑶𝑷 🚨
+<!-- 🚨 STOP 🚨 STOP 🚨 STOP 🚨
 
 Half of all issues filed here are duplicates, answered in the FAQ, or not appropriate for the bug tracker. Even if you think you've found a *bug*, please read the FAQ first, especially the Common "Bugs" That Aren't Bugs section!
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [N/A] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [N/A] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes an accessibility issue with the GitHub Issue Template that _either_ creates a large amount of noise for screen readers _or_ completely skips UTF-8 characters that are clearly intended to convey meaning. The either/or is based on the screen reader in use.

Here's a video (please have audio on) from a Twitter bot that demonstrates what this sounds like to folks using screen readers in the latter case: https://twitter.com/asciiArtHelpBot/status/1270761506179694592?s=20