### PR TITLE
Allow arrow function parameter parsing to bail out during speculation

### DIFF
--- a/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.js
+++ b/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.js
@@ -1,0 +1,28 @@
+//// [arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts]
+// regression test for https://github.com/microsoft/TypeScript/issues/32914
+declare var value: boolean;
+declare var a: any;
+
+const test = () => ({
+    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.
+    prop: !value, // remove ! to see that errors will be gone
+    run: () => { //replace arrow function with regular function to see that errors will be gone
+        // comment next line or remove "()" to see that errors will be gone
+        if(!a.b()) { return 'special'; }
+
+        return 'default';
+    }
+});
+
+//// [arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.js]
+var test = function () { return ({
+    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.
+    prop: !value,
+    run: function () {
+        // comment next line or remove "()" to see that errors will be gone
+        if (!a.b()) {
+            return 'special';
+        }
+        return 'default';
+    }
+}); };

--- a/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.symbols
+++ b/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts ===
+// regression test for https://github.com/microsoft/TypeScript/issues/32914
+declare var value: boolean;
+>value : Symbol(value, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 1, 11))
+
+declare var a: any;
+>a : Symbol(a, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 2, 11))
+
+const test = () => ({
+>test : Symbol(test, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 4, 5))
+
+    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.
+    prop: !value, // remove ! to see that errors will be gone
+>prop : Symbol(prop, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 4, 21))
+>value : Symbol(value, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 1, 11))
+
+    run: () => { //replace arrow function with regular function to see that errors will be gone
+>run : Symbol(run, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 6, 17))
+
+        // comment next line or remove "()" to see that errors will be gone
+        if(!a.b()) { return 'special'; }
+>a : Symbol(a, Decl(arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts, 2, 11))
+
+        return 'default';
+    }
+});

--- a/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.types
+++ b/tests/baselines/reference/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts ===
+// regression test for https://github.com/microsoft/TypeScript/issues/32914
+declare var value: boolean;
+>value : boolean
+
+declare var a: any;
+>a : any
+
+const test = () => ({
+>test : () => { prop: boolean; run: () => "special" | "default"; }
+>() => ({    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.    prop: !value, // remove ! to see that errors will be gone    run: () => { //replace arrow function with regular function to see that errors will be gone        // comment next line or remove "()" to see that errors will be gone        if(!a.b()) { return 'special'; }        return 'default';    }}) : () => { prop: boolean; run: () => "special" | "default"; }
+>({    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.    prop: !value, // remove ! to see that errors will be gone    run: () => { //replace arrow function with regular function to see that errors will be gone        // comment next line or remove "()" to see that errors will be gone        if(!a.b()) { return 'special'; }        return 'default';    }}) : { prop: boolean; run: () => "special" | "default"; }
+>{    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.    prop: !value, // remove ! to see that errors will be gone    run: () => { //replace arrow function with regular function to see that errors will be gone        // comment next line or remove "()" to see that errors will be gone        if(!a.b()) { return 'special'; }        return 'default';    }} : { prop: boolean; run: () => "special" | "default"; }
+
+    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.
+    prop: !value, // remove ! to see that errors will be gone
+>prop : boolean
+>!value : boolean
+>value : boolean
+
+    run: () => { //replace arrow function with regular function to see that errors will be gone
+>run : () => "special" | "default"
+>() => { //replace arrow function with regular function to see that errors will be gone        // comment next line or remove "()" to see that errors will be gone        if(!a.b()) { return 'special'; }        return 'default';    } : () => "special" | "default"
+
+        // comment next line or remove "()" to see that errors will be gone
+        if(!a.b()) { return 'special'; }
+>!a.b() : boolean
+>a.b() : any
+>a.b : any
+>a : any
+>b : any
+>'special' : "special"
+
+        return 'default';
+>'default' : "default"
+    }
+});

--- a/tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts
+++ b/tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts
@@ -1,0 +1,14 @@
+// regression test for https://github.com/microsoft/TypeScript/issues/32914
+declare var value: boolean;
+declare var a: any;
+
+const test = () => ({
+    // "Identifier expected." error on "!" and two "Duplicate identifier '(Missing)'." errors on space.
+    prop: !value, // remove ! to see that errors will be gone
+    run: () => { //replace arrow function with regular function to see that errors will be gone
+        // comment next line or remove "()" to see that errors will be gone
+        if(!a.b()) { return 'special'; }
+
+        return 'default';
+    }
+});


### PR DESCRIPTION
Fixes #32914
