### PR TITLE
isDynamicName skips parentheses for element access

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3061,7 +3061,7 @@ namespace ts {
         if (!(name.kind === SyntaxKind.ComputedPropertyName || name.kind === SyntaxKind.ElementAccessExpression)) {
             return false;
         }
-        const expr = isElementAccessExpression(name) ? name.argumentExpression : name.expression;
+        const expr = isElementAccessExpression(name) ? skipParentheses(name.argumentExpression) : name.expression;
         return !isStringOrNumericLiteralLike(expr) &&
             !isSignedNumericLiteral(expr) &&
             !isWellKnownSymbolSyntactically(expr);

--- a/tests/baselines/reference/propertyAssignmentOnParenthesizedNumber.symbols
+++ b/tests/baselines/reference/propertyAssignmentOnParenthesizedNumber.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/salsa/bug38934.js ===
+var x = {};
+>x : Symbol(x, Decl(bug38934.js, 0, 3))
+
+// should not crash and also should not result in a property '0' on x.
+x[(0)] = 1;
+>x : Symbol(x, Decl(bug38934.js, 0, 3))
+

--- a/tests/baselines/reference/propertyAssignmentOnParenthesizedNumber.types
+++ b/tests/baselines/reference/propertyAssignmentOnParenthesizedNumber.types
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/salsa/bug38934.js ===
+var x = {};
+>x : {}
+>{} : {}
+
+// should not crash and also should not result in a property '0' on x.
+x[(0)] = 1;
+>x[(0)] = 1 : 1
+>x[(0)] : any
+>x : {}
+>(0) : 0
+>0 : 0
+>1 : 1
+

--- a/tests/cases/conformance/salsa/propertyAssignmentOnParenthesizedNumber.ts
+++ b/tests/cases/conformance/salsa/propertyAssignmentOnParenthesizedNumber.ts
@@ -1,0 +1,8 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: bug38934.js
+
+var x = {};
+// should not crash and also should not result in a property '0' on x.
+x[(0)] = 1;


### PR DESCRIPTION
Neither `x[0]` nor `x[(0)]` should be dynamic names. Previously, the latter was because `isDynamicName` didn't skip parentheses.

Since the binder treats dynamic names in property assignments as assignment declarations, this incorrectly tried to create a binding for expressions like `x[(0)] = 1`.

This caused an assert because `x[(0)]` would not take the dynamic name code path during binding (`hasDynamicName` returned false), but the normal code path for static names.

Fixes #38934