### PR TITLE
Update request-pr-review script to latest version of octokit

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "node": ">=4.2.0"
     },
     "devDependencies": {
-        "@octokit/rest": "17.11.2",
+        "@octokit/rest": "latest",
         "@types/browserify": "latest",
         "@types/chai": "latest",
         "@types/convert-source-map": "latest",

--- a/scripts/request-pr-review.ts
+++ b/scripts/request-pr-review.ts
@@ -42,7 +42,7 @@ main().catch(console.error);
 
 async function main() {
     const gh = new Octokit({ auth: options.token });
-    const response = await gh.pulls.createReviewRequest({
+    const response = await gh.pulls.requestReviewers({
         owner: options.owner,
         repo: options.repo,
         pull_number,


### PR DESCRIPTION
This switches us back to `@octokit/rest@latest` and updates the `request-pr-review.ts` script to the latest version of octokit. 

@weswigham previously commented that GitHub revs their API frequently with breaking changes so its probably better that keep the script up to date rather than pinning the API version.
