### PR TITLE
Small fix in `getIsContextSensitiveAssignmentOrContextType`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22585,7 +22585,7 @@ namespace ts {
                             const id = lhs.expression;
                             const parentSymbol = resolveName(id, id.escapedText, SymbolFlags.Value, undefined, id.escapedText, /*isUse*/ true);
                             if (parentSymbol) {
-                                const annotated = getEffectiveTypeAnnotationNode(parentSymbol.valueDeclaration);
+                                const annotated = parentSymbol.valueDeclaration && getEffectiveTypeAnnotationNode(parentSymbol.valueDeclaration);
                                 if (annotated) {
                                     const nameStr = getElementOrPropertyAccessName(lhs);
                                     if (nameStr !== undefined) {

--- a/tests/baselines/reference/expandoFunctionContextualTypesNoValue.errors.txt
+++ b/tests/baselines/reference/expandoFunctionContextualTypesNoValue.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/expandoFunctionContextualTypesNoValue.ts(2,17): error TS2307: Cannot find module 'blah' or its corresponding type declarations.
+
+
+==== tests/cases/compiler/expandoFunctionContextualTypesNoValue.ts (1 errors) ====
+    // GH #38532
+    import Foo from "blah";
+                    ~~~~~~
+!!! error TS2307: Cannot find module 'blah' or its corresponding type declarations.
+    
+    export function Foo() { }
+    
+    Foo.bar = () => { };
+    

--- a/tests/baselines/reference/expandoFunctionContextualTypesNoValue.js
+++ b/tests/baselines/reference/expandoFunctionContextualTypesNoValue.js
@@ -1,0 +1,18 @@
+//// [expandoFunctionContextualTypesNoValue.ts]
+// GH #38532
+import Foo from "blah";
+
+export function Foo() { }
+
+Foo.bar = () => { };
+
+
+//// [expandoFunctionContextualTypesNoValue.js]
+"use strict";
+exports.__esModule = true;
+exports.Foo = void 0;
+// GH #38532
+var blah_1 = require("blah");
+function Foo() { }
+exports.Foo = Foo;
+blah_1["default"].bar = function () { };

--- a/tests/baselines/reference/expandoFunctionContextualTypesNoValue.symbols
+++ b/tests/baselines/reference/expandoFunctionContextualTypesNoValue.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/expandoFunctionContextualTypesNoValue.ts ===
+// GH #38532
+import Foo from "blah";
+>Foo : Symbol(Foo, Decl(expandoFunctionContextualTypesNoValue.ts, 1, 23), Decl(expandoFunctionContextualTypesNoValue.ts, 1, 6))
+
+export function Foo() { }
+>Foo : Symbol(Foo, Decl(expandoFunctionContextualTypesNoValue.ts, 1, 23), Decl(expandoFunctionContextualTypesNoValue.ts, 3, 25))
+
+Foo.bar = () => { };
+>Foo.bar : Symbol(Foo.bar, Decl(expandoFunctionContextualTypesNoValue.ts, 3, 25))
+>Foo : Symbol(Foo, Decl(expandoFunctionContextualTypesNoValue.ts, 1, 23), Decl(expandoFunctionContextualTypesNoValue.ts, 1, 6))
+>bar : Symbol(Foo.bar, Decl(expandoFunctionContextualTypesNoValue.ts, 3, 25))
+

--- a/tests/baselines/reference/expandoFunctionContextualTypesNoValue.types
+++ b/tests/baselines/reference/expandoFunctionContextualTypesNoValue.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/expandoFunctionContextualTypesNoValue.ts ===
+// GH #38532
+import Foo from "blah";
+>Foo : any
+
+export function Foo() { }
+>Foo : typeof import("tests/cases/compiler/expandoFunctionContextualTypesNoValue").Foo
+
+Foo.bar = () => { };
+>Foo.bar = () => { } : () => void
+>Foo.bar : () => void
+>Foo : typeof import("tests/cases/compiler/expandoFunctionContextualTypesNoValue").Foo
+>bar : () => void
+>() => { } : () => void
+

--- a/tests/cases/compiler/expandoFunctionContextualTypesNoValue.ts
+++ b/tests/cases/compiler/expandoFunctionContextualTypesNoValue.ts
@@ -1,0 +1,6 @@
+// GH #38532
+import Foo from "blah";
+
+export function Foo() { }
+
+Foo.bar = () => { };


### PR DESCRIPTION
Test that `parentSymbol.valueDeclaration` exists.

Fixes #38532
