### PR TITLE
Fix declaration emit for property references of imported object literal types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3488,16 +3488,17 @@ namespace ts {
          * Attempts to find the symbol corresponding to the container a symbol is in - usually this
          * is just its' `.parent`, but for locals, this value is `undefined`
          */
-        function getContainersOfSymbol(symbol: Symbol, enclosingDeclaration: Node | undefined): Symbol[] | undefined {
+        function getContainersOfSymbol(symbol: Symbol, enclosingDeclaration: Node | undefined, meaning: SymbolFlags): Symbol[] | undefined {
             const container = getParentOfSymbol(symbol);
             // Type parameters end up in the `members` lists but are not externally visible
             if (container && !(symbol.flags & SymbolFlags.TypeParameter)) {
                 const additionalContainers = mapDefined(container.declarations, fileSymbolIfFileSymbolExportEqualsContainer);
                 const reexportContainers = enclosingDeclaration && getAlternativeContainingModules(symbol, enclosingDeclaration);
+                const objectLiteralContainer = getVariableDeclarationOfObjectLiteral(container, meaning);
                 if (enclosingDeclaration && getAccessibleSymbolChain(container, enclosingDeclaration, SymbolFlags.Namespace, /*externalOnly*/ false)) {
-                    return concatenate(concatenate([container], additionalContainers), reexportContainers); // This order expresses a preference for the real container if it is in scope
+                    return append(concatenate(concatenate([container], additionalContainers), reexportContainers), objectLiteralContainer); // This order expresses a preference for the real container if it is in scope
                 }
-                const res = append(additionalContainers, container);
+                const res = append(append(additionalContainers, container), objectLiteralContainer);
                 return concatenate(res, reexportContainers);
             }
             const candidates = mapDefined(symbol.declarations, d => {
@@ -3519,6 +3520,18 @@ namespace ts {
 
             function fileSymbolIfFileSymbolExportEqualsContainer(d: Declaration) {
                 return container && getFileSymbolIfFileSymbolExportEqualsContainer(d, container);
+            }
+        }
+
+        function getVariableDeclarationOfObjectLiteral(symbol: Symbol, meaning: SymbolFlags) {
+            // If we're trying to reference some object literal in, eg `var a = { x: 1 }`, the symbol for the literal, `__object`, is distinct
+            // from the symbol of the declaration it is being assigned to. Since we can use the declaration to refer to the literal, however,
+            // we'd like to make that connection here - potentially causing us to paint the declaration's visibility, and therefore the literal.
+            const firstDecl: Node | false = !!length(symbol.declarations) && first(symbol.declarations);
+            if (meaning & SymbolFlags.Value && firstDecl && firstDecl.parent && isVariableDeclaration(firstDecl.parent)) {
+                if (isObjectLiteralExpression(firstDecl) && firstDecl === firstDecl.parent.initializer || isTypeLiteralNode(firstDecl) && firstDecl === firstDecl.parent.type) {
+                    return getSymbolOfNode(firstDecl.parent);
+                }
             }
         }
 
@@ -3915,16 +3928,7 @@ namespace ts {
                 // But it can't, hence the accessible is going to be undefined, but that doesn't mean m.c is inaccessible
                 // It is accessible if the parent m is accessible because then m.c can be accessed through qualification
 
-                let containers = getContainersOfSymbol(symbol, enclosingDeclaration);
-                // If we're trying to reference some object literal in, eg `var a = { x: 1 }`, the symbol for the literal, `__object`, is distinct
-                // from the symbol of the declaration it is being assigned to. Since we can use the declaration to refer to the literal, however,
-                // we'd like to make that connection here - potentially causing us to paint the declaration's visibility, and therefore the literal.
-                const firstDecl: Node | false = !!length(symbol.declarations) && first(symbol.declarations);
-                if (!length(containers) && meaning & SymbolFlags.Value && firstDecl && isObjectLiteralExpression(firstDecl)) {
-                    if (firstDecl.parent && isVariableDeclaration(firstDecl.parent) && firstDecl === firstDecl.parent.initializer) {
-                        containers = [getSymbolOfNode(firstDecl.parent)];
-                    }
-                }
+                const containers = getContainersOfSymbol(symbol, enclosingDeclaration, meaning);
                 const parentResult = isAnySymbolAccessible(containers, enclosingDeclaration, initialSymbol, initialSymbol === symbol ? getQualifiedLeftMeaning(meaning) : meaning, shouldComputeAliasesToMakeVisible, allowModules);
                 if (parentResult) {
                     return parentResult;
@@ -5071,7 +5075,7 @@ namespace ts {
                         needsQualification(accessibleSymbolChain[0], context.enclosingDeclaration, accessibleSymbolChain.length === 1 ? meaning : getQualifiedLeftMeaning(meaning))) {
 
                         // Go up and add our parent.
-                        const parents = getContainersOfSymbol(accessibleSymbolChain ? accessibleSymbolChain[0] : symbol, context.enclosingDeclaration);
+                        const parents = getContainersOfSymbol(accessibleSymbolChain ? accessibleSymbolChain[0] : symbol, context.enclosingDeclaration, meaning);
                         if (length(parents)) {
                             parentSpecifiers = parents!.map(symbol =>
                                 some(symbol.declarations, hasNonGlobalAugmentationExternalModuleSymbol)

--- a/tests/baselines/reference/uniqueSymbolPropertyDeclarationEmit.js
+++ b/tests/baselines/reference/uniqueSymbolPropertyDeclarationEmit.js
@@ -2,10 +2,12 @@
 
 //// [test.ts]
 import Op from './op';
+import { Po } from './po';
 
 export default function foo() {
   return {
     [Op.or]: [],
+    [Po.ro]: {}
   };
 }
 
@@ -15,6 +17,11 @@ declare const Op: {
 };
 
 export default Op;
+
+//// [po.d.ts]
+export declare const Po: {
+  readonly ro: unique symbol;
+};
 
 
 //// [op.js]
@@ -28,10 +35,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 exports.__esModule = true;
 var op_1 = __importDefault(require("./op"));
+var po_1 = require("./po");
 function foo() {
     var _a;
     return _a = {},
         _a[op_1["default"].or] = [],
+        _a[po_1.Po.ro] = {},
         _a;
 }
 exports["default"] = foo;
@@ -44,6 +53,8 @@ declare const Op: {
 export default Op;
 //// [test.d.ts]
 import Op from './op';
+import { Po } from './po';
 export default function foo(): {
     [Op.or]: any[];
+    [Po.ro]: {};
 };

--- a/tests/baselines/reference/uniqueSymbolPropertyDeclarationEmit.js
+++ b/tests/baselines/reference/uniqueSymbolPropertyDeclarationEmit.js
@@ -1,0 +1,49 @@
+//// [tests/cases/compiler/uniqueSymbolPropertyDeclarationEmit.ts] ////
+
+//// [test.ts]
+import Op from './op';
+
+export default function foo() {
+  return {
+    [Op.or]: [],
+  };
+}
+
+//// [op.ts]
+declare const Op: {
+  readonly or: unique symbol;
+};
+
+export default Op;
+
+
+//// [op.js]
+"use strict";
+exports.__esModule = true;
+exports["default"] = Op;
+//// [test.js]
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+exports.__esModule = true;
+var op_1 = __importDefault(require("./op"));
+function foo() {
+    var _a;
+    return _a = {},
+        _a[op_1["default"].or] = [],
+        _a;
+}
+exports["default"] = foo;
+
+
+//// [op.d.ts]
+declare const Op: {
+    readonly or: unique symbol;
+};
+export default Op;
+//// [test.d.ts]
+import Op from './op';
+export default function foo(): {
+    [Op.or]: any[];
+};

--- a/tests/cases/compiler/uniqueSymbolPropertyDeclarationEmit.ts
+++ b/tests/cases/compiler/uniqueSymbolPropertyDeclarationEmit.ts
@@ -1,0 +1,19 @@
+// @noTypesAndSymbols: true
+// @esModuleInterop: true
+// @declaration: true
+
+// @Filename: test.ts
+import Op from './op';
+
+export default function foo() {
+  return {
+    [Op.or]: [],
+  };
+}
+
+// @Filename: op.ts
+declare const Op: {
+  readonly or: unique symbol;
+};
+
+export default Op;

--- a/tests/cases/compiler/uniqueSymbolPropertyDeclarationEmit.ts
+++ b/tests/cases/compiler/uniqueSymbolPropertyDeclarationEmit.ts
@@ -4,10 +4,12 @@
 
 // @Filename: test.ts
 import Op from './op';
+import { Po } from './po';
 
 export default function foo() {
   return {
     [Op.or]: [],
+    [Po.ro]: {}
   };
 }
 
@@ -17,3 +19,8 @@ declare const Op: {
 };
 
 export default Op;
+
+// @Filename: po.d.ts
+export declare const Po: {
+  readonly ro: unique symbol;
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #38516

There were two problems:

1. There was code to handle the special case of swapping the symbol for an object literal for the symbol of its variable declaration, but that logic did not handle _type_ literals, as you’d find in a declaration file. I extended it to look at type literals as well.
2. That code  was only run when determining symbol accessibility, not when actually looking up the symbol chain. So I moved it into `getContainersOfSymbol`.
