### PR TITLE
Add outlining spans for call expression or arrow body

### DIFF
--- a/tests/cases/fourslash/getOutliningSpans.ts
+++ b/tests/cases/fourslash/getOutliningSpans.ts
@@ -106,14 +106,14 @@
 ////function f(x: number[], y: number[])[| {
 ////    return 3;
 ////}|]
-////f(
+////f[|(
 //////  single line array literal span won't render in VS
 ////    [|[0]|],
 ////    [|[
 ////        1,
 ////        2
 ////    ]|]
-////);
+////)|];
 
 
 verify.outliningSpansInCurrentFile(test.ranges(), "code");

--- a/tests/cases/fourslash/getOutliningSpansDepthChainedCalls.ts
+++ b/tests/cases/fourslash/getOutliningSpansDepthChainedCalls.ts
@@ -4,113 +4,113 @@
 
 ////declare var router: any;
 ////router
-////    .get("/", async(ctx) =>[|{
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
-////    .get("/", async(ctx) =>[|{
+////    }|])|]
+////    .get[|("/", async(ctx) =>[|{
 ////        ctx.body = "base";
-////    }|])
-////    .post("/a", async(ctx) =>[|{
+////    }|])|]
+////    .post[|("/a", async(ctx) =>[|{
 ////        //a
-////    }|])
+////    }|])|]
 
 verify.outliningSpansInCurrentFile(test.ranges());

--- a/tests/cases/fourslash/outliningSpansForArguments.ts
+++ b/tests/cases/fourslash/outliningSpansForArguments.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts"/>
+
+//// console.log(123, 456)l;
+//// console.log(
+//// );
+//// console.log[|(
+////     123, 456
+//// )|];
+//// console.log[|(
+////     123,
+////     456
+//// )|];
+//// () =>[| console.log[|(
+////     123,
+////     456
+//// )|]|];
+
+verify.outliningSpansInCurrentFile(test.ranges());

--- a/tests/cases/fourslash/outliningSpansForArrowFunctionBody.ts
+++ b/tests/cases/fourslash/outliningSpansForArrowFunctionBody.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts"/>
+
+//// () => 42;
+//// () => ( 42 );
+//// () =>[| {
+////     42
+//// }|];
+//// () =>[| (
+////     42
+//// )|];
+//// () =>[| "foo" +
+////     "bar" +
+////     "baz"|];
+
+verify.outliningSpansInCurrentFile(test.ranges());

--- a/tests/cases/fourslash/outliningSpansForFunction.ts
+++ b/tests/cases/fourslash/outliningSpansForFunction.ts
@@ -9,29 +9,29 @@
 ////
 ////(a: number, b: number) =>[| {
 ////    return a + b;
-////}|];
+////}|]
 ////
 ////const f1 = function[| (
 ////    a: number
 ////    b: number
 ////) {
 ////    return a + b;
-////}|];
+////}|]
 ////
 ////const f2 = function (a: number, b: number)[| {
 ////    return a + b;
-////}|];
+////}|]
 ////
 ////function f3[| (
 ////    a: number
 ////    b: number
 ////) {
 ////    return a + b;
-////}|];
+////}|]
 ////
 ////function f4(a: number, b: number)[| {
 ////    return a + b;
-////}|];
+////}|]
 ////
 ////class Foo[| {
 ////    constructor[|(
@@ -52,26 +52,26 @@
 ////    m1(a: number, b: number)[| {
 ////        return a + b;
 ////    }|]
-////}|];
+////}|]
 ////
 ////declare function foo(props: any): void;
 ////foo[|(
 ////    a =>[| {
 ////
 ////    }|]
-////)|];
+////)|]
 ////
 ////foo[|(
 ////    (a) =>[| {
 ////
 ////    }|]
-////)|];
+////)|]
 ////
 ////foo[|(
 ////    (a, b, c) =>[| {
 ////
 ////    }|]
-////)|];
+////)|]
 ////
 ////foo[|([|
 ////    (a,
@@ -79,6 +79,6 @@
 ////     c) => {
 ////
 ////    }|]
-////)|];
+////)|]
 
 verify.outliningSpansInCurrentFile(test.ranges());

--- a/tests/cases/fourslash/outliningSpansForFunction.ts
+++ b/tests/cases/fourslash/outliningSpansForFunction.ts
@@ -5,33 +5,33 @@
 ////    b: number
 ////) => {
 ////    return a + b;
-////}|]
-/////
-////(a: number, b: number) => [|{
+////}|];
+////
+////(a: number, b: number) =>[| {
 ////    return a + b;
-////}|]
+////}|];
 ////
 ////const f1 = function[| (
 ////    a: number
 ////    b: number
 ////) {
 ////    return a + b;
-////}|]
+////}|];
 ////
 ////const f2 = function (a: number, b: number)[| {
 ////    return a + b;
-////}|]
+////}|];
 ////
 ////function f3[| (
 ////    a: number
 ////    b: number
 ////) {
 ////    return a + b;
-////}|]
+////}|];
 ////
 ////function f4(a: number, b: number)[| {
 ////    return a + b;
-////}|]
+////}|];
 ////
 ////class Foo[| {
 ////    constructor[|(
@@ -52,33 +52,33 @@
 ////    m1(a: number, b: number)[| {
 ////        return a + b;
 ////    }|]
-////}|]
+////}|];
 ////
 ////declare function foo(props: any): void;
-////foo(
+////foo[|(
 ////    a =>[| {
 ////
 ////    }|]
-////)
+////)|];
 ////
-////foo(
+////foo[|(
 ////    (a) =>[| {
 ////
 ////    }|]
-////)
+////)|];
 ////
-////foo(
+////foo[|(
 ////    (a, b, c) =>[| {
 ////
 ////    }|]
-////)
+////)|];
 ////
-////foo([|
+////foo[|([|
 ////    (a,
 ////     b,
 ////     c) => {
 ////
 ////    }|]
-////)
+////)|];
 
 verify.outliningSpansInCurrentFile(test.ranges());


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #38597 

