### PR TITLE
Make parameter of setLocalDescription optional

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -12213,7 +12213,7 @@ interface RTCPeerConnection extends EventTarget {
     removeTrack(sender: RTCRtpSender): void;
     setConfiguration(configuration: RTCConfiguration): void;
     setIdentityProvider(provider: string, options?: RTCIdentityProviderOptions): void;
-    setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>;
+    setLocalDescription(description?: RTCSessionDescriptionInit): Promise<void>;
     setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void>;
     addEventListener<K extends keyof RTCPeerConnectionEventMap>(type: K, listener: (this: RTCPeerConnection, ev: RTCPeerConnectionEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;


### PR DESCRIPTION
The parameter is optional, if omitted "the WebRTC runtime tries to automatically do the right thing.".
See [spec definition](https://w3c.github.io/webrtc-pc/#interface-definition) and the corresponding [mdn page](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setLocalDescription#Parameters)


