### PR TITLE
Add missing index.ts files to user projects

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3355,7 +3355,7 @@ namespace ts {
                         type = finishNode(factory.createJSDocNonNullableType(type), pos);
                         break;
                     case SyntaxKind.QuestionToken:
-                        // If not in JSDoc and next token is start of a type we have a conditional type
+                        // If next token is start of a type we have a conditional type
                         if (lookAhead(nextTokenIsStartOfType)) {
                             return type;
                         }

--- a/tests/cases/user/acorn/index.ts
+++ b/tests/cases/user/acorn/index.ts
@@ -1,0 +1,1 @@
+import x = require('acorn');

--- a/tests/cases/user/acorn/tsconfig.json
+++ b/tests/cases/user/acorn/tsconfig.json
@@ -7,8 +7,16 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
-    "include": ["node_modules/acorn"]
+    "include": [
+        "node_modules/acorn",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/adonis-framework/index.ts
+++ b/tests/cases/user/adonis-framework/index.ts
@@ -1,0 +1,1 @@
+import x = require('adonis-framework/src/View');

--- a/tests/cases/user/adonis-framework/tsconfig.json
+++ b/tests/cases/user/adonis-framework/tsconfig.json
@@ -7,8 +7,16 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
-    "include": ["node_modules/adonis-framework"]
+    "include": [
+        "node_modules/adonis-framework",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/assert/index.ts
+++ b/tests/cases/user/assert/index.ts
@@ -1,0 +1,1 @@
+import x = require('assert');

--- a/tests/cases/user/assert/tsconfig.json
+++ b/tests/cases/user/assert/tsconfig.json
@@ -7,8 +7,16 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
-    "include": ["node_modules/assert"]
+    "include": [
+        "node_modules/assert",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/async/index.ts
+++ b/tests/cases/user/async/index.ts
@@ -1,0 +1,1 @@
+import async_ = require('async');

--- a/tests/cases/user/async/tsconfig.json
+++ b/tests/cases/user/async/tsconfig.json
@@ -10,5 +10,5 @@
         "types": ["node"],
         "lib": ["esnext", "dom"],
     },
-    "include": ["node_modules/async"]
+    "include": ["index.ts", "node_modules/async"]
 }

--- a/tests/cases/user/bcryptjs/index.ts
+++ b/tests/cases/user/bcryptjs/index.ts
@@ -1,0 +1,1 @@
+import x = require('bcryptjs');

--- a/tests/cases/user/bcryptjs/tsconfig.json
+++ b/tests/cases/user/bcryptjs/tsconfig.json
@@ -7,12 +7,18 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
     "include": [
         "node_modules/bcryptjs/scripts",
         "node_modules/bcryptjs/src",
-        "node_modules/bcryptjs/tests"
+        "node_modules/bcryptjs/tests",
+        "index.ts"
     ]
 }

--- a/tests/cases/user/bluebird/index.ts
+++ b/tests/cases/user/bluebird/index.ts
@@ -1,0 +1,1 @@
+import x = require('bluebird');

--- a/tests/cases/user/bluebird/tsconfig.json
+++ b/tests/cases/user/bluebird/tsconfig.json
@@ -7,8 +7,16 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
-    "include": ["node_modules/bluebird/js/release"]
+    "include": [
+        "node_modules/bluebird/js/release",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/clear-require/index.ts
+++ b/tests/cases/user/clear-require/index.ts
@@ -1,0 +1,1 @@
+import x = require('clear-require');

--- a/tests/cases/user/clear-require/tsconfig.json
+++ b/tests/cases/user/clear-require/tsconfig.json
@@ -7,8 +7,16 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "lib": ["esnext", "dom"],
-        "types": ["node"]
+        "lib": [
+            "esnext",
+            "dom"
+        ],
+        "types": [
+            "node"
+        ]
     },
-    "include": ["node_modules/clear-require"]
+    "include": [
+        "node_modules/clear-require",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/clone/index.ts
+++ b/tests/cases/user/clone/index.ts
@@ -1,0 +1,1 @@
+import x = require('clone');

--- a/tests/cases/user/clone/tsconfig.json
+++ b/tests/cases/user/clone/tsconfig.json
@@ -7,8 +7,16 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
-    "include": ["node_modules/clone"]
+    "include": [
+        "node_modules/clone",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/content-disposition/index.ts
+++ b/tests/cases/user/content-disposition/index.ts
@@ -1,0 +1,1 @@
+import x = require('content-disposition');

--- a/tests/cases/user/content-disposition/tsconfig.json
+++ b/tests/cases/user/content-disposition/tsconfig.json
@@ -7,8 +7,16 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
-    "include": ["node_modules/content-disposition"]
+    "include": [
+        "node_modules/content-disposition",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/debug/index.ts
+++ b/tests/cases/user/debug/index.ts
@@ -1,0 +1,1 @@
+import debug = require('debug');

--- a/tests/cases/user/debug/tsconfig.json
+++ b/tests/cases/user/debug/tsconfig.json
@@ -10,5 +10,5 @@
         "types": ["node"],
         "lib": ["esnext", "dom"],
     },
-    "include": ["node_modules/debug"]
+    "include": ["index.ts", "node_modules/debug"]
 }

--- a/tests/cases/user/enhanced-resolve/index.ts
+++ b/tests/cases/user/enhanced-resolve/index.ts
@@ -1,0 +1,1 @@
+import x = require('enhanced-resolve');

--- a/tests/cases/user/enhanced-resolve/tsconfig.json
+++ b/tests/cases/user/enhanced-resolve/tsconfig.json
@@ -7,10 +7,18 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ],
         "module": "CommonJS",
-        "target": "esnext",
+        "target": "esnext"
     },
-    "include": ["node_modules/enhanced-resolve"]
+    "include": [
+        "node_modules/enhanced-resolve",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/follow-redirects/index.ts
+++ b/tests/cases/user/follow-redirects/index.ts
@@ -1,0 +1,1 @@
+import x = require('follow-redirects');

--- a/tests/cases/user/follow-redirects/tsconfig.json
+++ b/tests/cases/user/follow-redirects/tsconfig.json
@@ -7,8 +7,16 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
-    "include": ["node_modules/follow-redirects"]
+    "include": [
+        "node_modules/follow-redirects",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/graceful-fs/index.ts
+++ b/tests/cases/user/graceful-fs/index.ts
@@ -1,0 +1,1 @@
+import x = require('graceful-fs');

--- a/tests/cases/user/graceful-fs/tsconfig.json
+++ b/tests/cases/user/graceful-fs/tsconfig.json
@@ -7,8 +7,16 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
-    "include": ["node_modules/graceful-fs"]
+    "include": [
+        "node_modules/graceful-fs",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/lodash/index.ts
+++ b/tests/cases/user/lodash/index.ts
@@ -1,0 +1,1 @@
+import x = require('lodash');

--- a/tests/cases/user/lodash/tsconfig.json
+++ b/tests/cases/user/lodash/tsconfig.json
@@ -7,9 +7,19 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
-    "include": ["node_modules/lodash"],
-    "exclude": ["node_modules/lodash/lodash.js"]
+    "include": [
+        "node_modules/lodash",
+        "index.ts"
+    ],
+    "exclude": [
+        "node_modules/lodash/lodash.js"
+    ]
 }

--- a/tests/cases/user/minimatch/index.ts
+++ b/tests/cases/user/minimatch/index.ts
@@ -1,0 +1,1 @@
+import x = require('minimatch');

--- a/tests/cases/user/minimatch/tsconfig.json
+++ b/tests/cases/user/minimatch/tsconfig.json
@@ -7,8 +7,16 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
-    "include": ["node_modules/minimatch"]
+    "include": [
+        "node_modules/minimatch",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/npm/index.ts
+++ b/tests/cases/user/npm/index.ts
@@ -1,0 +1,1 @@
+import x = require('npm');

--- a/tests/cases/user/npm/tsconfig.json
+++ b/tests/cases/user/npm/tsconfig.json
@@ -7,8 +7,17 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom", "scripthost"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom",
+            "scripthost"
+        ]
     },
-    "include": ["node_modules/npm"]
+    "include": [
+        "node_modules/npm",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/npmlog/index.ts
+++ b/tests/cases/user/npmlog/index.ts
@@ -1,0 +1,1 @@
+import x = require('npmlog');

--- a/tests/cases/user/npmlog/tsconfig.json
+++ b/tests/cases/user/npmlog/tsconfig.json
@@ -7,8 +7,16 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
-    "include": ["node_modules/npmlog"]
+    "include": [
+        "node_modules/npmlog",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/uglify-js/index.ts
+++ b/tests/cases/user/uglify-js/index.ts
@@ -1,0 +1,1 @@
+import x = require('uglify-js');

--- a/tests/cases/user/uglify-js/tsconfig.json
+++ b/tests/cases/user/uglify-js/tsconfig.json
@@ -7,8 +7,16 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
-    "include": ["node_modules/uglify-js"]
+    "include": [
+        "node_modules/uglify-js",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/url-search-params/index.ts
+++ b/tests/cases/user/url-search-params/index.ts
@@ -1,0 +1,1 @@
+import x = require('url-search-params');

--- a/tests/cases/user/url-search-params/tsconfig.json
+++ b/tests/cases/user/url-search-params/tsconfig.json
@@ -7,8 +7,16 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
-    "include": ["node_modules/url-search-params/build/url-search-params.node.js"]
+    "include": [
+        "node_modules/url-search-params/build/url-search-params.node.js",
+        "index.ts"
+    ]
 }

--- a/tests/cases/user/util/index.ts
+++ b/tests/cases/user/util/index.ts
@@ -1,0 +1,1 @@
+import x = require('util');

--- a/tests/cases/user/util/tsconfig.json
+++ b/tests/cases/user/util/tsconfig.json
@@ -7,8 +7,16 @@
         "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "types": ["node"],
-        "lib": ["esnext", "dom"],
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "esnext",
+            "dom"
+        ]
     },
-    "include": ["node_modules/util"]
+    "include": [
+        "node_modules/util",
+        "index.ts"
+    ]
 }


### PR DESCRIPTION
This makes the language service treat .js files inside node_modules as
part of the parent project, so that you can view the same errors in the
editor as you see in the baselines.

Also update a comment in the parser that I missed in an earlier PR. (#39123)
