### PR TITLE
Do not add reexported names to the exportSpecifiers list of moduleinfo

### DIFF
--- a/src/compiler/transformers/utilities.ts
+++ b/src/compiler/transformers/utilities.ts
@@ -8,9 +8,9 @@ namespace ts {
     export interface ExternalModuleInfo {
         externalImports: (ImportDeclaration | ImportEqualsDeclaration | ExportDeclaration)[]; // imports of other external modules
         externalHelpersImportDeclaration: ImportDeclaration | undefined; // import of external helpers
-        exportSpecifiers: Map<ExportSpecifier[]>; // export specifiers by name
+        exportSpecifiers: Map<ExportSpecifier[]>; // file-local export specifiers by name (no reexports)
         exportedBindings: Identifier[][]; // exported names of local declarations
-        exportedNames: Identifier[] | undefined; // all exported names local to module
+        exportedNames: Identifier[] | undefined; // all exported names in the module, both local and reexported
         exportEquals: ExportAssignment | undefined; // an export= declaration if one was present
         hasExportStarsToExportValues: boolean; // whether this module contains export*
     }
@@ -201,7 +201,9 @@ namespace ts {
             for (const specifier of cast(node.exportClause, isNamedExports).elements) {
                 if (!uniqueExports.get(idText(specifier.name))) {
                     const name = specifier.propertyName || specifier.name;
-                    exportSpecifiers.add(idText(name), specifier);
+                    if (!node.moduleSpecifier) {
+                        exportSpecifiers.add(idText(name), specifier);
+                    }
 
                     const decl = resolver.getReferencedImportDeclaration(name)
                         || resolver.getReferencedValueDeclaration(name);

--- a/tests/baselines/reference/reexportNameAliasedAndHoisted.js
+++ b/tests/baselines/reference/reexportNameAliasedAndHoisted.js
@@ -1,0 +1,35 @@
+//// [tests/cases/compiler/reexportNameAliasedAndHoisted.ts] ////
+
+//// [gridview.ts]
+export type Sizing = any;
+export const Sizing = null;
+//// [index.ts]
+// https://github.com/microsoft/TypeScript/issues/39195
+export { Sizing as GridViewSizing } from './gridview';
+export namespace Sizing {
+    export const Distribute = { type: 'distribute' };
+}
+
+//// [gridview.js]
+"use strict";
+exports.__esModule = true;
+exports.Sizing = void 0;
+exports.Sizing = null;
+//// [index.js]
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+exports.__esModule = true;
+exports.Sizing = exports.GridViewSizing = void 0;
+// https://github.com/microsoft/TypeScript/issues/39195
+var gridview_1 = require("./gridview");
+__createBinding(exports, gridview_1, "Sizing", "GridViewSizing");
+var Sizing;
+(function (Sizing) {
+    Sizing.Distribute = { type: 'distribute' };
+})(Sizing = exports.Sizing || (exports.Sizing = {}));

--- a/tests/baselines/reference/reexportNameAliasedAndHoisted.symbols
+++ b/tests/baselines/reference/reexportNameAliasedAndHoisted.symbols
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/gridview.ts ===
+export type Sizing = any;
+>Sizing : Symbol(Sizing, Decl(gridview.ts, 0, 0), Decl(gridview.ts, 1, 12))
+
+export const Sizing = null;
+>Sizing : Symbol(Sizing, Decl(gridview.ts, 0, 0), Decl(gridview.ts, 1, 12))
+
+=== tests/cases/compiler/index.ts ===
+// https://github.com/microsoft/TypeScript/issues/39195
+export { Sizing as GridViewSizing } from './gridview';
+>Sizing : Symbol(Sizing, Decl(gridview.ts, 0, 0), Decl(gridview.ts, 1, 12))
+>GridViewSizing : Symbol(GridViewSizing, Decl(index.ts, 1, 8))
+
+export namespace Sizing {
+>Sizing : Symbol(Sizing, Decl(index.ts, 1, 54))
+
+    export const Distribute = { type: 'distribute' };
+>Distribute : Symbol(Distribute, Decl(index.ts, 3, 16))
+>type : Symbol(type, Decl(index.ts, 3, 31))
+}

--- a/tests/baselines/reference/reexportNameAliasedAndHoisted.types
+++ b/tests/baselines/reference/reexportNameAliasedAndHoisted.types
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/gridview.ts ===
+export type Sizing = any;
+>Sizing : any
+
+export const Sizing = null;
+>Sizing : any
+>null : null
+
+=== tests/cases/compiler/index.ts ===
+// https://github.com/microsoft/TypeScript/issues/39195
+export { Sizing as GridViewSizing } from './gridview';
+>Sizing : any
+>GridViewSizing : any
+
+export namespace Sizing {
+>Sizing : typeof Sizing
+
+    export const Distribute = { type: 'distribute' };
+>Distribute : { type: string; }
+>{ type: 'distribute' } : { type: string; }
+>type : string
+>'distribute' : "distribute"
+}

--- a/tests/cases/compiler/reexportNameAliasedAndHoisted.ts
+++ b/tests/cases/compiler/reexportNameAliasedAndHoisted.ts
@@ -1,0 +1,9 @@
+// @filename: gridview.ts
+export type Sizing = any;
+export const Sizing = null;
+// @filename: index.ts
+// https://github.com/microsoft/TypeScript/issues/39195
+export { Sizing as GridViewSizing } from './gridview';
+export namespace Sizing {
+    export const Distribute = { type: 'distribute' };
+}


### PR DESCRIPTION
Fixes #39195

A quick audit of the module info datapoints which were refactored into a helper function in #38809:

* `exportSpecifiers` with this PR now again omits nonlocal specifiers (as all users expect only local specifiers, as they use the list to perform psuedo-name-resolution)
* `exportedBindings` _can_ contain the nonlocal exports (though didn't before #38809), since it's a map on original node ID, so including the reexports is fine (the remote entries simply won't be referenced by the users of the module info)
* `exportedNames` explicitly contains the reexports now to handle live bindings (which was the intended change in #38809).
