### PR TITLE
Leverage syntax cursor as part of reparse

### DIFF
--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -321,6 +321,8 @@ namespace ts {
      * @param context A lexical environment context for the visitor.
      */
     export function visitEachChild<T extends Node>(node: T, visitor: Visitor, context: TransformationContext): T;
+    /* @internal */
+    export function visitEachChild<T extends Node>(node: T, visitor: Visitor, context: TransformationContext, nodesVisitor?: NodesVisitor, tokenVisitor?: Visitor, nodeVisitor?: NodeVisitor): T; // eslint-disable-line @typescript-eslint/unified-signatures
     /**
      * Visits each child of a Node using the supplied visitor, possibly returning a new Node of the same kind in its place.
      *

--- a/tests/baselines/reference/FunctionDeclaration10_es6.errors.txt
+++ b/tests/baselines/reference/FunctionDeclaration10_es6.errors.txt
@@ -1,20 +1,11 @@
-tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts(1,16): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts(1,20): error TS2523: 'yield' expressions cannot be used in a parameter initializer.
 tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts(1,26): error TS1005: ',' expected.
-tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts(1,29): error TS1138: Parameter declaration expected.
-tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts(1,29): error TS2304: Cannot find name 'yield'.
-tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts(1,34): error TS1005: ';' expected.
 
 
-==== tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts (5 errors) ====
+==== tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts (2 errors) ====
     function * foo(a = yield => yield) {
-                   ~~~~~~~~~
-!!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+                       ~~~~~
+!!! error TS2523: 'yield' expressions cannot be used in a parameter initializer.
                              ~~
 !!! error TS1005: ',' expected.
-                                ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                                ~~~~~
-!!! error TS2304: Cannot find name 'yield'.
-                                     ~
-!!! error TS1005: ';' expected.
     }

--- a/tests/baselines/reference/FunctionDeclaration10_es6.js
+++ b/tests/baselines/reference/FunctionDeclaration10_es6.js
@@ -3,7 +3,5 @@ function * foo(a = yield => yield) {
 }
 
 //// [FunctionDeclaration10_es6.js]
-function* foo(a = yield) { }
-yield;
-{
+function* foo(a = yield, yield) {
 }

--- a/tests/baselines/reference/FunctionDeclaration10_es6.symbols
+++ b/tests/baselines/reference/FunctionDeclaration10_es6.symbols
@@ -2,4 +2,5 @@
 function * foo(a = yield => yield) {
 >foo : Symbol(foo, Decl(FunctionDeclaration10_es6.ts, 0, 0))
 >a : Symbol(a, Decl(FunctionDeclaration10_es6.ts, 0, 15))
+>yield : Symbol(yield, Decl(FunctionDeclaration10_es6.ts, 0, 27))
 }

--- a/tests/baselines/reference/FunctionDeclaration10_es6.types
+++ b/tests/baselines/reference/FunctionDeclaration10_es6.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration10_es6.ts ===
 function * foo(a = yield => yield) {
->foo : (a?: any) => any
+>foo : (a: any, yield: any) => Generator<never, void, unknown>
 >a : any
 >yield : any
 >yield : any

--- a/tests/baselines/reference/FunctionDeclaration12_es6.errors.txt
+++ b/tests/baselines/reference/FunctionDeclaration12_es6.errors.txt
@@ -1,13 +1,7 @@
-tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration12_es6.ts(1,20): error TS1005: '(' expected.
-tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration12_es6.ts(1,25): error TS1005: ',' expected.
-tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration12_es6.ts(1,28): error TS1005: '=>' expected.
+tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration12_es6.ts(1,20): error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
 
 
-==== tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration12_es6.ts (3 errors) ====
+==== tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration12_es6.ts (1 errors) ====
     var v = function * yield() { }
                        ~~~~~
-!!! error TS1005: '(' expected.
-                            ~
-!!! error TS1005: ',' expected.
-                               ~
-!!! error TS1005: '=>' expected.
+!!! error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.

--- a/tests/baselines/reference/FunctionDeclaration12_es6.js
+++ b/tests/baselines/reference/FunctionDeclaration12_es6.js
@@ -2,5 +2,4 @@
 var v = function * yield() { }
 
 //// [FunctionDeclaration12_es6.js]
-var v = function* () { }, yield;
-() => { };
+var v = function* yield() { };

--- a/tests/baselines/reference/FunctionDeclaration12_es6.symbols
+++ b/tests/baselines/reference/FunctionDeclaration12_es6.symbols
@@ -1,5 +1,5 @@
 === tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration12_es6.ts ===
 var v = function * yield() { }
 >v : Symbol(v, Decl(FunctionDeclaration12_es6.ts, 0, 3))
->yield : Symbol(yield, Decl(FunctionDeclaration12_es6.ts, 0, 18))
+>yield : Symbol(yield, Decl(FunctionDeclaration12_es6.ts, 0, 7))
 

--- a/tests/baselines/reference/FunctionDeclaration12_es6.types
+++ b/tests/baselines/reference/FunctionDeclaration12_es6.types
@@ -1,7 +1,6 @@
 === tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration12_es6.ts ===
 var v = function * yield() { }
->v : () => any
->function * : () => any
->yield : any
->() { } : () => void
+>v : () => Generator<never, void, unknown>
+>function * yield() { } : () => Generator<never, void, unknown>
+>yield : () => Generator<never, void, unknown>
 

--- a/tests/baselines/reference/FunctionDeclaration5_es6.errors.txt
+++ b/tests/baselines/reference/FunctionDeclaration5_es6.errors.txt
@@ -1,14 +1,8 @@
-tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration5_es6.ts(1,14): error TS1138: Parameter declaration expected.
-tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration5_es6.ts(1,14): error TS2304: Cannot find name 'yield'.
-tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration5_es6.ts(1,19): error TS1005: ';' expected.
+tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration5_es6.ts(1,14): error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
 
 
-==== tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration5_es6.ts (3 errors) ====
+==== tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration5_es6.ts (1 errors) ====
     function*foo(yield) {
                  ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                 ~~~~~
-!!! error TS2304: Cannot find name 'yield'.
-                      ~
-!!! error TS1005: ';' expected.
+!!! error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
     }

--- a/tests/baselines/reference/FunctionDeclaration5_es6.js
+++ b/tests/baselines/reference/FunctionDeclaration5_es6.js
@@ -3,7 +3,5 @@ function*foo(yield) {
 }
 
 //// [FunctionDeclaration5_es6.js]
-function* foo() { }
-yield;
-{
+function* foo(yield) {
 }

--- a/tests/baselines/reference/FunctionDeclaration5_es6.symbols
+++ b/tests/baselines/reference/FunctionDeclaration5_es6.symbols
@@ -1,4 +1,5 @@
 === tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration5_es6.ts ===
 function*foo(yield) {
 >foo : Symbol(foo, Decl(FunctionDeclaration5_es6.ts, 0, 0))
+>yield : Symbol(yield, Decl(FunctionDeclaration5_es6.ts, 0, 13))
 }

--- a/tests/baselines/reference/FunctionDeclaration5_es6.types
+++ b/tests/baselines/reference/FunctionDeclaration5_es6.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration5_es6.ts ===
 function*foo(yield) {
->foo : () => any
+>foo : (yield: any) => Generator<never, void, unknown>
 >yield : any
 }

--- a/tests/baselines/reference/asyncArrowFunction5_es2017.errors.txt
+++ b/tests/baselines/reference/asyncArrowFunction5_es2017.errors.txt
@@ -1,24 +1,8 @@
-tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts(1,11): error TS2304: Cannot find name 'async'.
-tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts(1,18): error TS2304: Cannot find name 'await'.
-tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts(1,24): error TS1005: ',' expected.
-tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts(1,26): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Promise' must be of type 'PromiseConstructor', but here has type 'any'.
-tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts(1,33): error TS1005: ',' expected.
-tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts(1,40): error TS1109: Expression expected.
+tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts(1,18): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
-==== tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts (6 errors) ====
+==== tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts (1 errors) ====
     var foo = async (await): Promise<void> => {
-              ~~~~~
-!!! error TS2304: Cannot find name 'async'.
                      ~~~~~
-!!! error TS2304: Cannot find name 'await'.
-                           ~
-!!! error TS1005: ',' expected.
-                             ~~~~~~~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Promise' must be of type 'PromiseConstructor', but here has type 'any'.
-!!! related TS6203 /.ts/lib.es2015.promise.d.ts:150:13: 'Promise' was also declared here.
-                                    ~
-!!! error TS1005: ',' expected.
-                                           ~~
-!!! error TS1109: Expression expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     }

--- a/tests/baselines/reference/asyncArrowFunction5_es2017.js
+++ b/tests/baselines/reference/asyncArrowFunction5_es2017.js
@@ -3,7 +3,5 @@ var foo = async (await): Promise<void> => {
 }
 
 //// [asyncArrowFunction5_es2017.js]
-var foo = async(await), Promise;
-;
-{
-}
+var foo = async (await) => {
+};

--- a/tests/baselines/reference/asyncArrowFunction5_es2017.symbols
+++ b/tests/baselines/reference/asyncArrowFunction5_es2017.symbols
@@ -1,5 +1,6 @@
 === tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts ===
 var foo = async (await): Promise<void> => {
 >foo : Symbol(foo, Decl(asyncArrowFunction5_es2017.ts, 0, 3))
->Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(asyncArrowFunction5_es2017.ts, 0, 24))
+>await : Symbol(await, Decl(asyncArrowFunction5_es2017.ts, 0, 17))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/asyncArrowFunction5_es2017.types
+++ b/tests/baselines/reference/asyncArrowFunction5_es2017.types
@@ -1,10 +1,6 @@
 === tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts ===
 var foo = async (await): Promise<void> => {
->foo : any
->async (await) : any
->async : any
+>foo : (await: any) => Promise<void>
+>async (await): Promise<void> => {} : (await: any) => Promise<void>
 >await : any
->Promise : PromiseConstructor
-><void> : void
-> : any
 }

--- a/tests/baselines/reference/asyncArrowFunction5_es5.errors.txt
+++ b/tests/baselines/reference/asyncArrowFunction5_es5.errors.txt
@@ -1,24 +1,8 @@
-tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts(1,11): error TS2304: Cannot find name 'async'.
-tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts(1,18): error TS2304: Cannot find name 'await'.
-tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts(1,24): error TS1005: ',' expected.
-tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts(1,26): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Promise' must be of type 'PromiseConstructor', but here has type 'any'.
-tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts(1,33): error TS1005: ',' expected.
-tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts(1,40): error TS1109: Expression expected.
+tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts(1,18): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
-==== tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts (6 errors) ====
+==== tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts (1 errors) ====
     var foo = async (await): Promise<void> => {
-              ~~~~~
-!!! error TS2304: Cannot find name 'async'.
                      ~~~~~
-!!! error TS2304: Cannot find name 'await'.
-                           ~
-!!! error TS1005: ',' expected.
-                             ~~~~~~~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Promise' must be of type 'PromiseConstructor', but here has type 'any'.
-!!! related TS6203 /.ts/lib.es2015.promise.d.ts:150:13: 'Promise' was also declared here.
-                                    ~
-!!! error TS1005: ',' expected.
-                                           ~~
-!!! error TS1109: Expression expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     }

--- a/tests/baselines/reference/asyncArrowFunction5_es5.js
+++ b/tests/baselines/reference/asyncArrowFunction5_es5.js
@@ -3,7 +3,9 @@ var foo = async (await): Promise<void> => {
 }
 
 //// [asyncArrowFunction5_es5.js]
-var foo = async(await), Promise;
-;
-{
-}
+var _this = this;
+var foo = function (await) { return __awaiter(_this, void 0, void 0, function () {
+    return __generator(this, function (_a) {
+        return [2 /*return*/];
+    });
+}); };

--- a/tests/baselines/reference/asyncArrowFunction5_es5.symbols
+++ b/tests/baselines/reference/asyncArrowFunction5_es5.symbols
@@ -1,5 +1,6 @@
 === tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts ===
 var foo = async (await): Promise<void> => {
 >foo : Symbol(foo, Decl(asyncArrowFunction5_es5.ts, 0, 3))
->Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(asyncArrowFunction5_es5.ts, 0, 24))
+>await : Symbol(await, Decl(asyncArrowFunction5_es5.ts, 0, 17))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
 }

--- a/tests/baselines/reference/asyncArrowFunction5_es5.types
+++ b/tests/baselines/reference/asyncArrowFunction5_es5.types
@@ -1,10 +1,6 @@
 === tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts ===
 var foo = async (await): Promise<void> => {
->foo : any
->async (await) : any
->async : any
+>foo : (await: any) => Promise<void>
+>async (await): Promise<void> => {} : (await: any) => Promise<void>
 >await : any
->Promise : PromiseConstructor
-><void> : void
-> : any
 }

--- a/tests/baselines/reference/asyncArrowFunction5_es6.errors.txt
+++ b/tests/baselines/reference/asyncArrowFunction5_es6.errors.txt
@@ -1,24 +1,8 @@
-tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts(1,11): error TS2304: Cannot find name 'async'.
-tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts(1,18): error TS2304: Cannot find name 'await'.
-tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts(1,24): error TS1005: ',' expected.
-tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts(1,26): error TS2403: Subsequent variable declarations must have the same type.  Variable 'Promise' must be of type 'PromiseConstructor', but here has type 'any'.
-tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts(1,33): error TS1005: ',' expected.
-tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts(1,40): error TS1109: Expression expected.
+tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts(1,18): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
-==== tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts (6 errors) ====
+==== tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts (1 errors) ====
     var foo = async (await): Promise<void> => {
-              ~~~~~
-!!! error TS2304: Cannot find name 'async'.
                      ~~~~~
-!!! error TS2304: Cannot find name 'await'.
-                           ~
-!!! error TS1005: ',' expected.
-                             ~~~~~~~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'Promise' must be of type 'PromiseConstructor', but here has type 'any'.
-!!! related TS6203 /.ts/lib.es2015.promise.d.ts:150:13: 'Promise' was also declared here.
-                                    ~
-!!! error TS1005: ',' expected.
-                                           ~~
-!!! error TS1109: Expression expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     }

--- a/tests/baselines/reference/asyncArrowFunction5_es6.js
+++ b/tests/baselines/reference/asyncArrowFunction5_es6.js
@@ -3,7 +3,5 @@ var foo = async (await): Promise<void> => {
 }
 
 //// [asyncArrowFunction5_es6.js]
-var foo = async(await), Promise;
-;
-{
-}
+var foo = (await) => __awaiter(this, void 0, void 0, function* () {
+});

--- a/tests/baselines/reference/asyncArrowFunction5_es6.symbols
+++ b/tests/baselines/reference/asyncArrowFunction5_es6.symbols
@@ -1,5 +1,6 @@
 === tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts ===
 var foo = async (await): Promise<void> => {
 >foo : Symbol(foo, Decl(asyncArrowFunction5_es6.ts, 0, 3))
->Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(asyncArrowFunction5_es6.ts, 0, 24))
+>await : Symbol(await, Decl(asyncArrowFunction5_es6.ts, 0, 17))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/asyncArrowFunction5_es6.types
+++ b/tests/baselines/reference/asyncArrowFunction5_es6.types
@@ -1,10 +1,6 @@
 === tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts ===
 var foo = async (await): Promise<void> => {
->foo : any
->async (await) : any
->async : any
+>foo : (await: any) => Promise<void>
+>async (await): Promise<void> => {} : (await: any) => Promise<void>
 >await : any
->Promise : PromiseConstructor
-><void> : void
-> : any
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es2017.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es2017.errors.txt
@@ -1,33 +1,11 @@
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,20): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,24): error TS2524: 'await' expressions cannot be used in a parameter initializer.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,30): error TS1109: Expression expected.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,33): error TS1138: Parameter declaration expected.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,33): error TS2304: Cannot find name 'await'.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,38): error TS1005: ';' expected.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,39): error TS1128: Declaration or statement expected.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,41): error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,49): error TS2532: Object is possibly 'undefined'.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,53): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts (9 errors) ====
+==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts (2 errors) ====
     async function foo(a = await => await): Promise<void> {
-                       ~~~~~~~~~
-!!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+                           ~~~~~
+!!! error TS2524: 'await' expressions cannot be used in a parameter initializer.
                                  ~~
 !!! error TS1109: Expression expected.
-                                    ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                                    ~~~~~
-!!! error TS2304: Cannot find name 'await'.
-                                         ~
-!!! error TS1005: ';' expected.
-                                          ~
-!!! error TS1128: Declaration or statement expected.
-                                            ~~~~~~~~~~~~~~~
-                                                    ~~~~
-!!! error TS2532: Object is possibly 'undefined'.
-                                                        ~
-!!! error TS1109: Expression expected.
     }
-    ~
-!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es2017.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es2017.js
@@ -3,6 +3,5 @@ async function foo(a = await => await): Promise<void> {
 }
 
 //// [asyncFunctionDeclaration10_es2017.js]
-async function foo(a = await ) { }
-await;
-Promise < void  > {};
+async function foo(a = await , await) {
+}

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es2017.symbols
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es2017.symbols
@@ -2,5 +2,6 @@
 async function foo(a = await => await): Promise<void> {
 >foo : Symbol(foo, Decl(asyncFunctionDeclaration10_es2017.ts, 0, 0))
 >a : Symbol(a, Decl(asyncFunctionDeclaration10_es2017.ts, 0, 19))
+>await : Symbol(await, Decl(asyncFunctionDeclaration10_es2017.ts, 0, 31))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es2017.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es2017.types
@@ -1,14 +1,8 @@
 === tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts ===
 async function foo(a = await => await): Promise<void> {
->foo : (a?: any) => any
+>foo : (a: any, await: any) => Promise<void>
 >a : any
 >await : any
 > : any
 >await : any
->Promise<void> {} : boolean
->Promise<void : boolean
->Promise : PromiseConstructor
->void : undefined
-> : any
->{} : {}
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es5.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es5.errors.txt
@@ -1,33 +1,11 @@
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,20): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,24): error TS2524: 'await' expressions cannot be used in a parameter initializer.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,30): error TS1109: Expression expected.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,33): error TS1138: Parameter declaration expected.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,33): error TS2304: Cannot find name 'await'.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,38): error TS1005: ';' expected.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,39): error TS1128: Declaration or statement expected.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,41): error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,49): error TS2532: Object is possibly 'undefined'.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,53): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts (9 errors) ====
+==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts (2 errors) ====
     async function foo(a = await => await): Promise<void> {
-                       ~~~~~~~~~
-!!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+                           ~~~~~
+!!! error TS2524: 'await' expressions cannot be used in a parameter initializer.
                                  ~~
 !!! error TS1109: Expression expected.
-                                    ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                                    ~~~~~
-!!! error TS2304: Cannot find name 'await'.
-                                         ~
-!!! error TS1005: ';' expected.
-                                          ~
-!!! error TS1128: Declaration or statement expected.
-                                            ~~~~~~~~~~~~~~~
-                                                    ~~~~
-!!! error TS2532: Object is possibly 'undefined'.
-                                                        ~
-!!! error TS1109: Expression expected.
     }
-    ~
-!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es5.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es5.js
@@ -3,11 +3,11 @@ async function foo(a = await => await): Promise<void> {
 }
 
 //// [asyncFunctionDeclaration10_es5.js]
-function foo(a) {
+function foo(a, await) {
     if (a === void 0) { a = yield ; }
-    return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
-        return [2 /*return*/];
-    }); });
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            return [2 /*return*/];
+        });
+    });
 }
-await;
-Promise < void  > {};

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es5.symbols
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es5.symbols
@@ -2,5 +2,6 @@
 async function foo(a = await => await): Promise<void> {
 >foo : Symbol(foo, Decl(asyncFunctionDeclaration10_es5.ts, 0, 0))
 >a : Symbol(a, Decl(asyncFunctionDeclaration10_es5.ts, 0, 19))
+>await : Symbol(await, Decl(asyncFunctionDeclaration10_es5.ts, 0, 31))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es5.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es5.types
@@ -1,14 +1,8 @@
 === tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts ===
 async function foo(a = await => await): Promise<void> {
->foo : (a?: any) => any
+>foo : (a: any, await: any) => Promise<void>
 >a : any
 >await : any
 > : any
 >await : any
->Promise<void> {} : boolean
->Promise<void : boolean
->Promise : PromiseConstructor
->void : undefined
-> : any
->{} : {}
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es6.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es6.errors.txt
@@ -1,33 +1,11 @@
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,20): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,24): error TS2524: 'await' expressions cannot be used in a parameter initializer.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,30): error TS1109: Expression expected.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,33): error TS1138: Parameter declaration expected.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,33): error TS2304: Cannot find name 'await'.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,38): error TS1005: ';' expected.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,39): error TS1128: Declaration or statement expected.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,41): error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,49): error TS2532: Object is possibly 'undefined'.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,53): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts (9 errors) ====
+==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts (2 errors) ====
     async function foo(a = await => await): Promise<void> {
-                       ~~~~~~~~~
-!!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+                           ~~~~~
+!!! error TS2524: 'await' expressions cannot be used in a parameter initializer.
                                  ~~
 !!! error TS1109: Expression expected.
-                                    ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                                    ~~~~~
-!!! error TS2304: Cannot find name 'await'.
-                                         ~
-!!! error TS1005: ';' expected.
-                                          ~
-!!! error TS1128: Declaration or statement expected.
-                                            ~~~~~~~~~~~~~~~
-                                                    ~~~~
-!!! error TS2532: Object is possibly 'undefined'.
-                                                        ~
-!!! error TS1109: Expression expected.
     }
-    ~
-!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es6.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es6.js
@@ -3,8 +3,7 @@ async function foo(a = await => await): Promise<void> {
 }
 
 //// [asyncFunctionDeclaration10_es6.js]
-function foo(a = yield ) {
-    return __awaiter(this, void 0, void 0, function* () { });
+function foo(a = yield , await) {
+    return __awaiter(this, void 0, void 0, function* () {
+    });
 }
-await;
-Promise < void  > {};

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es6.symbols
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es6.symbols
@@ -2,5 +2,6 @@
 async function foo(a = await => await): Promise<void> {
 >foo : Symbol(foo, Decl(asyncFunctionDeclaration10_es6.ts, 0, 0))
 >a : Symbol(a, Decl(asyncFunctionDeclaration10_es6.ts, 0, 19))
+>await : Symbol(await, Decl(asyncFunctionDeclaration10_es6.ts, 0, 31))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es6.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es6.types
@@ -1,14 +1,8 @@
 === tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts ===
 async function foo(a = await => await): Promise<void> {
->foo : (a?: any) => any
+>foo : (a: any, await: any) => Promise<void>
 >a : any
 >await : any
 > : any
 >await : any
->Promise<void> {} : boolean
->Promise<void : boolean
->Promise : PromiseConstructor
->void : undefined
-> : any
->{} : {}
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration12_es2017.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration12_es2017.errors.txt
@@ -1,16 +1,7 @@
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration12_es2017.ts(1,24): error TS1005: '(' expected.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration12_es2017.ts(1,29): error TS1005: ',' expected.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration12_es2017.ts(1,33): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration12_es2017.ts(1,47): error TS1005: '=>' expected.
+tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration12_es2017.ts(1,24): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
-==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration12_es2017.ts (4 errors) ====
+==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration12_es2017.ts (1 errors) ====
     var v = async function await(): Promise<void> { }
                            ~~~~~
-!!! error TS1005: '(' expected.
-                                ~
-!!! error TS1005: ',' expected.
-                                    ~~~~~~~~~~~~~
-!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
-                                                  ~
-!!! error TS1005: '=>' expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.

--- a/tests/baselines/reference/asyncFunctionDeclaration12_es2017.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration12_es2017.js
@@ -2,5 +2,4 @@
 var v = async function await(): Promise<void> { }
 
 //// [asyncFunctionDeclaration12_es2017.js]
-var v = async function () { }, await;
-() => { };
+var v = async function await() { };

--- a/tests/baselines/reference/asyncFunctionDeclaration12_es2017.symbols
+++ b/tests/baselines/reference/asyncFunctionDeclaration12_es2017.symbols
@@ -1,6 +1,6 @@
 === tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration12_es2017.ts ===
 var v = async function await(): Promise<void> { }
 >v : Symbol(v, Decl(asyncFunctionDeclaration12_es2017.ts, 0, 3))
->await : Symbol(await, Decl(asyncFunctionDeclaration12_es2017.ts, 0, 22))
+>await : Symbol(await, Decl(asyncFunctionDeclaration12_es2017.ts, 0, 7))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 

--- a/tests/baselines/reference/asyncFunctionDeclaration12_es2017.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration12_es2017.types
@@ -1,7 +1,6 @@
 === tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration12_es2017.ts ===
 var v = async function await(): Promise<void> { }
->v : () => any
->async function : () => any
->await : any
->(): Promise<void> { } : () => Promise<void>
+>v : () => Promise<void>
+>async function await(): Promise<void> { } : () => Promise<void>
+>await : () => Promise<void>
 

--- a/tests/baselines/reference/asyncFunctionDeclaration12_es5.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration12_es5.errors.txt
@@ -1,16 +1,7 @@
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration12_es5.ts(1,24): error TS1005: '(' expected.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration12_es5.ts(1,29): error TS1005: ',' expected.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration12_es5.ts(1,33): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration12_es5.ts(1,47): error TS1005: '=>' expected.
+tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration12_es5.ts(1,24): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
-==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration12_es5.ts (4 errors) ====
+==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration12_es5.ts (1 errors) ====
     var v = async function await(): Promise<void> { }
                            ~~~~~
-!!! error TS1005: '(' expected.
-                                ~
-!!! error TS1005: ',' expected.
-                                    ~~~~~~~~~~~~~
-!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
-                                                  ~
-!!! error TS1005: '=>' expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.

--- a/tests/baselines/reference/asyncFunctionDeclaration12_es5.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration12_es5.js
@@ -2,9 +2,8 @@
 var v = async function await(): Promise<void> { }
 
 //// [asyncFunctionDeclaration12_es5.js]
-var v = function () {
+var v = function await() {
     return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
         return [2 /*return*/];
     }); });
-}, await;
-(function () { });
+};

--- a/tests/baselines/reference/asyncFunctionDeclaration12_es5.symbols
+++ b/tests/baselines/reference/asyncFunctionDeclaration12_es5.symbols
@@ -1,6 +1,6 @@
 === tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration12_es5.ts ===
 var v = async function await(): Promise<void> { }
 >v : Symbol(v, Decl(asyncFunctionDeclaration12_es5.ts, 0, 3))
->await : Symbol(await, Decl(asyncFunctionDeclaration12_es5.ts, 0, 22))
+>await : Symbol(await, Decl(asyncFunctionDeclaration12_es5.ts, 0, 7))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
 

--- a/tests/baselines/reference/asyncFunctionDeclaration12_es5.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration12_es5.types
@@ -1,7 +1,6 @@
 === tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration12_es5.ts ===
 var v = async function await(): Promise<void> { }
->v : () => any
->async function : () => any
->await : any
->(): Promise<void> { } : () => Promise<void>
+>v : () => Promise<void>
+>async function await(): Promise<void> { } : () => Promise<void>
+>await : () => Promise<void>
 

--- a/tests/baselines/reference/asyncFunctionDeclaration12_es6.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration12_es6.errors.txt
@@ -1,16 +1,7 @@
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration12_es6.ts(1,24): error TS1005: '(' expected.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration12_es6.ts(1,29): error TS1005: ',' expected.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration12_es6.ts(1,33): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration12_es6.ts(1,47): error TS1005: '=>' expected.
+tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration12_es6.ts(1,24): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
-==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration12_es6.ts (4 errors) ====
+==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration12_es6.ts (1 errors) ====
     var v = async function await(): Promise<void> { }
                            ~~~~~
-!!! error TS1005: '(' expected.
-                                ~
-!!! error TS1005: ',' expected.
-                                    ~~~~~~~~~~~~~
-!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
-                                                  ~
-!!! error TS1005: '=>' expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.

--- a/tests/baselines/reference/asyncFunctionDeclaration12_es6.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration12_es6.js
@@ -2,7 +2,6 @@
 var v = async function await(): Promise<void> { }
 
 //// [asyncFunctionDeclaration12_es6.js]
-var v = function () {
+var v = function await() {
     return __awaiter(this, void 0, void 0, function* () { });
-}, await;
-() => { };
+};

--- a/tests/baselines/reference/asyncFunctionDeclaration12_es6.symbols
+++ b/tests/baselines/reference/asyncFunctionDeclaration12_es6.symbols
@@ -1,6 +1,6 @@
 === tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration12_es6.ts ===
 var v = async function await(): Promise<void> { }
 >v : Symbol(v, Decl(asyncFunctionDeclaration12_es6.ts, 0, 3))
->await : Symbol(await, Decl(asyncFunctionDeclaration12_es6.ts, 0, 22))
+>await : Symbol(await, Decl(asyncFunctionDeclaration12_es6.ts, 0, 7))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 

--- a/tests/baselines/reference/asyncFunctionDeclaration12_es6.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration12_es6.types
@@ -1,7 +1,6 @@
 === tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration12_es6.ts ===
 var v = async function await(): Promise<void> { }
->v : () => any
->async function : () => any
->await : any
->(): Promise<void> { } : () => Promise<void>
+>v : () => Promise<void>
+>async function await(): Promise<void> { } : () => Promise<void>
+>await : () => Promise<void>
 

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es2017.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es2017.errors.txt
@@ -1,27 +1,8 @@
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,20): error TS1138: Parameter declaration expected.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,20): error TS2304: Cannot find name 'await'.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,25): error TS1005: ';' expected.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,26): error TS1128: Declaration or statement expected.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,28): error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,36): error TS2532: Object is possibly 'undefined'.
-tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,40): error TS1109: Expression expected.
+tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,20): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
-==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts (7 errors) ====
+==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts (1 errors) ====
     async function foo(await): Promise<void> {
                        ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                       ~~~~~
-!!! error TS2304: Cannot find name 'await'.
-                            ~
-!!! error TS1005: ';' expected.
-                             ~
-!!! error TS1128: Declaration or statement expected.
-                               ~~~~~~~~~~~~~~~
-                                       ~~~~
-!!! error TS2532: Object is possibly 'undefined'.
-                                           ~
-!!! error TS1109: Expression expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     }
-    ~
-!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es2017.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es2017.js
@@ -3,6 +3,5 @@ async function foo(await): Promise<void> {
 }
 
 //// [asyncFunctionDeclaration5_es2017.js]
-async function foo() { }
-await;
-Promise < void  > {};
+async function foo(await) {
+}

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es2017.symbols
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es2017.symbols
@@ -1,5 +1,6 @@
 === tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts ===
 async function foo(await): Promise<void> {
 >foo : Symbol(foo, Decl(asyncFunctionDeclaration5_es2017.ts, 0, 0))
+>await : Symbol(await, Decl(asyncFunctionDeclaration5_es2017.ts, 0, 19))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es2017.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es2017.types
@@ -1,11 +1,5 @@
 === tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts ===
 async function foo(await): Promise<void> {
->foo : () => any
+>foo : (await: any) => Promise<void>
 >await : any
->Promise<void> {} : boolean
->Promise<void : boolean
->Promise : PromiseConstructor
->void : undefined
-> : any
->{} : {}
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es5.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es5.errors.txt
@@ -1,27 +1,8 @@
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,20): error TS1138: Parameter declaration expected.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,20): error TS2304: Cannot find name 'await'.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,25): error TS1005: ';' expected.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,26): error TS1128: Declaration or statement expected.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,28): error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,36): error TS2532: Object is possibly 'undefined'.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,40): error TS1109: Expression expected.
+tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,20): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
-==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts (7 errors) ====
+==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts (1 errors) ====
     async function foo(await): Promise<void> {
                        ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                       ~~~~~
-!!! error TS2304: Cannot find name 'await'.
-                            ~
-!!! error TS1005: ';' expected.
-                             ~
-!!! error TS1128: Declaration or statement expected.
-                               ~~~~~~~~~~~~~~~
-                                       ~~~~
-!!! error TS2532: Object is possibly 'undefined'.
-                                           ~
-!!! error TS1109: Expression expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     }
-    ~
-!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es5.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es5.js
@@ -3,10 +3,10 @@ async function foo(await): Promise<void> {
 }
 
 //// [asyncFunctionDeclaration5_es5.js]
-function foo() {
-    return __awaiter(this, void 0, void 0, function () { return __generator(this, function (_a) {
-        return [2 /*return*/];
-    }); });
+function foo(await) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            return [2 /*return*/];
+        });
+    });
 }
-await;
-Promise < void  > {};

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es5.symbols
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es5.symbols
@@ -1,5 +1,6 @@
 === tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts ===
 async function foo(await): Promise<void> {
 >foo : Symbol(foo, Decl(asyncFunctionDeclaration5_es5.ts, 0, 0))
+>await : Symbol(await, Decl(asyncFunctionDeclaration5_es5.ts, 0, 19))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es5.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es5.types
@@ -1,11 +1,5 @@
 === tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts ===
 async function foo(await): Promise<void> {
->foo : () => any
+>foo : (await: any) => Promise<void>
 >await : any
->Promise<void> {} : boolean
->Promise<void : boolean
->Promise : PromiseConstructor
->void : undefined
-> : any
->{} : {}
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es6.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es6.errors.txt
@@ -1,27 +1,8 @@
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,20): error TS1138: Parameter declaration expected.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,20): error TS2304: Cannot find name 'await'.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,25): error TS1005: ';' expected.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,26): error TS1128: Declaration or statement expected.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,28): error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,36): error TS2532: Object is possibly 'undefined'.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,40): error TS1109: Expression expected.
+tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,20): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
-==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts (7 errors) ====
+==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts (1 errors) ====
     async function foo(await): Promise<void> {
                        ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                       ~~~~~
-!!! error TS2304: Cannot find name 'await'.
-                            ~
-!!! error TS1005: ';' expected.
-                             ~
-!!! error TS1128: Declaration or statement expected.
-                               ~~~~~~~~~~~~~~~
-                                       ~~~~
-!!! error TS2532: Object is possibly 'undefined'.
-                                           ~
-!!! error TS1109: Expression expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     }
-    ~
-!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es6.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es6.js
@@ -3,8 +3,7 @@ async function foo(await): Promise<void> {
 }
 
 //// [asyncFunctionDeclaration5_es6.js]
-function foo() {
-    return __awaiter(this, void 0, void 0, function* () { });
+function foo(await) {
+    return __awaiter(this, void 0, void 0, function* () {
+    });
 }
-await;
-Promise < void  > {};

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es6.symbols
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es6.symbols
@@ -1,5 +1,6 @@
 === tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts ===
 async function foo(await): Promise<void> {
 >foo : Symbol(foo, Decl(asyncFunctionDeclaration5_es6.ts, 0, 0))
+>await : Symbol(await, Decl(asyncFunctionDeclaration5_es6.ts, 0, 19))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es6.types
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es6.types
@@ -1,11 +1,5 @@
 === tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts ===
 async function foo(await): Promise<void> {
->foo : () => any
+>foo : (await: any) => Promise<void>
 >await : any
->Promise<void> {} : boolean
->Promise<void : boolean
->Promise : PromiseConstructor
->void : undefined
-> : any
->{} : {}
 }

--- a/tests/baselines/reference/parser.asyncGenerators.classMethods.es2018.errors.txt
+++ b/tests/baselines/reference/parser.asyncGenerators.classMethods.es2018.errors.txt
@@ -3,28 +3,16 @@ tests/cases/conformance/parser/ecmascript2018/asyncGenerators/asyncGeneratorProp
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/asyncGeneratorSetAccessorIsError.ts(2,17): error TS1005: '(' expected.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitInParameterInitializerIsError.ts(2,19): error TS2524: 'await' expressions cannot be used in a parameter initializer.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitMissingValueIsError.ts(3,14): error TS1109: Expression expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(2,15): error TS1138: Parameter declaration expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(2,15): error TS2693: 'await' only refers to a type, but is being used as a value here.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(2,20): error TS1005: ';' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(4,1): error TS1128: Declaration or statement expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(3,18): error TS1003: Identifier expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(3,24): error TS1109: Expression expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(3,26): error TS1005: ';' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts(3,18): error TS1003: Identifier expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts(3,26): error TS1005: '=>' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(3,28): error TS1005: '(' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(3,34): error TS1109: Expression expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(3,36): error TS1005: ';' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts(3,28): error TS1005: '(' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts(3,36): error TS1005: '=>' expected.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(2,15): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(3,18): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts(3,18): error TS1213: Identifier expected. 'yield' is a reserved word in strict mode. Class definitions are automatically in strict mode.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(3,28): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts(3,28): error TS1213: Identifier expected. 'yield' is a reserved word in strict mode. Class definitions are automatically in strict mode.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldAsTypeIsStrictError.ts(4,16): error TS1213: Identifier expected. 'yield' is a reserved word in strict mode. Class definitions are automatically in strict mode.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldInClassComputedPropertyIsError.ts(2,14): error TS1213: Identifier expected. 'yield' is a reserved word in strict mode. Class definitions are automatically in strict mode.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldInClassComputedPropertyIsError.ts(2,14): error TS2693: 'yield' only refers to a type, but is being used as a value here.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldInParameterInitializerIsError.ts(2,19): error TS2523: 'yield' expressions cannot be used in a parameter initializer.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(2,15): error TS1138: Parameter declaration expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(2,15): error TS2693: 'yield' only refers to a type, but is being used as a value here.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(2,20): error TS1005: ';' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(4,1): error TS1128: Declaration or statement expected.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(2,15): error TS1213: Identifier expected. 'yield' is a reserved word in strict mode. Class definitions are automatically in strict mode.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldStarMissingValueIsError.ts(3,16): error TS1109: Expression expected.
 
 
@@ -43,32 +31,20 @@ tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldStarMissingVa
         async * yield() {
         }
     }
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts (4 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts (1 errors) ====
     class C4 {
         async * f(await) {
                   ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                  ~~~~~
-!!! error TS2693: 'await' only refers to a type, but is being used as a value here.
-                       ~
-!!! error TS1005: ';' expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
         }
     }
-    ~
-!!! error TS1128: Declaration or statement expected.
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts (4 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts (1 errors) ====
     class C5 {
         async * f(yield) {
                   ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                  ~~~~~
-!!! error TS2693: 'yield' only refers to a type, but is being used as a value here.
-                       ~
-!!! error TS1005: ';' expected.
+!!! error TS1213: Identifier expected. 'yield' is a reserved word in strict mode. Class definitions are automatically in strict mode.
         }
     }
-    ~
-!!! error TS1128: Declaration or statement expected.
 ==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitInParameterInitializerIsError.ts (1 errors) ====
     class C6 {
         async * f(a = await 1) {
@@ -90,51 +66,39 @@ tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldStarMissingVa
             }
         }
     }
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts (1 errors) ====
     class C9 {
         async * f() {
             function yield() {
                      ~~~~~
-!!! error TS1003: Identifier expected.
-                             ~
-!!! error TS1005: '=>' expected.
+!!! error TS1213: Identifier expected. 'yield' is a reserved word in strict mode. Class definitions are automatically in strict mode.
             }
         }
     }
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts (1 errors) ====
     class C10 {
         async * f() {
             const x = function yield() {
                                ~~~~~
-!!! error TS1005: '(' expected.
-                                       ~
-!!! error TS1005: '=>' expected.
+!!! error TS1213: Identifier expected. 'yield' is a reserved word in strict mode. Class definitions are automatically in strict mode.
             };
         }
     }
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts (3 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts (1 errors) ====
     class C11 {
         async * f() {
             function await() {
                      ~~~~~
-!!! error TS1003: Identifier expected.
-                           ~
-!!! error TS1109: Expression expected.
-                             ~
-!!! error TS1005: ';' expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
             }
         }
     }
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts (3 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts (1 errors) ====
     class C12 {
         async * f() {
             const x = function await() {
                                ~~~~~
-!!! error TS1005: '(' expected.
-                                     ~
-!!! error TS1109: Expression expected.
-                                       ~
-!!! error TS1005: ';' expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
             };
         }
     }

--- a/tests/baselines/reference/parser.asyncGenerators.classMethods.es2018.symbols
+++ b/tests/baselines/reference/parser.asyncGenerators.classMethods.es2018.symbols
@@ -28,6 +28,7 @@ class C4 {
 
     async * f(await) {
 >f : Symbol(C4.f, Decl(awaitParameterIsError.ts, 0, 10))
+>await : Symbol(await, Decl(awaitParameterIsError.ts, 1, 14))
     }
 }
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts ===
@@ -36,6 +37,7 @@ class C5 {
 
     async * f(yield) {
 >f : Symbol(C5.f, Decl(yieldParameterIsError.ts, 0, 10))
+>yield : Symbol(yield, Decl(yieldParameterIsError.ts, 1, 14))
     }
 }
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitInParameterInitializerIsError.ts ===
@@ -76,7 +78,7 @@ class C9 {
 >f : Symbol(C9.f, Decl(nestedFunctionDeclarationNamedYieldIsError.ts, 0, 10))
 
         function yield() {
-> : Symbol((Missing), Decl(nestedFunctionDeclarationNamedYieldIsError.ts, 1, 17))
+>yield : Symbol(yield, Decl(nestedFunctionDeclarationNamedYieldIsError.ts, 1, 17))
         }
     }
 }
@@ -89,6 +91,7 @@ class C10 {
 
         const x = function yield() {
 >x : Symbol(x, Decl(nestedFunctionExpressionNamedYieldIsError.ts, 2, 13))
+>yield : Symbol(yield, Decl(nestedFunctionExpressionNamedYieldIsError.ts, 2, 17))
 
         };
     }
@@ -101,7 +104,7 @@ class C11 {
 >f : Symbol(C11.f, Decl(nestedFunctionDeclarationNamedAwaitIsError.ts, 0, 11))
 
         function await() {
-> : Symbol((Missing), Decl(nestedFunctionDeclarationNamedAwaitIsError.ts, 1, 17))
+>await : Symbol(await, Decl(nestedFunctionDeclarationNamedAwaitIsError.ts, 1, 17))
         }
     }
 }
@@ -114,6 +117,7 @@ class C12 {
 
         const x = function await() {
 >x : Symbol(x, Decl(nestedFunctionExpressionNamedAwaitIsError.ts, 2, 13))
+>await : Symbol(await, Decl(nestedFunctionExpressionNamedAwaitIsError.ts, 2, 17))
 
         };
     }

--- a/tests/baselines/reference/parser.asyncGenerators.classMethods.es2018.types
+++ b/tests/baselines/reference/parser.asyncGenerators.classMethods.es2018.types
@@ -27,7 +27,7 @@ class C4 {
 >C4 : C4
 
     async * f(await) {
->f : () => any
+>f : (await: any) => AsyncGenerator<never, void, unknown>
 >await : any
     }
 }
@@ -36,7 +36,7 @@ class C5 {
 >C5 : C5
 
     async * f(yield) {
->f : () => any
+>f : (yield: any) => AsyncGenerator<never, void, unknown>
 >yield : any
     }
 }
@@ -78,12 +78,10 @@ class C9 {
 >C9 : C9
 
     async * f() {
->f : () => AsyncGenerator<() => void, void, unknown>
+>f : () => AsyncGenerator<never, void, unknown>
 
         function yield() {
-> : () => any
->yield() {        } : any
->() {        } : () => void
+>yield : () => void
         }
     }
 }
@@ -92,13 +90,12 @@ class C10 {
 >C10 : C10
 
     async * f() {
->f : () => AsyncGenerator<() => void, void, unknown>
+>f : () => AsyncGenerator<never, void, unknown>
 
         const x = function yield() {
->x : () => any
->function : () => any
->yield() {        } : any
->() {        } : () => void
+>x : () => void
+>function yield() {        } : () => void
+>yield : () => void
 
         };
     }
@@ -111,10 +108,7 @@ class C11 {
 >f : () => AsyncGenerator<never, void, unknown>
 
         function await() {
-> : () => any
->await() : any
->() : any
-> : any
+>await : () => void
         }
     }
 }
@@ -126,11 +120,9 @@ class C12 {
 >f : () => AsyncGenerator<never, void, unknown>
 
         const x = function await() {
->x : () => any
->function : () => any
->await() : any
->() : any
-> : any
+>x : () => void
+>function await() {        } : () => void
+>await : () => void
 
         };
     }

--- a/tests/baselines/reference/parser.asyncGenerators.functionDeclarations.es2018.errors.txt
+++ b/tests/baselines/reference/parser.asyncGenerators.functionDeclarations.es2018.errors.txt
@@ -1,19 +1,12 @@
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitInParameterInitializerIsError.ts(1,25): error TS2524: 'await' expressions cannot be used in a parameter initializer.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitMissingValueIsError.ts(2,10): error TS1109: Expression expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(1,21): error TS1138: Parameter declaration expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(1,26): error TS1005: ';' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(2,14): error TS1003: Identifier expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(2,20): error TS1109: Expression expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(2,22): error TS1005: ';' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts(2,14): error TS1003: Identifier expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts(2,22): error TS1005: '=>' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(2,24): error TS1005: '(' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(2,32): error TS1005: '=>' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts(2,24): error TS1005: '(' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts(2,32): error TS1005: '=>' expected.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(1,21): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(2,14): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts(2,14): error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(2,24): error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts(2,24): error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldInParameterInitializerIsError.ts(1,25): error TS2523: 'yield' expressions cannot be used in a parameter initializer.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(1,21): error TS1138: Parameter declaration expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(1,26): error TS1005: ';' expected.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(1,21): error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldStarMissingValueIsError.ts(2,12): error TS1109: Expression expected.
 
 
@@ -26,19 +19,15 @@ tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldStarMissingVa
 ==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldNameIsOk.ts (0 errors) ====
     async function * yield() {
     }
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts (1 errors) ====
     async function * f4(await) {
                         ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                             ~
-!!! error TS1005: ';' expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     }
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts (1 errors) ====
     async function * f5(yield) {
                         ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                             ~
-!!! error TS1005: ';' expected.
+!!! error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
     }
 ==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitInParameterInitializerIsError.ts (1 errors) ====
     async function * f6(a = await 1) {
@@ -55,42 +44,32 @@ tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldStarMissingVa
         async function * g() {
         }
     }
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts (1 errors) ====
     async function * f9() {
         function yield() {
                  ~~~~~
-!!! error TS1003: Identifier expected.
-                         ~
-!!! error TS1005: '=>' expected.
+!!! error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
         }
     }
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts (1 errors) ====
     async function * f10() {
         const x = function yield() {
                            ~~~~~
-!!! error TS1005: '(' expected.
-                                   ~
-!!! error TS1005: '=>' expected.
+!!! error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
         };
     }
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts (3 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts (1 errors) ====
     async function * f11() {
         function await() {
                  ~~~~~
-!!! error TS1003: Identifier expected.
-                       ~
-!!! error TS1109: Expression expected.
-                         ~
-!!! error TS1005: ';' expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
         }
     }
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts (1 errors) ====
     async function * f12() {
         const x = function yield() {
                            ~~~~~
-!!! error TS1005: '(' expected.
-                                   ~
-!!! error TS1005: '=>' expected.
+!!! error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
         };
     }
 ==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldIsOk.ts (0 errors) ====

--- a/tests/baselines/reference/parser.asyncGenerators.functionDeclarations.es2018.symbols
+++ b/tests/baselines/reference/parser.asyncGenerators.functionDeclarations.es2018.symbols
@@ -13,12 +13,12 @@ async function * yield() {
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts ===
 async function * f4(await) {
 >f4 : Symbol(f4, Decl(awaitParameterIsError.ts, 0, 0))
->await : Symbol(await, Decl(awaitNameIsOk.ts, 0, 0), Decl(awaitAsTypeIsOk.ts, 0, 0))
+>await : Symbol(await, Decl(awaitParameterIsError.ts, 0, 20))
 }
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts ===
 async function * f5(yield) {
 >f5 : Symbol(f5, Decl(yieldParameterIsError.ts, 0, 0))
->yield : Symbol(yield, Decl(yieldNameIsOk.ts, 0, 0), Decl(yieldAsTypeIsOk.ts, 0, 0))
+>yield : Symbol(yield, Decl(yieldParameterIsError.ts, 0, 20))
 }
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitInParameterInitializerIsError.ts ===
 async function * f6(a = await 1) {
@@ -43,7 +43,7 @@ async function * f9() {
 >f9 : Symbol(f9, Decl(nestedFunctionDeclarationNamedYieldIsError.ts, 0, 0))
 
     function yield() {
-> : Symbol((Missing), Decl(nestedFunctionDeclarationNamedYieldIsError.ts, 0, 23))
+>yield : Symbol(yield, Decl(nestedFunctionDeclarationNamedYieldIsError.ts, 0, 23))
     }
 }
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts ===
@@ -52,6 +52,7 @@ async function * f10() {
 
     const x = function yield() {
 >x : Symbol(x, Decl(nestedFunctionExpressionNamedYieldIsError.ts, 1, 9))
+>yield : Symbol(yield, Decl(nestedFunctionExpressionNamedYieldIsError.ts, 1, 13))
 
     };
 }
@@ -60,7 +61,7 @@ async function * f11() {
 >f11 : Symbol(f11, Decl(nestedFunctionDeclarationNamedAwaitIsError.ts, 0, 0))
 
     function await() {
-> : Symbol((Missing), Decl(nestedFunctionDeclarationNamedAwaitIsError.ts, 0, 24))
+>await : Symbol(await, Decl(nestedFunctionDeclarationNamedAwaitIsError.ts, 0, 24))
     }
 }
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts ===
@@ -69,6 +70,7 @@ async function * f12() {
 
     const x = function yield() {
 >x : Symbol(x, Decl(nestedFunctionExpressionNamedAwaitIsError.ts, 1, 9))
+>yield : Symbol(yield, Decl(nestedFunctionExpressionNamedAwaitIsError.ts, 1, 13))
 
     };
 }

--- a/tests/baselines/reference/parser.asyncGenerators.functionDeclarations.es2018.types
+++ b/tests/baselines/reference/parser.asyncGenerators.functionDeclarations.es2018.types
@@ -12,13 +12,13 @@ async function * yield() {
 }
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts ===
 async function * f4(await) {
->f4 : () => any
->await : () => AsyncGenerator<never, void, unknown>
+>f4 : (await: any) => AsyncGenerator<never, void, unknown>
+>await : any
 }
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts ===
 async function * f5(yield) {
->f5 : () => any
->yield : () => AsyncGenerator<never, void, unknown>
+>f5 : (yield: any) => AsyncGenerator<never, void, unknown>
+>yield : any
 }
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitInParameterInitializerIsError.ts ===
 async function * f6(a = await 1) {
@@ -43,23 +43,20 @@ async function * f8() {
 }
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts ===
 async function * f9() {
->f9 : () => AsyncGenerator<() => void, void, unknown>
+>f9 : () => AsyncGenerator<never, void, unknown>
 
     function yield() {
-> : () => any
->yield() {    } : any
->() {    } : () => void
+>yield : () => void
     }
 }
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts ===
 async function * f10() {
->f10 : () => AsyncGenerator<() => void, void, unknown>
+>f10 : () => AsyncGenerator<never, void, unknown>
 
     const x = function yield() {
->x : () => any
->function : () => any
->yield() {    } : any
->() {    } : () => void
+>x : () => void
+>function yield() {    } : () => void
+>yield : () => void
 
     };
 }
@@ -68,21 +65,17 @@ async function * f11() {
 >f11 : () => AsyncGenerator<never, void, unknown>
 
     function await() {
-> : () => any
->await() : any
->() : any
-> : any
+>await : () => void
     }
 }
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts ===
 async function * f12() {
->f12 : () => AsyncGenerator<() => void, void, unknown>
+>f12 : () => AsyncGenerator<never, void, unknown>
 
     const x = function yield() {
->x : () => any
->function : () => any
->yield() {    } : any
->() {    } : () => void
+>x : () => void
+>function yield() {    } : () => void
+>yield : () => void
 
     };
 }

--- a/tests/baselines/reference/parser.asyncGenerators.functionExpressions.es2018.errors.txt
+++ b/tests/baselines/reference/parser.asyncGenerators.functionExpressions.es2018.errors.txt
@@ -1,79 +1,39 @@
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitInParameterInitializerIsError.ts(1,34): error TS2524: 'await' expressions cannot be used in a parameter initializer.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitMissingValueIsError.ts(2,10): error TS1109: Expression expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitNameIsError.ts(1,29): error TS1005: '(' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitNameIsError.ts(1,29): error TS2451: Cannot redeclare block-scoped variable 'await'.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitNameIsError.ts(1,34): error TS1005: ',' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitNameIsError.ts(1,37): error TS1005: '=>' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(1,30): error TS1138: Parameter declaration expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(1,30): error TS2451: Cannot redeclare block-scoped variable 'await'.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(1,35): error TS1005: ',' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(2,14): error TS1003: Identifier expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(2,20): error TS1109: Expression expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(2,22): error TS1005: ';' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts(2,14): error TS1003: Identifier expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts(2,22): error TS1005: '=>' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(2,24): error TS1005: '(' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(2,30): error TS1109: Expression expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(2,32): error TS1005: ';' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts(2,24): error TS1005: '(' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts(2,32): error TS1005: '=>' expected.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitNameIsError.ts(1,29): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(1,30): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(2,14): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts(2,14): error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(2,24): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts(2,24): error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldInParameterInitializerIsError.ts(1,34): error TS2523: 'yield' expressions cannot be used in a parameter initializer.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldNameIsError.ts(1,29): error TS1005: '(' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldNameIsError.ts(1,29): error TS2451: Cannot redeclare block-scoped variable 'yield'.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldNameIsError.ts(1,34): error TS1005: ',' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldNameIsError.ts(1,37): error TS1005: '=>' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(1,30): error TS1138: Parameter declaration expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(1,30): error TS2451: Cannot redeclare block-scoped variable 'yield'.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(1,35): error TS1005: ',' expected.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldNameIsError.ts(1,29): error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(1,30): error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldStarMissingValueIsError.ts(2,12): error TS1109: Expression expected.
 
 
 ==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/functionExpressionIsOk.ts (0 errors) ====
     const f1 = async function * f() {
     };
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitNameIsError.ts (4 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitNameIsError.ts (1 errors) ====
     const f2 = async function * await() {
                                 ~~~~~
-!!! error TS1005: '(' expected.
-                                ~~~~~
-!!! error TS2451: Cannot redeclare block-scoped variable 'await'.
-!!! related TS6203 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts:1:30: 'await' was also declared here.
-                                     ~
-!!! error TS1005: ',' expected.
-                                        ~
-!!! error TS1005: '=>' expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     };
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldNameIsError.ts (4 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldNameIsError.ts (1 errors) ====
     const f3 = async function * yield() {
                                 ~~~~~
-!!! error TS1005: '(' expected.
-                                ~~~~~
-!!! error TS2451: Cannot redeclare block-scoped variable 'yield'.
-!!! related TS6203 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts:1:30: 'yield' was also declared here.
-                                     ~
-!!! error TS1005: ',' expected.
-                                        ~
-!!! error TS1005: '=>' expected.
+!!! error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
     };
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts (3 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts (1 errors) ====
     const f4 = async function * (await) {
                                  ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                                 ~~~~~
-!!! error TS2451: Cannot redeclare block-scoped variable 'await'.
-!!! related TS6203 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitNameIsError.ts:1:29: 'await' was also declared here.
-                                      ~
-!!! error TS1005: ',' expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     };
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts (3 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts (1 errors) ====
     const f5 = async function * (yield) {
                                  ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                                 ~~~~~
-!!! error TS2451: Cannot redeclare block-scoped variable 'yield'.
-!!! related TS6203 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldNameIsError.ts:1:29: 'yield' was also declared here.
-                                      ~
-!!! error TS1005: ',' expected.
+!!! error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
     };
 ==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitInParameterInitializerIsError.ts (1 errors) ====
     const f6 = async function * (a = await 1) {
@@ -90,44 +50,32 @@ tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldStarMissingVa
         async function * g() {
         }
     };
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts (1 errors) ====
     const f9 = async function * () {
         function yield() {
                  ~~~~~
-!!! error TS1003: Identifier expected.
-                         ~
-!!! error TS1005: '=>' expected.
+!!! error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
         }
     };
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts (1 errors) ====
     const f10 = async function * () {
         const x = function yield() {
                            ~~~~~
-!!! error TS1005: '(' expected.
-                                   ~
-!!! error TS1005: '=>' expected.
+!!! error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
         };
     };
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts (3 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts (1 errors) ====
     const f11 = async function * () {
         function await() {
                  ~~~~~
-!!! error TS1003: Identifier expected.
-                       ~
-!!! error TS1109: Expression expected.
-                         ~
-!!! error TS1005: ';' expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
         }
     };
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts (3 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts (1 errors) ====
     const f12 = async function * () {
         const x = function await() {
                            ~~~~~
-!!! error TS1005: '(' expected.
-                                 ~
-!!! error TS1109: Expression expected.
-                                   ~
-!!! error TS1005: ';' expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
         };
     };
 ==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldIsOk.ts (0 errors) ====

--- a/tests/baselines/reference/parser.asyncGenerators.functionExpressions.es2018.symbols
+++ b/tests/baselines/reference/parser.asyncGenerators.functionExpressions.es2018.symbols
@@ -7,13 +7,13 @@ const f1 = async function * f() {
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitNameIsError.ts ===
 const f2 = async function * await() {
 >f2 : Symbol(f2, Decl(awaitNameIsError.ts, 0, 5))
->await : Symbol(await, Decl(awaitNameIsError.ts, 0, 27), Decl(awaitAsTypeIsOk.ts, 0, 0))
+>await : Symbol(await, Decl(awaitNameIsError.ts, 0, 10))
 
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldNameIsError.ts ===
 const f3 = async function * yield() {
 >f3 : Symbol(f3, Decl(yieldNameIsError.ts, 0, 5))
->yield : Symbol(yield, Decl(yieldNameIsError.ts, 0, 27), Decl(yieldAsTypeIsOk.ts, 0, 0))
+>yield : Symbol(yield, Decl(yieldNameIsError.ts, 0, 10))
 
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts ===
@@ -53,7 +53,7 @@ const f9 = async function * () {
 >f9 : Symbol(f9, Decl(nestedFunctionDeclarationNamedYieldIsError.ts, 0, 5))
 
     function yield() {
-> : Symbol((Missing), Decl(nestedFunctionDeclarationNamedYieldIsError.ts, 0, 32))
+>yield : Symbol(yield, Decl(nestedFunctionDeclarationNamedYieldIsError.ts, 0, 32))
     }
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts ===
@@ -62,6 +62,7 @@ const f10 = async function * () {
 
     const x = function yield() {
 >x : Symbol(x, Decl(nestedFunctionExpressionNamedYieldIsError.ts, 1, 9))
+>yield : Symbol(yield, Decl(nestedFunctionExpressionNamedYieldIsError.ts, 1, 13))
 
     };
 };
@@ -70,7 +71,7 @@ const f11 = async function * () {
 >f11 : Symbol(f11, Decl(nestedFunctionDeclarationNamedAwaitIsError.ts, 0, 5))
 
     function await() {
-> : Symbol((Missing), Decl(nestedFunctionDeclarationNamedAwaitIsError.ts, 0, 33))
+>await : Symbol(await, Decl(nestedFunctionDeclarationNamedAwaitIsError.ts, 0, 33))
     }
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts ===
@@ -79,6 +80,7 @@ const f12 = async function * () {
 
     const x = function await() {
 >x : Symbol(x, Decl(nestedFunctionExpressionNamedAwaitIsError.ts, 1, 9))
+>await : Symbol(await, Decl(nestedFunctionExpressionNamedAwaitIsError.ts, 1, 13))
 
     };
 };
@@ -120,26 +122,26 @@ const f18 = async function * () {
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitAsTypeIsOk.ts ===
 interface await {}
->await : Symbol(await, Decl(awaitNameIsError.ts, 0, 27), Decl(awaitAsTypeIsOk.ts, 0, 0))
+>await : Symbol(await, Decl(awaitAsTypeIsOk.ts, 0, 0))
 
 const f19 = async function * () {
 >f19 : Symbol(f19, Decl(awaitAsTypeIsOk.ts, 1, 5))
 
     let x: await;
 >x : Symbol(x, Decl(awaitAsTypeIsOk.ts, 2, 7))
->await : Symbol(await, Decl(awaitNameIsError.ts, 0, 27), Decl(awaitAsTypeIsOk.ts, 0, 0))
+>await : Symbol(await, Decl(awaitAsTypeIsOk.ts, 0, 0))
 
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldAsTypeIsOk.ts ===
 interface yield {}
->yield : Symbol(yield, Decl(yieldNameIsError.ts, 0, 27), Decl(yieldAsTypeIsOk.ts, 0, 0))
+>yield : Symbol(yield, Decl(yieldAsTypeIsOk.ts, 0, 0))
 
 const f20 = async function * () {
 >f20 : Symbol(f20, Decl(yieldAsTypeIsOk.ts, 1, 5))
 
     let x: yield;
 >x : Symbol(x, Decl(yieldAsTypeIsOk.ts, 2, 7))
->yield : Symbol(yield, Decl(yieldNameIsError.ts, 0, 27), Decl(yieldAsTypeIsOk.ts, 0, 0))
+>yield : Symbol(yield, Decl(yieldAsTypeIsOk.ts, 0, 0))
 
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldInNestedComputedPropertyIsOk.ts ===

--- a/tests/baselines/reference/parser.asyncGenerators.functionExpressions.es2018.types
+++ b/tests/baselines/reference/parser.asyncGenerators.functionExpressions.es2018.types
@@ -7,31 +7,29 @@ const f1 = async function * f() {
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitNameIsError.ts ===
 const f2 = async function * await() {
->f2 : () => any
->async function * : () => any
->await : any
->() {} : () => void
+>f2 : () => AsyncGenerator<never, void, unknown>
+>async function * await() {} : () => AsyncGenerator<never, void, unknown>
+>await : () => AsyncGenerator<never, void, unknown>
 
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldNameIsError.ts ===
 const f3 = async function * yield() {
->f3 : () => any
->async function * : () => any
->yield : any
->() {} : () => void
+>f3 : () => AsyncGenerator<never, void, unknown>
+>async function * yield() {} : () => AsyncGenerator<never, void, unknown>
+>yield : () => AsyncGenerator<never, void, unknown>
 
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts ===
 const f4 = async function * (await) {
->f4 : () => any
->async function * ( : () => any
+>f4 : (await: any) => AsyncGenerator<never, void, unknown>
+>async function * (await) {} : (await: any) => AsyncGenerator<never, void, unknown>
 >await : any
 
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts ===
 const f5 = async function * (yield) {
->f5 : () => any
->async function * ( : () => any
+>f5 : (yield: any) => AsyncGenerator<never, void, unknown>
+>async function * (yield) {} : (yield: any) => AsyncGenerator<never, void, unknown>
 >yield : any
 
 };
@@ -63,25 +61,22 @@ const f8 = async function * () {
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts ===
 const f9 = async function * () {
->f9 : () => AsyncGenerator<() => void, void, unknown>
->async function * () {    function yield() {    }} : () => AsyncGenerator<() => void, void, unknown>
+>f9 : () => AsyncGenerator<never, void, unknown>
+>async function * () {    function yield() {    }} : () => AsyncGenerator<never, void, unknown>
 
     function yield() {
-> : () => any
->yield() {    } : any
->() {    } : () => void
+>yield : () => void
     }
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts ===
 const f10 = async function * () {
->f10 : () => AsyncGenerator<() => void, void, unknown>
->async function * () {    const x = function yield() {    };} : () => AsyncGenerator<() => void, void, unknown>
+>f10 : () => AsyncGenerator<never, void, unknown>
+>async function * () {    const x = function yield() {    };} : () => AsyncGenerator<never, void, unknown>
 
     const x = function yield() {
->x : () => any
->function : () => any
->yield() {    } : any
->() {    } : () => void
+>x : () => void
+>function yield() {    } : () => void
+>yield : () => void
 
     };
 };
@@ -91,10 +86,7 @@ const f11 = async function * () {
 >async function * () {    function await() {    }} : () => AsyncGenerator<never, void, unknown>
 
     function await() {
-> : () => any
->await() : any
->() : any
-> : any
+>await : () => void
     }
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts ===
@@ -103,11 +95,9 @@ const f12 = async function * () {
 >async function * () {    const x = function await() {    };} : () => AsyncGenerator<never, void, unknown>
 
     const x = function await() {
->x : () => any
->function : () => any
->await() : any
->() : any
-> : any
+>x : () => void
+>function await() {    } : () => void
+>await : () => void
 
     };
 };

--- a/tests/baselines/reference/parser.asyncGenerators.objectLiteralMethods.es2018.errors.txt
+++ b/tests/baselines/reference/parser.asyncGenerators.objectLiteralMethods.es2018.errors.txt
@@ -3,27 +3,13 @@ tests/cases/conformance/parser/ecmascript2018/asyncGenerators/asyncGeneratorProp
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/asyncGeneratorSetAccessorIsError.ts(2,17): error TS1005: '(' expected.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitInParameterInitializerIsError.ts(2,19): error TS2524: 'await' expressions cannot be used in a parameter initializer.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitMissingValueIsError.ts(3,14): error TS1109: Expression expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(2,15): error TS1138: Parameter declaration expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(2,15): error TS2693: 'await' only refers to a type, but is being used as a value here.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(2,20): error TS1005: ',' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(2,22): error TS1136: Property assignment expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(4,1): error TS1128: Declaration or statement expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(3,18): error TS1003: Identifier expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(3,24): error TS1109: Expression expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(3,26): error TS1005: ';' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts(3,18): error TS1003: Identifier expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts(3,26): error TS1005: '=>' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(3,28): error TS1005: '(' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(3,34): error TS1109: Expression expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(3,36): error TS1005: ';' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts(3,28): error TS1005: '(' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts(3,36): error TS1005: '=>' expected.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts(2,15): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(3,18): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts(3,18): error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts(3,28): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts(3,28): error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldInParameterInitializerIsError.ts(2,19): error TS2523: 'yield' expressions cannot be used in a parameter initializer.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(2,15): error TS1138: Parameter declaration expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(2,15): error TS2693: 'yield' only refers to a type, but is being used as a value here.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(2,20): error TS1005: ',' expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(2,22): error TS1136: Property assignment expected.
-tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(4,1): error TS1128: Declaration or statement expected.
+tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts(2,15): error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
 tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldStarMissingValueIsError.ts(3,16): error TS1109: Expression expected.
 
 
@@ -42,36 +28,20 @@ tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldStarMissingVa
         async * yield() {
         }
     };
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts (5 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts (1 errors) ====
     const o4 = {
         async * f(await) {
                   ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                  ~~~~~
-!!! error TS2693: 'await' only refers to a type, but is being used as a value here.
-                       ~
-!!! error TS1005: ',' expected.
-                         ~
-!!! error TS1136: Property assignment expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
         }
     };
-    ~
-!!! error TS1128: Declaration or statement expected.
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts (5 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts (1 errors) ====
     const o5 = {
         async * f(yield) {
                   ~~~~~
-!!! error TS1138: Parameter declaration expected.
-                  ~~~~~
-!!! error TS2693: 'yield' only refers to a type, but is being used as a value here.
-                       ~
-!!! error TS1005: ',' expected.
-                         ~
-!!! error TS1136: Property assignment expected.
+!!! error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
         }
     };
-    ~
-!!! error TS1128: Declaration or statement expected.
 ==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitInParameterInitializerIsError.ts (1 errors) ====
     const o6 = {
         async * f(a = await 1) {
@@ -93,51 +63,39 @@ tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldStarMissingVa
             }
         }
     };
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts (1 errors) ====
     const o9 = {
         async * f() {
             function yield() {
                      ~~~~~
-!!! error TS1003: Identifier expected.
-                             ~
-!!! error TS1005: '=>' expected.
+!!! error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
             }
         }
     };
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts (1 errors) ====
     const o10 = {
         async * f() {
             const x = function yield() {
                                ~~~~~
-!!! error TS1005: '(' expected.
-                                       ~
-!!! error TS1005: '=>' expected.
+!!! error TS1359: Identifier expected. 'yield' is a reserved word that cannot be used here.
             };
         }
     };
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts (3 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts (1 errors) ====
     const o11 = {
         async * f() {
             function await() {
                      ~~~~~
-!!! error TS1003: Identifier expected.
-                           ~
-!!! error TS1109: Expression expected.
-                             ~
-!!! error TS1005: ';' expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
             }
         }
     };
-==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts (3 errors) ====
+==== tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedAwaitIsError.ts (1 errors) ====
     const o12 = {
         async * f() {
             const x = function await() {
                                ~~~~~
-!!! error TS1005: '(' expected.
-                                     ~
-!!! error TS1109: Expression expected.
-                                       ~
-!!! error TS1005: ';' expected.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
             };
         }
     };

--- a/tests/baselines/reference/parser.asyncGenerators.objectLiteralMethods.es2018.symbols
+++ b/tests/baselines/reference/parser.asyncGenerators.objectLiteralMethods.es2018.symbols
@@ -78,7 +78,7 @@ const o9 = {
 >f : Symbol(f, Decl(nestedFunctionDeclarationNamedYieldIsError.ts, 0, 12))
 
         function yield() {
-> : Symbol((Missing), Decl(nestedFunctionDeclarationNamedYieldIsError.ts, 1, 17))
+>yield : Symbol(yield, Decl(nestedFunctionDeclarationNamedYieldIsError.ts, 1, 17))
         }
     }
 };
@@ -91,6 +91,7 @@ const o10 = {
 
         const x = function yield() {
 >x : Symbol(x, Decl(nestedFunctionExpressionNamedYieldIsError.ts, 2, 13))
+>yield : Symbol(yield, Decl(nestedFunctionExpressionNamedYieldIsError.ts, 2, 17))
 
         };
     }
@@ -103,7 +104,7 @@ const o11 = {
 >f : Symbol(f, Decl(nestedFunctionDeclarationNamedAwaitIsError.ts, 0, 13))
 
         function await() {
-> : Symbol((Missing), Decl(nestedFunctionDeclarationNamedAwaitIsError.ts, 1, 17))
+>await : Symbol(await, Decl(nestedFunctionDeclarationNamedAwaitIsError.ts, 1, 17))
         }
     }
 };
@@ -116,6 +117,7 @@ const o12 = {
 
         const x = function await() {
 >x : Symbol(x, Decl(nestedFunctionExpressionNamedAwaitIsError.ts, 2, 13))
+>await : Symbol(await, Decl(nestedFunctionExpressionNamedAwaitIsError.ts, 2, 17))
 
         };
     }

--- a/tests/baselines/reference/parser.asyncGenerators.objectLiteralMethods.es2018.types
+++ b/tests/baselines/reference/parser.asyncGenerators.objectLiteralMethods.es2018.types
@@ -27,21 +27,21 @@ const o3 = {
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/awaitParameterIsError.ts ===
 const o4 = {
->o4 : { f(): any; await: any; }
->{    async * f(await) : { f(): any; await: any; }
+>o4 : { f(await: any): AsyncGenerator<never, void, unknown>; }
+>{    async * f(await) {    }} : { f(await: any): AsyncGenerator<never, void, unknown>; }
 
     async * f(await) {
->f : () => any
+>f : (await: any) => AsyncGenerator<never, void, unknown>
 >await : any
     }
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldParameterIsError.ts ===
 const o5 = {
->o5 : { f(): any; yield: any; }
->{    async * f(yield) : { f(): any; yield: any; }
+>o5 : { f(yield: any): AsyncGenerator<never, void, unknown>; }
+>{    async * f(yield) {    }} : { f(yield: any): AsyncGenerator<never, void, unknown>; }
 
     async * f(yield) {
->f : () => any
+>f : (yield: any) => AsyncGenerator<never, void, unknown>
 >yield : any
     }
 };
@@ -83,32 +83,29 @@ const o8 = {
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionDeclarationNamedYieldIsError.ts ===
 const o9 = {
->o9 : { f(): AsyncGenerator<() => void, void, unknown>; }
->{    async * f() {        function yield() {        }    }} : { f(): AsyncGenerator<() => void, void, unknown>; }
+>o9 : { f(): AsyncGenerator<never, void, unknown>; }
+>{    async * f() {        function yield() {        }    }} : { f(): AsyncGenerator<never, void, unknown>; }
 
     async * f() {
->f : () => AsyncGenerator<() => void, void, unknown>
+>f : () => AsyncGenerator<never, void, unknown>
 
         function yield() {
-> : () => any
->yield() {        } : any
->() {        } : () => void
+>yield : () => void
         }
     }
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts ===
 const o10 = {
->o10 : { f(): AsyncGenerator<() => void, void, unknown>; }
->{    async * f() {        const x = function yield() {        };    }} : { f(): AsyncGenerator<() => void, void, unknown>; }
+>o10 : { f(): AsyncGenerator<never, void, unknown>; }
+>{    async * f() {        const x = function yield() {        };    }} : { f(): AsyncGenerator<never, void, unknown>; }
 
     async * f() {
->f : () => AsyncGenerator<() => void, void, unknown>
+>f : () => AsyncGenerator<never, void, unknown>
 
         const x = function yield() {
->x : () => any
->function : () => any
->yield() {        } : any
->() {        } : () => void
+>x : () => void
+>function yield() {        } : () => void
+>yield : () => void
 
         };
     }
@@ -122,10 +119,7 @@ const o11 = {
 >f : () => AsyncGenerator<never, void, unknown>
 
         function await() {
-> : () => any
->await() : any
->() : any
-> : any
+>await : () => void
         }
     }
 };
@@ -138,11 +132,9 @@ const o12 = {
 >f : () => AsyncGenerator<never, void, unknown>
 
         const x = function await() {
->x : () => any
->function : () => any
->await() : any
->() : any
-> : any
+>x : () => void
+>function await() {        } : () => void
+>await : () => void
 
         };
     }

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).errors.txt
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).errors.txt
@@ -59,6 +59,19 @@ tests/cases/conformance/externalModules/index.ts(46,3): error TS1378: Top-level 
     // await allowed in aliased import
     import { await as _await } from "./other";
     
+    // newlines
+    // await in throw
+    throw await
+        1;
+    
+    // await in var
+    let y = await
+        1;
+    
+    // await in expression statement;
+    await
+        1;
+    
 ==== tests/cases/conformance/externalModules/other.ts (0 errors) ====
     const _await = 1;
     

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).js
@@ -53,6 +53,19 @@ class C {
 // await allowed in aliased import
 import { await as _await } from "./other";
 
+// newlines
+// await in throw
+throw await
+    1;
+
+// await in var
+let y = await
+    1;
+
+// await in expression statement;
+await
+    1;
+
 //// [other.ts]
 const _await = 1;
 
@@ -106,3 +119,10 @@ let C = class C {
 C = __decorate([
     (await dec)
 ], C);
+// newlines
+// await in throw
+throw await 1;
+// await in var
+let y = await 1;
+// await in expression statement;
+await 1;

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).symbols
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).symbols
@@ -102,6 +102,21 @@ import { await as _await } from "./other";
 >await : Symbol(await, Decl(other.ts, 3, 8))
 >_await : Symbol(_await, Decl(index.ts, 50, 8))
 
+// newlines
+// await in throw
+throw await
+    1;
+
+// await in var
+let y = await
+>y : Symbol(y, Decl(index.ts, 58, 3))
+
+    1;
+
+// await in expression statement;
+await
+    1;
+
 === tests/cases/conformance/externalModules/other.ts ===
 const _await = 1;
 >_await : Symbol(_await, Decl(other.ts, 0, 5))

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).types
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).types
@@ -143,6 +143,29 @@ import { await as _await } from "./other";
 >await : 1
 >_await : 1
 
+// newlines
+// await in throw
+throw await
+>await    1 : 1
+
+    1;
+>1 : 1
+
+// await in var
+let y = await
+>y : number
+>await    1 : 1
+
+    1;
+>1 : 1
+
+// await in expression statement;
+await
+>await    1 : 1
+
+    1;
+>1 : 1
+
 === tests/cases/conformance/externalModules/other.ts ===
 const _await = 1;
 >_await : 1

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2017).js
@@ -53,6 +53,19 @@ class C {
 // await allowed in aliased import
 import { await as _await } from "./other";
 
+// newlines
+// await in throw
+throw await
+    1;
+
+// await in var
+let y = await
+    1;
+
+// await in expression statement;
+await
+    1;
+
 //// [other.ts]
 const _await = 1;
 
@@ -106,3 +119,10 @@ let C = class C {
 C = __decorate([
     (await dec)
 ], C);
+// newlines
+// await in throw
+throw await 1;
+// await in var
+let y = await 1;
+// await in expression statement;
+await 1;

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2017).symbols
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2017).symbols
@@ -102,6 +102,21 @@ import { await as _await } from "./other";
 >await : Symbol(await, Decl(other.ts, 3, 8))
 >_await : Symbol(_await, Decl(index.ts, 50, 8))
 
+// newlines
+// await in throw
+throw await
+    1;
+
+// await in var
+let y = await
+>y : Symbol(y, Decl(index.ts, 58, 3))
+
+    1;
+
+// await in expression statement;
+await
+    1;
+
 === tests/cases/conformance/externalModules/other.ts ===
 const _await = 1;
 >_await : Symbol(_await, Decl(other.ts, 0, 5))

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2017).types
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2017).types
@@ -143,6 +143,29 @@ import { await as _await } from "./other";
 >await : 1
 >_await : 1
 
+// newlines
+// await in throw
+throw await
+>await    1 : 1
+
+    1;
+>1 : 1
+
+// await in var
+let y = await
+>y : number
+>await    1 : 1
+
+    1;
+>1 : 1
+
+// await in expression statement;
+await
+>await    1 : 1
+
+    1;
+>1 : 1
+
 === tests/cases/conformance/externalModules/other.ts ===
 const _await = 1;
 >_await : 1

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).errors.txt
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).errors.txt
@@ -59,6 +59,19 @@ tests/cases/conformance/externalModules/index.ts(46,3): error TS1378: Top-level 
     // await allowed in aliased import
     import { await as _await } from "./other";
     
+    // newlines
+    // await in throw
+    throw await
+        1;
+    
+    // await in var
+    let y = await
+        1;
+    
+    // await in expression statement;
+    await
+        1;
+    
 ==== tests/cases/conformance/externalModules/other.ts (0 errors) ====
     const _await = 1;
     

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).js
@@ -53,6 +53,19 @@ class C {
 // await allowed in aliased import
 import { await as _await } from "./other";
 
+// newlines
+// await in throw
+throw await
+    1;
+
+// await in var
+let y = await
+    1;
+
+// await in expression statement;
+await
+    1;
+
 //// [other.ts]
 const _await = 1;
 
@@ -75,7 +88,7 @@ System.register([], function (exports_1, context_1) {
 //// [index.js]
 System.register([], function (exports_1, context_1) {
     "use strict";
-    var x, C1, C2, C3, C;
+    var x, C1, C2, C3, C, y;
     var __moduleName = context_1 && context_1.id;
     return {
         setters: [],
@@ -122,6 +135,13 @@ System.register([], function (exports_1, context_1) {
             C = __decorate([
                 (await dec)
             ], C);
+            // newlines
+            // await in throw
+            throw await 1;
+            // await in var
+            y = await 1;
+            // await in expression statement;
+            await 1;
         }
     };
 });

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).symbols
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).symbols
@@ -102,6 +102,21 @@ import { await as _await } from "./other";
 >await : Symbol(await, Decl(other.ts, 3, 8))
 >_await : Symbol(_await, Decl(index.ts, 50, 8))
 
+// newlines
+// await in throw
+throw await
+    1;
+
+// await in var
+let y = await
+>y : Symbol(y, Decl(index.ts, 58, 3))
+
+    1;
+
+// await in expression statement;
+await
+    1;
+
 === tests/cases/conformance/externalModules/other.ts ===
 const _await = 1;
 >_await : Symbol(_await, Decl(other.ts, 0, 5))

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).types
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).types
@@ -143,6 +143,29 @@ import { await as _await } from "./other";
 >await : 1
 >_await : 1
 
+// newlines
+// await in throw
+throw await
+>await    1 : 1
+
+    1;
+>1 : 1
+
+// await in var
+let y = await
+>y : number
+>await    1 : 1
+
+    1;
+>1 : 1
+
+// await in expression statement;
+await
+>await    1 : 1
+
+    1;
+>1 : 1
+
 === tests/cases/conformance/externalModules/other.ts ===
 const _await = 1;
 >_await : 1

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2017).js
@@ -53,6 +53,19 @@ class C {
 // await allowed in aliased import
 import { await as _await } from "./other";
 
+// newlines
+// await in throw
+throw await
+    1;
+
+// await in var
+let y = await
+    1;
+
+// await in expression statement;
+await
+    1;
+
 //// [other.ts]
 const _await = 1;
 
@@ -75,7 +88,7 @@ System.register([], function (exports_1, context_1) {
 //// [index.js]
 System.register([], function (exports_1, context_1) {
     "use strict";
-    var x, C1, C2, C3, C;
+    var x, C1, C2, C3, C, y;
     var __moduleName = context_1 && context_1.id;
     return {
         setters: [],
@@ -122,6 +135,13 @@ System.register([], function (exports_1, context_1) {
             C = __decorate([
                 (await dec)
             ], C);
+            // newlines
+            // await in throw
+            throw await 1;
+            // await in var
+            y = await 1;
+            // await in expression statement;
+            await 1;
         }
     };
 });

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2017).symbols
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2017).symbols
@@ -102,6 +102,21 @@ import { await as _await } from "./other";
 >await : Symbol(await, Decl(other.ts, 3, 8))
 >_await : Symbol(_await, Decl(index.ts, 50, 8))
 
+// newlines
+// await in throw
+throw await
+    1;
+
+// await in var
+let y = await
+>y : Symbol(y, Decl(index.ts, 58, 3))
+
+    1;
+
+// await in expression statement;
+await
+    1;
+
 === tests/cases/conformance/externalModules/other.ts ===
 const _await = 1;
 >_await : Symbol(_await, Decl(other.ts, 0, 5))

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2017).types
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2017).types
@@ -143,6 +143,29 @@ import { await as _await } from "./other";
 >await : 1
 >_await : 1
 
+// newlines
+// await in throw
+throw await
+>await    1 : 1
+
+    1;
+>1 : 1
+
+// await in var
+let y = await
+>y : number
+>await    1 : 1
+
+    1;
+>1 : 1
+
+// await in expression statement;
+await
+>await    1 : 1
+
+    1;
+>1 : 1
+
 === tests/cases/conformance/externalModules/other.ts ===
 const _await = 1;
 >_await : 1

--- a/tests/baselines/reference/topLevelAwaitErrors.1.errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.1.errors.txt
@@ -5,8 +5,12 @@ tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(5,16): error TS
 tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(8,14): error TS1005: '>' expected.
 tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(8,16): error TS2693: 'string' only refers to a type, but is being used as a value here.
 tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(11,17): error TS1109: Expression expected.
+tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(11,22): error TS1109: Expression expected.
+tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(11,23): error TS2693: 'string' only refers to a type, but is being used as a value here.
+tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(11,29): error TS1005: ',' expected.
 tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(15,8): error TS1109: Expression expected.
 tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(18,2): error TS1109: Expression expected.
+tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(18,8): error TS2304: Cannot find name 'x'.
 tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(21,2): error TS1109: Expression expected.
 tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(26,6): error TS1109: Expression expected.
 tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(30,6): error TS1109: Expression expected.
@@ -16,7 +20,7 @@ tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(41,14): error T
 tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(42,20): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts (16 errors) ====
+==== tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts (20 errors) ====
     export {};
     
     // reparse call as invalid await should error
@@ -42,6 +46,12 @@ tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(42,20): error T
     class C extends await<string> {
                     ~~~~~
 !!! error TS1109: Expression expected.
+                         ~
+!!! error TS1109: Expression expected.
+                          ~~~~~~
+!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+                                ~
+!!! error TS1005: ',' expected.
     }
     
     // await in class decorators should fail
@@ -53,6 +63,8 @@ tests/cases/conformance/externalModules/topLevelAwaitErrors.1.ts(42,20): error T
     @await(x)
      ~~~~~
 !!! error TS1109: Expression expected.
+           ~
+!!! error TS2304: Cannot find name 'x'.
     class C2 {}
     
     @await

--- a/tests/baselines/reference/topLevelAwaitErrors.1.js
+++ b/tests/baselines/reference/topLevelAwaitErrors.1.js
@@ -51,7 +51,7 @@ await , string > (1);
 // reparse tagged template as invalid await should error
 await , string > ``;
 // reparse class extends clause should fail
-class C extends  {
+class C extends string {
 }
 // await in class decorators should fail
 let C1 = class C1 {
@@ -62,6 +62,7 @@ C1 = __decorate([
 let C2 = class C2 {
 };
 C2 = __decorate([
+    (x)
 ], C2);
 let C3 = class C3 {
 };
@@ -77,6 +78,7 @@ class C5 {
     ["foo"]() { }
 }
 __decorate([
+    (1)
 ], C5.prototype, "foo", null);
 class C6 {
     ["foo"]() { }
@@ -94,7 +96,7 @@ __decorate([
     __param(0, )
 ], C7.prototype, "method1", null);
 __decorate([
-    __param(0, )
+    __param(0, (1))
 ], C7.prototype, "method2", null);
 __decorate([
     __param(0, (await ))

--- a/tests/baselines/reference/topLevelAwaitErrors.1.types
+++ b/tests/baselines/reference/topLevelAwaitErrors.1.types
@@ -32,7 +32,7 @@ await <number, string> ``;
 // reparse class extends clause should fail
 class C extends await<string> {
 >C : C
-> : any
+>string : any
 }
 
 // await in class decorators should fail
@@ -45,7 +45,9 @@ class C1 {}
 >C1 : C1
 
 @await(x)
+>await(x) : any
 > : any
+>x : any
 
 class C2 {}
 >C2 : C2
@@ -71,7 +73,9 @@ class C5 {
 >C5 : C5
 
     @await(1)
+>await(1) : any
 > : any
+>1 : 1
 
     ["foo"]() {}
 >["foo"] : () => void
@@ -101,7 +105,9 @@ class C7 {
 
     method2(@await(1) [x]) {}
 >method2 : ([x]: [any]) => void
+>await(1) : any
 > : any
+>1 : 1
 >x : any
 
     method3(@(await) [x]) {}

--- a/tests/cases/conformance/externalModules/topLevelAwait.1.ts
+++ b/tests/cases/conformance/externalModules/topLevelAwait.1.ts
@@ -55,6 +55,19 @@ class C {
 // await allowed in aliased import
 import { await as _await } from "./other";
 
+// newlines
+// await in throw
+throw await
+    1;
+
+// await in var
+let y = await
+    1;
+
+// await in expression statement;
+await
+    1;
+
 // @filename: other.ts
 const _await = 1;
 


### PR DESCRIPTION
When reparsing top-level `await`, we might end up in a state where reparse would have consumed more tokens than the original statement. This changes top-level `await` reparse to leverage a `SyntaxCursor` and continue to reparse following statements if the current statement's `end` changes.

This also changes our parse for _BindingIdentifier_ to *allow* `yield` and `await` during parse, but error on them during bind just as we do for other strict-mode reserved identifiers.

Fixes #39186
