### PR TITLE
Erase type parameters to a type which behaves as never in a union and unknown in an intersection or any otherwise

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13605,6 +13605,9 @@ namespace ts {
             if (objectType === wildcardType || indexType === wildcardType) {
                 return wildcardType;
             }
+            if (objectType === erasedType || indexType === erasedType) {
+                return erasedType;
+            }
             // If the object type has a string index signature and no other members we know that the result will
             // always be the type of that index signature and we can simplify accordingly.
             if (isStringIndexSignatureOnlyType(objectType) && !(indexType.flags & TypeFlags.Nullable) && isTypeAssignableToKind(indexType, TypeFlags.String | TypeFlags.Number)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -700,6 +700,7 @@ namespace ts {
         const anyType = createIntrinsicType(TypeFlags.Any, "any");
         const autoType = createIntrinsicType(TypeFlags.Any, "any");
         const wildcardType = createIntrinsicType(TypeFlags.Any, "any");
+        const erasedType = createIntrinsicType(TypeFlags.Any | TypeFlags.Never | TypeFlags.Unknown, "any");
         const errorType = createIntrinsicType(TypeFlags.Any, "error");
         const nonInferrableAnyType = createIntrinsicType(TypeFlags.Any, "any", ObjectFlags.ContainsWideningType);
         const unknownType = createIntrinsicType(TypeFlags.Unknown, "unknown");
@@ -12896,8 +12897,8 @@ namespace ts {
                     typeSet.set(type.id.toString(), type);
                 }
             }
-            else {
-                if (flags & TypeFlags.AnyOrUnknown) {
+            else if (!(flags & TypeFlags.Unknown)) {
+                if (flags & TypeFlags.Any) {
                     if (type === wildcardType) includes |= TypeFlags.IncludesWildcard;
                 }
                 else if ((strictNullChecks || !(flags & TypeFlags.Nullable)) && !typeSet.has(type.id.toString())) {
@@ -14461,7 +14462,7 @@ namespace ts {
         }
 
         function createTypeEraser(sources: readonly TypeParameter[]): TypeMapper {
-            return createTypeMapper(sources, /*targets*/ undefined);
+            return createTypeMapper(sources, arrayOf(sources.length, () => erasedType));
         }
 
         /**

--- a/tests/baselines/reference/complexRecursiveCollections.errors.txt
+++ b/tests/baselines/reference/complexRecursiveCollections.errors.txt
@@ -1,3 +1,6 @@
+tests/cases/compiler/immutable.ts(189,20): error TS2430: Interface 'Stack<T>' incorrectly extends interface 'Indexed<T>'.
+  The types returned by 'concat(...).map(...).filter(...)' are incompatible between these types.
+    Type 'Set<any>' is not assignable to type 'Indexed<any>'.
 tests/cases/compiler/immutable.ts(341,22): error TS2430: Interface 'Keyed<K, V>' incorrectly extends interface 'Collection<K, V>'.
   The types returned by 'toSeq()' are incompatible between these types.
     Type 'Keyed<K, V>' is not assignable to type 'this'.
@@ -33,7 +36,7 @@ tests/cases/compiler/immutable.ts(391,22): error TS2430: Interface 'Set<T>' inco
         flatMap<M>(mapper: (value: T, key: void, iter: this) => Ara<M>, context?: any): N2<M>;
         toSeq(): N2<T>;
     }
-==== tests/cases/compiler/immutable.ts (3 errors) ====
+==== tests/cases/compiler/immutable.ts (4 errors) ====
     // Test that complex recursive collections can pass the `extends` assignability check without
     // running out of memory. This bug was exposed in Typescript 2.4 when more generic signatures
     // started being checked.
@@ -223,6 +226,10 @@ tests/cases/compiler/immutable.ts(391,22): error TS2430: Interface 'Set<T>' inco
       export function Stack<T>(): Stack<T>;
       export function Stack<T>(collection: Iterable<T>): Stack<T>;
       export interface Stack<T> extends Collection.Indexed<T> {
+                       ~~~~~
+!!! error TS2430: Interface 'Stack<T>' incorrectly extends interface 'Indexed<T>'.
+!!! error TS2430:   The types returned by 'concat(...).map(...).filter(...)' are incompatible between these types.
+!!! error TS2430:     Type 'Set<any>' is not assignable to type 'Indexed<any>'.
         // Reading values
         peek(): T | undefined;
         // Persistent changes

--- a/tests/baselines/reference/complexRecursiveCollections.types
+++ b/tests/baselines/reference/complexRecursiveCollections.types
@@ -1137,7 +1137,7 @@ declare module Immutable {
 >Seq : typeof Seq
 
     function isSeq(maybeSeq: any): maybeSeq is Seq.Indexed<any> | Seq.Keyed<any, any>;
->isSeq : (maybeSeq: any) => maybeSeq is Indexed<any> | Keyed<any, any>
+>isSeq : (maybeSeq: any) => maybeSeq is Keyed<any, any> | Indexed<any>
 >maybeSeq : any
 >Seq : any
 >Seq : any

--- a/tests/baselines/reference/functionInferenceDecomposesIntersection.js
+++ b/tests/baselines/reference/functionInferenceDecomposesIntersection.js
@@ -1,0 +1,33 @@
+//// [functionInferenceDecomposesIntersection.ts]
+declare namespace React {
+    type WeakValidationMap<T> = {
+        [K in keyof T]?: null extends T[K] ? string : string
+    };
+
+    interface FunctionComponent<P = {}> {
+        propTypes?: WeakValidationMap<P>;
+    }
+}
+
+type A<T1> = <T2>() => React.FunctionComponent<T1 & T2>;
+
+function B<T>(_: A<T>) {}
+
+interface C {
+    r: string;
+}
+
+function myFunction<T2>(): React.FunctionComponent<C & T2> {
+    return {};
+}
+
+// B<C>(myFunction) // No error
+B(myFunction) // should be the same as above (T in B inferred as C)
+
+//// [functionInferenceDecomposesIntersection.js]
+function B(_) { }
+function myFunction() {
+    return {};
+}
+// B<C>(myFunction) // No error
+B(myFunction); // should be the same as above (T in B inferred as C)

--- a/tests/baselines/reference/functionInferenceDecomposesIntersection.symbols
+++ b/tests/baselines/reference/functionInferenceDecomposesIntersection.symbols
@@ -1,0 +1,66 @@
+=== tests/cases/compiler/functionInferenceDecomposesIntersection.ts ===
+declare namespace React {
+>React : Symbol(React, Decl(functionInferenceDecomposesIntersection.ts, 0, 0))
+
+    type WeakValidationMap<T> = {
+>WeakValidationMap : Symbol(WeakValidationMap, Decl(functionInferenceDecomposesIntersection.ts, 0, 25))
+>T : Symbol(T, Decl(functionInferenceDecomposesIntersection.ts, 1, 27))
+
+        [K in keyof T]?: null extends T[K] ? string : string
+>K : Symbol(K, Decl(functionInferenceDecomposesIntersection.ts, 2, 9))
+>T : Symbol(T, Decl(functionInferenceDecomposesIntersection.ts, 1, 27))
+>T : Symbol(T, Decl(functionInferenceDecomposesIntersection.ts, 1, 27))
+>K : Symbol(K, Decl(functionInferenceDecomposesIntersection.ts, 2, 9))
+
+    };
+
+    interface FunctionComponent<P = {}> {
+>FunctionComponent : Symbol(FunctionComponent, Decl(functionInferenceDecomposesIntersection.ts, 3, 6))
+>P : Symbol(P, Decl(functionInferenceDecomposesIntersection.ts, 5, 32))
+
+        propTypes?: WeakValidationMap<P>;
+>propTypes : Symbol(FunctionComponent.propTypes, Decl(functionInferenceDecomposesIntersection.ts, 5, 41))
+>WeakValidationMap : Symbol(WeakValidationMap, Decl(functionInferenceDecomposesIntersection.ts, 0, 25))
+>P : Symbol(P, Decl(functionInferenceDecomposesIntersection.ts, 5, 32))
+    }
+}
+
+type A<T1> = <T2>() => React.FunctionComponent<T1 & T2>;
+>A : Symbol(A, Decl(functionInferenceDecomposesIntersection.ts, 8, 1))
+>T1 : Symbol(T1, Decl(functionInferenceDecomposesIntersection.ts, 10, 7))
+>T2 : Symbol(T2, Decl(functionInferenceDecomposesIntersection.ts, 10, 14))
+>React : Symbol(React, Decl(functionInferenceDecomposesIntersection.ts, 0, 0))
+>FunctionComponent : Symbol(React.FunctionComponent, Decl(functionInferenceDecomposesIntersection.ts, 3, 6))
+>T1 : Symbol(T1, Decl(functionInferenceDecomposesIntersection.ts, 10, 7))
+>T2 : Symbol(T2, Decl(functionInferenceDecomposesIntersection.ts, 10, 14))
+
+function B<T>(_: A<T>) {}
+>B : Symbol(B, Decl(functionInferenceDecomposesIntersection.ts, 10, 56))
+>T : Symbol(T, Decl(functionInferenceDecomposesIntersection.ts, 12, 11))
+>_ : Symbol(_, Decl(functionInferenceDecomposesIntersection.ts, 12, 14))
+>A : Symbol(A, Decl(functionInferenceDecomposesIntersection.ts, 8, 1))
+>T : Symbol(T, Decl(functionInferenceDecomposesIntersection.ts, 12, 11))
+
+interface C {
+>C : Symbol(C, Decl(functionInferenceDecomposesIntersection.ts, 12, 25))
+
+    r: string;
+>r : Symbol(C.r, Decl(functionInferenceDecomposesIntersection.ts, 14, 13))
+}
+
+function myFunction<T2>(): React.FunctionComponent<C & T2> {
+>myFunction : Symbol(myFunction, Decl(functionInferenceDecomposesIntersection.ts, 16, 1))
+>T2 : Symbol(T2, Decl(functionInferenceDecomposesIntersection.ts, 18, 20))
+>React : Symbol(React, Decl(functionInferenceDecomposesIntersection.ts, 0, 0))
+>FunctionComponent : Symbol(React.FunctionComponent, Decl(functionInferenceDecomposesIntersection.ts, 3, 6))
+>C : Symbol(C, Decl(functionInferenceDecomposesIntersection.ts, 12, 25))
+>T2 : Symbol(T2, Decl(functionInferenceDecomposesIntersection.ts, 18, 20))
+
+    return {};
+}
+
+// B<C>(myFunction) // No error
+B(myFunction) // should be the same as above (T in B inferred as C)
+>B : Symbol(B, Decl(functionInferenceDecomposesIntersection.ts, 10, 56))
+>myFunction : Symbol(myFunction, Decl(functionInferenceDecomposesIntersection.ts, 16, 1))
+

--- a/tests/baselines/reference/functionInferenceDecomposesIntersection.types
+++ b/tests/baselines/reference/functionInferenceDecomposesIntersection.types
@@ -1,0 +1,43 @@
+=== tests/cases/compiler/functionInferenceDecomposesIntersection.ts ===
+declare namespace React {
+    type WeakValidationMap<T> = {
+>WeakValidationMap : WeakValidationMap<T>
+
+        [K in keyof T]?: null extends T[K] ? string : string
+>null : null
+
+    };
+
+    interface FunctionComponent<P = {}> {
+        propTypes?: WeakValidationMap<P>;
+>propTypes : WeakValidationMap<P>
+    }
+}
+
+type A<T1> = <T2>() => React.FunctionComponent<T1 & T2>;
+>A : A<T1>
+>React : any
+
+function B<T>(_: A<T>) {}
+>B : <T>(_: A<T>) => void
+>_ : A<T>
+
+interface C {
+    r: string;
+>r : string
+}
+
+function myFunction<T2>(): React.FunctionComponent<C & T2> {
+>myFunction : <T2>() => React.FunctionComponent<C & T2>
+>React : any
+
+    return {};
+>{} : {}
+}
+
+// B<C>(myFunction) // No error
+B(myFunction) // should be the same as above (T in B inferred as C)
+>B(myFunction) : void
+>B : <T>(_: A<T>) => void
+>myFunction : <T2>() => React.FunctionComponent<C & T2>
+

--- a/tests/baselines/reference/subtypingWithCallSignatures2.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures2.types
@@ -762,8 +762,8 @@ var r15arg1 = <T>(x: T) => <T[]>null
 >null : null
 
 var r15 = foo15(r15arg1); // any
->r15 : any
->foo15(r15arg1) : any
+>r15 : { (x: number): number[]; (x: string): string[]; }
+>foo15(r15arg1) : { (x: number): number[]; (x: string): string[]; }
 >foo15 : { (a: { (x: number): number[]; (x: string): string[]; }): { (x: number): number[]; (x: string): string[]; }; (a: any): any; }
 >r15arg1 : <T>(x: T) => T[]
 
@@ -789,8 +789,8 @@ var r17arg1 = <T>(x: (a: T) => T) => <T[]>null;
 >null : null
 
 var r17 = foo17(r17arg1); // any
->r17 : any
->foo17(r17arg1) : any
+>r17 : { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }
+>foo17(r17arg1) : { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }
 >foo17 : { (a: { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }): { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }; (a: any): any; }
 >r17arg1 : <T>(x: (a: T) => T) => T[]
 

--- a/tests/baselines/reference/subtypingWithCallSignatures3.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures3.types
@@ -457,8 +457,8 @@ module Errors {
 >null : null
 
     var r8 = foo16(r8arg); // any
->r8 : any
->foo16(r8arg) : any
+>r8 : { (x: { (a: number): number; (a?: number): number; }): number[]; (x: { (a: boolean): boolean; (a?: boolean): boolean; }): boolean[]; }
+>foo16(r8arg) : { (x: { (a: number): number; (a?: number): number; }): number[]; (x: { (a: boolean): boolean; (a?: boolean): boolean; }): boolean[]; }
 >foo16 : { (a2: { (x: { (a: number): number; (a?: number): number; }): number[]; (x: { (a: boolean): boolean; (a?: boolean): boolean; }): boolean[]; }): { (x: { (a: number): number; (a?: number): number; }): number[]; (x: { (a: boolean): boolean; (a?: boolean): boolean; }): boolean[]; }; (a2: any): any; }
 >r8arg : <T>(x: (a: T) => T) => T[]
 

--- a/tests/baselines/reference/subtypingWithConstructSignatures2.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures2.types
@@ -675,8 +675,8 @@ var r15arg1: new <T>(x: T) => T[];
 >x : T
 
 var r15 = foo15(r15arg1); // any
->r15 : any
->foo15(r15arg1) : any
+>r15 : { new (x: number): number[]; new (x: string): string[]; }
+>foo15(r15arg1) : { new (x: number): number[]; new (x: string): string[]; }
 >foo15 : { (a: { new (x: number): number[]; new (x: string): string[]; }): { new (x: number): number[]; new (x: string): string[]; }; (a: any): any; }
 >r15arg1 : new <T>(x: T) => T[]
 
@@ -696,8 +696,8 @@ var r17arg1: new <T>(x: (a: T) => T) => T[];
 >a : T
 
 var r17 = foo17(r17arg1); // any
->r17 : any
->foo17(r17arg1) : any
+>r17 : { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }
+>foo17(r17arg1) : { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }
 >foo17 : { (a: { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }): { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }; (a: any): any; }
 >r17arg1 : new <T>(x: (a: T) => T) => T[]
 

--- a/tests/baselines/reference/subtypingWithConstructSignatures3.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures3.types
@@ -406,8 +406,8 @@ module Errors {
 >a : T
 
     var r8 = foo16(r8arg); // any
->r8 : any
->foo16(r8arg) : any
+>r8 : { new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }
+>foo16(r8arg) : { new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }
 >foo16 : { (a2: { new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }): { new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }; (a2: any): any; }
 >r8arg : new <T>(x: new (a: T) => T) => T[]
 

--- a/tests/cases/compiler/functionInferenceDecomposesIntersection.ts
+++ b/tests/cases/compiler/functionInferenceDecomposesIntersection.ts
@@ -1,0 +1,25 @@
+
+declare namespace React {
+    type WeakValidationMap<T> = {
+        [K in keyof T]?: null extends T[K] ? string : string
+    };
+
+    interface FunctionComponent<P = {}> {
+        propTypes?: WeakValidationMap<P>;
+    }
+}
+
+type A<T1> = <T2>() => React.FunctionComponent<T1 & T2>;
+
+function B<T>(_: A<T>) {}
+
+interface C {
+    r: string;
+}
+
+function myFunction<T2>(): React.FunctionComponent<C & T2> {
+    return {};
+}
+
+// B<C>(myFunction) // No error
+B(myFunction) // should be the same as above (T in B inferred as C)


### PR DESCRIPTION
This has the effect of omitting the parameters from inference calculations, _without_ subsuming that data provided by the other members of the union/intersection.

Fixes #39080
