### PR TITLE
not narrow static property without type annotation in constructor.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7628,7 +7628,7 @@ namespace ts {
                 return addOptionality(type, isOptional);
             }
 
-            if (isPropertyDeclaration(declaration) && (noImplicitAny || isInJSFile(declaration))) {
+            if (isPropertyDeclaration(declaration) && !hasStaticModifier(declaration) && (noImplicitAny || isInJSFile(declaration)) ) {
                 // We have a property declaration with no type annotation or initializer, in noImplicitAny mode or a .js file.
                 // Use control flow analysis of this.xxx assignments in the constructor to determine the type of the property.
                 const constructor = findConstructorDeclaration(declaration.parent);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7628,7 +7628,7 @@ namespace ts {
                 return addOptionality(type, isOptional);
             }
 
-            if (isPropertyDeclaration(declaration) && !hasStaticModifier(declaration) && (noImplicitAny || isInJSFile(declaration)) ) {
+            if (isPropertyDeclaration(declaration) && !hasStaticModifier(declaration) && (noImplicitAny || isInJSFile(declaration))) {
                 // We have a property declaration with no type annotation or initializer, in noImplicitAny mode or a .js file.
                 // Use control flow analysis of this.xxx assignments in the constructor to determine the type of the property.
                 const constructor = findConstructorDeclaration(declaration.parent);

--- a/tests/baselines/reference/staticVisibility2.errors.txt
+++ b/tests/baselines/reference/staticVisibility2.errors.txt
@@ -1,0 +1,15 @@
+tests/cases/compiler/staticVisibility2.ts(2,12): error TS7008: Member 'sideLength' implicitly has an 'any' type.
+tests/cases/compiler/staticVisibility2.ts(4,14): error TS2576: Property 'sideLength' is a static member of type 'Square'
+
+
+==== tests/cases/compiler/staticVisibility2.ts (2 errors) ====
+    class Square {
+        static sideLength;
+               ~~~~~~~~~~
+!!! error TS7008: Member 'sideLength' implicitly has an 'any' type.
+        constructor(sideLength: number) {
+            this.sideLength = sideLength;
+                 ~~~~~~~~~~
+!!! error TS2576: Property 'sideLength' is a static member of type 'Square'
+        }
+    }

--- a/tests/baselines/reference/staticVisibility2.js
+++ b/tests/baselines/reference/staticVisibility2.js
@@ -1,0 +1,15 @@
+//// [staticVisibility2.ts]
+class Square {
+    static sideLength;
+    constructor(sideLength: number) {
+        this.sideLength = sideLength;
+    }
+}
+
+//// [staticVisibility2.js]
+var Square = /** @class */ (function () {
+    function Square(sideLength) {
+        this.sideLength = sideLength;
+    }
+    return Square;
+}());

--- a/tests/baselines/reference/staticVisibility2.symbols
+++ b/tests/baselines/reference/staticVisibility2.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/staticVisibility2.ts ===
+class Square {
+>Square : Symbol(Square, Decl(staticVisibility2.ts, 0, 0))
+
+    static sideLength;
+>sideLength : Symbol(Square.sideLength, Decl(staticVisibility2.ts, 0, 14))
+
+    constructor(sideLength: number) {
+>sideLength : Symbol(sideLength, Decl(staticVisibility2.ts, 2, 16))
+
+        this.sideLength = sideLength;
+>this : Symbol(Square, Decl(staticVisibility2.ts, 0, 0))
+>sideLength : Symbol(sideLength, Decl(staticVisibility2.ts, 2, 16))
+    }
+}

--- a/tests/baselines/reference/staticVisibility2.types
+++ b/tests/baselines/reference/staticVisibility2.types
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/staticVisibility2.ts ===
+class Square {
+>Square : Square
+
+    static sideLength;
+>sideLength : any
+
+    constructor(sideLength: number) {
+>sideLength : number
+
+        this.sideLength = sideLength;
+>this.sideLength = sideLength : number
+>this.sideLength : any
+>this : this
+>sideLength : any
+>sideLength : number
+    }
+}

--- a/tests/cases/compiler/staticVisibility2.ts
+++ b/tests/cases/compiler/staticVisibility2.ts
@@ -1,0 +1,7 @@
+// @noImplicitAny: true
+class Square {
+    static sideLength;
+    constructor(sideLength: number) {
+        this.sideLength = sideLength;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #39226
