### PR TITLE
update JSON.parse argument signature

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1036,7 +1036,7 @@ interface JSON {
      * @param reviver A function that transforms the results. This function is called for each member of the object.
      * If a member contains nested objects, the nested objects are transformed before the parent object is.
      */
-    parse(text: string, reviver?: (this: any, key: string, value: any) => any): any;
+    parse(text: string | number | boolean | null, reviver?: (this: any, key: string, value: any) => any): any;
     /**
      * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
      * @param value A JavaScript value, usually an object or array, to be converted.


### PR DESCRIPTION
Testing with the Node REPL, `JSON.parse()` accepts all copy-by-value primitives and returns them directly.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->