### PR TITLE
Don’t auto-import paths that are in a referenced project’s outDir

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4233,6 +4233,7 @@ namespace ts {
                         useCaseSensitiveFileNames: maybeBind(host, host.useCaseSensitiveFileNames),
                         redirectTargetsMap: host.redirectTargetsMap,
                         getProjectReferenceRedirect: fileName => host.getProjectReferenceRedirect(fileName),
+                        getResolvedProjectReferenceToRedirect: fileName => host.getResolvedProjectReferenceToRedirect(fileName),
                         isSourceOfProjectReferenceRedirect: fileName => host.isSourceOfProjectReferenceRedirect(fileName),
                         fileExists: fileName => host.fileExists(fileName),
                     } : undefined },

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -202,7 +202,7 @@ namespace ts.moduleSpecifiers {
                 return undefined; // Don't want to a package to globally import from itself
             }
 
-            targets.forEach(target => {
+            return forEach(targets, target => {
                 if (compareStrings(target.slice(0, resolved.length + 1), resolved + "/") !== Comparison.EqualTo) {
                     return;
                 }
@@ -210,8 +210,7 @@ namespace ts.moduleSpecifiers {
                 const relative = getRelativePathFromDirectory(resolved, target, getCanonicalFileName);
                 const option = resolvePath(path, relative);
                 if (!host.fileExists || host.fileExists(option)) {
-                    const result = cb(option);
-                    if (result) return result;
+                    return cb(option);
                 }
             });
         });

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -7745,6 +7745,7 @@ namespace ts {
         getSourceFiles(): readonly SourceFile[];
         readonly redirectTargetsMap: RedirectTargetsMap;
         getProjectReferenceRedirect(fileName: string): string | undefined;
+        getResolvedProjectReferenceToRedirect(fileName: string): ResolvedProjectReference | undefined;
         isSourceOfProjectReferenceRedirect(fileName: string): boolean;
     }
 

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -2829,9 +2829,14 @@ namespace FourSlash {
                 const change = ts.first(codeFix.changes);
                 ts.Debug.assert(change.fileName === fileName);
                 this.applyEdits(change.fileName, change.textChanges);
-                const text = range ? this.rangeText(range) : this.getFileContent(this.activeFile.fileName);
+                const text = range ? this.rangeText(range) : this.getFileContent(fileName);
                 actualTextArray.push(text);
-                scriptInfo.updateContent(originalContent);
+
+                // Undo changes to perform next fix
+                const span = change.textChanges[0].span;
+                const deletedText = originalContent.substr(span.start, change.textChanges[0].span.length);
+                const insertedText = change.textChanges[0].newText;
+                this.editScriptAndUpdateMarkers(fileName, span.start, span.start + insertedText.length, deletedText);
             }
             if (expectedTextArray.length !== actualTextArray.length) {
                 this.raiseError(`Expected ${expectedTextArray.length} import fixes, got ${actualTextArray.length}`);

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -154,23 +154,23 @@ namespace Harness.LanguageService {
             return fileNames;
         }
 
-        private tryRealpath(fileName: string): string {
+        public realpath(path: string): string {
             try {
-                return this.vfs.realpathSync(fileName);
+                return this.vfs.realpathSync(path);
             }
             catch {
-                return fileName;
+                return path;
             }
         }
 
         public getScriptInfo(fileName: string): ScriptInfo | undefined {
-            return this.scriptInfos.get(this.tryRealpath(vpath.resolve(this.vfs.cwd(), fileName)));
+            return this.scriptInfos.get(this.realpath(vpath.resolve(this.vfs.cwd(), fileName)));
         }
 
         public addScript(fileName: string, content: string, isRootFile: boolean): void {
             this.vfs.mkdirpSync(vpath.dirname(fileName));
             this.vfs.writeFileSync(fileName, content);
-            this.scriptInfos.set(this.tryRealpath(vpath.resolve(this.vfs.cwd(), fileName)), new ScriptInfo(fileName, content, isRootFile));
+            this.scriptInfos.set(this.realpath(vpath.resolve(this.vfs.cwd(), fileName)), new ScriptInfo(fileName, content, isRootFile));
         }
 
         public renameFileOrDirectory(oldPath: string, newPath: string): void {
@@ -182,7 +182,7 @@ namespace Harness.LanguageService {
                 const newFileName = updater(key);
                 if (newFileName !== undefined) {
                     this.scriptInfos.delete(key);
-                    this.scriptInfos.set(this.tryRealpath(newFileName), scriptInfo);
+                    this.scriptInfos.set(this.realpath(newFileName), scriptInfo);
                     scriptInfo.fileName = newFileName;
                 }
             });
@@ -710,6 +710,10 @@ namespace Harness.LanguageService {
         writeMessage = ts.noop; // overridden
         write(message: string): void {
             this.writeMessage(message);
+        }
+
+        realpath(path: string) {
+            return this.host.realpath(path);
         }
 
         readFile(fileName: string): string | undefined {

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -154,14 +154,23 @@ namespace Harness.LanguageService {
             return fileNames;
         }
 
+        private tryRealpath(fileName: string): string {
+            try {
+                return this.vfs.realpathSync(fileName);
+            }
+            catch {
+                return fileName;
+            }
+        }
+
         public getScriptInfo(fileName: string): ScriptInfo | undefined {
-            return this.scriptInfos.get(vpath.resolve(this.vfs.cwd(), fileName));
+            return this.scriptInfos.get(this.tryRealpath(vpath.resolve(this.vfs.cwd(), fileName)));
         }
 
         public addScript(fileName: string, content: string, isRootFile: boolean): void {
             this.vfs.mkdirpSync(vpath.dirname(fileName));
             this.vfs.writeFileSync(fileName, content);
-            this.scriptInfos.set(vpath.resolve(this.vfs.cwd(), fileName), new ScriptInfo(fileName, content, isRootFile));
+            this.scriptInfos.set(this.tryRealpath(vpath.resolve(this.vfs.cwd(), fileName)), new ScriptInfo(fileName, content, isRootFile));
         }
 
         public renameFileOrDirectory(oldPath: string, newPath: string): void {
@@ -173,7 +182,7 @@ namespace Harness.LanguageService {
                 const newFileName = updater(key);
                 if (newFileName !== undefined) {
                     this.scriptInfos.delete(key);
-                    this.scriptInfos.set(newFileName, scriptInfo);
+                    this.scriptInfos.set(this.tryRealpath(newFileName), scriptInfo);
                     scriptInfo.fileName = newFileName;
                 }
             });

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1736,6 +1736,7 @@ namespace ts {
             getSourceFiles: () => program.getSourceFiles(),
             redirectTargetsMap: program.redirectTargetsMap,
             getProjectReferenceRedirect: fileName => program.getProjectReferenceRedirect(fileName),
+            getResolvedProjectReferenceToRedirect: fileName => program.getResolvedProjectReferenceToRedirect(fileName),
             isSourceOfProjectReferenceRedirect: fileName => program.isSourceOfProjectReferenceRedirect(fileName),
         };
     }

--- a/tests/cases/fourslash/server/autoImportProjectReferenceRedirect1.ts
+++ b/tests/cases/fourslash/server/autoImportProjectReferenceRedirect1.ts
@@ -1,0 +1,40 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /packages/a/tsconfig.json
+// @Symlink: /node_modules/a/tsconfig.json
+//// { "compilerOptions": { "module": "commonjs", "composite": true, "outDir": "dist", "rootDir": "src" } }
+
+// @Filename: /packages/a/package.json
+// @Symlink: /node_modules/a/package.json
+//// { "name": "a", "main": "dist/index.js", "typings": "dist/index.d.ts" }
+
+// @Filename: /packages/a/src/index.ts
+// @Symlink: /node_modules/a/src/index.ts
+//// import "./a";
+//// export class Index {}
+
+// @Filename: /packages/a/dist/index.d.ts
+// @Symlink: /node_modules/a/dist/index.d.ts
+//// import "./a";
+//// export class Index {}
+
+// @Filename: /packages/a/src/a.ts
+// @Symlink: /node_modules/a/src/a.ts
+//// export class A {}
+
+// @Filename: /packages/a/dist/a.d.ts
+// @Symlink: /node_modules/a/dist/a.d.ts
+//// export class A {}
+
+
+// @Filename: /packages/b/tsconfig.json
+//// { "compilerOptions": { "module": "commonjs", "outDir": "dist", "rootDir": "src" }, "references": [{ "path": "../a" }] }
+
+// @Filename: /packages/b/src/util.ts
+//// import { A } from "a";
+
+// @Filename: /packages/b/src/index.ts
+//// A/**/
+
+goTo.marker("");
+verify.importFixAtPosition([`import { A } from "a/src/a";\n\nA`]);

--- a/tests/cases/fourslash/server/autoImportProjectReferenceRedirect1.ts
+++ b/tests/cases/fourslash/server/autoImportProjectReferenceRedirect1.ts
@@ -26,4 +26,4 @@
 //// A/**/
 
 goTo.marker("");
-verify.importFixAtPosition([`import { A } from "a/src/a";\n\nA`]);
+verify.importFixAtPosition([`import { A } from "a/src/a";\r\n\r\nA`]);

--- a/tests/cases/fourslash/server/autoImportProjectReferenceRedirect1.ts
+++ b/tests/cases/fourslash/server/autoImportProjectReferenceRedirect1.ts
@@ -1,29 +1,18 @@
 /// <reference path="../fourslash.ts" />
 
+// @link: /packages/a -> /node_modules/a
+
 // @Filename: /packages/a/tsconfig.json
-// @Symlink: /node_modules/a/tsconfig.json
 //// { "compilerOptions": { "module": "commonjs", "composite": true, "outDir": "dist", "rootDir": "src" } }
 
 // @Filename: /packages/a/package.json
-// @Symlink: /node_modules/a/package.json
 //// { "name": "a", "main": "dist/index.js", "typings": "dist/index.d.ts" }
 
 // @Filename: /packages/a/src/index.ts
-// @Symlink: /node_modules/a/src/index.ts
-//// import "./a";
-//// export class Index {}
-
-// @Filename: /packages/a/dist/index.d.ts
-// @Symlink: /node_modules/a/dist/index.d.ts
 //// import "./a";
 //// export class Index {}
 
 // @Filename: /packages/a/src/a.ts
-// @Symlink: /node_modules/a/src/a.ts
-//// export class A {}
-
-// @Filename: /packages/a/dist/a.d.ts
-// @Symlink: /node_modules/a/dist/a.d.ts
 //// export class A {}
 
 

--- a/tests/cases/fourslash/server/autoImportProjectReferenceRedirect2.ts
+++ b/tests/cases/fourslash/server/autoImportProjectReferenceRedirect2.ts
@@ -1,12 +1,7 @@
 /// <reference path="../fourslash.ts" />
 
-// @link: /packages/a -> /node_modules/a
-
 // @Filename: /packages/a/tsconfig.json
 //// { "compilerOptions": { "module": "commonjs", "composite": true, "outDir": "dist", "rootDir": "src" } }
-
-// @Filename: /packages/a/package.json
-//// { "name": "a", "main": "dist/index.js", "typings": "dist/index.d.ts" }
 
 // @Filename: /packages/a/src/index.ts
 //// import "./a";
@@ -15,9 +10,20 @@
 // @Filename: /packages/a/src/a.ts
 //// export class A {}
 
-
 // @Filename: /packages/b/tsconfig.json
-//// { "compilerOptions": { "module": "commonjs", "outDir": "dist", "rootDir": "src" }, "references": [{ "path": "../a" }] }
+//// {
+////   "compilerOptions": {
+////     "module": "commonjs",
+////     "outDir": "dist",
+////     "rootDir": "src",
+////     "baseUrl": ".",
+////     "paths": {
+////       "a": ["../a/src/index"],
+////       "a/*": ["../a/*"]
+////     }
+////   },
+////   "references": [{ "path": "../a" }]
+//// }
 
 // @Filename: /packages/b/src/util.ts
 //// import {} from "a";


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #38856 

We started getting auto-imports from referenced project `outDir`s due to #37482. We _do_ potentially need to look in `outDir` because the result could be the `typings` or `main` entry of the project’s `package.json` (which would be referenced in symlinked monorepo setups), in which case the resulting module specifier would be the bare non-relative package name. But if that file does _not_ match the `typings` or `main` entry (or cannot be referenced through node_modules), we don’t want to use that file as a possible path to import, and we certainly don’t want it to crowd out the non-redirect source file.
