### PR TITLE
Preserve newlines between try/catch/finally, if/else, do/while

### DIFF
--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Catch.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Catch.ts
@@ -9,8 +9,7 @@ async function f():Promise<void> {
     try {
         const result = await fetch('https://typescriptlang.org');
         console.log(result);
-    }
-    catch (err) {
+    } catch (err) {
         console.log(err);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchAndRej.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchAndRej.ts
@@ -10,12 +10,10 @@ async function f():Promise<void> {
         try {
             const result = await fetch('https://typescriptlang.org');
             console.log(result);
-        }
-        catch (rejection) {
+        } catch (rejection) {
             console.log("rejected:", rejection);
         }
-    }
-    catch (err) {
+    } catch (err) {
         console.log(err);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchAndRejRef.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchAndRejRef.ts
@@ -19,12 +19,10 @@ async function f():Promise<void> {
         try {
             const result = await fetch('https://typescriptlang.org');
             return res(result);
-        }
-        catch (rejection) {
+        } catch (rejection) {
             return rej(rejection);
         }
-    }
-    catch (err) {
+    } catch (err) {
         return catch_err(err);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThen.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThen.js
@@ -19,8 +19,7 @@ async function f(){
     try {
         const result_1 = await fetch("https://typescriptlang.org");
         result = await res(result_1);
-    }
-    catch (reject) {
+    } catch (reject) {
         result = await rej(reject);
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThen.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThen.ts
@@ -19,8 +19,7 @@ async function f(){
     try {
         const result_1 = await fetch("https://typescriptlang.org");
         result = await res(result_1);
-    }
-    catch (reject) {
+    } catch (reject) {
         result = await rej(reject);
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMatchingTypes01.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMatchingTypes01.ts
@@ -19,8 +19,7 @@ async function f(){
     try {
         const result_1 = await fetch("https://typescriptlang.org");
         result = await res(result_1);
-    }
-    catch (reject) {
+    } catch (reject) {
         result = await rej(reject);
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMatchingTypes01NoAnnotations.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMatchingTypes01NoAnnotations.js
@@ -19,8 +19,7 @@ async function f(){
     try {
         const result_1 = await fetch("https://typescriptlang.org");
         result = await res(result_1);
-    }
-    catch (reject) {
+    } catch (reject) {
         result = await rej(reject);
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMatchingTypes01NoAnnotations.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMatchingTypes01NoAnnotations.ts
@@ -19,8 +19,7 @@ async function f(){
     try {
         const result_1 = await fetch("https://typescriptlang.org");
         result = await res(result_1);
-    }
-    catch (reject) {
+    } catch (reject) {
         result = await rej(reject);
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMatchingTypes02.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMatchingTypes02.ts
@@ -15,8 +15,7 @@ async function f(){
     try {
         const res = await fetch("https://typescriptlang.org");
         result = 0;
-    }
-    catch (rej) {
+    } catch (rej) {
         result = 1;
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMatchingTypes02NoAnnotations.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMatchingTypes02NoAnnotations.js
@@ -15,8 +15,7 @@ async function f(){
     try {
         const res = await fetch("https://typescriptlang.org");
         result = 0;
-    }
-    catch (rej) {
+    } catch (rej) {
         result = 1;
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMatchingTypes02NoAnnotations.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMatchingTypes02NoAnnotations.ts
@@ -15,8 +15,7 @@ async function f(){
     try {
         const res = await fetch("https://typescriptlang.org");
         result = 0;
-    }
-    catch (rej) {
+    } catch (rej) {
         result = 1;
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes01.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes01.js
@@ -19,8 +19,7 @@ async function f(){
     try {
         const result_1 = await fetch("https://typescriptlang.org");
         result = await res(result_1);
-    }
-    catch (reject) {
+    } catch (reject) {
         result = await rej(reject);
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes01.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes01.ts
@@ -19,8 +19,7 @@ async function f(){
     try {
         const result_1 = await fetch("https://typescriptlang.org");
         result = await res(result_1);
-    }
-    catch (reject) {
+    } catch (reject) {
         result = await rej(reject);
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes02.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes02.ts
@@ -19,8 +19,7 @@ async function f(){
     try {
         const result_1 = await fetch("https://typescriptlang.org");
         result = await res(result_1);
-    }
-    catch (reject) {
+    } catch (reject) {
         result = await rej(reject);
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes02NoAnnotations.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes02NoAnnotations.js
@@ -19,8 +19,7 @@ async function f(){
     try {
         const result_1 = await fetch("https://typescriptlang.org");
         result = await res(result_1);
-    }
-    catch (reject) {
+    } catch (reject) {
         result = await rej(reject);
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes02NoAnnotations.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes02NoAnnotations.ts
@@ -19,8 +19,7 @@ async function f(){
     try {
         const result_1 = await fetch("https://typescriptlang.org");
         result = await res(result_1);
-    }
-    catch (reject) {
+    } catch (reject) {
         result = await rej(reject);
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes03.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes03.js
@@ -19,8 +19,7 @@ async function f(){
     try {
         const result_1 = await fetch("https://typescriptlang.org");
         result = await res(result_1);
-    }
-    catch (reject) {
+    } catch (reject) {
         result = await rej(reject);
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes03.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes03.ts
@@ -19,8 +19,7 @@ async function f(){
     try {
         const result_1 = await fetch("https://typescriptlang.org");
         result = await res(result_1);
-    }
-    catch (reject) {
+    } catch (reject) {
         result = await rej(reject);
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes04.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchFollowedByThenMismatchTypes04.ts
@@ -39,8 +39,7 @@ async function f(){
     try {
         const result_1 = await fetch("https://typescriptlang.org");
         result = await res(result_1);
-    }
-    catch (reject) {
+    } catch (reject) {
         result = await rej(reject);
     }
     return res(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchNoBrackets.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchNoBrackets.ts
@@ -9,8 +9,7 @@ async function f():Promise<void> {
     try {
         const result = await fetch('https://typescriptlang.org');
         return console.log(result);
-    }
-    catch (err) {
+    } catch (err) {
         return console.log(err);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchRef.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchRef.ts
@@ -16,8 +16,7 @@ async function f():Promise<void> {
     try {
         const result = await fetch('https://typescriptlang.org');
         return res(result);
-    }
-    catch (err) {
+    } catch (err) {
         return catch_err(err);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRet.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRet.ts
@@ -16,8 +16,7 @@ async function innerPromise(): Promise<string> {
     try {
         const blob = await resp.blob();
         blob_1 = blob.byteOffset;
-    }
-    catch (err) {
+    } catch (err) {
         blob_1 = 'Error';
     }
     return blob_1.toString();

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding1.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding1.ts
@@ -16,8 +16,7 @@ async function innerPromise(): Promise<string> {
     try {
         const { blob } = await resp.blob();
         blob_1 = blob.byteOffset;
-    }
-    catch ({ message }) {
+    } catch ({ message }) {
         blob_1 = 'Error ' + message;
     }
     return blob_1.toString();

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding2.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding2.ts
@@ -16,8 +16,7 @@ async function innerPromise(): Promise<string> {
     try {
         const blob = await resp.blob();
         result = blob.byteOffset;
-    }
-    catch (err) {
+    } catch (err) {
         result = 'Error';
     }
     const { x } = result;

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding3.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding3.ts
@@ -16,8 +16,7 @@ async function innerPromise(): Promise<string> {
     try {
         const { blob } = await resp.blob();
         result = blob.byteOffset;
-    }
-    catch ({ message }) {
+    } catch ({ message }) {
         result = 'Error ' + message;
     }
     const [x, y] = result;

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding4.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding4.ts
@@ -16,8 +16,7 @@ async function innerPromise(): Promise<string> {
     try {
         const { blob } = await resp.blob();
         result = [0, blob.byteOffset];
-    }
-    catch ({ message }) {
+    } catch ({ message }) {
         result = ['Error ', message];
     }
     const [x, y] = result;

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_LocalReturn.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_LocalReturn.js
@@ -12,8 +12,7 @@ async function f() {
     let x = fetch("https://typescriptlang.org").then(res => console.log(res));
     try {
         return x;
-    }
-    catch (err) {
+    } catch (err) {
         return console.log("Error!", err);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_LocalReturn.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_LocalReturn.ts
@@ -12,8 +12,7 @@ async function f() {
     let x = fetch("https://typescriptlang.org").then(res => console.log(res));
     try {
         return x;
-    }
-    catch (err) {
+    } catch (err) {
         return console.log("Error!", err);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_MultipleCatches.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_MultipleCatches.ts
@@ -10,12 +10,10 @@ async function f(): Promise<void> {
         try {
             const res = await fetch('https://typescriptlang.org');
             return console.log(res);
-        }
-        catch (err) {
+        } catch (err) {
             return console.log("err", err);
         }
-    }
-    catch (err2) {
+    } catch (err2) {
         return console.log("err2", err2);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoCatchHandler.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoCatchHandler.js
@@ -10,6 +10,5 @@ async function f() {
     try {
         const x = await fetch('https://typescriptlang.org');
         return x.statusText;
-    }
-    catch (e) { }
+    } catch (e) { }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoCatchHandler.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoCatchHandler.ts
@@ -10,6 +10,5 @@ async function f() {
     try {
         const x = await fetch('https://typescriptlang.org');
         return x.statusText;
-    }
-    catch (e) { }
+    } catch (e) { }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoRes.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoRes.ts
@@ -9,8 +9,7 @@ function /*[#|*/f/*|]*/():Promise<void | Response> {
 async function f():Promise<void | Response> {
     try {
         await fetch('https://typescriptlang.org');
-    }
-    catch (rejection) {
+    } catch (rejection) {
         return console.log("rejected:", rejection);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoRes2.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoRes2.ts
@@ -9,8 +9,7 @@ function /*[#|*/f/*|]*/():Promise<void | Response> {
 async function f():Promise<void | Response> {
     try {
         await fetch('https://typescriptlang.org');
-    }
-    catch (rej) {
+    } catch (rej) {
         return console.log(rej);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoRes3.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoRes3.ts
@@ -9,8 +9,7 @@ function /*[#|*/f/*|]*/():Promise<void | Response> {
 async function f():Promise<void | Response> {
     try {
         return fetch('https://typescriptlang.org');
-    }
-    catch (rej) {
+    } catch (rej) {
         return console.log(rej);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoRes4.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoRes4.js
@@ -9,8 +9,7 @@ function /*[#|*/f/*|]*/() {
 async function f() {
     try {
         await fetch('https://typescriptlang.org');
-    }
-    catch (rejection) {
+    } catch (rejection) {
         return console.log("rejected:", rejection);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoRes4.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoRes4.ts
@@ -9,8 +9,7 @@ function /*[#|*/f/*|]*/() {
 async function f() {
     try {
         await fetch('https://typescriptlang.org');
-    }
-    catch (rejection) {
+    } catch (rejection) {
         return console.log("rejected:", rejection);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Param2.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Param2.ts
@@ -17,8 +17,7 @@ function my_print (resp): Promise<void> {
 async function f() {
     try {
         return my_print(fetch("https://typescriptlang.org").then(res => console.log(res)));
-    }
-    catch (err) {
+    } catch (err) {
         return console.log("Error!", err);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_PromiseCallInner.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_PromiseCallInner.js
@@ -10,8 +10,7 @@ function /*[#|*/f/*|]*/() {
 async function f() {
     try {
         return fetch(Promise.resolve(1).then(res => "https://typescriptlang.org"));
-    }
-    catch (err) {
+    } catch (err) {
         return console.log(err);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_PromiseCallInner.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_PromiseCallInner.ts
@@ -10,8 +10,7 @@ function /*[#|*/f/*|]*/() {
 async function f() {
     try {
         return fetch(Promise.resolve(1).then(res => "https://typescriptlang.org"));
-    }
-    catch (err) {
+    } catch (err) {
         return console.log(err);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Scope2.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Scope2.ts
@@ -13,8 +13,7 @@ async function f(){
         const i_1 = await fetch("https://typescriptlang.org");
         const res = i_1.ok;
         return i + 1;
-    }
-    catch (err) {
+    } catch (err) {
         return i - 1;
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsRejectedPromiseInTryBlock.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsRejectedPromiseInTryBlock.js
@@ -12,8 +12,7 @@ async function f() {
     try {
         const x = await Promise.resolve(1);
         return await Promise.reject(x);
-    }
-    catch (err) {
+    } catch (err) {
         return console.log(err);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsRejectedPromiseInTryBlock.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsRejectedPromiseInTryBlock.ts
@@ -12,8 +12,7 @@ async function f() {
     try {
         const x = await Promise.resolve(1);
         return await Promise.reject(x);
-    }
-    catch (err) {
+    } catch (err) {
         return console.log(err);
     }
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParams.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParams.js
@@ -11,8 +11,7 @@ async function f() {
     try {
         const x = await Promise.resolve();
         x_2 = 1;
-    }
-    catch (x_1) {
+    } catch (x_1) {
         x_2 = "a";
     }
     return !!x_2;

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParams.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParams.ts
@@ -11,8 +11,7 @@ async function f() {
     try {
         const x = await Promise.resolve();
         x_2 = 1;
-    }
-    catch (x_1) {
+    } catch (x_1) {
         x_2 = "a";
     }
     return !!x_2;

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParamsBindingPattern.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParamsBindingPattern.js
@@ -11,8 +11,7 @@ async function f() {
     try {
         await Promise.resolve();
         result = ({ x: 3 });
-    }
-    catch (e) {
+    } catch (e) {
         result = ({ x: "a" });
     }
     const { x } = result;

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParamsBindingPattern.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParamsBindingPattern.ts
@@ -11,8 +11,7 @@ async function f() {
     try {
         await Promise.resolve();
         result = ({ x: 3 });
-    }
-    catch (e) {
+    } catch (e) {
         result = ({ x: "a" });
     }
     const { x } = result;

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchTypeArgument1.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchTypeArgument1.ts
@@ -16,8 +16,7 @@ async function get() {
     try {
         return Promise
             .resolve<APIResponse<{ email: string; }>>({ success: true, data: { email: "" } });
-    }
-    catch (e) {
+    } catch (e) {
         const result: APIResponse<{ email: string; }> = ({ success: false });
         return result;
     }

--- a/tests/cases/fourslash/convertToEs6Class_emptyCatchClause.ts
+++ b/tests/cases/fourslash/convertToEs6Class_emptyCatchClause.ts
@@ -13,8 +13,7 @@ verify.codeFix({
 `class MyClass {
     constructor() { }
     foo() {
-        try { }
-        catch () { }
+        try { } catch () { }
     }
 }
 `,

--- a/tests/cases/fourslash/textChangesPreserveNewlines9.ts
+++ b/tests/cases/fourslash/textChangesPreserveNewlines9.ts
@@ -1,0 +1,57 @@
+/// <reference path="fourslash.ts" />
+
+////function foo() {
+////    /*1*/if (true) {
+////        console.log(1);
+////    } else {
+////        console.log(1);
+////    }
+////
+////    do {
+////        console.log(1);
+////    }
+////
+////    while (true);
+////
+////    try {
+////        console.log(1);
+////    } catch {
+////        void 0;
+////    } finally {
+////        void 0;
+////    }/*2*/
+////}
+
+goTo.select("1", "2");
+edit.applyRefactor({
+  refactorName: "Extract Symbol",
+  actionName: "function_scope_1",
+  actionDescription: "Extract to function in global scope",
+  newContent:
+`function foo() {
+    /*RENAME*/newFunction();
+}
+
+function newFunction() {
+    if (true) {
+        console.log(1);
+    } else {
+        console.log(1);
+    }
+
+    do {
+        console.log(1);
+    }
+
+    while (true);
+
+    try {
+        console.log(1);
+    } catch {
+        void 0;
+    } finally {
+        void 0;
+    }
+}
+`
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #38017 
