### PR TITLE
fix(39047): Default formatter cant format JS Optional catch binding properly

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -348,8 +348,8 @@ namespace ts.formatting {
                 anyToken,
                 [isNonJsxSameLineTokenContext, isNonJsxElementOrFragmentContext, isNotForContext],
                 RuleAction.InsertSpace),
-            // This low-pri rule takes care of "try {" and "finally {" in case the rule SpaceBeforeOpenBraceInControl didn't execute on FormatOnEnter.
-            rule("SpaceAfterTryFinally", [SyntaxKind.TryKeyword, SyntaxKind.FinallyKeyword], SyntaxKind.OpenBraceToken, [isNonJsxSameLineTokenContext], RuleAction.InsertSpace),
+            // This low-pri rule takes care of "try {", "catch {" and "finally {" in case the rule SpaceBeforeOpenBraceInControl didn't execute on FormatOnEnter.
+            rule("SpaceAfterTryCatchFinally", [SyntaxKind.TryKeyword, SyntaxKind.CatchKeyword, SyntaxKind.FinallyKeyword], SyntaxKind.OpenBraceToken, [isNonJsxSameLineTokenContext], RuleAction.InsertSpace),
         ];
 
         return [

--- a/tests/cases/fourslash/formatCatch.ts
+++ b/tests/cases/fourslash/formatCatch.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts"/>
+
+////try {
+////} /*0*/catch        {
+////}
+////
+////try {
+////} /*1*/catch{
+////}
+
+format.document();
+
+for (const marker of test.markers()) {
+    goTo.marker(marker);
+    verify.currentLineContentIs("} catch {");
+}


### PR DESCRIPTION
Fixes #39047