### PR TITLE
Fix type of computed name following spread

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23824,10 +23824,15 @@ namespace ts {
             return links.resolvedType;
         }
 
+        function isSymbolWithNumericName(symbol: Symbol) {
+            const firstDecl = symbol.declarations?.[0];
+            return isNumericLiteralName(symbol.escapedName) || (firstDecl && isNamedDeclaration(firstDecl) && isNumericName(firstDecl.name));
+        }
+
         function getObjectLiteralIndexInfo(node: ObjectLiteralExpression, offset: number, properties: Symbol[], kind: IndexKind): IndexInfo {
             const propTypes: Type[] = [];
             for (let i = offset; i < properties.length; i++) {
-                if (kind === IndexKind.String || isNumericName(node.properties[i].name!)) {
+                if (kind === IndexKind.String || isSymbolWithNumericName(properties[i])) {
                     propTypes.push(getTypeOfSymbol(properties[i]));
                 }
             }
@@ -23880,8 +23885,7 @@ namespace ts {
             }
 
             let offset = 0;
-            for (let i = 0; i < node.properties.length; i++) {
-                const memberDecl = node.properties[i];
+            for (const memberDecl of node.properties) {
                 let member = getSymbolOfNode(memberDecl);
                 const computedNameType = memberDecl.name && memberDecl.name.kind === SyntaxKind.ComputedPropertyName && !isWellKnownSymbolSyntactically(memberDecl.name.expression) ?
                     checkComputedPropertyName(memberDecl.name) : undefined;
@@ -23965,7 +23969,7 @@ namespace ts {
                         checkSpreadPropOverrides(type, allPropertiesTable, memberDecl);
                     }
                     spread = getSpreadType(spread, type, node.symbol, objectFlags, inConstContext);
-                    offset = i + 1;
+                    offset = propertiesArray.length;
                     continue;
                 }
                 else {

--- a/tests/baselines/reference/spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.js
+++ b/tests/baselines/reference/spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.js
@@ -1,0 +1,19 @@
+//// [spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts]
+declare const m: { [k: string]: string };
+const x: { [k: string]: string } = { ...m, ["a" + "b"]: "" };
+
+//// [spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.js]
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var _a;
+var x = __assign(__assign({}, m), (_a = {}, _a["a" + "b"] = "", _a));

--- a/tests/baselines/reference/spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.symbols
+++ b/tests/baselines/reference/spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.symbols
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts ===
+declare const m: { [k: string]: string };
+>m : Symbol(m, Decl(spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts, 0, 13))
+>k : Symbol(k, Decl(spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts, 0, 20))
+
+const x: { [k: string]: string } = { ...m, ["a" + "b"]: "" };
+>x : Symbol(x, Decl(spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts, 1, 5))
+>k : Symbol(k, Decl(spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts, 1, 12))
+>m : Symbol(m, Decl(spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts, 0, 13))
+>["a" + "b"] : Symbol(["a" + "b"], Decl(spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts, 1, 42))
+

--- a/tests/baselines/reference/spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.types
+++ b/tests/baselines/reference/spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts ===
+declare const m: { [k: string]: string };
+>m : { [k: string]: string; }
+>k : string
+
+const x: { [k: string]: string } = { ...m, ["a" + "b"]: "" };
+>x : { [k: string]: string; }
+>k : string
+>{ ...m, ["a" + "b"]: "" } : { [x: string]: string; }
+>m : { [k: string]: string; }
+>["a" + "b"] : string
+>"a" + "b" : string
+>"a" : "a"
+>"b" : "b"
+>"" : ""
+

--- a/tests/cases/compiler/spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts
+++ b/tests/cases/compiler/spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts
@@ -1,0 +1,3 @@
+// @strict: true
+declare const m: { [k: string]: string };
+const x: { [k: string]: string } = { ...m, ["a" + "b"]: "" };


### PR DESCRIPTION
Fixes #39278

We weren't checking the right set of property names - because of how a spread works, after a spread, there's a complete disjoint between the properties symbol array and the properties on the expression node - we tried to capture that with with an `offset` variable so we could still use the nodes we already have to look up symbol names, but while that sometimes worked when a spread added props (depending on which past state we're talking about), it didn't handle cases where a spread added _zero_ properties. In any case, to fix this, I stop trying to associate the expression property list with the symbol property list (which has been error prone), and lookup names from the symbols, and, additionally, mark what slice of the _property symbol_ array we need to be looking at (before #39083, the offset variable was trying to specify a slice of the node array list, but that didn't handle spreads well when it was matched back up to the symbol list).

Context PRs: #12248 and more recently #39083