### PR TITLE
Emit fallback for decorator metadata for type only imports

### DIFF
--- a/tests/baselines/reference/decoratorMetadataWithTypeOnlyImport.js
+++ b/tests/baselines/reference/decoratorMetadataWithTypeOnlyImport.js
@@ -1,0 +1,60 @@
+//// [tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport.ts] ////
+
+//// [service.ts]
+export class Service {
+}
+//// [component.ts]
+import type { Service } from "./service";
+
+declare var decorator: any;
+
+@decorator
+class MyComponent {
+    constructor(public Service: Service) {
+    }
+
+    @decorator
+    method(x: this) {
+    }
+}
+
+//// [service.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Service = void 0;
+var Service = /** @class */ (function () {
+    function Service() {
+    }
+    return Service;
+}());
+exports.Service = Service;
+//// [component.js]
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var MyComponent = /** @class */ (function () {
+    function MyComponent(Service) {
+        this.Service = Service;
+    }
+    MyComponent.prototype.method = function (x) {
+    };
+    __decorate([
+        decorator,
+        __metadata("design:type", Function),
+        __metadata("design:paramtypes", [Object]),
+        __metadata("design:returntype", void 0)
+    ], MyComponent.prototype, "method", null);
+    MyComponent = __decorate([
+        decorator,
+        __metadata("design:paramtypes", [Function])
+    ], MyComponent);
+    return MyComponent;
+}());

--- a/tests/baselines/reference/decoratorMetadataWithTypeOnlyImport.symbols
+++ b/tests/baselines/reference/decoratorMetadataWithTypeOnlyImport.symbols
@@ -1,0 +1,30 @@
+=== tests/cases/conformance/decorators/service.ts ===
+export class Service {
+>Service : Symbol(Service, Decl(service.ts, 0, 0))
+}
+=== tests/cases/conformance/decorators/component.ts ===
+import type { Service } from "./service";
+>Service : Symbol(Service, Decl(component.ts, 0, 13))
+
+declare var decorator: any;
+>decorator : Symbol(decorator, Decl(component.ts, 2, 11))
+
+@decorator
+>decorator : Symbol(decorator, Decl(component.ts, 2, 11))
+
+class MyComponent {
+>MyComponent : Symbol(MyComponent, Decl(component.ts, 2, 27))
+
+    constructor(public Service: Service) {
+>Service : Symbol(MyComponent.Service, Decl(component.ts, 6, 16))
+>Service : Symbol(Service, Decl(component.ts, 0, 13))
+    }
+
+    @decorator
+>decorator : Symbol(decorator, Decl(component.ts, 2, 11))
+
+    method(x: this) {
+>method : Symbol(MyComponent.method, Decl(component.ts, 7, 5))
+>x : Symbol(x, Decl(component.ts, 10, 11))
+    }
+}

--- a/tests/baselines/reference/decoratorMetadataWithTypeOnlyImport.types
+++ b/tests/baselines/reference/decoratorMetadataWithTypeOnlyImport.types
@@ -1,0 +1,29 @@
+=== tests/cases/conformance/decorators/service.ts ===
+export class Service {
+>Service : Service
+}
+=== tests/cases/conformance/decorators/component.ts ===
+import type { Service } from "./service";
+>Service : Service
+
+declare var decorator: any;
+>decorator : any
+
+@decorator
+>decorator : any
+
+class MyComponent {
+>MyComponent : MyComponent
+
+    constructor(public Service: Service) {
+>Service : Service
+    }
+
+    @decorator
+>decorator : any
+
+    method(x: this) {
+>method : (x: this) => void
+>x : this
+    }
+}

--- a/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport.ts
+++ b/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport.ts
@@ -1,0 +1,21 @@
+// @experimentalDecorators: true
+// @emitDecoratorMetadata: true
+// @target: es5
+// @module: commonjs
+// @filename: service.ts
+export class Service {
+}
+// @filename: component.ts
+import type { Service } from "./service";
+
+declare var decorator: any;
+
+@decorator
+class MyComponent {
+    constructor(public Service: Service) {
+    }
+
+    @decorator
+    method(x: this) {
+    }
+}


### PR DESCRIPTION
This fixes our emit for decorator metadata when the referenced type comes from a type-only import.

Fixes #37672
