### PR TITLE
Fix crash on completion in jsdoc namepath

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1464,7 +1464,7 @@ namespace ts.Completions {
         function filterGlobalCompletion(symbols: Symbol[]): void {
             const isTypeOnly = isTypeOnlyCompletion();
             if (isTypeOnly) {
-                keywordFilters = isTypeAssertion()
+                keywordFilters = contextToken && isAssertionExpression(contextToken.parent)
                     ? KeywordCompletionFilters.TypeAssertionKeywords
                     : KeywordCompletionFilters.TypeKeywords;
             }
@@ -1492,10 +1492,6 @@ namespace ts.Completions {
                 // expressions are value space (which includes the value namespaces)
                 return !!(getCombinedLocalAndExportSymbolFlags(symbol) & SymbolFlags.Value);
             });
-        }
-
-        function isTypeAssertion(): boolean {
-            return isAssertionExpression(contextToken.parent);
         }
 
         function isTypeOnlyCompletion(): boolean {

--- a/tests/cases/fourslash/completionJSDocNamePath.ts
+++ b/tests/cases/fourslash/completionJSDocNamePath.ts
@@ -1,0 +1,15 @@
+// @noLib: true
+
+/// <reference path='fourslash.ts'/>
+
+// fix crash from #38407
+
+//// /**
+////  * @returns {modu/*1*/le:ControlFlow}
+////  */
+//// export function cargo() {
+//// }
+
+goTo.marker('1');
+verify.completions({ marker: "1", excludes: ["module", "ControlFlow"] });
+


### PR DESCRIPTION
In completions.ts, contextToken may be undefined, so the isAssertionExpression call in filterGlobalCompletion needs to check for undefined.

Fixes #38407