### PR TITLE
JSDoc uses same newlines as normal scanner

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -2352,8 +2352,12 @@ namespace ts {
                     return token = SyntaxKind.WhitespaceTrivia;
                 case CharacterCodes.at:
                     return token = SyntaxKind.AtToken;
-                case CharacterCodes.lineFeed:
                 case CharacterCodes.carriageReturn:
+                    if (text.charCodeAt(pos) === CharacterCodes.lineFeed) {
+                        pos++;
+                    }
+                    // falls through
+                case CharacterCodes.lineFeed:
                     tokenFlags |= TokenFlags.PrecedingLineBreak;
                     return token = SyntaxKind.NewLineTrivia;
                 case CharacterCodes.asterisk:

--- a/src/testRunner/unittests/publicApi.ts
+++ b/src/testRunner/unittests/publicApi.ts
@@ -53,6 +53,24 @@ describe("unittests:: Public APIs:: createPrivateIdentifier", () => {
     });
 });
 
+describe("unittests:: Public APIs:: JSDoc newlines", () => {
+    it("are preserved verbatim", () => {
+        const testFilePath = "/file.ts";
+        const testFileText = `
+/**
+* @example
+* Some\n * text\r\n * with newlines.
+*/
+function test() {}`;
+
+        const testSourceFile = ts.createSourceFile(testFilePath, testFileText, ts.ScriptTarget.Latest, true);
+        const funcDec = testSourceFile.statements.find(ts.isFunctionDeclaration)!;
+        const tags = ts.getJSDocTags(funcDec);
+        assert.isDefined(tags[0].comment);
+        assert.equal(tags[0].comment, "Some\n text\r\n with newlines.");
+    });
+});
+
 describe("unittests:: Public APIs:: isPropertyName", () => {
     it("checks if a PrivateIdentifier is a valid property name", () => {
         const prop = ts.factory.createPrivateIdentifier("#foo");

--- a/src/testRunner/unittests/publicApi.ts
+++ b/src/testRunner/unittests/publicApi.ts
@@ -63,7 +63,7 @@ describe("unittests:: Public APIs:: JSDoc newlines", () => {
 */
 function test() {}`;
 
-        const testSourceFile = ts.createSourceFile(testFilePath, testFileText, ts.ScriptTarget.Latest, true);
+        const testSourceFile = ts.createSourceFile(testFilePath, testFileText, ts.ScriptTarget.Latest, /*setParentNodes*/ true);
         const funcDec = testSourceFile.statements.find(ts.isFunctionDeclaration)!;
         const tags = ts.getJSDocTags(funcDec);
         assert.isDefined(tags[0].comment);


### PR DESCRIPTION
Previously, scanJsDocToken treated each newline character separately, so the sequence `\r\n` would be treated as two lines. This is unexpected, and not the way the normal scanner does it.

This change makes the jsdoc scanner behave the same as the normal scanner.

Fixes #35511