### PR TITLE
Update launch.template.json for new node debugger

### DIFF
--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -19,8 +19,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "node",
-      "protocol": "inspector",
+      "type": "pwa-node",
       "request": "launch",
       "name": "Mocha Tests (currently opened test)",
       "runtimeArgs": ["--nolazy"],
@@ -51,7 +50,7 @@
     },
     {
       // See: https://github.com/microsoft/TypeScript/wiki/Debugging-Language-Service-in-VS-Code
-      "type": "node",
+      "type": "pwa-node",
       "request": "attach",
       "name": "Attach to VS Code TS Server via Port",
       "processId": "${command:PickProcess}"


### PR DESCRIPTION
Without this, the new debugger won’t respect the “Auto-expand getters” setting, which makes debugging the TS codebase a huge pain: https://github.com/microsoft/vscode-js-debug/issues/447#issuecomment-639619286