### PR TITLE
Fix for relating covered discriminants in unions

### DIFF
--- a/tests/baselines/reference/assignmentCompatWithDiscriminatedUnion.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithDiscriminatedUnion.errors.txt
@@ -222,3 +222,12 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
             };
         }
     }
+    
+    // https://github.com/microsoft/TypeScript/issues/39357
+    namespace GH39357 {
+        type A = ["a", number] | ["b", number] | ["c", string];
+        type B = "a" | "b" | "c";
+        declare const b: B;
+        const a: A = b === "a" || b === "b" ? [b, 1] : ["c", ""];
+    }
+    

--- a/tests/baselines/reference/assignmentCompatWithDiscriminatedUnion.js
+++ b/tests/baselines/reference/assignmentCompatWithDiscriminatedUnion.js
@@ -193,6 +193,15 @@ namespace GH20889 {
     }
 }
 
+// https://github.com/microsoft/TypeScript/issues/39357
+namespace GH39357 {
+    type A = ["a", number] | ["b", number] | ["c", string];
+    type B = "a" | "b" | "c";
+    declare const b: B;
+    const a: A = b === "a" || b === "b" ? [b, 1] : ["c", ""];
+}
+
+
 //// [assignmentCompatWithDiscriminatedUnion.js]
 // see 'typeRelatedToDiscriminatedType' in checker.ts:
 // IteratorResult
@@ -289,3 +298,8 @@ var GH20889;
         };
     }
 })(GH20889 || (GH20889 = {}));
+// https://github.com/microsoft/TypeScript/issues/39357
+var GH39357;
+(function (GH39357) {
+    var a = b === "a" || b === "b" ? [b, 1] : ["c", ""];
+})(GH39357 || (GH39357 = {}));

--- a/tests/baselines/reference/assignmentCompatWithDiscriminatedUnion.symbols
+++ b/tests/baselines/reference/assignmentCompatWithDiscriminatedUnion.symbols
@@ -492,3 +492,26 @@ namespace GH20889 {
         };
     }
 }
+
+// https://github.com/microsoft/TypeScript/issues/39357
+namespace GH39357 {
+>GH39357 : Symbol(GH39357, Decl(assignmentCompatWithDiscriminatedUnion.ts, 192, 1))
+
+    type A = ["a", number] | ["b", number] | ["c", string];
+>A : Symbol(A, Decl(assignmentCompatWithDiscriminatedUnion.ts, 195, 19))
+
+    type B = "a" | "b" | "c";
+>B : Symbol(B, Decl(assignmentCompatWithDiscriminatedUnion.ts, 196, 59))
+
+    declare const b: B;
+>b : Symbol(b, Decl(assignmentCompatWithDiscriminatedUnion.ts, 198, 17))
+>B : Symbol(B, Decl(assignmentCompatWithDiscriminatedUnion.ts, 196, 59))
+
+    const a: A = b === "a" || b === "b" ? [b, 1] : ["c", ""];
+>a : Symbol(a, Decl(assignmentCompatWithDiscriminatedUnion.ts, 199, 9))
+>A : Symbol(A, Decl(assignmentCompatWithDiscriminatedUnion.ts, 195, 19))
+>b : Symbol(b, Decl(assignmentCompatWithDiscriminatedUnion.ts, 198, 17))
+>b : Symbol(b, Decl(assignmentCompatWithDiscriminatedUnion.ts, 198, 17))
+>b : Symbol(b, Decl(assignmentCompatWithDiscriminatedUnion.ts, 198, 17))
+}
+

--- a/tests/baselines/reference/assignmentCompatWithDiscriminatedUnion.types
+++ b/tests/baselines/reference/assignmentCompatWithDiscriminatedUnion.types
@@ -464,3 +464,35 @@ namespace GH20889 {
         };
     }
 }
+
+// https://github.com/microsoft/TypeScript/issues/39357
+namespace GH39357 {
+>GH39357 : typeof GH39357
+
+    type A = ["a", number] | ["b", number] | ["c", string];
+>A : A
+
+    type B = "a" | "b" | "c";
+>B : "a" | "b" | "c"
+
+    declare const b: B;
+>b : "a" | "b" | "c"
+
+    const a: A = b === "a" || b === "b" ? [b, 1] : ["c", ""];
+>a : A
+>b === "a" || b === "b" ? [b, 1] : ["c", ""] : ["a" | "b", number] | ["c", string]
+>b === "a" || b === "b" : boolean
+>b === "a" : boolean
+>b : "a" | "b" | "c"
+>"a" : "a"
+>b === "b" : boolean
+>b : "b" | "c"
+>"b" : "b"
+>[b, 1] : ["a" | "b", number]
+>b : "a" | "b"
+>1 : 1
+>["c", ""] : ["c", string]
+>"c" : "c"
+>"" : ""
+}
+

--- a/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithDiscriminatedUnion.ts
+++ b/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithDiscriminatedUnion.ts
@@ -191,3 +191,11 @@ namespace GH20889 {
         };
     }
 }
+
+// https://github.com/microsoft/TypeScript/issues/39357
+namespace GH39357 {
+    type A = ["a", number] | ["b", number] | ["c", string];
+    type B = "a" | "b" | "c";
+    declare const b: B;
+    const a: A = b === "a" || b === "b" ? [b, 1] : ["c", ""];
+}


### PR DESCRIPTION
In #30779 we added the ability to relate a source type to a target when the target is a discriminated union and the source is covered by the target. This did not work when the target was a union of tuple types as the relationship check would fail when comparing the synthesized index types for each tuple in `indexTypesRelatedTo`. This was further complicated by the fact that the new variadic tuple type logic added to `propertiesRelatedTo` fails to exclude relationship checks for non-variable elements whose indices are included in the `excludedProperties` map.

This PR does two things to address these issues:
- Adds discriminant exclusion into the tuple-specific branch in `propertiesRelatedTo` so that it aligns with the existing, non-tuple-specific logic.
- Skips the `indexTypesRelatedTo` check when both the source type and the target type are tuples, as the index type check should be sufficiently covered by the tuple-specific branch in `propertiesRelatedTo`. 

Alternatively, rather than skipping the `indexTypesRelatedTo` check, we could synthesize a copy of the source and target tuple types with the excluded discriminants erased to `never` so that they are excluded from the index type. That would result in the allocation of types purely to accommodate `indexTypesRelatedTo`, which would then be subsequently discarded. This seems like an unnecessary cost, as `propertiesRelatedTo` sufficiently covers the numeric index type case.

Fixes #39357
