### PR TITLE
Insert auto-imports in sorted order

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -819,6 +819,18 @@ namespace ts {
         return deduplicateSorted(sort(array, comparer), equalityComparer || comparer || compareStringsCaseSensitive as any as Comparer<T>);
     }
 
+    export function arrayIsSorted<T>(array: readonly T[], comparer: Comparer<T>) {
+        if (array.length < 2) return true;
+        let prevElement = array[0];
+        for (const element of array.slice(1)) {
+            if (comparer(prevElement, element) === Comparison.GreaterThan) {
+                return false;
+            }
+            prevElement = element;
+        }
+        return true;
+    }
+
     export function arrayIsEqualTo<T>(array1: readonly T[] | undefined, array2: readonly T[] | undefined, equalityComparer: (a: T, b: T, index: number) => boolean = equateValues): boolean {
         if (!array1 || !array2) {
             return array1 === array2;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4336,6 +4336,9 @@ namespace ts {
     /* @internal */
     export type AnyImportOrRequire = AnyImportSyntax | RequireVariableDeclaration;
 
+    /* @internal */
+    export type AnyImportOrRequireStatement = AnyImportSyntax | RequireVariableStatement;
+
 
     /* @internal */
     export type AnyImportOrReExport = AnyImportSyntax | ExportDeclaration;
@@ -4357,8 +4360,17 @@ namespace ts {
 
     /* @internal */
     export interface RequireVariableDeclaration extends VariableDeclaration {
+        readonly initializer: RequireOrImportCall;
+    }
 
-        initializer: RequireOrImportCall;
+    /* @internal */
+    export interface RequireVariableStatement extends VariableStatement {
+        readonly declarationList: RequireVariableDeclarationList;
+    }
+
+    /* @internal */
+    export interface RequireVariableDeclarationList extends VariableDeclarationList {
+        readonly declarations: NodeArray<RequireVariableDeclaration>;
     }
 
     /* @internal */

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1934,8 +1934,10 @@ namespace ts {
         return isVariableDeclaration(node) && !!node.initializer && isRequireCall(node.initializer, requireStringLiteralLikeArgument);
     }
 
-    export function isRequireVariableDeclarationStatement(node: Node, requireStringLiteralLikeArgument = true): node is VariableStatement {
-        return isVariableStatement(node) && every(node.declarationList.declarations, decl => isRequireVariableDeclaration(decl, requireStringLiteralLikeArgument));
+    export function isRequireVariableStatement(node: Node, requireStringLiteralLikeArgument = true): node is RequireVariableStatement {
+        return isVariableStatement(node)
+            && node.declarationList.declarations.length > 0
+            && every(node.declarationList.declarations, decl => isRequireVariableDeclaration(decl, requireStringLiteralLikeArgument));
     }
 
     export function isSingleOrDoubleQuote(charCode: number) {

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -138,7 +138,7 @@ namespace ts.codefix {
                 doAddExistingFix(changeTracker, sourceFile, importClauseOrBindingPattern, defaultImport, namedImports, canUseTypeOnlyImport);
             });
 
-            let newDeclarations: Statement | readonly Statement[] | undefined;
+            let newDeclarations: AnyImportOrRequireStatement | readonly AnyImportOrRequireStatement[] | undefined;
             newImports.forEach(({ useRequire, ...imports }, moduleSpecifier) => {
                 const getDeclarations = useRequire ? getNewRequires : getNewImports;
                 newDeclarations = combine(newDeclarations, getDeclarations(moduleSpecifier, quotePreference, imports));
@@ -671,15 +671,30 @@ namespace ts.codefix {
         }
 
         if (namedImports.length) {
-            const specifiers = namedImports.map(name => factory.createImportSpecifier(/*propertyName*/ undefined, factory.createIdentifier(name)));
-            if (clause.namedBindings && cast(clause.namedBindings, isNamedImports).elements.length) {
-                for (const spec of specifiers) {
-                    changes.insertNodeInListAfter(sourceFile, last(cast(clause.namedBindings, isNamedImports).elements), spec);
+            const existingSpecifiers = clause.namedBindings && cast(clause.namedBindings, isNamedImports).elements;
+            const newSpecifiers = stableSort(
+                namedImports.map(name => factory.createImportSpecifier(/*propertyName*/ undefined, factory.createIdentifier(name))),
+                OrganizeImports.compareImportOrExportSpecifiers);
+
+            if (existingSpecifiers?.length) {
+                for (const spec of newSpecifiers) {
+                    const insertionIndex = OrganizeImports.getImportSpecifierInsertionIndex(existingSpecifiers, spec);
+                    const prevSpecifier = (clause.namedBindings as NamedImports).elements[insertionIndex - 1];
+                    if (prevSpecifier) {
+                        changes.insertNodeInListAfter(sourceFile, prevSpecifier, spec);
+                    }
+                    else {
+                        changes.insertNodeBefore(
+                            sourceFile,
+                            existingSpecifiers[0],
+                            spec,
+                            !positionsAreOnSameLine(existingSpecifiers[0].getStart(), clause.parent.getStart(), sourceFile));
+                    }
                 }
             }
             else {
-                if (specifiers.length) {
-                    const namedImports = factory.createNamedImports(specifiers);
+                if (newSpecifiers.length) {
+                    const namedImports = factory.createNamedImports(newSpecifiers);
                     if (clause.namedBindings) {
                         changes.replaceNode(sourceFile, clause.namedBindings, namedImports);
                     }
@@ -727,9 +742,9 @@ namespace ts.codefix {
             readonly name: string;
         };
     }
-    function getNewImports(moduleSpecifier: string, quotePreference: QuotePreference, imports: ImportsCollection): Statement | readonly Statement[] {
+    function getNewImports(moduleSpecifier: string, quotePreference: QuotePreference, imports: ImportsCollection): AnyImportSyntax | readonly AnyImportSyntax[] {
         const quotedModuleSpecifier = makeStringLiteral(moduleSpecifier, quotePreference);
-        let statements: Statement | readonly Statement[] | undefined;
+        let statements: AnyImportSyntax | readonly AnyImportSyntax[] | undefined;
         if (imports.defaultImport !== undefined || imports.namedImports?.length) {
             statements = combine(statements, makeImport(
                 imports.defaultImport === undefined ? undefined : factory.createIdentifier(imports.defaultImport),
@@ -756,9 +771,9 @@ namespace ts.codefix {
         return Debug.checkDefined(statements);
     }
 
-    function getNewRequires(moduleSpecifier: string, quotePreference: QuotePreference, imports: ImportsCollection): Statement | readonly Statement[] {
+    function getNewRequires(moduleSpecifier: string, quotePreference: QuotePreference, imports: ImportsCollection): RequireVariableStatement | readonly RequireVariableStatement[] {
         const quotedModuleSpecifier = makeStringLiteral(moduleSpecifier, quotePreference);
-        let statements: Statement | readonly Statement[] | undefined;
+        let statements: RequireVariableStatement | readonly RequireVariableStatement[] | undefined;
         // const { default: foo, bar, etc } = require('./mod');
         if (imports.defaultImport || imports.namedImports?.length) {
             const bindingElements = imports.namedImports?.map(name => factory.createBindingElement(/*dotDotDotToken*/ undefined, /*propertyName*/ undefined, name)) || [];
@@ -776,7 +791,7 @@ namespace ts.codefix {
         return Debug.checkDefined(statements);
     }
 
-    function createConstEqualsRequireDeclaration(name: string | ObjectBindingPattern, quotedModuleSpecifier: StringLiteral): VariableStatement {
+    function createConstEqualsRequireDeclaration(name: string | ObjectBindingPattern, quotedModuleSpecifier: StringLiteral): RequireVariableStatement {
         return factory.createVariableStatement(
             /*modifiers*/ undefined,
             factory.createVariableDeclarationList([
@@ -785,7 +800,7 @@ namespace ts.codefix {
                     /*exclamationToken*/ undefined,
                     /*type*/ undefined,
                     factory.createCallExpression(factory.createIdentifier("require"), /*typeArguments*/ undefined, [quotedModuleSpecifier]))],
-                NodeFlags.Const));
+                NodeFlags.Const)) as RequireVariableStatement;
     }
 
     function symbolHasMeaning({ declarations }: Symbol, meaning: SemanticMeaning): boolean {

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -676,7 +676,7 @@ namespace ts.codefix {
                 namedImports.map(name => factory.createImportSpecifier(/*propertyName*/ undefined, factory.createIdentifier(name))),
                 OrganizeImports.compareImportOrExportSpecifiers);
 
-            if (existingSpecifiers?.length) {
+            if (existingSpecifiers?.length && OrganizeImports.importSpecifiersAreSorted(existingSpecifiers)) {
                 for (const spec of newSpecifiers) {
                     const insertionIndex = OrganizeImports.getImportSpecifierInsertionIndex(existingSpecifiers, spec);
                     const prevSpecifier = (clause.namedBindings as NamedImports).elements[insertionIndex - 1];
@@ -690,6 +690,11 @@ namespace ts.codefix {
                             spec,
                             !positionsAreOnSameLine(existingSpecifiers[0].getStart(), clause.parent.getStart(), sourceFile));
                     }
+                }
+            }
+            else if (existingSpecifiers?.length) {
+                for (const spec of newSpecifiers) {
+                    changes.insertNodeAtEndOfList(sourceFile, existingSpecifiers, spec);
                 }
             }
             else {

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -429,23 +429,21 @@ namespace ts.OrganizeImports {
         }
     }
 
-    export function importsAreSorted(imports: readonly AnyImportOrRequireStatement[]) {
+    export function importsAreSorted(imports: readonly AnyImportOrRequireStatement[]): imports is SortedReadonlyArray<AnyImportOrRequireStatement> {
         return arrayIsSorted(imports, compareImportsOrRequireStatements);
     }
 
-    export function importSpecifiersAreSorted(imports: readonly ImportSpecifier[]) {
+    export function importSpecifiersAreSorted(imports: readonly ImportSpecifier[]): imports is SortedReadonlyArray<ImportSpecifier> {
         return arrayIsSorted(imports, compareImportOrExportSpecifiers);
     }
 
-    export function getImportDeclarationInsertionIndex(imports: readonly AnyImportOrRequireStatement[], newImport: AnyImportOrRequireStatement) {
-        if (!importsAreSorted(imports)) return imports.length;
-        const index = binarySearch(imports, newImport, identity, compareImportsOrRequireStatements);
+    export function getImportDeclarationInsertionIndex(sortedImports: SortedReadonlyArray<AnyImportOrRequireStatement>, newImport: AnyImportOrRequireStatement) {
+        const index = binarySearch(sortedImports, newImport, identity, compareImportsOrRequireStatements);
         return index < 0 ? ~index : index;
     }
 
-    export function getImportSpecifierInsertionIndex(imports: readonly ImportSpecifier[], newImport: ImportSpecifier) {
-        if (!importSpecifiersAreSorted(imports)) return imports.length;
-        const index = binarySearch(imports, newImport, identity, compareImportOrExportSpecifiers);
+    export function getImportSpecifierInsertionIndex(sortedImports: SortedReadonlyArray<ImportSpecifier>, newImport: ImportSpecifier) {
+        const index = binarySearch(sortedImports, newImport, identity, compareImportOrExportSpecifiers);
         return index < 0 ? ~index : index;
     }
 

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -455,6 +455,13 @@ namespace ts.OrganizeImports {
         return compareValues(getImportKindOrder(s1), getImportKindOrder(s2));
     }
 
+    // 1. Side-effect imports
+    // 2. Type-only imports
+    // 3. Namespace imports
+    // 4. Default imports
+    // 5. Named imports
+    // 6. ImportEqualsDeclarations
+    // 7. Require variable statements
     function getImportKindOrder(s1: AnyImportOrRequireStatement) {
         switch (s1.kind) {
             case SyntaxKind.ImportDeclaration:

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -17,7 +17,9 @@ namespace ts.OrganizeImports {
 
         const changeTracker = textChanges.ChangeTracker.fromContext({ host, formatContext, preferences });
 
-        const coalesceAndOrganizeImports = (importGroup: readonly ImportDeclaration[]) => coalesceImports(removeUnusedImports(importGroup, sourceFile, program));
+        const coalesceAndOrganizeImports = (importGroup: readonly ImportDeclaration[]) => stableSort(
+            coalesceImports(removeUnusedImports(importGroup, sourceFile, program)),
+            (s1, s2) => compareImportsOrRequireStatements(s1, s2));
 
         // All of the old ImportDeclarations in the file, in syntactic order.
         const topLevelImportDecls = sourceFile.statements.filter(isImportDeclaration);
@@ -55,7 +57,7 @@ namespace ts.OrganizeImports {
             suppressLeadingTrivia(oldImportDecls[0]);
 
             const oldImportGroups = group(oldImportDecls, importDecl => getExternalModuleName(importDecl.moduleSpecifier!)!);
-            const sortedImportGroups = stableSort(oldImportGroups, (group1, group2) => compareModuleSpecifiers(group1[0].moduleSpecifier!, group2[0].moduleSpecifier!));
+            const sortedImportGroups = stableSort(oldImportGroups, (group1, group2) => compareModuleSpecifiers(group1[0].moduleSpecifier, group2[0].moduleSpecifier));
             const newImportDecls = flatMap(sortedImportGroups, importGroup =>
                 getExternalModuleName(importGroup[0].moduleSpecifier!)
                     ? coalesce(importGroup)
@@ -395,15 +397,18 @@ namespace ts.OrganizeImports {
     }
 
     function sortSpecifiers<T extends ImportOrExportSpecifier>(specifiers: readonly T[]) {
-        return stableSort(specifiers, (s1, s2) =>
-            compareIdentifiers(s1.propertyName || s1.name, s2.propertyName || s2.name) ||
-            compareIdentifiers(s1.name, s2.name));
+        return stableSort(specifiers, compareImportOrExportSpecifiers);
+    }
+
+    export function compareImportOrExportSpecifiers<T extends ImportOrExportSpecifier>(s1: T, s2: T) {
+        return compareIdentifiers(s1.propertyName || s1.name, s2.propertyName || s2.name)
+            || compareIdentifiers(s1.name, s2.name);
     }
 
     /* internal */ // Exported for testing
-    export function compareModuleSpecifiers(m1: Expression, m2: Expression) {
-        const name1 = getExternalModuleName(m1);
-        const name2 = getExternalModuleName(m2);
+    export function compareModuleSpecifiers(m1: Expression | undefined, m2: Expression | undefined) {
+        const name1 = m1 === undefined ? undefined : getExternalModuleName(m1);
+        const name2 = m2 === undefined ? undefined : getExternalModuleName(m2);
         return compareBooleans(name1 === undefined, name2 === undefined) ||
             compareBooleans(isExternalModuleNameRelative(name1!), isExternalModuleNameRelative(name2!)) ||
             compareStringsCaseInsensitive(name1!, name2!);
@@ -411,5 +416,59 @@ namespace ts.OrganizeImports {
 
     function compareIdentifiers(s1: Identifier, s2: Identifier) {
         return compareStringsCaseInsensitive(s1.text, s2.text);
+    }
+
+    function getModuleSpecifierExpression(declaration: AnyImportOrRequireStatement): Expression | undefined {
+        switch (declaration.kind) {
+            case SyntaxKind.ImportEqualsDeclaration:
+                return tryCast(declaration.moduleReference, isExternalModuleReference)?.expression;
+            case SyntaxKind.ImportDeclaration:
+                return declaration.moduleSpecifier;
+            case SyntaxKind.VariableStatement:
+                return declaration.declarationList.declarations[0].initializer.arguments[0];
+        }
+    }
+
+    export function importsAreSorted(imports: readonly AnyImportOrRequireStatement[]) {
+        return arrayIsSorted(imports, compareImportsOrRequireStatements);
+    }
+
+    export function importSpecifiersAreSorted(imports: readonly ImportSpecifier[]) {
+        return arrayIsSorted(imports, compareImportOrExportSpecifiers);
+    }
+
+    export function getImportDeclarationInsertionIndex(imports: readonly AnyImportOrRequireStatement[], newImport: AnyImportOrRequireStatement) {
+        if (!importsAreSorted(imports)) return imports.length;
+        const index = binarySearch(imports, newImport, identity, compareImportsOrRequireStatements);
+        return index < 0 ? ~index : index;
+    }
+
+    export function getImportSpecifierInsertionIndex(imports: readonly ImportSpecifier[], newImport: ImportSpecifier) {
+        if (!importSpecifiersAreSorted(imports)) return imports.length;
+        const index = binarySearch(imports, newImport, identity, compareImportOrExportSpecifiers);
+        return index < 0 ? ~index : index;
+    }
+
+    export function compareImportsOrRequireStatements(s1: AnyImportOrRequireStatement, s2: AnyImportOrRequireStatement) {
+        return compareModuleSpecifiers(getModuleSpecifierExpression(s1), getModuleSpecifierExpression(s2)) || compareImportKind(s1, s2);
+    }
+
+    function compareImportKind(s1: AnyImportOrRequireStatement, s2: AnyImportOrRequireStatement) {
+        return compareValues(getImportKindOrder(s1), getImportKindOrder(s2));
+    }
+
+    function getImportKindOrder(s1: AnyImportOrRequireStatement) {
+        switch (s1.kind) {
+            case SyntaxKind.ImportDeclaration:
+                if (!s1.importClause) return 0;
+                if (s1.importClause.isTypeOnly) return 1;
+                if (s1.importClause.namedBindings?.kind === SyntaxKind.NamespaceImport) return 2;
+                if (s1.importClause.name) return 3;
+                return 4;
+            case SyntaxKind.ImportEqualsDeclaration:
+                return 5;
+            case SyntaxKind.VariableStatement:
+                return 6;
+        }
     }
 }

--- a/src/services/refactors/moveToNewFile.ts
+++ b/src/services/refactors/moveToNewFile.ts
@@ -269,7 +269,7 @@ namespace ts.refactor {
         | ImportEqualsDeclaration
         | VariableStatement;
 
-    function createOldFileImportsFromNewFile(newFileNeedExport: ReadonlySymbolSet, newFileNameWithExtension: string, useEs6Imports: boolean, quotePreference: QuotePreference): Statement | undefined {
+    function createOldFileImportsFromNewFile(newFileNeedExport: ReadonlySymbolSet, newFileNameWithExtension: string, useEs6Imports: boolean, quotePreference: QuotePreference): AnyImportOrRequireStatement | undefined {
         let defaultImport: Identifier | undefined;
         const imports: string[] = [];
         newFileNeedExport.forEach(symbol => {
@@ -283,7 +283,7 @@ namespace ts.refactor {
         return makeImportOrRequire(defaultImport, imports, newFileNameWithExtension, useEs6Imports, quotePreference);
     }
 
-    function makeImportOrRequire(defaultImport: Identifier | undefined, imports: readonly string[], path: string, useEs6Imports: boolean, quotePreference: QuotePreference): Statement | undefined {
+    function makeImportOrRequire(defaultImport: Identifier | undefined, imports: readonly string[], path: string, useEs6Imports: boolean, quotePreference: QuotePreference): AnyImportOrRequireStatement | undefined {
         path = ensurePathIsNonModuleName(path);
         if (useEs6Imports) {
             const specifiers = imports.map(i => factory.createImportSpecifier(/*propertyName*/ undefined, factory.createIdentifier(i)));
@@ -293,7 +293,7 @@ namespace ts.refactor {
             Debug.assert(!defaultImport, "No default import should exist"); // If there's a default export, it should have been an es6 module.
             const bindingElements = imports.map(i => factory.createBindingElement(/*dotDotDotToken*/ undefined, /*propertyName*/ undefined, i));
             return bindingElements.length
-                ? makeVariableStatement(factory.createObjectBindingPattern(bindingElements), /*type*/ undefined, createRequireCall(factory.createStringLiteral(path)))
+                ? makeVariableStatement(factory.createObjectBindingPattern(bindingElements), /*type*/ undefined, createRequireCall(factory.createStringLiteral(path))) as RequireVariableStatement
                 : undefined;
         }
     }

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -472,9 +472,9 @@ namespace ts.textChanges {
             this.insertNodesAt(sourceFile, start, typeParameters, { prefix: "<", suffix: ">" });
         }
 
-        private getOptionsForInsertNodeBefore(before: Node, inserted: Node, doubleNewlines: boolean): InsertNodeOptions {
+        private getOptionsForInsertNodeBefore(before: Node, inserted: Node, blankLineBetween: boolean): InsertNodeOptions {
             if (isStatement(before) || isClassElement(before)) {
-                return { suffix: doubleNewlines ? this.newLineCharacter + this.newLineCharacter : this.newLineCharacter };
+                return { suffix: blankLineBetween ? this.newLineCharacter + this.newLineCharacter : this.newLineCharacter };
             }
             else if (isVariableDeclaration(before)) { // insert `x = 1, ` into `const x = 1, y = 2;
                 return { suffix: ", " };
@@ -484,6 +484,9 @@ namespace ts.textChanges {
             }
             else if (isStringLiteral(before) && isImportDeclaration(before.parent) || isNamedImports(before)) {
                 return { suffix: ", " };
+            }
+            else if (isImportSpecifier(before)) {
+                return { suffix: "," + (blankLineBetween ? this.newLineCharacter : " ") };
             }
             return Debug.failBadSyntaxKind(before); // We haven't handled this kind of node yet -- add it
         }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1876,12 +1876,11 @@ namespace ts {
         const decl = isArray(imports) ? imports[0] : imports;
         const importKindPredicate: (node: Node) => node is AnyImportOrRequireStatement = decl.kind === SyntaxKind.VariableStatement ? isRequireVariableStatement : isAnyImportSyntax;
         const existingImportStatements = filter(sourceFile.statements, importKindPredicate);
-        const isSorted = existingImportStatements && OrganizeImports.importsAreSorted(existingImportStatements);
         const sortedNewImports = isArray(imports) ? stableSort(imports, OrganizeImports.compareImportsOrRequireStatements) : [imports];
         if (!existingImportStatements.length) {
             changes.insertNodesAtTopOfFile(sourceFile, sortedNewImports, blankLineBetween);
         }
-        else if (isSorted) {
+        else if (existingImportStatements && OrganizeImports.importsAreSorted(existingImportStatements)) {
             for (const newImport of sortedNewImports) {
                 const insertionIndex = OrganizeImports.getImportDeclarationInsertionIndex(existingImportStatements, newImport);
                 if (insertionIndex === 0) {

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1872,23 +1872,35 @@ namespace ts {
         return node.modifiers && find(node.modifiers, m => m.kind === kind);
     }
 
-    export function insertImports(changes: textChanges.ChangeTracker, sourceFile: SourceFile, imports: Statement | readonly Statement[], blankLineBetween: boolean): void {
+    export function insertImports(changes: textChanges.ChangeTracker, sourceFile: SourceFile, imports: AnyImportOrRequireStatement | readonly AnyImportOrRequireStatement[], blankLineBetween: boolean): void {
         const decl = isArray(imports) ? imports[0] : imports;
-        const importKindPredicate = decl.kind === SyntaxKind.VariableStatement ? isRequireVariableDeclarationStatement : isAnyImportSyntax;
-        const lastImportDeclaration = findLast(sourceFile.statements, statement => importKindPredicate(statement));
-        if (lastImportDeclaration) {
-            if (isArray(imports)) {
-                changes.insertNodesAfter(sourceFile, lastImportDeclaration, imports);
-            }
-            else {
-                changes.insertNodeAfter(sourceFile, lastImportDeclaration, imports);
-            }
+        const importKindPredicate: (node: Node) => node is AnyImportOrRequireStatement = decl.kind === SyntaxKind.VariableStatement ? isRequireVariableStatement : isAnyImportSyntax;
+        const existingImportStatements = filter(sourceFile.statements, importKindPredicate);
+        const isSorted = existingImportStatements && OrganizeImports.importsAreSorted(existingImportStatements);
+        const sortedNewImports = isArray(imports) ? stableSort(imports, OrganizeImports.compareImportsOrRequireStatements) : [imports];
+        if (!existingImportStatements.length) {
+            changes.insertNodesAtTopOfFile(sourceFile, sortedNewImports, blankLineBetween);
         }
-        else if (isArray(imports)) {
-            changes.insertNodesAtTopOfFile(sourceFile, imports, blankLineBetween);
+        else if (isSorted) {
+            for (const newImport of sortedNewImports) {
+                const insertionIndex = OrganizeImports.getImportDeclarationInsertionIndex(existingImportStatements, newImport);
+                if (insertionIndex === 0) {
+                    changes.insertNodeBefore(sourceFile, existingImportStatements[0], newImport, /*blankLineBetween*/ false);
+                }
+                else {
+                    const prevImport = existingImportStatements[insertionIndex - 1];
+                    changes.insertNodeAfter(sourceFile, prevImport, newImport);
+                }
+            }
         }
         else {
-            changes.insertNodeAtTopOfFile(sourceFile, imports, blankLineBetween);
+            const lastExistingImport = lastOrUndefined(existingImportStatements);
+            if (lastExistingImport) {
+                changes.insertNodesAfter(sourceFile, lastExistingImport, sortedNewImports);
+            }
+            else {
+                changes.insertNodesAtTopOfFile(sourceFile, sortedNewImports, blankLineBetween);
+            }
         }
     }
 

--- a/tests/baselines/reference/organizeImports/TypeOnly.ts
+++ b/tests/baselines/reference/organizeImports/TypeOnly.ts
@@ -8,8 +8,8 @@ import type { A, B } from "lib";
 export { A, B, X, Y, Z };
 // ==ORGANIZED==
 
-import { X, Z } from "lib";
 import type Y from "lib";
 import type { A, B } from "lib";
+import { X, Z } from "lib";
 
 export { A, B, X, Y, Z };

--- a/tests/cases/fourslash/codeFixInferFromUsageContextualImport4.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageContextualImport4.ts
@@ -25,8 +25,8 @@ verify.codeFix({
   index: 0,
   description: "Infer parameter types from usage",
   newFileContent:
-`import { getEmail } from './getEmail';
-import { User, Settings } from './a';
+`import { User, Settings } from './a';
+import { getEmail } from './getEmail';
 
 export function f(user: User, settings: Settings) {
     getEmail(user, settings);

--- a/tests/cases/fourslash/codeFixUndeclaredMethodFunctionArgs_importArgumentType.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredMethodFunctionArgs_importArgumentType.ts
@@ -19,7 +19,7 @@ verify.codeFix({
     description: [ts.Diagnostics.Declare_method_0.message, "foo"],
     index: 0,
     newFileContent:
-`import { create, A } from "./a";
+`import { A, create } from "./a";
 class B {
     bar() {
         create(args => this.foo(args));

--- a/tests/cases/fourslash/codeFixUndeclaredMethodFunctionArgs_importArgumentType1.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredMethodFunctionArgs_importArgumentType1.ts
@@ -25,8 +25,8 @@ verify.codeFix({
     description: [ts.Diagnostics.Declare_method_0.message, "foo"],
     index: 0,
     newFileContent:
-`import { create, B } from "./b";
-import { A } from "./a";
+`import { A } from "./a";
+import { B, create } from "./b";
 class C {
     bar() {
         create(args => this.foo(args));

--- a/tests/cases/fourslash/codeFixUndeclaredMethodFunctionArgs_importArgumentType2.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredMethodFunctionArgs_importArgumentType2.ts
@@ -31,9 +31,9 @@ verify.codeFix({
     description: [ts.Diagnostics.Declare_method_0.message, "foo"],
     index: 0,
     newFileContent:
-`import { create, C } from "./c";
+`import { A } from "./a";
 import { B } from "./b";
-import { A } from "./a";
+import { C, create } from "./c";
 class D {
     bar() {
         create(args => this.foo(args));

--- a/tests/cases/fourslash/completionsImport_default_alreadyExistedWithRename.ts
+++ b/tests/cases/fourslash/completionsImport_default_alreadyExistedWithRename.ts
@@ -25,7 +25,7 @@ verify.applyCodeActionFromCompletion("", {
     name: "foo",
     source: "/a",
     description: `Import default 'foo' from module "./a"`,
-    newFileContent: `import f_o_o from "./a";
-import foo from "./a";
+    newFileContent: `import foo from "./a";
+import f_o_o from "./a";
 f;`,
 });

--- a/tests/cases/fourslash/completionsImport_named_addToNamedImports.ts
+++ b/tests/cases/fourslash/completionsImport_named_addToNamedImports.ts
@@ -26,6 +26,6 @@ verify.applyCodeActionFromCompletion("", {
     name: "foo",
     source: "/a",
     description: `Add 'foo' to existing import declaration from "./a"`,
-    newFileContent: `import { x, foo } from "./a";
+    newFileContent: `import { foo, x } from "./a";
 f;`,
 });

--- a/tests/cases/fourslash/completionsImport_named_didNotExistBefore.ts
+++ b/tests/cases/fourslash/completionsImport_named_didNotExistBefore.ts
@@ -39,6 +39,6 @@ verify.applyCodeActionFromCompletion("", {
     name: "Test1",
     source: "/a",
     description: `Add 'Test1' to existing import declaration from "./a"`,
-    newFileContent: `import { Test2, Test1 } from "./a";
+    newFileContent: `import { Test1, Test2 } from "./a";
 t`,
 });

--- a/tests/cases/fourslash/completionsImport_reExport_wrongName.ts
+++ b/tests/cases/fourslash/completionsImport_reExport_wrongName.ts
@@ -46,8 +46,8 @@ verify.applyCodeActionFromCompletion("", {
     name: "y",
     source: "/index",
     description: `Import 'y' from module "."`,
-    newFileContent: `import { x } from "./a";
-import { y } from ".";
+    newFileContent: `import { y } from ".";
+import { x } from "./a";
 
 `,
 });

--- a/tests/cases/fourslash/extract-method32.ts
+++ b/tests/cases/fourslash/extract-method32.ts
@@ -21,7 +21,7 @@ edit.applyRefactor({
   actionName: "function_scope_1",
   actionDescription: "Extract to function in module scope",
   newContent:
-`import { a, A } from "./a";
+`import { A, a } from "./a";
 
 function foo() {
     const arg = a;

--- a/tests/cases/fourslash/extract-method33.ts
+++ b/tests/cases/fourslash/extract-method33.ts
@@ -29,8 +29,8 @@ edit.applyRefactor({
   actionName: "function_scope_1",
   actionDescription: "Extract to function in module scope",
   newContent:
-`import { b, B } from "./b";
-import { A } from "./a";
+`import { A } from "./a";
+import { B, b } from "./b";
 
 function foo() {
     const prop = b;

--- a/tests/cases/fourslash/extract-method34.ts
+++ b/tests/cases/fourslash/extract-method34.ts
@@ -38,9 +38,9 @@ edit.applyRefactor({
   actionName: "function_scope_1",
   actionDescription: "Extract to function in module scope",
   newContent:
-`import { c, C } from "./c";
+`import { A } from "./a";
 import { B } from "./b";
-import { A } from "./a";
+import { C, c } from "./c";
 
 function foo() {
     const prop = c;

--- a/tests/cases/fourslash/extract-method35.ts
+++ b/tests/cases/fourslash/extract-method35.ts
@@ -23,7 +23,7 @@ edit.applyRefactor({
   actionName: "function_scope_1",
   actionDescription: "Extract to method in class 'Foo'",
   newContent:
-`import { a, A } from "./a";
+`import { A, a } from "./a";
 
 class Foo {
     foo() {

--- a/tests/cases/fourslash/extract-method36.ts
+++ b/tests/cases/fourslash/extract-method36.ts
@@ -31,8 +31,8 @@ edit.applyRefactor({
   actionName: "function_scope_1",
   actionDescription: "Extract to method in class 'Foo'",
   newContent:
-`import { b, B } from "./b";
-import { A } from "./a";
+`import { A } from "./a";
+import { B, b } from "./b";
 
 class Foo {
     foo() {

--- a/tests/cases/fourslash/extract-method37.ts
+++ b/tests/cases/fourslash/extract-method37.ts
@@ -40,9 +40,9 @@ edit.applyRefactor({
   actionName: "function_scope_1",
   actionDescription: "Extract to method in class 'Foo'",
   newContent:
-`import { c, C } from "./c";
+`import { A } from "./a";
 import { B } from "./b";
-import { A } from "./a";
+import { C, c } from "./c";
 
 class Foo {
     foo() {

--- a/tests/cases/fourslash/importNameCodeFixExistingImport0.ts
+++ b/tests/cases/fourslash/importNameCodeFixExistingImport0.ts
@@ -7,4 +7,4 @@
 //// export function f1() {}
 //// export var v1 = 5;
 
-verify.importFixAtPosition([`{ v1, f1 }`]);
+verify.importFixAtPosition([`{ f1, v1 }`]);

--- a/tests/cases/fourslash/importNameCodeFixExistingImport1.ts
+++ b/tests/cases/fourslash/importNameCodeFixExistingImport1.ts
@@ -8,4 +8,4 @@
 //// export var v1 = 5;
 //// export default var d1 = 6;
 
-verify.importFixAtPosition([`{ v1, f1 }`]);
+verify.importFixAtPosition([`{ f1, v1 }`]);

--- a/tests/cases/fourslash/importNameCodeFixExistingImport10.ts
+++ b/tests/cases/fourslash/importNameCodeFixExistingImport10.ts
@@ -14,8 +14,8 @@
 
 verify.importFixAtPosition([
 `{
+    f1,
     v1,
-    v2,
-    f1
+    v2
 }`
 ]);

--- a/tests/cases/fourslash/importNameCodeFixExistingImport11.ts
+++ b/tests/cases/fourslash/importNameCodeFixExistingImport11.ts
@@ -14,8 +14,8 @@
 
 verify.importFixAtPosition([
 `{
+    f1,
     v1, v2,
-    v3,
-    f1
+    v3
 }`
 ]);

--- a/tests/cases/fourslash/importNameCodeFixExistingImport6.ts
+++ b/tests/cases/fourslash/importNameCodeFixExistingImport6.ts
@@ -10,4 +10,4 @@
 //// export var v1 = 5;
 //// export function f1();
 
-verify.importFixAtPosition([`{ v1, f1 }`]);
+verify.importFixAtPosition([`{ f1, v1 }`]);

--- a/tests/cases/fourslash/importNameCodeFixExistingImport7.ts
+++ b/tests/cases/fourslash/importNameCodeFixExistingImport7.ts
@@ -7,4 +7,4 @@
 //// export var v1 = 5;
 //// export function f1();
 
-verify.importFixAtPosition([`{ v1, f1 }`]);
+verify.importFixAtPosition([`{ f1, v1 }`]);

--- a/tests/cases/fourslash/importNameCodeFixExistingImport8.ts
+++ b/tests/cases/fourslash/importNameCodeFixExistingImport8.ts
@@ -1,12 +1,12 @@
 /// <reference path="fourslash.ts" />
 
 //// import [|{v1, v2, v3,}|] from "./module";
-//// f1/*0*/();
+//// v4/*0*/();
 
 // @Filename: module.ts
-//// export function f1() {}
+//// export function v4() {}
 //// export var v1 = 5;
 //// export var v2 = 5;
 //// export var v3 = 5;
 
-verify.importFixAtPosition([`{v1, v2, v3, f1,}`]);
+verify.importFixAtPosition([`{v1, v2, v3, v4,}`]);

--- a/tests/cases/fourslash/importNameCodeFixExistingImport9.ts
+++ b/tests/cases/fourslash/importNameCodeFixExistingImport9.ts
@@ -11,6 +11,7 @@
 
 verify.importFixAtPosition([
 `{
-    v1, f1
+    f1,
+    v1
 }`
 ]);

--- a/tests/cases/fourslash/importNameCodeFixExistingImportEquals0.ts
+++ b/tests/cases/fourslash/importNameCodeFixExistingImportEquals0.ts
@@ -12,7 +12,7 @@
 verify.importFixAtPosition([
 `import ns = require("ambient-module");
 var x = ns.v1 + 5;`,
-`import ns = require("ambient-module");
-import { v1 } from "ambient-module";
+`import { v1 } from "ambient-module";
+import ns = require("ambient-module");
 var x = v1 + 5;`,
 ]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportAmbient1.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportAmbient1.ts
@@ -1,8 +1,8 @@
 /// <reference path="fourslash.ts" />
 
 //// import d from "other-ambient-module";
-//// [|import * as ns from "yet-another-ambient-module";
-//// var x = v1/*0*/ + 5;|]
+//// import * as ns from "yet-another-ambient-module";
+//// var x = v1/*0*/ + 5;
 
 // @Filename: ambientModule.ts
 //// declare module "ambient-module" {
@@ -22,7 +22,8 @@
 //// }
 
 verify.importFixAtPosition([
-`import * as ns from "yet-another-ambient-module";
-import { v1 } from "ambient-module";
+`import { v1 } from "ambient-module";
+import d from "other-ambient-module";
+import * as ns from "yet-another-ambient-module";
 var x = v1 + 5;`
 ]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportAmbient3.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportAmbient3.ts
@@ -2,8 +2,8 @@
 
 //// let a = "I am a non-trivial statement that appears before imports";
 //// import d from "other-ambient-module"
-//// [|import * as ns from "yet-another-ambient-module"
-//// var x = v1/*0*/ + 5;|]
+//// import * as ns from "yet-another-ambient-module"
+//// var x = v1/*0*/ + 5;
 
 // @Filename: ambientModule.ts
 //// declare module "ambient-module" {
@@ -24,7 +24,9 @@
 
 // test cases when there are no semicolons at the line end
 verify.importFixAtPosition([
-`import * as ns from "yet-another-ambient-module"
+`let a = "I am a non-trivial statement that appears before imports";
 import { v1 } from "ambient-module";
+import d from "other-ambient-module"
+import * as ns from "yet-another-ambient-module"
 var x = v1 + 5;`
 ]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyle0.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyle0.ts
@@ -11,8 +11,8 @@
 //// export var v2 = 6;
 
 verify.importFixAtPosition([
-`import { v2 } from './module2';
-import { f1 } from './module1';
+`import { f1 } from './module1';
+import { v2 } from './module2';
 
 f1();`
 ]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyle1.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyle1.ts
@@ -11,8 +11,8 @@
 //// export var v2 = 6;
 
 verify.importFixAtPosition([
-`import { v2 } from "./module2";
-import { f1 } from "./module1";
+`import { f1 } from "./module1";
+import { v2 } from "./module2";
 
 f1();`
 ]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyle2.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyle2.ts
@@ -11,8 +11,8 @@
 //// export var v2 = 6;
 
 verify.importFixAtPosition([
-`import m2 = require('./module2');
-import { f1 } from './module1';
+`import { f1 } from './module1';
+import m2 = require('./module2');
 
 f1();`
 ]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyleMixed0.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyleMixed0.ts
@@ -15,9 +15,9 @@
 //// export var v3 = 6;
 
 verify.importFixAtPosition([
-`import { v2 } from "./module2";
+`import { f1 } from "./module1";
+import { v2 } from "./module2";
 import { v3 } from './module3';
-import { f1 } from "./module1";
 
 f1();`
 ]);

--- a/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyleMixed1.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportFileQuoteStyleMixed1.ts
@@ -15,9 +15,9 @@
 //// export var v3 = 6;
 
 verify.importFixAtPosition([
-`import { v2 } from './module2';
+`import { f1 } from './module1';
+import { v2 } from './module2';
 import { v3 } from "./module3";
-import { f1 } from './module1';
 
 f1();`
 ]);

--- a/tests/cases/fourslash/importNameCodeFixUMDGlobal1.ts
+++ b/tests/cases/fourslash/importNameCodeFixUMDGlobal1.ts
@@ -14,8 +14,8 @@
 //// export as namespace bar1; 
 
 verify.importFixAtPosition([
-`import { bar } from "./foo";
-import * as bar1 from "./foo";
+`import * as bar1 from "./foo";
+import { bar } from "./foo";
 
 export function test() { };
 bar1.bar();`

--- a/tests/cases/fourslash/importNameCodeFixUMDGlobalReact0.ts
+++ b/tests/cases/fourslash/importNameCodeFixUMDGlobalReact0.ts
@@ -29,8 +29,8 @@
 goTo.file("/a.tsx");
 
 verify.importFixAtPosition([
-    `import { Component } from "react";
-import * as React from "react";
+    `import * as React from "react";
+import { Component } from "react";
 export class MyMap extends Component { }
 <MyMap/>;`]);
 
@@ -38,6 +38,6 @@ export class MyMap extends Component { }
 goTo.file("/b.tsx");
 
 verify.importFixAtPosition([
-`import { Component } from "react";
-import * as React from "react";
+`import * as React from "react";
+import { Component } from "react";
 <></>;`]);

--- a/tests/cases/fourslash/importNameCodeFixUMDGlobalReact1.ts
+++ b/tests/cases/fourslash/importNameCodeFixUMDGlobalReact1.ts
@@ -25,7 +25,7 @@
 goTo.file("/a.tsx");
 
 verify.importFixAtPosition([
-`import { Component } from "react";
-import * as React from "react";
+`import * as React from "react";
+import { Component } from "react";
 export class MyMap extends Component { }
 <MyMap></MyMap>;`]);

--- a/tests/cases/fourslash/importNameCodeFix_all.ts
+++ b/tests/cases/fourslash/importNameCodeFix_all.ts
@@ -37,10 +37,10 @@ verify.codeFixAll({
     fixId: "fixMissingImport",
     fixAllDescription: "Add all missing imports",
     newFileContent:
-`import bd, * as b from "./b";
+`import ad, { a0 } from "./a";
+import bd, * as b from "./b";
 import cd, { c0 } from "./c";
 import dd, { d0, d1 } from "./d";
-import ad, { a0 } from "./a";
 import e = require("./e");
 
 ad; ad; a0; a0;

--- a/tests/cases/fourslash/importNameCodeFix_all2.ts
+++ b/tests/cases/fourslash/importNameCodeFix_all2.ts
@@ -15,8 +15,8 @@ goTo.file("/index.ts");
 verify.codeFixAll({
   fixId: "fixMissingImport",
   fixAllDescription: "Add all missing imports",
-  newFileContent: `import { join } from "./path";
-import { homedir } from "./os";
+  newFileContent: `import { homedir } from "./os";
+import { join } from "./path";
 
 join();
 homedir();`

--- a/tests/cases/fourslash/importNameCodeFix_avoidRelativeNodeModules.ts
+++ b/tests/cases/fourslash/importNameCodeFix_avoidRelativeNodeModules.ts
@@ -21,7 +21,7 @@
 
 goTo.file("/c/foo.ts");
 verify.importFixAtPosition([
-`import { b } from "b";
-import { a } from "a";
+`import { a } from "a";
+import { b } from "b";
 a;`,
 ]);

--- a/tests/cases/fourslash/importNameCodeFix_fileWithNoTrailingNewline.ts
+++ b/tests/cases/fourslash/importNameCodeFix_fileWithNoTrailingNewline.ts
@@ -13,7 +13,6 @@
 goTo.file("/c.ts");
 verify.importFixAtPosition([
 `foo;
-import { bar } from "./b";
 import { foo } from "./a";
-`,
+import { bar } from "./b";`,
 ]);

--- a/tests/cases/fourslash/importNameCodeFix_jsx.ts
+++ b/tests/cases/fourslash/importNameCodeFix_jsx.ts
@@ -33,6 +33,6 @@ import { Foo } from "./Foo";
 // When JSX namespace is missing, provide fix for that
 goTo.file("/d.tsx");
 verify.importFixAtPosition([
-`import { Foo } from "./Foo";
-import { React } from "react";
+`import { React } from "react";
+import { Foo } from "./Foo";
 <Foo />;`]);

--- a/tests/cases/fourslash/importNameCodeFix_order.ts
+++ b/tests/cases/fourslash/importNameCodeFix_order.ts
@@ -15,7 +15,7 @@ goTo.file("/c.ts");
 verify.importFixAtPosition([
 `import { bar, foo } from "./b";
 foo;`,
-`import { bar } from "./b";
-import { foo } from "./a";
+`import { foo } from "./a";
+import { bar } from "./b";
 foo;`,
 ]);

--- a/tests/cases/fourslash/importNameCodeFix_require.ts
+++ b/tests/cases/fourslash/importNameCodeFix_require.ts
@@ -25,9 +25,9 @@ verify.codeFixAll({
   fixId: "fixMissingImport",
   fixAllDescription: "Add all missing imports",
   newFileContent:
-`const foo = require("./foo");
+`const { default: Blah } = require("./blah");
+const foo = require("./foo");
 const { util1, util2 } = require("./utils");
-const { default: Blah } = require("./blah");
 
 foo();
 util1();

--- a/tests/cases/fourslash/importNameCodeFix_withJson.ts
+++ b/tests/cases/fourslash/importNameCodeFix_withJson.ts
@@ -9,7 +9,7 @@
 ////a/**/
 
 goTo.file("/b.ts");
-verify.importFixAtPosition([`import "./anything.json";
-import { a } from "./a";
+verify.importFixAtPosition([`import { a } from "./a";
+import "./anything.json";
 
 a`]);

--- a/tests/cases/fourslash/quickfixImplementInterfaceUnreachableTypeUsesRelativeImport.ts
+++ b/tests/cases/fourslash/quickfixImplementInterfaceUnreachableTypeUsesRelativeImport.ts
@@ -18,8 +18,8 @@ verify.codeFix({
     description: "Implement interface 'Foo'",
     newFileContent: {
         "/tests/cases/fourslash/index.ts":
-`import { Foo } from './interface';
-import { Class } from './class';
+`import { Class } from './class';
+import { Foo } from './interface';
 
 class X implements Foo {
     x: Class;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #33839

When import declarations/specifiers are already sorted, we insert new declarations/specifiers in the appropriate location. The sort order of import specifiers is alphabetical (reusing the existing logic from organize imports). The sort order for import declarations is alphabetical by module specifier, with module specifier ties being broken by the secondary sort order:

1. Side-effect imports
2. Type-only imports
3. Namespace imports
4. Default imports
5. Named imports
6. ImportEqualsDeclarations
7. Require variable statements

The organize imports logic has been updated to use that tiebreaker as well.