### PR TITLE
Mark @typedef as a type declaration

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -36110,13 +36110,14 @@ namespace ts {
                 name.parent.name === name;
         }
 
-        function isTypeDeclaration(node: Node): node is TypeParameterDeclaration | ClassDeclaration | InterfaceDeclaration | TypeAliasDeclaration | EnumDeclaration | ImportClause | ImportSpecifier | ExportSpecifier {
+        function isTypeDeclaration(node: Node): node is TypeParameterDeclaration | ClassDeclaration | InterfaceDeclaration | TypeAliasDeclaration | JSDocTypedefTag | EnumDeclaration | ImportClause | ImportSpecifier | ExportSpecifier {
             switch (node.kind) {
                 case SyntaxKind.TypeParameter:
                 case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.InterfaceDeclaration:
                 case SyntaxKind.TypeAliasDeclaration:
                 case SyntaxKind.EnumDeclaration:
+                case SyntaxKind.JSDocTypedefTag:
                     return true;
                 case SyntaxKind.ImportClause:
                     return (node as ImportClause).isTypeOnly;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -36107,10 +36107,10 @@ namespace ts {
         function isTypeDeclarationName(name: Node): boolean {
             return name.kind === SyntaxKind.Identifier &&
                 isTypeDeclaration(name.parent) &&
-                name.parent.name === name;
+                getNameOfDeclaration(name.parent) === name;
         }
 
-        function isTypeDeclaration(node: Node): node is TypeParameterDeclaration | ClassDeclaration | InterfaceDeclaration | TypeAliasDeclaration | JSDocTypedefTag | EnumDeclaration | ImportClause | ImportSpecifier | ExportSpecifier {
+        function isTypeDeclaration(node: Node): node is TypeParameterDeclaration | ClassDeclaration | InterfaceDeclaration | TypeAliasDeclaration | JSDocTypedefTag | JSDocCallbackTag | JSDocEnumTag | EnumDeclaration | ImportClause | ImportSpecifier | ExportSpecifier {
             switch (node.kind) {
                 case SyntaxKind.TypeParameter:
                 case SyntaxKind.ClassDeclaration:
@@ -36118,6 +36118,8 @@ namespace ts {
                 case SyntaxKind.TypeAliasDeclaration:
                 case SyntaxKind.EnumDeclaration:
                 case SyntaxKind.JSDocTypedefTag:
+                case SyntaxKind.JSDocCallbackTag:
+                case SyntaxKind.JSDocEnumTag:
                     return true;
                 case SyntaxKind.ImportClause:
                     return (node as ImportClause).isTypeOnly;

--- a/tests/cases/fourslash/jsdocDeprecated_suggestion5.ts
+++ b/tests/cases/fourslash/jsdocDeprecated_suggestion5.ts
@@ -7,4 +7,17 @@
 //// /** @type {U2} */
 //// const u2 = { email: "" }
 
+//// /**
+////  * @callback K
+////  * @param {any} ctx
+////  * @return {void}
+////  */
+//// /** @type {K} */
+//// const cc = _k => {}
+
+//// /** @enum {number} */
+//// const DOOM = { e: 1, m: 1 }
+//// /** @type {DOOM} */
+//// const kneeDeep = DOOM.e
+
 verify.getSuggestionDiagnostics([])

--- a/tests/cases/fourslash/jsdocDeprecated_suggestion5.ts
+++ b/tests/cases/fourslash/jsdocDeprecated_suggestion5.ts
@@ -1,0 +1,10 @@
+///<reference path="fourslash.ts" />
+
+// @checkJs: true
+// @allowJs: true
+// @Filename: jsdocDeprecated_suggestion5.js
+//// /** @typedef {{ email: string, nickName?: string }} U2 */
+//// /** @type {U2} */
+//// const u2 = { email: "" }
+
+verify.getSuggestionDiagnostics([])


### PR DESCRIPTION
This is only important right now for marking uses of deprecated tags due to the way that deprecated type references are computed. But I'm surprised it hasn't caused problems elsewhere.

Fixes #39466