### PR TITLE
Dont include auto type reference directives on syntax only server

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -282,6 +282,7 @@ namespace ts.server {
             this.languageServiceEnabled = true;
             if (projectService.syntaxOnly) {
                 this.compilerOptions.noResolve = true;
+                this.compilerOptions.types = [];
             }
 
             this.setInternalCompilerOptionsForEmittingJsFiles();

--- a/src/testRunner/unittests/tsserver/semanticOperationsOnSyntaxServer.ts
+++ b/src/testRunner/unittests/tsserver/semanticOperationsOnSyntaxServer.ts
@@ -95,5 +95,19 @@ class c { prop = "hello"; foo() { return this.prop; } }`
             }
             assert.isTrue(hasException);
         });
+
+        it("should not include auto type reference directives", () => {
+            const { host, session, file1 } = setup();
+            const atTypes: File = {
+                path: `/node_modules/@types/somemodule/index.d.ts`,
+                content: "export const something = 10;"
+            };
+            host.ensureFileOrFolder(atTypes);
+            const service = session.getProjectService();
+            openFilesForSession([file1], session);
+            checkNumberOfProjects(service, { inferredProjects: 1 });
+            const project = service.inferredProjects[0];
+            checkProjectActualFiles(project, [libFile.path, file1.path]); // Should not contain atTypes
+        });
     });
 }


### PR DESCRIPTION
Detected while working on the goto def on syntax only server that we were including `node_modules/@types` auto type directives on syntax only server. This disables it.
I am not sure if this is desired behavior or not though
