### PR TITLE
Properly handle rest parameters in function declarations with @type annotations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7802,7 +7802,9 @@ namespace ts {
                 if (isInJSFile(declaration)) {
                     const typeTag = getJSDocType(func);
                     if (typeTag && isFunctionTypeNode(typeTag)) {
-                        return getTypeAtPosition(getSignatureFromDeclaration(typeTag), func.parameters.indexOf(declaration));
+                        const signature = getSignatureFromDeclaration(typeTag);
+                        const pos = func.parameters.indexOf(declaration);
+                        return declaration.dotDotDotToken ? getRestTypeAtPosition(signature, pos) : getTypeAtPosition(signature, pos);
                     }
                 }
                 // Use contextual parameter type if one is available

--- a/tests/baselines/reference/jsdocFunctionType.errors.txt
+++ b/tests/baselines/reference/jsdocFunctionType.errors.txt
@@ -73,3 +73,15 @@ tests/cases/conformance/jsdoc/functions.js(65,14): error TS2345: Argument of typ
 !!! error TS2345:   Property 'length' is missing in type 'E' but required in type '{ length: number; }'.
 !!! related TS2728 tests/cases/conformance/jsdoc/functions.js:12:28: 'length' is declared here.
     
+    // Repro from #39229
+    
+    /**
+     * @type {(...args: [string, string] | [number, string, string]) => void}
+     */
+    function foo(...args) {
+      args;
+    }
+    
+    foo('abc', 'def');
+    foo(42, 'abc', 'def');
+    

--- a/tests/baselines/reference/jsdocFunctionType.symbols
+++ b/tests/baselines/reference/jsdocFunctionType.symbols
@@ -141,3 +141,22 @@ var y3 = id2(E);
 >id2 : Symbol(id2, Decl(functions.js, 8, 53))
 >E : Symbol(E, Decl(functions.js, 59, 3))
 
+// Repro from #39229
+
+/**
+ * @type {(...args: [string, string] | [number, string, string]) => void}
+ */
+function foo(...args) {
+>foo : Symbol(foo, Decl(functions.js, 64, 16))
+>args : Symbol(args, Decl(functions.js, 71, 13))
+
+  args;
+>args : Symbol(args, Decl(functions.js, 71, 13))
+}
+
+foo('abc', 'def');
+>foo : Symbol(foo, Decl(functions.js, 64, 16))
+
+foo(42, 'abc', 'def');
+>foo : Symbol(foo, Decl(functions.js, 64, 16))
+

--- a/tests/baselines/reference/jsdocFunctionType.types
+++ b/tests/baselines/reference/jsdocFunctionType.types
@@ -165,3 +165,29 @@ var y3 = id2(E);
 >id2 : (c: new (arg1: number) => { length: number; }) => new (arg1: number) => { length: number; }
 >E : typeof E
 
+// Repro from #39229
+
+/**
+ * @type {(...args: [string, string] | [number, string, string]) => void}
+ */
+function foo(...args) {
+>foo : (...args: [string, string] | [number, string, string]) => void
+>args : [string, string] | [number, string, string]
+
+  args;
+>args : [string, string] | [number, string, string]
+}
+
+foo('abc', 'def');
+>foo('abc', 'def') : void
+>foo : (...args: [string, string] | [number, string, string]) => void
+>'abc' : "abc"
+>'def' : "def"
+
+foo(42, 'abc', 'def');
+>foo(42, 'abc', 'def') : void
+>foo : (...args: [string, string] | [number, string, string]) => void
+>42 : 42
+>'abc' : "abc"
+>'def' : "def"
+

--- a/tests/cases/conformance/jsdoc/jsdocFunctionType.ts
+++ b/tests/cases/conformance/jsdoc/jsdocFunctionType.ts
@@ -70,3 +70,15 @@ var E = function(n) {
 
 
 var y3 = id2(E);
+
+// Repro from #39229
+
+/**
+ * @type {(...args: [string, string] | [number, string, string]) => void}
+ */
+function foo(...args) {
+  args;
+}
+
+foo('abc', 'def');
+foo(42, 'abc', 'def');


### PR DESCRIPTION
Fixes #39229.