### PR TITLE
Resolve only relative references tree in the project (in syntax only mode)

### DIFF
--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -320,6 +320,7 @@ namespace ts {
             configFileName ?
                 getDirectoryPath(getNormalizedAbsolutePath(configFileName, currentDirectory)) :
                 currentDirectory,
+            ResolutionKind.All,
             /*logChangesWhenResolvingModule*/ false
         );
         // Resolve module using host module resolution strategy if provided otherwise use resolution cache to resolve module names

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -281,10 +281,8 @@ namespace ts.server {
 
             this.languageServiceEnabled = true;
             if (projectService.syntaxOnly) {
-                this.compilerOptions.noResolve = true;
                 this.compilerOptions.types = [];
             }
-
             this.setInternalCompilerOptionsForEmittingJsFiles();
             const host = this.projectService.host;
             if (this.projectService.logger.loggingEnabled()) {
@@ -296,7 +294,12 @@ namespace ts.server {
             this.realpath = maybeBind(host, host.realpath);
 
             // Use the current directory as resolution root only if the project created using current directory string
-            this.resolutionCache = createResolutionCache(this, currentDirectory && this.currentDirectory, /*logChangesWhenResolvingModule*/ true);
+            this.resolutionCache = createResolutionCache(
+                this,
+                currentDirectory && this.currentDirectory,
+                projectService.syntaxOnly ? ResolutionKind.RelativeReferences : ResolutionKind.All,
+                /*logChangesWhenResolvingModule*/ true
+            );
             this.languageService = createLanguageService(this, this.documentRegistry, this.projectService.syntaxOnly);
             if (lastFileExceededProgramSize) {
                 this.disableLanguageService(lastFileExceededProgramSize);

--- a/src/testRunner/unittests/tsserver/semanticOperationsOnSyntaxServer.ts
+++ b/src/testRunner/unittests/tsserver/semanticOperationsOnSyntaxServer.ts
@@ -3,35 +3,67 @@ namespace ts.projectSystem {
         function setup() {
             const file1: File = {
                 path: `${tscWatch.projectRoot}/a.ts`,
-                content: `import { y } from "./b";
+                content: `import { y, cc } from "./b";
+import { something } from "something";
 class c { prop = "hello"; foo() { return this.prop; } }`
             };
             const file2: File = {
                 path: `${tscWatch.projectRoot}/b.ts`,
-                content: "export const y = 10;"
+                content: `export { cc } from "./c";
+import { something } from "something";
+                export const y = 10;`
+            };
+            const file3: File = {
+                path: `${tscWatch.projectRoot}/c.ts`,
+                content: `export const cc = 10;`
+            };
+            const something: File = {
+                path: `${tscWatch.projectRoot}/node_modules/something/index.d.ts`,
+                content: "export const something = 10;"
             };
             const configFile: File = {
                 path: `${tscWatch.projectRoot}/tsconfig.json`,
                 content: "{}"
             };
-            const host = createServerHost([file1, file2, libFile, configFile]);
+            const host = createServerHost([file1, file2, file3, something, libFile, configFile]);
             const session = createSession(host, { syntaxOnly: true, useSingleInferredProject: true });
-            return { host, session, file1, file2, configFile };
+            return { host, session, file1, file2, file3, something, configFile };
         }
 
         it("open files are added to inferred project even if config file is present and semantic operations succeed", () => {
-            const { host, session, file1, file2 } = setup();
+            const { host, session, file1, file2, file3, something } = setup();
             const service = session.getProjectService();
             openFilesForSession([file1], session);
             checkNumberOfProjects(service, { inferredProjects: 1 });
             const project = service.inferredProjects[0];
-            checkProjectActualFiles(project, [libFile.path, file1.path]); // Import is not resolved
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, file3.path]); // Relative import is resolved but not non relative
             verifyCompletions();
+            verifyGoToDefToB();
+            verifyGoToDefToC();
 
             openFilesForSession([file2], session);
             checkNumberOfProjects(service, { inferredProjects: 1 });
-            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path]);
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, file3.path]);
             verifyCompletions();
+            verifyGoToDefToB();
+            verifyGoToDefToC();
+
+            openFilesForSession([file3], session);
+            checkNumberOfProjects(service, { inferredProjects: 1 });
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, file3.path]);
+
+            openFilesForSession([something], session);
+            checkNumberOfProjects(service, { inferredProjects: 1 });
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, file3.path, something.path]);
+
+            // Close open files and verify resolutions
+            closeFilesForSession([file3], session);
+            checkNumberOfProjects(service, { inferredProjects: 1 });
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, file3.path, something.path]);
+
+            closeFilesForSession([file2], session);
+            checkNumberOfProjects(service, { inferredProjects: 1 });
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, file3.path, something.path]);
 
             function verifyCompletions() {
                 assert.isTrue(project.languageServiceEnabled);
@@ -61,6 +93,34 @@ class c { prop = "hello"; foo() { return this.prop; } }`
                     replacementSpan: undefined,
                     source: undefined
                 };
+            }
+
+            function verifyGoToDefToB() {
+                const response = session.executeCommandSeq<protocol.DefinitionAndBoundSpanRequest>({
+                    command: protocol.CommandTypes.DefinitionAndBoundSpan,
+                    arguments: protocolFileLocationFromSubstring(file1, "y")
+                }).response as protocol.DefinitionInfoAndBoundSpan;
+                assert.deepEqual(response, {
+                    definitions: [{
+                        file: file2.path,
+                        ...protocolTextSpanWithContextFromSubstring({ fileText: file2.content, text: "y", contextText: "export const y = 10;" })
+                    }],
+                    textSpan: protocolTextSpanWithContextFromSubstring({ fileText: file1.content, text: "y" })
+                });
+            }
+
+            function verifyGoToDefToC() {
+                const response = session.executeCommandSeq<protocol.DefinitionAndBoundSpanRequest>({
+                    command: protocol.CommandTypes.DefinitionAndBoundSpan,
+                    arguments: protocolFileLocationFromSubstring(file1, "cc")
+                }).response as protocol.DefinitionInfoAndBoundSpan;
+                assert.deepEqual(response, {
+                    definitions: [{
+                        file: file3.path,
+                        ...protocolTextSpanWithContextFromSubstring({ fileText: file3.content, text: "cc", contextText: "export const cc = 10;" })
+                    }],
+                    textSpan: protocolTextSpanWithContextFromSubstring({ fileText: file1.content, text: "cc" })
+                });
             }
         });
 
@@ -97,7 +157,7 @@ class c { prop = "hello"; foo() { return this.prop; } }`
         });
 
         it("should not include auto type reference directives", () => {
-            const { host, session, file1 } = setup();
+            const { host, session, file1, file2, file3 } = setup();
             const atTypes: File = {
                 path: `/node_modules/@types/somemodule/index.d.ts`,
                 content: "export const something = 10;"
@@ -107,7 +167,7 @@ class c { prop = "hello"; foo() { return this.prop; } }`
             openFilesForSession([file1], session);
             checkNumberOfProjects(service, { inferredProjects: 1 });
             const project = service.inferredProjects[0];
-            checkProjectActualFiles(project, [libFile.path, file1.path]); // Should not contain atTypes
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, file3.path]); // Should not contain atTypes
         });
     });
 }


### PR DESCRIPTION
This resolves and follows all relative module references instead of just in open files
