### PR TITLE
Fix test semantic merge conflict between #39348 and #39130

### DIFF
--- a/tests/cases/fourslash/codeFixClassImplementInterfaceAutoImports.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceAutoImports.ts
@@ -32,7 +32,7 @@ import A from './types1';
 import { B, C, D } from './types2';
 
 export class C implements Base {
-    a: Readonly<A> & { kind: "a"; };
+    a: Readonly<A> & { kind: 'a'; };
     b<T extends B = B>(p1: C): D<C> {
         throw new Error('Method not implemented.');
     }


### PR DESCRIPTION
#39348 preserves the file quotemark style, resulting in a change in #39130's test.

Fixes the `master` build.
