### PR TITLE
Remove unnecessary assert in tryReuseStructureFromOldProgram

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1236,8 +1236,6 @@ namespace ts {
                 return oldProgram.structureIsReused = StructureIsReused.Not;
             }
 
-            Debug.assert(!(oldProgram.structureIsReused! & (StructureIsReused.Completely | StructureIsReused.SafeModules)));
-
             // there is an old program, check if we can reuse its structure
             const oldRootNames = oldProgram.getRootFileNames();
             if (!arrayIsEqualTo(oldRootNames, rootNames)) {


### PR DESCRIPTION
This assert made no sense sine we donot use the value from existing structureIsUsed at all
Fixes #36718
