### PR TITLE
fix(39410): Refacoring "Convert named export to default" removes function typeings

### DIFF
--- a/src/services/refactors/convertExport.ts
+++ b/src/services/refactors/convertExport.ts
@@ -110,10 +110,11 @@ namespace ts.refactor {
                     changes.insertNodeAfter(exportingSourceFile, exportKeyword, factory.createToken(SyntaxKind.DefaultKeyword));
                     break;
                 case SyntaxKind.VariableStatement:
-                    // If 'x' isn't used in this file, `export const x = 0;` --> `export default 0;`
-                    if (!FindAllReferences.Core.isSymbolReferencedInFile(exportName, checker, exportingSourceFile)) {
+                    // If 'x' isn't used in this file and doesn't have type definition, `export const x = 0;` --> `export default 0;`
+                    const decl = first(exportNode.declarationList.declarations);
+                    if (!FindAllReferences.Core.isSymbolReferencedInFile(exportName, checker, exportingSourceFile) && !decl.type) {
                         // We checked in `getInfo` that an initializer exists.
-                        changes.replaceNode(exportingSourceFile, exportNode, factory.createExportDefault(Debug.checkDefined(first(exportNode.declarationList.declarations).initializer, "Initializer was previously known to be present")));
+                        changes.replaceNode(exportingSourceFile, exportNode, factory.createExportDefault(Debug.checkDefined(decl.initializer, "Initializer was previously known to be present")));
                         break;
                     }
                     // falls through

--- a/tests/cases/fourslash/refactorConvertExport_exportNodeKinds.ts
+++ b/tests/cases/fourslash/refactorConvertExport_exportNodeKinds.ts
@@ -28,6 +28,9 @@
 ////export const x = 0;
 ////x;
 
+// @Filename: /var_with_type.ts
+////export const fn: (n: number) => number = (n) => 1;
+
 const tests: { [fileName: string]: string | undefined } = {
     fn: `export default function f() {}`,
 
@@ -59,6 +62,11 @@ export default T;
 `const x = 0;
 export default x;
 x;`,
+
+    var_with_type:
+`const fn: (n: number) => number = (n) => 1;
+export default fn;
+`,
 };
 
 for (const name in tests) {


### PR DESCRIPTION
Fixes #39410
