### PR TITLE
fix(39524): Diagnostic message contains a stray "[object Object]"

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4755,7 +4755,7 @@ namespace ts {
         if (isPropertyAccessExpression(expr)) {
             const baseStr = tryGetPropertyAccessOrIdentifierToString(expr.expression);
             if (baseStr !== undefined) {
-                return baseStr + "." + expr.name;
+                return baseStr + "." + entityNameToString(expr.name);
             }
         }
         else if (isIdentifier(expr)) {

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.errors.txt
@@ -35,9 +35,10 @@ tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(76,1): error TS7053: 
 tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(81,1): error TS7053: Element implicitly has an 'any' type because expression of type 'StrEnum' can't be used to index type '{ a: number; }'.
   Property '[StrEnum.b]' does not exist on type '{ a: number; }'.
 tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(93,5): error TS2538: Type 'Dog' cannot be used as an index type.
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(99,1): error TS7052: Element implicitly has an 'any' type because type 'MyMap<string, string>' has no index signature. Did you mean to call 'm.prop.get'?
 
 
-==== tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts (30 errors) ====
+==== tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts (31 errors) ====
     var a = {}["hello"];
             ~~~~~~~~~~~
 !!! error TS7053: Element implicitly has an 'any' type because expression of type '"hello"' can't be used to index type '{}'.
@@ -198,4 +199,12 @@ tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(93,5): error TS2538: 
     map[rover] = "Rover";
         ~~~~~
 !!! error TS2538: Type 'Dog' cannot be used as an index type.
+    
+    interface I {
+      prop: MyMap<string, string>
+    }
+    declare const m: I;
+    m.prop['a'];
+    ~~~~~~~~~~~
+!!! error TS7052: Element implicitly has an 'any' type because type 'MyMap<string, string>' has no index signature. Did you mean to call 'm.prop.get'?
     

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.js
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.js
@@ -93,6 +93,12 @@ let rover: Dog = { bark() {} };
 declare let map: MyMap<Dog, string>;
 map[rover] = "Rover";
 
+interface I {
+  prop: MyMap<string, string>
+}
+declare const m: I;
+m.prop['a'];
+
 
 //// [noImplicitAnyStringIndexerOnObject.js]
 var a = {}["hello"];
@@ -168,3 +174,4 @@ var strEnumKey;
 o[strEnumKey];
 var rover = { bark: function () { } };
 map[rover] = "Rover";
+m.prop['a'];

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.symbols
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.symbols
@@ -277,3 +277,19 @@ map[rover] = "Rover";
 >map : Symbol(map, Decl(noImplicitAnyStringIndexerOnObject.ts, 91, 11))
 >rover : Symbol(rover, Decl(noImplicitAnyStringIndexerOnObject.ts, 89, 3))
 
+interface I {
+>I : Symbol(I, Decl(noImplicitAnyStringIndexerOnObject.ts, 92, 21))
+
+  prop: MyMap<string, string>
+>prop : Symbol(I.prop, Decl(noImplicitAnyStringIndexerOnObject.ts, 94, 13))
+>MyMap : Symbol(MyMap, Decl(noImplicitAnyStringIndexerOnObject.ts, 80, 14))
+}
+declare const m: I;
+>m : Symbol(m, Decl(noImplicitAnyStringIndexerOnObject.ts, 97, 13))
+>I : Symbol(I, Decl(noImplicitAnyStringIndexerOnObject.ts, 92, 21))
+
+m.prop['a'];
+>m.prop : Symbol(I.prop, Decl(noImplicitAnyStringIndexerOnObject.ts, 94, 13))
+>m : Symbol(m, Decl(noImplicitAnyStringIndexerOnObject.ts, 97, 13))
+>prop : Symbol(I.prop, Decl(noImplicitAnyStringIndexerOnObject.ts, 94, 13))
+

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.types
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.types
@@ -418,3 +418,17 @@ map[rover] = "Rover";
 >rover : Dog
 >"Rover" : "Rover"
 
+interface I {
+  prop: MyMap<string, string>
+>prop : MyMap<string, string>
+}
+declare const m: I;
+>m : I
+
+m.prop['a'];
+>m.prop['a'] : any
+>m.prop : MyMap<string, string>
+>m : I
+>prop : MyMap<string, string>
+>'a' : "a"
+

--- a/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
+++ b/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
@@ -93,3 +93,9 @@ let rover: Dog = { bark() {} };
 
 declare let map: MyMap<Dog, string>;
 map[rover] = "Rover";
+
+interface I {
+  prop: MyMap<string, string>
+}
+declare const m: I;
+m.prop['a'];


### PR DESCRIPTION
Fixes #39524
