### PR TITLE
Fix @param type parameter lookup

### DIFF
--- a/tests/baselines/reference/paramTagTypeResolution2.symbols
+++ b/tests/baselines/reference/paramTagTypeResolution2.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/jsdoc/38572.js ===
+/**
+ * @template T
+ * @param {T} a
+ * @param {{[K in keyof T]: (value: T[K]) => void }} b
+ */
+function f(a, b) {
+>f : Symbol(f, Decl(38572.js, 0, 0))
+>a : Symbol(a, Decl(38572.js, 5, 11))
+>b : Symbol(b, Decl(38572.js, 5, 13))
+}
+
+f({ x: 42 }, { x(param) { param.toFixed() } });
+>f : Symbol(f, Decl(38572.js, 0, 0))
+>x : Symbol(x, Decl(38572.js, 8, 3))
+>x : Symbol(x, Decl(38572.js, 8, 14))
+>param : Symbol(param, Decl(38572.js, 8, 17))
+>param.toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
+>param : Symbol(param, Decl(38572.js, 8, 17))
+>toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
+

--- a/tests/baselines/reference/paramTagTypeResolution2.types
+++ b/tests/baselines/reference/paramTagTypeResolution2.types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/jsdoc/38572.js ===
+/**
+ * @template T
+ * @param {T} a
+ * @param {{[K in keyof T]: (value: T[K]) => void }} b
+ */
+function f(a, b) {
+>f : <T>(a: T, b: { [K in keyof T]: (value: T[K]) => void; }) => void
+>a : T
+>b : { [K in keyof T]: (value: T[K]) => void; }
+}
+
+f({ x: 42 }, { x(param) { param.toFixed() } });
+>f({ x: 42 }, { x(param) { param.toFixed() } }) : void
+>f : <T>(a: T, b: { [K in keyof T]: (value: T[K]) => void; }) => void
+>{ x: 42 } : { x: number; }
+>x : number
+>42 : 42
+>{ x(param) { param.toFixed() } } : { x(param: number): void; }
+>x : (param: number) => void
+>param : number
+>param.toFixed() : string
+>param.toFixed : (fractionDigits?: number) => string
+>param : number
+>toFixed : (fractionDigits?: number) => string
+

--- a/tests/cases/conformance/jsdoc/paramTagTypeResolution2.ts
+++ b/tests/cases/conformance/jsdoc/paramTagTypeResolution2.ts
@@ -1,0 +1,14 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: 38572.js
+
+/**
+ * @template T
+ * @param {T} a
+ * @param {{[K in keyof T]: (value: T[K]) => void }} b
+ */
+function f(a, b) {
+}
+
+f({ x: 42 }, { x(param) { param.toFixed() } });


### PR DESCRIPTION
Previously, getObjectTypeInstantiation had special-case code to look up type parameters for `@param` as if they were in the parameter location.

This should occur in the main lookup loop of `getOuterTypeParameters`, however. The current code only runs once, which is not sufficient, and it also jumps to the parameter for any type contained in a `@param`, which skips type parameters that occur in the tag itself.


Fixes #38572
