### PR TITLE
fix(39515): Add all imports inserts all commas before imports in files with crlf line endings

### DIFF
--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -794,7 +794,8 @@ namespace ts.textChanges {
                     const indentation = formatting.SmartIndenter.findFirstNonWhitespaceColumn(afterStartLinePosition, afterStart, sourceFile, this.formatContext.options);
                     // insert element before the line break on the line that contains 'after' element
                     let insertPos = skipTrivia(sourceFile.text, end, /*stopAfterLineBreak*/ true, /*stopAtComments*/ false);
-                    if (insertPos !== end && isLineBreak(sourceFile.text.charCodeAt(insertPos - 1))) {
+                    // find position before "\n" or "\r\n"
+                    while (insertPos !== end && isLineBreak(sourceFile.text.charCodeAt(insertPos - 1))) {
                         insertPos--;
                     }
                     this.replaceRange(sourceFile, createRange(insertPos), newNode, { indentation, prefix: this.newLineCharacter });

--- a/src/testRunner/unittests/services/textChanges.ts
+++ b/src/testRunner/unittests/services/textChanges.ts
@@ -620,6 +620,20 @@ import {
             });
         }
         {
+            const runTest = (name: string, text: string) => runSingleFileTest(name, /*placeOpenBraceOnNewLineForFunctions*/ false, text, /*validateNodes*/ false, (sourceFile, changeTracker) => {
+                for (const specifier of ["x3", "x4", "x5"]) {
+                    // eslint-disable-next-line boolean-trivia
+                    changeTracker.insertNodeInListAfter(sourceFile, findChild("x2", sourceFile), factory.createImportSpecifier(undefined, factory.createIdentifier(specifier)));
+                }
+            });
+
+            const crlfText = "import {\r\nx1,\r\nx2\r\n} from \"bar\";";
+            runTest("insertNodeInListAfter19", crlfText);
+
+            const lfText = "import {\nx1,\nx2\n} from \"bar\";";
+            runTest("insertNodeInListAfter20", lfText);
+        }
+        {
             const text = `
 class A {
     x;

--- a/tests/baselines/reference/textChanges/insertNodeInListAfter19.js
+++ b/tests/baselines/reference/textChanges/insertNodeInListAfter19.js
@@ -1,0 +1,13 @@
+===ORIGINAL===
+import {
+x1,
+x2
+} from "bar";
+===MODIFIED===
+import {
+x1,
+x2,
+x3,
+x4,
+x5
+} from "bar";

--- a/tests/baselines/reference/textChanges/insertNodeInListAfter20.js
+++ b/tests/baselines/reference/textChanges/insertNodeInListAfter20.js
@@ -1,0 +1,13 @@
+===ORIGINAL===
+import {
+x1,
+x2
+} from "bar";
+===MODIFIED===
+import {
+x1,
+x2,
+x3,
+x4,
+x5
+} from "bar";


### PR DESCRIPTION
Fixes #39515