### PR TITLE
fix(types/mocha): change deprecated Mocha types

### DIFF
--- a/src/testRunner/externalCompileRunner.ts
+++ b/src/testRunner/externalCompileRunner.ts
@@ -30,7 +30,7 @@ namespace Harness {
 
             // eslint-disable-next-line @typescript-eslint/no-this-alias
             const cls = this;
-            describe(`${this.kind()} code samples`, function (this: Mocha.ISuiteCallbackContext) {
+            describe(`${this.kind()} code samples`, function (this: Mocha.Suite) {
                 this.timeout(600_000); // 10 minutes
                 for (const test of testList) {
                     cls.runTest(typeof test === "string" ? test : test.file);
@@ -41,7 +41,7 @@ namespace Harness {
             // eslint-disable-next-line @typescript-eslint/no-this-alias
             const cls = this;
             const timeout = 600_000; // 10 minutes
-            describe(directoryName, function (this: Mocha.ISuiteCallbackContext) {
+            describe(directoryName, function (this: Mocha.Suite) {
                 this.timeout(timeout);
                 const cp: typeof import("child_process") = require("child_process");
 
@@ -127,7 +127,7 @@ ${stripAbsoluteImportPaths(result.stderr.toString().replace(/\r\n/g, "\n"))}`;
 
             // eslint-disable-next-line @typescript-eslint/no-this-alias
             const cls = this;
-            describe(`${this.kind()} code samples`, function (this: Mocha.ISuiteCallbackContext) {
+            describe(`${this.kind()} code samples`, function (this: Mocha.Suite) {
                 this.timeout(cls.timeout); // 20 minutes
                 before(() => {
                     cls.exec("docker", ["build", ".", "-t", "typescript/typescript"], { cwd: IO.getWorkspaceRoot() }); // cached because workspace is hashed to determine cacheability

--- a/src/testRunner/rwcRunner.ts
+++ b/src/testRunner/rwcRunner.ts
@@ -47,7 +47,7 @@ namespace RWC {
                 caseSensitive = false;
             });
 
-            it("can compile", function (this: Mocha.ITestCallbackContext) {
+            it("can compile", function (this: Mocha.Context) {
                 this.timeout(800_000); // Allow long timeouts for RWC compilations
                 let opts!: ts.ParsedCommandLine;
 
@@ -145,7 +145,7 @@ namespace RWC {
             });
 
 
-            it("has the expected emitted code", function (this: Mocha.ITestCallbackContext) {
+            it("has the expected emitted code", function (this: Mocha.Context) {
                 this.timeout(100_000); // Allow longer timeouts for RWC js verification
                 Harness.Baseline.runMultifileBaseline(baseName, "", () => {
                     return Harness.Compiler.iterateOutputs(compilerResult.js.values());


### PR DESCRIPTION
`Mocha.ISuiteCallbackContext`  -> `Mocha.Suite`
`Mocha.ITestCallbackContext`  -> `Mocha.Context`

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46017/files#diff-6382e04d36916e2e024c09fb5e10e4e6