### PR TITLE
Fix find-all-references on undefined

### DIFF
--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -1102,9 +1102,6 @@ namespace FourSlash {
             baselineContent += JSON.stringify(references, undefined, 2);
             Harness.Baseline.runBaseline(this.getBaselineFileNameForContainingTestFile(".baseline.jsonc"), baselineContent);
 
-            function commentEachLine(source: string) {
-                return source.split(/\r?\n/).map(l => "// " + l).join("\n");
-            }
             function getBaselineContentForFile(fileName: string, content: string) {
                 let newContent = `=== ${fileName} ===\n`;
                 let pos = 0;
@@ -1120,7 +1117,7 @@ namespace FourSlash {
                     pos = end;
                 }
                 newContent += content.slice(pos);
-                return commentEachLine(newContent);
+                return newContent.split(/\r?\n/).map(l => "// " + l).join("\n");
             }
         }
 

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -1084,6 +1084,20 @@ namespace FourSlash {
             }
         }
 
+        public verifyBaselineFindAllReferences(markerName: string) {
+            const marker = this.getMarkerByName(markerName);
+            const references = this.languageService.findReferences(marker.fileName, marker.position);
+            const commentEachLine = (source: string) => source.split(/\r?\n/).map(l => "// " + l).join("\n");
+            const baselineContent =
+                commentEachLine(
+                    this.getFileContent(marker.fileName).slice(0, marker.position) +
+                    "/*FIND ALL REFERENCES*/" +
+                    this.getFileContent(marker.fileName).slice(marker.position)) +
+                "\n\n" + JSON.stringify(references, undefined, 2);
+
+            Harness.Baseline.runBaseline(this.getBaselineFileNameForContainingTestFile(".baseline.jsonc"), baselineContent);
+        }
+
         public verifyNoReferences(markerNameOrRange?: string | Range) {
             if (markerNameOrRange !== undefined) this.goToMarkerOrRange(markerNameOrRange);
             const refs = this.getReferencesAtCaret();

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -316,6 +316,10 @@ namespace FourSlashInterface {
             this.state.verifyTypeOfSymbolAtLocation(range, symbol, expected);
         }
 
+        public baselineFindAllReferences(markerName: string) {
+            this.state.verifyBaselineFindAllReferences(markerName);
+        }
+
         public referenceGroups(starts: ArrayOrSingle<string> | ArrayOrSingle<FourSlash.Range>, parts: ReferenceGroup[]) {
             this.state.verifyReferenceGroups(starts, parts);
         }

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -304,7 +304,7 @@ namespace ts.FindAllReferences {
                     const { symbol } = def;
                     const { displayParts, kind } = getDefinitionKindAndDisplayParts(symbol, checker, originalNode);
                     const name = displayParts.map(p => p.text).join("");
-                    const declaration = firstOrUndefined(symbol.declarations);
+                    const declaration = symbol.declarations && firstOrUndefined(symbol.declarations);
                     return {
                         node: declaration ?
                             getNameOfDeclaration(declaration) || declaration :

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -304,7 +304,7 @@ namespace ts.FindAllReferences {
                     const { symbol } = def;
                     const { displayParts, kind } = getDefinitionKindAndDisplayParts(symbol, checker, originalNode);
                     const name = displayParts.map(p => p.text).join("");
-                    const declaration = symbol.declarations ? first(symbol.declarations) : undefined;
+                    const declaration = firstOrUndefined(symbol.declarations);
                     return {
                         node: declaration ?
                             getNameOfDeclaration(declaration) || declaration :

--- a/tests/baselines/reference/findAllReferencesUndefined.baseline.jsonc
+++ b/tests/baselines/reference/findAllReferencesUndefined.baseline.jsonc
@@ -1,11 +1,17 @@
-// /*FIND ALL REFERENCES*/undefined;
+// === /a.ts ===
+// /*FIND ALL REFS*/[|undefined|];
+// 
+// void [|undefined|];
+
+// === /b.ts ===
+// [|undefined|];
 
 [
   {
     "definition": {
       "containerKind": "",
       "containerName": "",
-      "fileName": "/tests/cases/fourslash/findAllReferencesUndefined.ts",
+      "fileName": "/a.ts",
       "kind": "var",
       "name": "var undefined",
       "textSpan": {
@@ -33,7 +39,25 @@
           "start": 0,
           "length": 9
         },
-        "fileName": "/tests/cases/fourslash/findAllReferencesUndefined.ts",
+        "fileName": "/a.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      },
+      {
+        "textSpan": {
+          "start": 17,
+          "length": 9
+        },
+        "fileName": "/a.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      },
+      {
+        "textSpan": {
+          "start": 0,
+          "length": 9
+        },
+        "fileName": "/b.ts",
         "isWriteAccess": false,
         "isDefinition": false
       }

--- a/tests/baselines/reference/findAllReferencesUndefined.baseline.jsonc
+++ b/tests/baselines/reference/findAllReferencesUndefined.baseline.jsonc
@@ -1,0 +1,42 @@
+// /*FIND ALL REFERENCES*/undefined;
+
+[
+  {
+    "definition": {
+      "containerKind": "",
+      "containerName": "",
+      "fileName": "/tests/cases/fourslash/findAllReferencesUndefined.ts",
+      "kind": "var",
+      "name": "var undefined",
+      "textSpan": {
+        "start": 0,
+        "length": 9
+      },
+      "displayParts": [
+        {
+          "text": "var",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "undefined",
+          "kind": "propertyName"
+        }
+      ]
+    },
+    "references": [
+      {
+        "textSpan": {
+          "start": 0,
+          "length": 9
+        },
+        "fileName": "/tests/cases/fourslash/findAllReferencesUndefined.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      }
+    ]
+  }
+]

--- a/tests/cases/fourslash/findAllReferencesUndefined.ts
+++ b/tests/cases/fourslash/findAllReferencesUndefined.ts
@@ -1,0 +1,5 @@
+/// <reference path="fourslash.ts" />
+
+//// /**/undefined;
+
+verify.baselineFindAllReferences("");

--- a/tests/cases/fourslash/findAllReferencesUndefined.ts
+++ b/tests/cases/fourslash/findAllReferencesUndefined.ts
@@ -1,5 +1,11 @@
 /// <reference path="fourslash.ts" />
 
+// @Filename: /a.ts
 //// /**/undefined;
+////
+//// void undefined;
+
+// @Filename: /b.ts
+//// undefined;
 
 verify.baselineFindAllReferences("");

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -289,6 +289,7 @@ declare namespace FourSlashInterface {
         goToType(startMarkerNames: ArrayOrSingle<string>, endMarkerNames: ArrayOrSingle<string>): void;
         verifyGetEmitOutputForCurrentFile(expected: string): void;
         verifyGetEmitOutputContentsForCurrentFile(expected: ts.OutputFile[]): void;
+        baselineFindAllReferences(markerName: string): void;
         noReferences(markerNameOrRange?: string | Range): void;
         symbolAtLocation(startRange: Range, ...declarationRanges: Range[]): void;
         typeOfSymbolAtLocation(range: Range, symbol: any, expected: string): void;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Not sure why you’d want to find-all-refs on `undefined`, but it works on `null`, and after fixing the crash, it Just Works™ on `undefined` too.

Also includes a baseliner for find-all-references.

Fixes #38408
