### PR TITLE
Don’t give all instantiated signatures in JS strict arity

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5350,7 +5350,7 @@ namespace ts {
         // We do not propagate `IsInnerCallChain` to instantiated signatures, as that would result in us
         // attempting to add `| undefined` on each recursive call to `getReturnTypeOfSignature` when
         // instantiating the return type.
-        PropagatingFlags = HasRestParameter | HasLiteralTypes,
+        PropagatingFlags = HasRestParameter | HasLiteralTypes | IsUntypedSignatureInJSFile,
 
         CallChainFlags = IsInnerCallChain | IsOuterCallChain,
     }

--- a/tests/baselines/reference/unannotatedParametersAreOptional.symbols
+++ b/tests/baselines/reference/unannotatedParametersAreOptional.symbols
@@ -1,0 +1,62 @@
+=== tests/cases/conformance/salsa/test.js ===
+function f(x) {}
+>f : Symbol(f, Decl(test.js, 0, 0))
+>x : Symbol(x, Decl(test.js, 0, 11))
+
+f(); // Always been ok
+>f : Symbol(f, Decl(test.js, 0, 0))
+
+class C {
+>C : Symbol(C, Decl(test.js, 1, 4))
+
+  static m(x) {}
+>m : Symbol(C.m, Decl(test.js, 3, 9))
+>x : Symbol(x, Decl(test.js, 4, 11))
+
+  p = x => {}
+>p : Symbol(C.p, Decl(test.js, 4, 16))
+>x : Symbol(x, Decl(test.js, 5, 5))
+
+  m(x) {}
+>m : Symbol(C.m, Decl(test.js, 5, 13))
+>x : Symbol(x, Decl(test.js, 6, 4))
+}
+
+C.m();       // Always been ok
+>C.m : Symbol(C.m, Decl(test.js, 3, 9))
+>C : Symbol(C, Decl(test.js, 1, 4))
+>m : Symbol(C.m, Decl(test.js, 3, 9))
+
+new C().m(); // Regression #39261
+>new C().m : Symbol(C.m, Decl(test.js, 5, 13))
+>C : Symbol(C, Decl(test.js, 1, 4))
+>m : Symbol(C.m, Decl(test.js, 5, 13))
+
+new C().p(); // Regression #39261
+>new C().p : Symbol(C.p, Decl(test.js, 4, 16))
+>C : Symbol(C, Decl(test.js, 1, 4))
+>p : Symbol(C.p, Decl(test.js, 4, 16))
+
+const obj = {
+>obj : Symbol(obj, Decl(test.js, 13, 5))
+
+  m(x) {},
+>m : Symbol(m, Decl(test.js, 13, 13))
+>x : Symbol(x, Decl(test.js, 14, 4))
+
+  p: x => {}
+>p : Symbol(p, Decl(test.js, 14, 10))
+>x : Symbol(x, Decl(test.js, 15, 4))
+
+};
+
+obj.m(); // Always been ok
+>obj.m : Symbol(m, Decl(test.js, 13, 13))
+>obj : Symbol(obj, Decl(test.js, 13, 5))
+>m : Symbol(m, Decl(test.js, 13, 13))
+
+obj.p(); // Always been ok
+>obj.p : Symbol(p, Decl(test.js, 14, 10))
+>obj : Symbol(obj, Decl(test.js, 13, 5))
+>p : Symbol(p, Decl(test.js, 14, 10))
+

--- a/tests/baselines/reference/unannotatedParametersAreOptional.types
+++ b/tests/baselines/reference/unannotatedParametersAreOptional.types
@@ -1,0 +1,73 @@
+=== tests/cases/conformance/salsa/test.js ===
+function f(x) {}
+>f : (x: any) => void
+>x : any
+
+f(); // Always been ok
+>f() : void
+>f : (x: any) => void
+
+class C {
+>C : C
+
+  static m(x) {}
+>m : (x: any) => void
+>x : any
+
+  p = x => {}
+>p : (x: any) => void
+>x => {} : (x: any) => void
+>x : any
+
+  m(x) {}
+>m : (x: any) => void
+>x : any
+}
+
+C.m();       // Always been ok
+>C.m() : void
+>C.m : (x: any) => void
+>C : typeof C
+>m : (x: any) => void
+
+new C().m(); // Regression #39261
+>new C().m() : void
+>new C().m : (x: any) => void
+>new C() : C
+>C : typeof C
+>m : (x: any) => void
+
+new C().p(); // Regression #39261
+>new C().p() : void
+>new C().p : (x: any) => void
+>new C() : C
+>C : typeof C
+>p : (x: any) => void
+
+const obj = {
+>obj : { m(x: any): void; p: (x: any) => void; }
+>{  m(x) {},  p: x => {}} : { m(x: any): void; p: (x: any) => void; }
+
+  m(x) {},
+>m : (x: any) => void
+>x : any
+
+  p: x => {}
+>p : (x: any) => void
+>x => {} : (x: any) => void
+>x : any
+
+};
+
+obj.m(); // Always been ok
+>obj.m() : void
+>obj.m : (x: any) => void
+>obj : { m(x: any): void; p: (x: any) => void; }
+>m : (x: any) => void
+
+obj.p(); // Always been ok
+>obj.p() : void
+>obj.p : (x: any) => void
+>obj : { m(x: any): void; p: (x: any) => void; }
+>p : (x: any) => void
+

--- a/tests/cases/conformance/salsa/unannotatedParametersAreOptional.ts
+++ b/tests/cases/conformance/salsa/unannotatedParametersAreOptional.ts
@@ -1,0 +1,25 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: test.js
+
+function f(x) {}
+f(); // Always been ok
+
+class C {
+  static m(x) {}
+  p = x => {}
+  m(x) {}
+}
+
+C.m();       // Always been ok
+new C().m(); // Regression #39261
+new C().p(); // Regression #39261
+
+const obj = {
+  m(x) {},
+  p: x => {}
+};
+
+obj.m(); // Always been ok
+obj.p(); // Always been ok


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #39261
