### PR TITLE
fix(38868): Annotate with type from JSDocs generates a line break between generics instead of a comma

### DIFF
--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -469,7 +469,7 @@ namespace ts.textChanges {
         public insertTypeParameters(sourceFile: SourceFile, node: SignatureDeclaration, typeParameters: readonly TypeParameterDeclaration[]): void {
             // If no `(`, is an arrow function `x => x`, so use the pos of the first parameter
             const start = (findChildOfKind(node, SyntaxKind.OpenParenToken, sourceFile) || first(node.parameters)).getStart(sourceFile);
-            this.insertNodesAt(sourceFile, start, typeParameters, { prefix: "<", suffix: ">" });
+            this.insertNodesAt(sourceFile, start, typeParameters, { prefix: "<", suffix: ">", joiner: ", " });
         }
 
         private getOptionsForInsertNodeBefore(before: Node, inserted: Node, blankLineBetween: boolean): InsertNodeOptions {

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc23.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc23.ts
@@ -1,0 +1,32 @@
+/// <reference path='fourslash.ts' />
+// @strict: true
+/////**
+//// * @typedef Foo
+//// * @template L, R
+//// */
+/////**
+//// * @param {function(R): boolean} a
+//// * @param {function(R): L} b
+//// * @returns {function(R): Foo.<L, R>}
+//// * @template L, R
+//// */
+////function foo(a, b) {
+////}
+
+verify.codeFix({
+    description: ts.Diagnostics.Annotate_with_type_from_JSDoc.message,
+    index: 2,
+    newFileContent:
+`/**
+ * @typedef Foo
+ * @template L, R
+ */
+/**
+ * @param {function(R): boolean} a
+ * @param {function(R): L} b
+ * @returns {function(R): Foo.<L, R>}
+ * @template L, R
+ */
+function foo<L, R>(a: (arg0: R) => boolean, b: (arg0: R) => L): (arg0: R) => Foo<L, R> {
+}`,
+});


### PR DESCRIPTION
Fixes #38868
