### PR TITLE
Add DockerFile for ChromeDevTools

### DIFF
--- a/tests/cases/docker/chrome-devtools-frontend-next/Dockerfile
+++ b/tests/cases/docker/chrome-devtools-frontend-next/Dockerfile
@@ -11,4 +11,4 @@ COPY --from=typescript/typescript /typescript/typescript-*.tgz typescript.tgz
 RUN mkdir /typescript
 RUN tar -xzvf /typescript.tgz -C /typescript
 RUN ln -s /typescript/package ./node_modules/typescript
-CMD [ "autoninja", "-C", "out/Default" ]
+RUN autoninja -C out/Default front_end

--- a/tests/cases/docker/chrome-devtools-frontend-next/Dockerfile
+++ b/tests/cases/docker/chrome-devtools-frontend-next/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:current
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools
+ENV PATH=/depot_tools:$PATH
+WORKDIR /
+RUN mkdir devtools
+WORKDIR devtools
+RUN fetch devtools-frontend
+WORKDIR devtools-frontend
+RUN gn gen out/Default
+COPY --from=typescript/typescript /typescript/typescript-*.tgz typescript.tgz
+RUN mkdir /typescript
+RUN tar -xzvf /typescript.tgz -C /typescript
+RUN ln -s /typescript/package ./node_modules/typescript
+CMD [ "autoninja", "-C", "out/Default" ]

--- a/tests/cases/docker/chrome-devtools-frontend-next/Dockerfile
+++ b/tests/cases/docker/chrome-devtools-frontend-next/Dockerfile
@@ -7,8 +7,11 @@ WORKDIR devtools
 RUN fetch devtools-frontend
 WORKDIR devtools-frontend
 RUN gn gen out/Default
-COPY --from=typescript/typescript /typescript/typescript-*.tgz typescript.tgz
+COPY --from=typescript/typescript /typescript/typescript-*.tgz /typescript.tgz
 RUN mkdir /typescript
 RUN tar -xzvf /typescript.tgz -C /typescript
 RUN ln -s /typescript/package ./node_modules/typescript
-RUN autoninja -C out/Default front_end
+# We don't want to show the ordering of which tasks ran in Ninja, as that is non-deterministic.
+# Instead, only show the errors in the log, from the first occurrence of a FAILED task.
+# If the task passes, then there is no log written.
+CMD ["autoninja", "-C", "out/Default", ">", "error.log", "||", "tail", "-n", "+$(sed", "-n", "'/FAILED/='", "error.log)", "error.log"]


### PR DESCRIPTION
Note that I was not able to verify it fully works, as it throws an
authentication error on typescript/typescript on the Docker Hub.

This is part of #39568

CC @weswigham
