### PR TITLE
Add twoslash repros to issues in this repo 

### DIFF
--- a/.github/workflows/twoslash-repros.yaml
+++ b/.github/workflows/twoslash-repros.yaml
@@ -1,0 +1,18 @@
+name: Twoslash Code Sample Repros
+
+on:
+  push:
+    branches:
+      - orta-twoslash-repros
+  schedule:
+    - cron:  '0 8 * * *'
+  repository_dispatch:
+    types: run-twoslash-repros
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: microsoft/TypeScript-Twoslash-Repro-Action@master
+      with: 
+        github-token: ${{ secrets.TS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #35389 

From https://github.com/microsoft/TypeScript-Website/issues/130#issuecomment-653931944

## Compiler-back Bug Repros

![giphy-3](https://user-images.githubusercontent.com/49038/86540917-60879b00-bed6-11ea-874e-f73fe3f2ea2a.gif)
[source](https://giphy.com/gifs/l3nSQg4ZcjBhbgzrq)

Keeping on top of compiler bugs is hard work, even just hitting watch on the TypeScript repo gets you many hundreds of emails a day from GitHub. Proving and validating a bug is easier now, thanks to the Playground improvements (supporting many TS versions, a lot more compiler flags etc), but it's still hard to keep on top of and Ryan C basically lives in an almost permanent state of triage in our issues.

To give us the chance to improve our bug reports via automation, I wrote [an RFC pitching that we can support letting people write compiler backed bug reports](https://github.com/microsoft/TypeScript/issues/35389) in issues/comments which we can use to know when a bug is fixed, and if it has regressed in the future.

There are two parts to this system:

 - Making good bug reports
 - Verifying Bugs

#### Making Good Bug Reports

This is done by offering a web-app which gives you real-time information about the bug report you are making. Here's an example of the bug workbench which shows an inconsistency in the way we present a particular type  ( https://github.com/microsoft/TypeScript/issues/39262 )

<a href="https://www.staging-typescript.org/dev/bug-workbench/?#code/PTAEAkHsDcFMCdQAMAqTQGcAWkDuHQBvUAQwC5QBWUAXwFgAoAFwE8AHWUFUAXlAAUAlgGMA1gB5i5KgBpQAIwoAiDE3iCAdgHMltOUpJKAfI0YgIMBMgAe6bHgJCxk0hUpzFoFWs069XwxMGcyg4RFQ7HHwiVypaRgATWGEAGxJ4TmFIDVVQFgoUMzBQEtKy0AA9AH5E5LSM0CycplBrAoBuIvLusurGIA"><img width="1238" alt="Screen Shot 2020-07-05 at 3 19 02 PM" src="https://user-images.githubusercontent.com/49038/86540393-ef92b400-bed2-11ea-9607-1000a346916c.png"></a>

The app uses the same [twoslash](https://www.npmjs.com/package/@typescript/twoslash) syntax we use in [code snippets inside the TypeScript website](https://github.com/microsoft/TypeScript-Website/search?q=ts+twoslash&unscoped_q=ts+twoslash&type=Code) to highlight type information for a particular identifier. The workbench calls the results of these queries assertions, you can assert things like:

- Compiler errors
- What an identifier says it is (like above)
- The emitted .js/.d.ts/.map files from a sample
- Completion entries

The site's goal is to teach you the syntax, and get you making repros quickly, so there's a lot of documentation in the app:

<a href="https://www.staging-typescript.org/dev/bug-workbench/?#code/PTAEAkHsDcFMCdQAMAqTQGcAWkDuHQBvUAQwC5QBWUAXwFgAoAFwE8AHWUFUAXlAAUAlgGMA1gB5i5KgBpQAIwoAiDE3iCAdgHMltOUpJKAfI0YgIMBMgAe6bHgJCxk0hUpzFoFWs069XwxMGcyg4RFQ7HHwiVypaRgATWGEAGxJ4TmFIDVVQFgoUMzBQEtKy0AA9AH5E5LSM0CycplBrAoBuIvLusurGIA"><img width="1238" alt="Screen Shot 2020-07-05 at 3 26 57 PM" src="https://user-images.githubusercontent.com/49038/86540510-fd950480-bed3-11ea-8594-eaef2c6478ba.png"></a>

I've been using it to write code samples for the TypeScript v2 website as it's faster than using my text editor and the CLI.

#### Verifying Bugs

Once you've got your repro, it gets pasted into an issue or a comment on an issue. From here it gets picker up by the verification tools. This is a GitHub Action you can find at [microsoft/TypeScript-Twoslash-Repro-Action](https://github.com/microsoft/TypeScript-Twoslash-Repro-Action/) and its job is to run nightly and provide useful information about the state of your compiler-backed bug report.

You would write a repro like:

<img width="1061" alt="Screen Shot 2020-07-05 at 3 04 33 PM" src="https://user-images.githubusercontent.com/49038/86540568-65e3e600-bed4-11ea-887a-35e1ca3968e6.png">

Then overnight the bot would post something like this:

<img width="1063" alt="Screen Shot 2020-07-05 at 3 32 17 PM" src="https://user-images.githubusercontent.com/49038/86540611-be1ae800-bed4-11ea-8fce-b8d1f983a885.png">

Expanding the historical section, you can see that the verification step has also checked the repro against older builds:

<img width="1065" alt="Screen Shot 2020-07-05 at 3 33 22 PM" src="https://user-images.githubusercontent.com/49038/86540663-f6222b00-bed4-11ea-806d-8351d40009c1.png">

So, it looks like the bug only existed for 3.8 and 3.9. This bug was looked at after I created the repro and is actually fixed now, so the nightly run updates the original comment so that someone looking over the issue can see the new results against historical data.