### PR TITLE
tests(39373): add addition tests

### DIFF
--- a/tests/baselines/reference/declarationEmitExpressionInExtends6.errors.txt
+++ b/tests/baselines/reference/declarationEmitExpressionInExtends6.errors.txt
@@ -10,6 +10,6 @@
 ==== /node_modules/@types/node/index.d.ts (0 errors) ====
     declare const require: any;
     
-==== /a.ts (0 errors) ====
+==== /a.js (0 errors) ====
     export class Foo {}
     

--- a/tests/baselines/reference/declarationEmitExpressionInExtends7.errors.txt
+++ b/tests/baselines/reference/declarationEmitExpressionInExtends7.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/declarationEmitExpressionInExtends7.ts(1,30): error TS2304: Cannot find name 'SomeUndefinedFunction'.
+tests/cases/compiler/declarationEmitExpressionInExtends7.ts(1,30): error TS4021: 'extends' clause of exported class has or is using private name 'SomeUndefinedFunction'.
+
+
+==== tests/cases/compiler/declarationEmitExpressionInExtends7.ts (2 errors) ====
+    export default class extends SomeUndefinedFunction {}
+                                 ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2304: Cannot find name 'SomeUndefinedFunction'.
+                                 ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS4021: 'extends' clause of exported class has or is using private name 'SomeUndefinedFunction'.
+    

--- a/tests/baselines/reference/declarationEmitExpressionInExtends7.js
+++ b/tests/baselines/reference/declarationEmitExpressionInExtends7.js
@@ -1,17 +1,8 @@
-//// [tests/cases/compiler/declarationEmitExpressionInExtends6.ts] ////
-
-//// [index.d.ts]
-declare const require: any;
-
-//// [a.js]
-export class Foo {}
-
-//// [b.ts]
-const { Foo } = require("./a");
-export default class extends Foo {}
+//// [declarationEmitExpressionInExtends7.ts]
+export default class extends SomeUndefinedFunction {}
 
 
-//// [b.js]
+//// [declarationEmitExpressionInExtends7.js]
 "use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
@@ -27,12 +18,11 @@ var __extends = (this && this.__extends) || (function () {
     };
 })();
 exports.__esModule = true;
-var Foo = require("./a").Foo;
 var default_1 = /** @class */ (function (_super) {
     __extends(default_1, _super);
     function default_1() {
         return _super !== null && _super.apply(this, arguments) || this;
     }
     return default_1;
-}(Foo));
+}(SomeUndefinedFunction));
 exports["default"] = default_1;

--- a/tests/baselines/reference/declarationEmitExpressionInExtends7.symbols
+++ b/tests/baselines/reference/declarationEmitExpressionInExtends7.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/declarationEmitExpressionInExtends7.ts ===
+export default class extends SomeUndefinedFunction {}
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/declarationEmitExpressionInExtends7.types
+++ b/tests/baselines/reference/declarationEmitExpressionInExtends7.types
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/declarationEmitExpressionInExtends7.ts ===
+export default class extends SomeUndefinedFunction {}
+>SomeUndefinedFunction : any
+

--- a/tests/cases/compiler/declarationEmitExpressionInExtends6.ts
+++ b/tests/cases/compiler/declarationEmitExpressionInExtends6.ts
@@ -1,12 +1,13 @@
 // @module: commonjs
 // @declaration: true
+// @allowJs: true
 // @types: node
 // @currentDirectory: /
 
 // @Filename: /node_modules/@types/node/index.d.ts
 declare const require: any;
 
-// @Filename: /a.ts
+// @Filename: /a.js
 export class Foo {}
 
 // @Filename: /b.ts

--- a/tests/cases/compiler/declarationEmitExpressionInExtends7.ts
+++ b/tests/cases/compiler/declarationEmitExpressionInExtends7.ts
@@ -1,0 +1,2 @@
+// @declaration: true
+export default class extends SomeUndefinedFunction {}


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/pull/39567#issuecomment-659745579

Actually we can cover the new message without `require`, as it did for cases for named classes - [declarationEmitExpressionInExtends4](https://github.com/microsoft/TypeScript/blob/master/tests/cases/compiler/declarationEmitExpressionInExtends4.ts). I just followed the code from the bug description. I added a new one similar to `declarationEmitExpressionInExtends4` and changed the original test based on your comment. If you think one of them useless I'll leave only one.

cc @DanielRosenwasser 