### PR TITLE
Explicitly add dependency on node to compiler tsconfig, remove es6+ string method usage

### DIFF
--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -746,7 +746,7 @@ namespace ts {
                 for (const containingFilePath of Debug.assertDefined(resolution.files)) {
                     (filesWithInvalidatedResolutions || (filesWithInvalidatedResolutions = new Set())).add(containingFilePath);
                     // When its a file with inferred types resolution, invalidate type reference directive resolution
-                    hasChangedAutomaticTypeDirectiveNames = hasChangedAutomaticTypeDirectiveNames || containingFilePath.endsWith(inferredTypesContainingFile);
+                    hasChangedAutomaticTypeDirectiveNames = hasChangedAutomaticTypeDirectiveNames || endsWith(containingFilePath, inferredTypesContainingFile);
                 }
             }
             return invalidated;

--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "extends": "../tsconfig-base",
     "compilerOptions": {
-        "outFile": "../../built/local/compiler.js"
+        "outFile": "../../built/local/compiler.js",
+        "types": ["node"]
     },
 
     "references": [


### PR DESCRIPTION
Fixes our own build post-LKG by making the `compiler`'s dependency on `node` explicit.

> The why is subtle - it's because of https://github.com/microsoft/TypeScript/commit/37e6e2761c89d920a4f63bf07115984b9989fc5f . This broke us because we do not have a direct reference to the node types anywhere in our codebase. Instead, we were implicitly pulling in the types for source-map-support here: https://github.com/microsoft/TypeScript/blob/master/src/compiler/sys.ts#L1255 
which in turn included node and thus the es6 lib.

We may want to flag 37e6e2761c89d920a4f63bf07115984b9989fc5f  as a breaking change (and thus mention it in the release announcement), considering we broke ourselves :V