### PR TITLE
Redo in narrowing for intersections

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21430,7 +21430,7 @@ namespace ts {
             }
 
             function narrowByInKeyword(type: Type, literal: LiteralExpression, assumeTrue: boolean) {
-                if (type.flags & (TypeFlags.Union | TypeFlags.Object) || isThisTypeParameter(type)) {
+                if (type.flags & (TypeFlags.Union | TypeFlags.Object | TypeFlags.Intersection) || isThisTypeParameter(type)) {
                     const propName = escapeLeadingUnderscores(literal.text);
                     return filterType(type, t => isTypePresencePossible(t, propName, assumeTrue));
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21430,7 +21430,9 @@ namespace ts {
             }
 
             function narrowByInKeyword(type: Type, literal: LiteralExpression, assumeTrue: boolean) {
-                if (type.flags & (TypeFlags.Union | TypeFlags.Object | TypeFlags.Intersection) || isThisTypeParameter(type)) {
+                if (type.flags & (TypeFlags.Union | TypeFlags.Object)
+                    || isThisTypeParameter(type)
+                    || type.flags & TypeFlags.Intersection && every((type as IntersectionType).types, t => t.symbol !== globalThisSymbol)) {
                     const propName = escapeLeadingUnderscores(literal.text);
                     return filterType(type, t => isTypePresencePossible(t, propName, assumeTrue));
                 }

--- a/tests/baselines/reference/inKeywordTypeguard.errors.txt
+++ b/tests/baselines/reference/inKeywordTypeguard.errors.txt
@@ -165,4 +165,11 @@ tests/cases/compiler/inKeywordTypeguard.ts(94,26): error TS2339: Property 'a' do
             let n: never = x;
         }
     }
+    function negativeIntersectionTest() {
+        if ("ontouchstart" in window) {
+            window.ontouchstart
+        } else {
+            window.ontouchstart
+        }
+    }
     

--- a/tests/baselines/reference/inKeywordTypeguard.errors.txt
+++ b/tests/baselines/reference/inKeywordTypeguard.errors.txt
@@ -19,10 +19,9 @@ tests/cases/compiler/inKeywordTypeguard.ts(74,32): error TS2339: Property 'a' do
 tests/cases/compiler/inKeywordTypeguard.ts(82,39): error TS2339: Property 'b' does not exist on type 'A'.
 tests/cases/compiler/inKeywordTypeguard.ts(84,39): error TS2339: Property 'a' does not exist on type 'B'.
 tests/cases/compiler/inKeywordTypeguard.ts(94,26): error TS2339: Property 'a' does not exist on type 'never'.
-tests/cases/compiler/inKeywordTypeguard.ts(103,13): error TS2322: Type '{ a: string; } & { b: string; }' is not assignable to type 'never'.
 
 
-==== tests/cases/compiler/inKeywordTypeguard.ts (18 errors) ====
+==== tests/cases/compiler/inKeywordTypeguard.ts (17 errors) ====
     class A { a: string; }
     class B { b: string; }
     
@@ -164,8 +163,6 @@ tests/cases/compiler/inKeywordTypeguard.ts(103,13): error TS2322: Type '{ a: str
             let s: string = x.a;
         } else {
             let n: never = x;
-                ~
-!!! error TS2322: Type '{ a: string; } & { b: string; }' is not assignable to type 'never'.
         }
     }
     

--- a/tests/baselines/reference/inKeywordTypeguard.js
+++ b/tests/baselines/reference/inKeywordTypeguard.js
@@ -104,6 +104,13 @@ function positiveIntersectionTest(x: { a: string } & { b: string }) {
         let n: never = x;
     }
 }
+function negativeIntersectionTest() {
+    if ("ontouchstart" in window) {
+        window.ontouchstart
+    } else {
+        window.ontouchstart
+    }
+}
 
 
 //// [inKeywordTypeguard.js]
@@ -243,5 +250,13 @@ function positiveIntersectionTest(x) {
     }
     else {
         var n = x;
+    }
+}
+function negativeIntersectionTest() {
+    if ("ontouchstart" in window) {
+        window.ontouchstart;
+    }
+    else {
+        window.ontouchstart;
     }
 }

--- a/tests/baselines/reference/inKeywordTypeguard.symbols
+++ b/tests/baselines/reference/inKeywordTypeguard.symbols
@@ -261,4 +261,22 @@ function positiveIntersectionTest(x: { a: string } & { b: string }) {
 >x : Symbol(x, Decl(inKeywordTypeguard.ts, 98, 34))
     }
 }
+function negativeIntersectionTest() {
+>negativeIntersectionTest : Symbol(negativeIntersectionTest, Decl(inKeywordTypeguard.ts, 104, 1))
+
+    if ("ontouchstart" in window) {
+>window : Symbol(window, Decl(lib.dom.d.ts, --, --))
+
+        window.ontouchstart
+>window.ontouchstart : Symbol(ontouchstart, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>window : Symbol(window, Decl(lib.dom.d.ts, --, --))
+>ontouchstart : Symbol(ontouchstart, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    } else {
+        window.ontouchstart
+>window.ontouchstart : Symbol(ontouchstart, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>window : Symbol(window, Decl(lib.dom.d.ts, --, --))
+>ontouchstart : Symbol(ontouchstart, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+    }
+}
 

--- a/tests/baselines/reference/inKeywordTypeguard.types
+++ b/tests/baselines/reference/inKeywordTypeguard.types
@@ -321,4 +321,24 @@ function positiveIntersectionTest(x: { a: string } & { b: string }) {
 >x : never
     }
 }
+function negativeIntersectionTest() {
+>negativeIntersectionTest : () => void
+
+    if ("ontouchstart" in window) {
+>"ontouchstart" in window : boolean
+>"ontouchstart" : "ontouchstart"
+>window : Window & typeof globalThis
+
+        window.ontouchstart
+>window.ontouchstart : ((this: GlobalEventHandlers, ev: TouchEvent) => any) & ((this: Window, ev: TouchEvent) => any)
+>window : Window & typeof globalThis
+>ontouchstart : ((this: GlobalEventHandlers, ev: TouchEvent) => any) & ((this: Window, ev: TouchEvent) => any)
+
+    } else {
+        window.ontouchstart
+>window.ontouchstart : ((this: GlobalEventHandlers, ev: TouchEvent) => any) & ((this: Window, ev: TouchEvent) => any)
+>window : Window & typeof globalThis
+>ontouchstart : ((this: GlobalEventHandlers, ev: TouchEvent) => any) & ((this: Window, ev: TouchEvent) => any)
+    }
+}
 

--- a/tests/baselines/reference/inKeywordTypeguard.types
+++ b/tests/baselines/reference/inKeywordTypeguard.types
@@ -318,7 +318,7 @@ function positiveIntersectionTest(x: { a: string } & { b: string }) {
     } else {
         let n: never = x;
 >n : never
->x : { a: string; } & { b: string; }
+>x : never
     }
 }
 

--- a/tests/cases/compiler/inKeywordTypeguard.ts
+++ b/tests/cases/compiler/inKeywordTypeguard.ts
@@ -103,3 +103,10 @@ function positiveIntersectionTest(x: { a: string } & { b: string }) {
         let n: never = x;
     }
 }
+function negativeIntersectionTest() {
+    if ("ontouchstart" in window) {
+        window.ontouchstart
+    } else {
+        window.ontouchstart
+    }
+}


### PR DESCRIPTION
This fixes the breaking change from the 3.9 beta by adding a simple exemption for `typeof globalThis`. It does not do the more complicated fix of exempting optional properties from in-narrowing; I'm going to look at that next, but I need to convince myself whether it'll actually help.

Fixes #37039
Fixes #38162 (mostly)
