### PR TITLE
fix(31126): No completions for interface `extends` clause for members of nested namespaces

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1149,13 +1149,12 @@ namespace ts.Completions {
                 || isPartOfTypeNode(node.parent)
                 || isPossiblyTypeArgumentPosition(contextToken, sourceFile, typeChecker);
             const isRhsOfImportDeclaration = isInRightSideOfInternalImportEqualsDeclaration(node);
-            if (isEntityName(node) || isImportType) {
+            if (isEntityName(node) || isImportType || isPropertyAccessExpression(node)) {
                 const isNamespaceName = isModuleDeclaration(node.parent);
                 if (isNamespaceName) isNewIdentifierLocation = true;
                 let symbol = typeChecker.getSymbolAtLocation(node);
                 if (symbol) {
                     symbol = skipAlias(symbol, typeChecker);
-
                     if (symbol.flags & (SymbolFlags.Module | SymbolFlags.Enum)) {
                         // Extract module or enum members
                         const exportedSymbols = typeChecker.getExportsOfModule(symbol);

--- a/tests/cases/fourslash/completionListInNestedNamespaceName.ts
+++ b/tests/cases/fourslash/completionListInNestedNamespaceName.ts
@@ -1,0 +1,27 @@
+/// <reference path='fourslash.ts'/>
+
+////namespace A {
+////    export namespace B {
+////        export interface C {}
+////    }
+////}
+////
+////interface T1 extends A/*1*/
+////
+////declare const t2: A/*2*/
+////
+////const t3 = (x: A/*3*/) => {}
+////
+////interface T4 {
+////   c: A/*4*/
+////}
+
+for (const marker of test.markers()) {
+    goTo.marker(marker);
+    edit.insert(".");
+    verify.completions({ exact: ["B"] });
+    edit.insert("B.");
+    verify.completions({ exact: ["C"] });
+    edit.insert("C.");
+    verify.completions({ exact: undefined });
+}


### PR DESCRIPTION
Fixes #31126 