### PR TITLE
Fixes confusing logs and unnecessary configFile checks from navto by keeping project with result.

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2102,6 +2102,7 @@ namespace ts.server {
          * @returns: true if set of files in the project stays the same and false - otherwise.
          */
         updateGraph(): boolean {
+            const isInitialLoad = this.isInitialLoadPending();
             this.isInitialLoadPending = returnFalse;
             const reloadLevel = this.pendingReload;
             this.pendingReload = ConfigFileProgramReloadLevel.None;
@@ -2115,7 +2116,7 @@ namespace ts.server {
                     this.openFileWatchTriggered.clear();
                     const reason = Debug.checkDefined(this.pendingReloadReason);
                     this.pendingReloadReason = undefined;
-                    this.projectService.reloadConfiguredProject(this, reason);
+                    this.projectService.reloadConfiguredProject(this, reason, isInitialLoad);
                     result = true;
                     break;
                 default:


### PR DESCRIPTION
This fixes multiple issues:
1. When combining result, we now keep project it got the result from so that can be used to map the result correctly if some kind of manipulation is needed. 
2. Info now logs correct information about 'loading' and not 'reloading' when solution project is loaded (because it was just created and not loaded when file was opened to delay that as long as it is needed)
3. default config file name is cached for the file instead of having to recalculate it everytime someone asks for default project for open file.
Fixes #38491

