### PR TITLE
The iteration type of overloaded iterator signatures derives from the intersection of their return types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33600,7 +33600,7 @@ namespace ts {
                 return setCachedIterationTypes(type, resolver.iterableCacheKey, noIterationTypes);
             }
 
-            const iteratorType = getUnionType(map(signatures, getReturnTypeOfSignature), UnionReduction.Subtype);
+            const iteratorType = getIntersectionType(map(signatures, getReturnTypeOfSignature));
             const iterationTypes = getIterationTypesOfIterator(iteratorType, resolver, errorNode) ?? noIterationTypes;
             return setCachedIterationTypes(type, resolver.iterableCacheKey, iterationTypes);
         }
@@ -33806,7 +33806,7 @@ namespace ts {
 
             // Resolve the *yield* and *return* types from the return type of the method (i.e. `IteratorResult`)
             let yieldType: Type;
-            const methodReturnType = methodReturnTypes ? getUnionType(methodReturnTypes, UnionReduction.Subtype) : neverType;
+            const methodReturnType = methodReturnTypes ? getIntersectionType(methodReturnTypes) : neverType;
             const resolvedMethodReturnType = resolver.resolveIterationType(methodReturnType, errorNode) || anyType;
             const iterationTypes = getIterationTypesOfIteratorResult(resolvedMethodReturnType);
             if (iterationTypes === noIterationTypes) {

--- a/tests/baselines/reference/for-of58.js
+++ b/tests/baselines/reference/for-of58.js
@@ -1,0 +1,17 @@
+//// [for-of58.ts]
+type X = { x: 'x' };
+type Y = { y: 'y' };
+
+declare const arr: X[] & Y[];
+
+for (const item of arr) {
+    item.x;
+    item.y;
+}
+
+
+//// [for-of58.js]
+for (const item of arr) {
+    item.x;
+    item.y;
+}

--- a/tests/baselines/reference/for-of58.symbols
+++ b/tests/baselines/reference/for-of58.symbols
@@ -1,0 +1,29 @@
+=== tests/cases/conformance/es6/for-ofStatements/for-of58.ts ===
+type X = { x: 'x' };
+>X : Symbol(X, Decl(for-of58.ts, 0, 0))
+>x : Symbol(x, Decl(for-of58.ts, 0, 10))
+
+type Y = { y: 'y' };
+>Y : Symbol(Y, Decl(for-of58.ts, 0, 20))
+>y : Symbol(y, Decl(for-of58.ts, 1, 10))
+
+declare const arr: X[] & Y[];
+>arr : Symbol(arr, Decl(for-of58.ts, 3, 13))
+>X : Symbol(X, Decl(for-of58.ts, 0, 0))
+>Y : Symbol(Y, Decl(for-of58.ts, 0, 20))
+
+for (const item of arr) {
+>item : Symbol(item, Decl(for-of58.ts, 5, 10))
+>arr : Symbol(arr, Decl(for-of58.ts, 3, 13))
+
+    item.x;
+>item.x : Symbol(x, Decl(for-of58.ts, 0, 10))
+>item : Symbol(item, Decl(for-of58.ts, 5, 10))
+>x : Symbol(x, Decl(for-of58.ts, 0, 10))
+
+    item.y;
+>item.y : Symbol(y, Decl(for-of58.ts, 1, 10))
+>item : Symbol(item, Decl(for-of58.ts, 5, 10))
+>y : Symbol(y, Decl(for-of58.ts, 1, 10))
+}
+

--- a/tests/baselines/reference/for-of58.types
+++ b/tests/baselines/reference/for-of58.types
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/es6/for-ofStatements/for-of58.ts ===
+type X = { x: 'x' };
+>X : X
+>x : "x"
+
+type Y = { y: 'y' };
+>Y : Y
+>y : "y"
+
+declare const arr: X[] & Y[];
+>arr : X[] & Y[]
+
+for (const item of arr) {
+>item : X & Y
+>arr : X[] & Y[]
+
+    item.x;
+>item.x : "x"
+>item : X & Y
+>x : "x"
+
+    item.y;
+>item.y : "y"
+>item : X & Y
+>y : "y"
+}
+

--- a/tests/cases/conformance/es6/for-ofStatements/for-of58.ts
+++ b/tests/cases/conformance/es6/for-ofStatements/for-of58.ts
@@ -1,0 +1,10 @@
+// @target: es6
+type X = { x: 'x' };
+type Y = { y: 'y' };
+
+declare const arr: X[] & Y[];
+
+for (const item of arr) {
+    item.x;
+    item.y;
+}


### PR DESCRIPTION
Fixes #35421 

I think the correct behavior for #35421 is intuitive, but the short explanation is

1. Iteration types are obtained by taking some return types from some methods (`[Symbol.iterator]()`, then that return type’s `next()`, `return()`, and `throw()` methods)
2. Intersected function/method signatures are synonymous with overloads, represented by the constituents of the array returned by `getIntersectionsOfType()` in the checker
3. So if there are multiple signatures for `[Symbol.iterator]()` or `next()` and friends, to get a single return type from them, we’d need to take the intersection of the return types from each signature (since the return type is a covariant position). Prior to this PR, we were taking the union instead.

If you work out the types by doing the member-wise intersection of `Array<X> & Array<Y>` on the `[Symbol.iterator]()` method, you can also easily convince yourself that you eventually get to a return type of `{ value: X & Y, done?: boolean }` (simplifying the union from `IteratorResult<T>` for clarity).
