### PR TITLE
Add separate flag serverMode for server mode

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -621,7 +621,7 @@ namespace ts.server {
         CommandNames.ProvideCallHierarchyOutgoingCalls,
     ];
 
-    const invalidSyntxOnlyCommands: readonly CommandNames[] = [
+    const invalidSyntaxOnlyCommands: readonly CommandNames[] = [
         ...invalidApproximateSemanticOnlyCommands,
         CommandNames.Definition,
         CommandNames.DefinitionFull,
@@ -759,7 +759,7 @@ namespace ts.server {
                     );
                     break;
                 case LanguageServiceMode.SyntaxOnly:
-                    invalidSyntxOnlyCommands.forEach(commandName =>
+                    invalidSyntaxOnlyCommands.forEach(commandName =>
                         this.handlers.set(commandName, request => {
                             throw new Error(`Request: ${request.command} not allowed on syntax only server`);
                         })

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -585,7 +585,7 @@ namespace ts.server {
             undefined;
     }
 
-    const invalidSyntaxOnlyCommands: readonly CommandNames[] = [
+    const invalidApproximateSemanticOnlyCommands: readonly CommandNames[] = [
         CommandNames.OpenExternalProject,
         CommandNames.OpenExternalProjects,
         CommandNames.CloseExternalProject,
@@ -621,6 +621,36 @@ namespace ts.server {
         CommandNames.ProvideCallHierarchyOutgoingCalls,
     ];
 
+    const invalidSyntxOnlyCommands: readonly CommandNames[] = [
+        ...invalidApproximateSemanticOnlyCommands,
+        CommandNames.Definition,
+        CommandNames.DefinitionFull,
+        CommandNames.DefinitionAndBoundSpan,
+        CommandNames.DefinitionAndBoundSpanFull,
+        CommandNames.TypeDefinition,
+        CommandNames.Implementation,
+        CommandNames.ImplementationFull,
+        CommandNames.References,
+        CommandNames.ReferencesFull,
+        CommandNames.Rename,
+        CommandNames.RenameLocationsFull,
+        CommandNames.RenameInfoFull,
+        CommandNames.Quickinfo,
+        CommandNames.QuickinfoFull,
+        CommandNames.CompletionInfo,
+        CommandNames.Completions,
+        CommandNames.CompletionsFull,
+        CommandNames.CompletionDetails,
+        CommandNames.CompletionDetailsFull,
+        CommandNames.SignatureHelp,
+        CommandNames.SignatureHelpFull,
+        CommandNames.Navto,
+        CommandNames.NavtoFull,
+        CommandNames.Occurrences,
+        CommandNames.DocumentHighlights,
+        CommandNames.DocumentHighlightsFull,
+    ];
+
     export interface SessionOptions {
         host: ServerHost;
         cancellationToken: ServerCancellationToken;
@@ -637,7 +667,9 @@ namespace ts.server {
         eventHandler?: ProjectServiceEventHandler;
         /** Has no effect if eventHandler is also specified. */
         suppressDiagnosticEvents?: boolean;
+        /** @deprecated use serverMode instead */
         syntaxOnly?: boolean;
+        serverMode?: LanguageServiceMode;
         throttleWaitMilliseconds?: number;
         noGetErrOnBackgroundUpdate?: boolean;
 
@@ -709,18 +741,32 @@ namespace ts.server {
                 allowLocalPluginLoads: opts.allowLocalPluginLoads,
                 typesMapLocation: opts.typesMapLocation,
                 syntaxOnly: opts.syntaxOnly,
+                serverMode: opts.serverMode,
             };
             this.projectService = new ProjectService(settings);
             this.projectService.setPerformanceEventHandler(this.performanceEventHandler.bind(this));
             this.gcTimer = new GcTimer(this.host, /*delay*/ 7000, this.logger);
 
-            // Make sure to setup handlers to throw error for not allowed commands on syntax server;
-            if (this.projectService.syntaxOnly) {
-                invalidSyntaxOnlyCommands.forEach(commandName =>
-                    this.handlers.set(commandName, request => {
-                        throw new Error(`Request: ${request.command} not allowed on syntaxServer`);
-                    })
-                );
+            // Make sure to setup handlers to throw error for not allowed commands on syntax server
+            switch (this.projectService.serverMode) {
+                case LanguageServiceMode.Semantic:
+                    break;
+                case LanguageServiceMode.ApproximateSemanticOnly:
+                    invalidApproximateSemanticOnlyCommands.forEach(commandName =>
+                        this.handlers.set(commandName, request => {
+                            throw new Error(`Request: ${request.command} not allowed on approximate semantic only server`);
+                        })
+                    );
+                    break;
+                case LanguageServiceMode.SyntaxOnly:
+                    invalidSyntxOnlyCommands.forEach(commandName =>
+                        this.handlers.set(commandName, request => {
+                            throw new Error(`Request: ${request.command} not allowed on syntax only server`);
+                        })
+                    );
+                    break;
+                default:
+                    Debug.assertNever(this.projectService.serverMode);
             }
         }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1171,7 +1171,7 @@ namespace ts {
         }
     }
 
-    const invalidOperationsOnSyntaxOnly: readonly (keyof LanguageService)[] = [
+    const invalidOperationsOnApproximateSemanticOnly: readonly (keyof LanguageService)[] = [
         "getSyntacticDiagnostics",
         "getSemanticDiagnostics",
         "getSuggestionDiagnostics",
@@ -1191,10 +1191,42 @@ namespace ts {
         "provideCallHierarchyOutgoingCalls",
     ];
 
+    const invalidOperationsOnSyntaxOnly: readonly (keyof LanguageService)[] = [
+        ...invalidOperationsOnApproximateSemanticOnly,
+        "getCompletionsAtPosition",
+        "getCompletionEntryDetails",
+        "getCompletionEntrySymbol",
+        "getSignatureHelpItems",
+        "getQuickInfoAtPosition",
+        "getDefinitionAtPosition",
+        "getDefinitionAndBoundSpan",
+        "getImplementationAtPosition",
+        "getTypeDefinitionAtPosition",
+        "getReferencesAtPosition",
+        "findReferences",
+        "getOccurrencesAtPosition",
+        "getDocumentHighlights",
+        "getNavigateToItems",
+        "getRenameInfo",
+        "findRenameLocations",
+        "getApplicableRefactors",
+    ];
     export function createLanguageService(
         host: LanguageServiceHost,
         documentRegistry: DocumentRegistry = createDocumentRegistry(host.useCaseSensitiveFileNames && host.useCaseSensitiveFileNames(), host.getCurrentDirectory()),
-        syntaxOnly = false): LanguageService {
+        syntaxOnlyOrLanguageServiceMode?: boolean | LanguageServiceMode,
+    ): LanguageService {
+        let languageServiceMode: LanguageServiceMode;
+        if (syntaxOnlyOrLanguageServiceMode === undefined) {
+            languageServiceMode = LanguageServiceMode.Semantic;
+        }
+        else if (typeof syntaxOnlyOrLanguageServiceMode === "boolean") {
+            // languageServiceMode = SyntaxOnly
+            languageServiceMode = syntaxOnlyOrLanguageServiceMode ? LanguageServiceMode.SyntaxOnly : LanguageServiceMode.Semantic;
+        }
+        else {
+            languageServiceMode = syntaxOnlyOrLanguageServiceMode;
+        }
 
         const syntaxTreeCache: SyntaxTreeCache = new SyntaxTreeCache(host);
         let program: Program;
@@ -1244,6 +1276,7 @@ namespace ts {
         }
 
         function synchronizeHostData(): void {
+            Debug.assert(languageServiceMode !== LanguageServiceMode.SyntaxOnly);
             // perform fast check if host supports it
             if (host.getProjectVersion) {
                 const hostProjectVersion = host.getProjectVersion();
@@ -1429,6 +1462,11 @@ namespace ts {
 
         // TODO: GH#18217 frequently asserted as defined
         function getProgram(): Program | undefined {
+            if (languageServiceMode === LanguageServiceMode.SyntaxOnly) {
+                Debug.assert(program === undefined);
+                return undefined;
+            }
+
             synchronizeHostData();
 
             return program;
@@ -2504,14 +2542,26 @@ namespace ts {
             uncommentSelection,
         };
 
-        if (syntaxOnly) {
-            invalidOperationsOnSyntaxOnly.forEach(key =>
-                ls[key] = () => {
-                    throw new Error(`LanguageService Operation: ${key} not allowed on syntaxServer`);
-                }
-            );
+        switch (languageServiceMode) {
+            case LanguageServiceMode.Semantic:
+                break;
+            case LanguageServiceMode.ApproximateSemanticOnly:
+                invalidOperationsOnApproximateSemanticOnly.forEach(key =>
+                    ls[key] = () => {
+                        throw new Error(`LanguageService Operation: ${key} not allowed on approximate semantic only server`);
+                    }
+                );
+                break;
+            case LanguageServiceMode.SyntaxOnly:
+                invalidOperationsOnSyntaxOnly.forEach(key =>
+                    ls[key] = () => {
+                        throw new Error(`LanguageService Operation: ${key} not allowed on syntax only server`);
+                    }
+                );
+                break;
+            default:
+                Debug.assertNever(languageServiceMode);
         }
-
         return ls;
     }
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -221,6 +221,12 @@ namespace ts {
         durationMs: number;
     }
 
+    export enum LanguageServiceMode {
+        Semantic,
+        ApproximateSemanticOnly,
+        SyntaxOnly,
+    }
+
     //
     // Public interface of the host of a language service instance.
     //

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -145,6 +145,7 @@
         "unittests/tscWatch/watchApi.ts",
         "unittests/tscWatch/watchEnvironment.ts",
         "unittests/tsserver/applyChangesToOpenFiles.ts",
+        "unittests/tsserver/approximateSemanticOnlyServer.ts",
         "unittests/tsserver/autoImportProvider.ts",
         "unittests/tsserver/cachingFileSystemInformation.ts",
         "unittests/tsserver/cancellationToken.ts",

--- a/src/testRunner/unittests/tsserver/approximateSemanticOnlyServer.ts
+++ b/src/testRunner/unittests/tsserver/approximateSemanticOnlyServer.ts
@@ -1,5 +1,5 @@
 namespace ts.projectSystem {
-    describe("unittests:: tsserver:: Semantic operations on Syntax server", () => {
+    describe("unittests:: tsserver:: Semantic operations on Approximate Semantic only server", () => {
         function setup() {
             const file1: File = {
                 path: `${tscWatch.projectRoot}/a.ts`,
@@ -26,78 +26,99 @@ import { something } from "something";
                 content: "{}"
             };
             const host = createServerHost([file1, file2, file3, something, libFile, configFile]);
-            const session = createSession(host, { syntaxOnly: true, useSingleInferredProject: true });
+            const session = createSession(host, { serverMode: LanguageServiceMode.ApproximateSemanticOnly, useSingleInferredProject: true });
             return { host, session, file1, file2, file3, something, configFile };
         }
 
-        function verifySessionException<T extends server.protocol.Request>(session: TestSession, request: Partial<T>) {
-            let hasException = false;
-            try {
-                session.executeCommandSeq(request);
-            }
-            catch (e) {
-                assert.equal(e.message, `Request: ${request.command} not allowed on syntax only server`);
-                hasException = true;
-            }
-            assert.isTrue(hasException);
-        }
-
-        it("open files are added to inferred project even if config file is present and semantic operations fail", () => {
+        it("open files are added to inferred project even if config file is present and semantic operations succeed", () => {
             const { host, session, file1, file2, file3, something } = setup();
             const service = session.getProjectService();
             openFilesForSession([file1], session);
             checkNumberOfProjects(service, { inferredProjects: 1 });
             const project = service.inferredProjects[0];
-            checkProjectActualFiles(project, emptyArray);
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path]); // Relative import from open file is resolves but not non relative
             verifyCompletions();
             verifyGoToDefToB();
 
             openFilesForSession([file2], session);
             checkNumberOfProjects(service, { inferredProjects: 1 });
-            checkProjectActualFiles(project, emptyArray);
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, file3.path]);
             verifyCompletions();
             verifyGoToDefToB();
             verifyGoToDefToC();
 
             openFilesForSession([file3], session);
             checkNumberOfProjects(service, { inferredProjects: 1 });
-            checkProjectActualFiles(project, emptyArray);
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, file3.path]);
 
             openFilesForSession([something], session);
             checkNumberOfProjects(service, { inferredProjects: 1 });
-            checkProjectActualFiles(project, emptyArray);
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, file3.path, something.path]);
 
             // Close open files and verify resolutions
             closeFilesForSession([file3], session);
             checkNumberOfProjects(service, { inferredProjects: 1 });
-            checkProjectActualFiles(project, emptyArray);
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, file3.path, something.path]);
 
             closeFilesForSession([file2], session);
             checkNumberOfProjects(service, { inferredProjects: 1 });
-            checkProjectActualFiles(project, emptyArray);
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, file3.path, something.path]);
 
             function verifyCompletions() {
-                assert.isFalse(project.languageServiceEnabled);
+                assert.isTrue(project.languageServiceEnabled);
                 checkWatchedFiles(host, emptyArray);
                 checkWatchedDirectories(host, emptyArray, /*recursive*/ true);
                 checkWatchedDirectories(host, emptyArray, /*recursive*/ false);
-                verifySessionException<protocol.CompletionsRequest>(session, {
+                const response = session.executeCommandSeq<protocol.CompletionsRequest>({
                     command: protocol.CommandTypes.Completions,
                     arguments: protocolFileLocationFromSubstring(file1, "prop", { index: 1 })
-                });
+                }).response as protocol.CompletionEntry[];
+                assert.deepEqual(response, [
+                    completionEntry("foo", ScriptElementKind.memberFunctionElement),
+                    completionEntry("prop", ScriptElementKind.memberVariableElement),
+                ]);
+            }
+
+            function completionEntry(name: string, kind: ScriptElementKind): protocol.CompletionEntry {
+                return {
+                    name,
+                    kind,
+                    kindModifiers: "",
+                    sortText: Completions.SortText.LocationPriority,
+                    hasAction: undefined,
+                    insertText: undefined,
+                    isPackageJsonImport: undefined,
+                    isRecommended: undefined,
+                    replacementSpan: undefined,
+                    source: undefined
+                };
             }
 
             function verifyGoToDefToB() {
-                verifySessionException<protocol.DefinitionAndBoundSpanRequest>(session, {
+                const response = session.executeCommandSeq<protocol.DefinitionAndBoundSpanRequest>({
                     command: protocol.CommandTypes.DefinitionAndBoundSpan,
                     arguments: protocolFileLocationFromSubstring(file1, "y")
+                }).response as protocol.DefinitionInfoAndBoundSpan;
+                assert.deepEqual(response, {
+                    definitions: [{
+                        file: file2.path,
+                        ...protocolTextSpanWithContextFromSubstring({ fileText: file2.content, text: "y", contextText: "export const y = 10;" })
+                    }],
+                    textSpan: protocolTextSpanWithContextFromSubstring({ fileText: file1.content, text: "y" })
                 });
             }
 
             function verifyGoToDefToC() {
-                verifySessionException<protocol.DefinitionAndBoundSpanRequest>(session, {
+                const response = session.executeCommandSeq<protocol.DefinitionAndBoundSpanRequest>({
                     command: protocol.CommandTypes.DefinitionAndBoundSpan,
                     arguments: protocolFileLocationFromSubstring(file1, "cc")
+                }).response as protocol.DefinitionInfoAndBoundSpan;
+                assert.deepEqual(response, {
+                    definitions: [{
+                        file: file3.path,
+                        ...protocolTextSpanWithContextFromSubstring({ fileText: file3.content, text: "cc", contextText: "export const cc = 10;" })
+                    }],
+                    textSpan: protocolTextSpanWithContextFromSubstring({ fileText: file1.content, text: "cc" })
                 });
             }
         });
@@ -106,27 +127,36 @@ import { something } from "something";
             const { session, file1 } = setup();
             const service = session.getProjectService();
             openFilesForSession([file1], session);
-            verifySessionException<protocol.SemanticDiagnosticsSyncRequest>(session, {
+            let hasException = false;
+            const request: protocol.SemanticDiagnosticsSyncRequest = {
                 type: "request",
                 seq: 1,
                 command: protocol.CommandTypes.SemanticDiagnosticsSync,
                 arguments: { file: file1.path }
-            });
+            };
+            try {
+                session.executeCommand(request);
+            }
+            catch (e) {
+                assert.equal(e.message, `Request: semanticDiagnosticsSync not allowed on approximate semantic only server`);
+                hasException = true;
+            }
+            assert.isTrue(hasException);
 
-            let hasException = false;
+            hasException = false;
             const project = service.inferredProjects[0];
             try {
                 project.getLanguageService().getSemanticDiagnostics(file1.path);
             }
             catch (e) {
-                assert.equal(e.message, `LanguageService Operation: getSemanticDiagnostics not allowed on syntax only server`);
+                assert.equal(e.message, `LanguageService Operation: getSemanticDiagnostics not allowed on approximate semantic only server`);
                 hasException = true;
             }
             assert.isTrue(hasException);
         });
 
         it("should not include auto type reference directives", () => {
-            const { host, session, file1 } = setup();
+            const { host, session, file1, file2 } = setup();
             const atTypes: File = {
                 path: `/node_modules/@types/somemodule/index.d.ts`,
                 content: "export const something = 10;"
@@ -136,7 +166,7 @@ import { something } from "something";
             openFilesForSession([file1], session);
             checkNumberOfProjects(service, { inferredProjects: 1 });
             const project = service.inferredProjects[0];
-            checkProjectActualFiles(project, emptyArray); // Should not contain atTypes
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path]); // Should not contain atTypes
         });
 
         it("should not include referenced files from unopened files", () => {
@@ -165,23 +195,23 @@ function fooB() { }`
                 content: "{}"
             };
             const host = createServerHost([file1, file2, file3, something, libFile, configFile]);
-            const session = createSession(host, { syntaxOnly: true, useSingleInferredProject: true });
+            const session = createSession(host, { serverMode: LanguageServiceMode.ApproximateSemanticOnly, useSingleInferredProject: true });
             const service = session.getProjectService();
             openFilesForSession([file1], session);
             checkNumberOfProjects(service, { inferredProjects: 1 });
             const project = service.inferredProjects[0];
-            checkProjectActualFiles(project, emptyArray);
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, something.path]); // Should not contains c
 
             openFilesForSession([file2], session);
             checkNumberOfProjects(service, { inferredProjects: 1 });
-            assert.isFalse(project.dirty);
+            assert.isTrue(project.dirty);
             project.updateGraph();
-            checkProjectActualFiles(project, emptyArray);
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, file3.path, something.path]);
 
             closeFilesForSession([file2], session);
             checkNumberOfProjects(service, { inferredProjects: 1 });
-            assert.isTrue(project.dirty);
-            checkProjectActualFiles(project, emptyArray);
+            assert.isFalse(project.dirty);
+            checkProjectActualFiles(project, [libFile.path, file1.path, file2.path, file3.path, something.path]);
         });
     });
 }

--- a/src/testRunner/unittests/tsserver/inferredProjects.ts
+++ b/src/testRunner/unittests/tsserver/inferredProjects.ts
@@ -86,7 +86,7 @@ namespace ts.projectSystem {
             const proj = projectService.inferredProjects[0];
             assert.isDefined(proj);
 
-            assert.isTrue(proj.languageServiceEnabled);
+            assert.isFalse(proj.languageServiceEnabled);
         });
 
         it("project settings for inferred projects", () => {

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -516,6 +516,7 @@ namespace ts.server {
                 canUseEvents: true,
                 suppressDiagnosticEvents,
                 syntaxOnly,
+                serverMode,
                 noGetErrOnBackgroundUpdate,
                 globalPlugins,
                 pluginProbeLocations,
@@ -948,6 +949,26 @@ namespace ts.server {
         return arg.split(",").filter(name => name !== "");
     }
 
+    let unknownServerMode: string | undefined;
+    function parseServerMode(): LanguageServiceMode | undefined {
+        const mode = findArgument("--serverMode");
+        if (mode === undefined) {
+            return undefined;
+        }
+
+        switch (mode.toLowerCase()) {
+            case "semantic":
+                return LanguageServiceMode.Semantic;
+            case "approximatesemanticonly":
+                return LanguageServiceMode.ApproximateSemanticOnly;
+            case "syntaxonly":
+                return LanguageServiceMode.SyntaxOnly;
+            default:
+                unknownServerMode = mode;
+                return undefined;
+        }
+    }
+
     const globalPlugins = parseStringArray("--globalPlugins");
     const pluginProbeLocations = parseStringArray("--pluginProbeLocations");
     const allowLocalPluginLoads = hasArgument("--allowLocalPluginLoads");
@@ -957,6 +978,7 @@ namespace ts.server {
     const disableAutomaticTypingAcquisition = hasArgument("--disableAutomaticTypingAcquisition");
     const suppressDiagnosticEvents = hasArgument("--suppressDiagnosticEvents");
     const syntaxOnly = hasArgument("--syntaxOnly");
+    const serverMode = parseServerMode();
     const telemetryEnabled = hasArgument(Arguments.EnableTelemetry);
     const noGetErrOnBackgroundUpdate = hasArgument("--noGetErrOnBackgroundUpdate");
 
@@ -964,6 +986,7 @@ namespace ts.server {
     logger.info(`Version: ${version}`);
     logger.info(`Arguments: ${process.argv.join(" ")}`);
     logger.info(`Platform: ${os.platform()} NodeVersion: ${nodeVersion} CaseSensitive: ${sys.useCaseSensitiveFileNames}`);
+    logger.info(`ServerMode: ${serverMode} syntaxOnly: ${syntaxOnly} hasUnknownServerMode: ${unknownServerMode}`);
 
     const ioSession = new IOSession();
     process.on("uncaughtException", err => {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -5313,6 +5313,11 @@ declare namespace ts {
         kind: "UpdateGraph" | "CreatePackageJsonAutoImportProvider";
         durationMs: number;
     }
+    enum LanguageServiceMode {
+        Semantic = 0,
+        ApproximateSemanticOnly = 1,
+        SyntaxOnly = 2
+    }
     interface LanguageServiceHost extends GetEffectiveTypeRootsHost {
         getCompilationSettings(): CompilerOptions;
         getNewLine?(): string;
@@ -6324,7 +6329,7 @@ declare namespace ts {
     function getSupportedCodeFixes(): string[];
     function createLanguageServiceSourceFile(fileName: string, scriptSnapshot: IScriptSnapshot, scriptTarget: ScriptTarget, version: string, setNodeParents: boolean, scriptKind?: ScriptKind): SourceFile;
     function updateLanguageServiceSourceFile(sourceFile: SourceFile, scriptSnapshot: IScriptSnapshot, version: string, textChangeRange: TextChangeRange | undefined, aggressiveChecks?: boolean): SourceFile;
-    function createLanguageService(host: LanguageServiceHost, documentRegistry?: DocumentRegistry, syntaxOnly?: boolean): LanguageService;
+    function createLanguageService(host: LanguageServiceHost, documentRegistry?: DocumentRegistry, syntaxOnlyOrLanguageServiceMode?: boolean | LanguageServiceMode): LanguageService;
     /**
      * Get the path of the default library files (lib.d.ts) as distributed with the typescript
      * node package.
@@ -9482,7 +9487,9 @@ declare namespace ts.server {
         pluginProbeLocations?: readonly string[];
         allowLocalPluginLoads?: boolean;
         typesMapLocation?: string;
+        /** @deprecated use serverMode instead */
         syntaxOnly?: boolean;
+        serverMode?: LanguageServiceMode;
     }
     export class ProjectService {
         private readonly scriptInfoInNodeModulesWatchers;
@@ -9554,7 +9561,9 @@ declare namespace ts.server {
         readonly allowLocalPluginLoads: boolean;
         private currentPluginConfigOverrides;
         readonly typesMapLocation: string | undefined;
-        readonly syntaxOnly?: boolean;
+        /** @deprecated use serverMode instead */
+        readonly syntaxOnly: boolean;
+        readonly serverMode: LanguageServiceMode;
         /** Tracks projects that we have already sent telemetry for. */
         private readonly seenProjects;
         private performanceEventHandler?;
@@ -9772,7 +9781,9 @@ declare namespace ts.server {
         eventHandler?: ProjectServiceEventHandler;
         /** Has no effect if eventHandler is also specified. */
         suppressDiagnosticEvents?: boolean;
+        /** @deprecated use serverMode instead */
         syntaxOnly?: boolean;
+        serverMode?: LanguageServiceMode;
         throttleWaitMilliseconds?: number;
         noGetErrOnBackgroundUpdate?: boolean;
         globalPlugins?: readonly string[];

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -5313,6 +5313,11 @@ declare namespace ts {
         kind: "UpdateGraph" | "CreatePackageJsonAutoImportProvider";
         durationMs: number;
     }
+    enum LanguageServiceMode {
+        Semantic = 0,
+        ApproximateSemanticOnly = 1,
+        SyntaxOnly = 2
+    }
     interface LanguageServiceHost extends GetEffectiveTypeRootsHost {
         getCompilationSettings(): CompilerOptions;
         getNewLine?(): string;
@@ -6324,7 +6329,7 @@ declare namespace ts {
     function getSupportedCodeFixes(): string[];
     function createLanguageServiceSourceFile(fileName: string, scriptSnapshot: IScriptSnapshot, scriptTarget: ScriptTarget, version: string, setNodeParents: boolean, scriptKind?: ScriptKind): SourceFile;
     function updateLanguageServiceSourceFile(sourceFile: SourceFile, scriptSnapshot: IScriptSnapshot, version: string, textChangeRange: TextChangeRange | undefined, aggressiveChecks?: boolean): SourceFile;
-    function createLanguageService(host: LanguageServiceHost, documentRegistry?: DocumentRegistry, syntaxOnly?: boolean): LanguageService;
+    function createLanguageService(host: LanguageServiceHost, documentRegistry?: DocumentRegistry, syntaxOnlyOrLanguageServiceMode?: boolean | LanguageServiceMode): LanguageService;
     /**
      * Get the path of the default library files (lib.d.ts) as distributed with the typescript
      * node package.


### PR DESCRIPTION
this PR adds --serverMode which takes precedence over --syntaxOnly at any time.  

Current names: (open to suggestion if we prefer something else)
```ts
export enum LanguageServiceMode {
        Semantic,
        ApproximateSemanticOnly,
        SyntaxOnly,
    }
```