### PR TITLE
Add diagnostic info to getNameForExportedSymbol crash

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2867,9 +2867,20 @@ namespace ts {
         if (symbol.escapedName === InternalSymbolName.ExportEquals || symbol.escapedName === InternalSymbolName.Default) {
             // Name of "export default foo;" is "foo". Name of "export default 0" is the filename converted to camelCase.
             return firstDefined(symbol.declarations, d => isExportAssignment(d) && isIdentifier(d.expression) ? d.expression.text : undefined)
-                || codefix.moduleSymbolToValidIdentifier(Debug.checkDefined(symbol.parent), scriptTarget);
+                || codefix.moduleSymbolToValidIdentifier(getSymbolParentOrFail(symbol), scriptTarget);
         }
         return symbol.name;
+    }
+
+    function getSymbolParentOrFail(symbol: Symbol) {
+        return Debug.checkDefined(
+            symbol.parent,
+            `Symbol parent was undefined. Flags: ${Debug.formatSymbolFlags(symbol.flags)}. ` +
+            `Declarations: ${symbol.declarations?.map(d => {
+                const kind = Debug.formatSyntaxKind(d.kind);
+                const { expression } = d as any;
+                return kind + (expression ? ` (expression: ${Debug.formatSyntaxKind(expression.kind)})` : "");
+            }).join(", ")}.`);
     }
 
     /**

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2878,8 +2878,9 @@ namespace ts {
             `Symbol parent was undefined. Flags: ${Debug.formatSymbolFlags(symbol.flags)}. ` +
             `Declarations: ${symbol.declarations?.map(d => {
                 const kind = Debug.formatSyntaxKind(d.kind);
+                const inJS = isInJSFile(d);
                 const { expression } = d as any;
-                return kind + (expression ? ` (expression: ${Debug.formatSyntaxKind(expression.kind)})` : "");
+                return (inJS ? "[JS]" : "") + kind + (expression ? ` (expression: ${Debug.formatSyntaxKind(expression.kind)})` : "");
             }).join(", ")}.`);
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Should add some useful info to stack traces in #39048. I’m not sure how an ExportDefault or ExportEquals symbol could lack a parent, but maybe their flags will help track that down.
