### PR TITLE
Make `getLocalSymbolForExportDefault` look harder for an export

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4769,7 +4769,11 @@ namespace ts {
     }
 
     export function getLocalSymbolForExportDefault(symbol: Symbol) {
-        return isExportDefaultSymbol(symbol) ? symbol.declarations[0].localSymbol : undefined;
+        if (!isExportDefaultSymbol(symbol)) return undefined;
+        for (const decl of symbol.declarations) {
+            if (decl.localSymbol) return decl.localSymbol;
+        }
+        return undefined;
     }
 
     function isExportDefaultSymbol(symbol: Symbol): boolean {

--- a/tests/baselines/reference/exportDefaultInterfaceAndValue.js
+++ b/tests/baselines/reference/exportDefaultInterfaceAndValue.js
@@ -1,0 +1,11 @@
+//// [exportDefaultInterfaceAndValue.ts]
+export default interface A { a: string; }
+export default function() { return 1; }
+declare var x: A;
+
+
+//// [exportDefaultInterfaceAndValue.js]
+"use strict";
+exports.__esModule = true;
+function default_1() { return 1; }
+exports["default"] = default_1;

--- a/tests/baselines/reference/exportDefaultInterfaceAndValue.symbols
+++ b/tests/baselines/reference/exportDefaultInterfaceAndValue.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/exportDefaultInterfaceAndValue.ts ===
+export default interface A { a: string; }
+>A : Symbol(A, Decl(exportDefaultInterfaceAndValue.ts, 0, 41), Decl(exportDefaultInterfaceAndValue.ts, 0, 0))
+>a : Symbol(A.a, Decl(exportDefaultInterfaceAndValue.ts, 0, 28))
+
+export default function() { return 1; }
+declare var x: A;
+>x : Symbol(x, Decl(exportDefaultInterfaceAndValue.ts, 2, 11))
+>A : Symbol(A, Decl(exportDefaultInterfaceAndValue.ts, 0, 41), Decl(exportDefaultInterfaceAndValue.ts, 0, 0))
+

--- a/tests/baselines/reference/exportDefaultInterfaceAndValue.types
+++ b/tests/baselines/reference/exportDefaultInterfaceAndValue.types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/exportDefaultInterfaceAndValue.ts ===
+export default interface A { a: string; }
+>a : string
+
+export default function() { return 1; }
+>1 : 1
+
+declare var x: A;
+>x : A
+

--- a/tests/cases/compiler/exportDefaultInterfaceAndValue.ts
+++ b/tests/cases/compiler/exportDefaultInterfaceAndValue.ts
@@ -1,0 +1,3 @@
+export default interface A { a: string; }
+export default function() { return 1; }
+declare var x: A;


### PR DESCRIPTION
Look for a symbol that has a `.localSymbol` property instead of blindly
using the first one.

Fixes #37829.
