### PR TITLE
Fix this-parameter emit for JSDocFunction types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5849,7 +5849,7 @@ namespace ts {
 
                     /** Note that `new:T` parameters are not handled, but should be before calling this function. */
                     function getNameForJSDocFunctionParameter(p: ParameterDeclaration, index: number) {
-                        return p.name && isIdentifier(p.name) && p.name.escapedText === 'this' ? 'this'
+                        return p.name && isIdentifier(p.name) && p.name.escapedText === "this" ? "this"
                             : getEffectiveDotDotDotForParameter(p) ? `args`
                             : `arg${index}`;
                     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5777,7 +5777,7 @@ namespace ts {
                                     /*decorators*/ undefined,
                                     /*modifiers*/ undefined,
                                     getEffectiveDotDotDotForParameter(p),
-                                    p.name || getEffectiveDotDotDotForParameter(p) ? `args` : `arg${i}`,
+                                    getNameForJSDocFunctionParameter(p, i),
                                     p.questionToken,
                                     visitNode(p.type, visitExistingNodeTreeSymbols),
                                     /*initializer*/ undefined
@@ -5792,7 +5792,7 @@ namespace ts {
                                     /*decorators*/ undefined,
                                     /*modifiers*/ undefined,
                                     getEffectiveDotDotDotForParameter(p),
-                                    p.name || getEffectiveDotDotDotForParameter(p) ? `args` : `arg${i}`,
+                                    getNameForJSDocFunctionParameter(p, i),
                                     p.questionToken,
                                     visitNode(p.type, visitExistingNodeTreeSymbols),
                                     /*initializer*/ undefined
@@ -5845,6 +5845,13 @@ namespace ts {
 
                     function getEffectiveDotDotDotForParameter(p: ParameterDeclaration) {
                         return p.dotDotDotToken || (p.type && isJSDocVariadicType(p.type) ? factory.createToken(SyntaxKind.DotDotDotToken) : undefined);
+                    }
+
+                    /** Note that `new:T` parameters are not handled, but should be before calling this function. */
+                    function getNameForJSDocFunctionParameter(p: ParameterDeclaration, index: number) {
+                        return p.name && isIdentifier(p.name) && p.name.escapedText === 'this' ? 'this'
+                            : getEffectiveDotDotDotForParameter(p) ? `args`
+                            : `arg${index}`;
                     }
 
                     function rewriteModuleSpecifier(parent: ImportTypeNode, lit: StringLiteral) {

--- a/tests/baselines/reference/jsDeclarationsRestArgsWithThisTypeInJSDocFunction.js
+++ b/tests/baselines/reference/jsDeclarationsRestArgsWithThisTypeInJSDocFunction.js
@@ -1,0 +1,32 @@
+//// [bug38550.js]
+export class Clazz {
+  /**
+   * @param {function(this:Object, ...*):*} functionDeclaration
+   */
+  method(functionDeclaration) {}
+}
+
+
+//// [bug38550.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Clazz = void 0;
+var Clazz = /** @class */ (function () {
+    function Clazz() {
+    }
+    /**
+     * @param {function(this:Object, ...*):*} functionDeclaration
+     */
+    Clazz.prototype.method = function (functionDeclaration) { };
+    return Clazz;
+}());
+exports.Clazz = Clazz;
+
+
+//// [bug38550.d.ts]
+export class Clazz {
+    /**
+     * @param {function(this:Object, ...*):*} functionDeclaration
+     */
+    method(functionDeclaration: (this: any, ...args: any[]) => any): void;
+}

--- a/tests/baselines/reference/jsDeclarationsRestArgsWithThisTypeInJSDocFunction.symbols
+++ b/tests/baselines/reference/jsDeclarationsRestArgsWithThisTypeInJSDocFunction.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/jsdoc/declarations/bug38550.js ===
+export class Clazz {
+>Clazz : Symbol(Clazz, Decl(bug38550.js, 0, 0))
+
+  /**
+   * @param {function(this:Object, ...*):*} functionDeclaration
+   */
+  method(functionDeclaration) {}
+>method : Symbol(Clazz.method, Decl(bug38550.js, 0, 20))
+>functionDeclaration : Symbol(functionDeclaration, Decl(bug38550.js, 4, 9))
+}
+

--- a/tests/baselines/reference/jsDeclarationsRestArgsWithThisTypeInJSDocFunction.types
+++ b/tests/baselines/reference/jsDeclarationsRestArgsWithThisTypeInJSDocFunction.types
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/jsdoc/declarations/bug38550.js ===
+export class Clazz {
+>Clazz : Clazz
+
+  /**
+   * @param {function(this:Object, ...*):*} functionDeclaration
+   */
+  method(functionDeclaration) {}
+>method : (functionDeclaration: (this: any, ...args: any[]) => any) => void
+>functionDeclaration : (this: any, ...arg1: any[]) => any
+}
+

--- a/tests/baselines/reference/jsdocDisallowedInTypescript.types
+++ b/tests/baselines/reference/jsdocDisallowedInTypescript.types
@@ -35,7 +35,7 @@ function hof(ctor: function(new: number, string)) {
 >'hi' : "hi"
 }
 function hof2(f: function(this: number, string): string) {
->hof2 : (f: (args: number, arg1: string) => string) => string
+>hof2 : (f: (this: number, arg1: string) => string) => string
 >f : (this: number, arg1: string) => string
 >this : number
 

--- a/tests/baselines/reference/jsdocFunctionType.types
+++ b/tests/baselines/reference/jsdocFunctionType.types
@@ -4,7 +4,7 @@
  * @return {function(this: string, number): number}
  */
 function id1(c) {
->id1 : (c: (args: string, arg1: number) => number) => (args: string, arg1: number) => number
+>id1 : (c: (this: string, arg1: number) => number) => (this: string, arg1: number) => number
 >c : (this: string, arg1: number) => number
 
     return c

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsRestArgsWithThisTypeInJSDocFunction.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsRestArgsWithThisTypeInJSDocFunction.ts
@@ -1,0 +1,12 @@
+// @allowJs: true
+// @checkJs: true
+// @target: es5
+// @outDir: ./out
+// @declaration: true
+// @filename: bug38550.js
+export class Clazz {
+  /**
+   * @param {function(this:Object, ...*):*} functionDeclaration
+   */
+  method(functionDeclaration) {}
+}


### PR DESCRIPTION
Previously, parameters with names that were not `new` were treated like rest parameters. This is incorrect: parameters with the name `this` should emit a `this` parameter.

Fixes #38550

Note that some existing type baselines were wrong, and we just never noticed.
Edit: Arguably this means I shouldn't add a new test for this fix, to keep the test suite small. Opinions?