### PR TITLE
In JS declaration emit, move imports painted in nested contexts to the root private context

### DIFF
--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespace.js
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespace.js
@@ -1,0 +1,99 @@
+//// [tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportAliasExposedWithinNamespace.ts] ////
+
+//// [file.js]
+/**
+ * @namespace myTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const myTypes = {
+    // SOME PROPS HERE
+};
+
+/** @typedef {string|RegExp|Array<string|RegExp>} myTypes.typeA */
+
+/**
+ * @typedef myTypes.typeB
+ * @property {myTypes.typeA}    prop1 - Prop 1.
+ * @property {string}           prop2 - Prop 2.
+ */
+
+/** @typedef {myTypes.typeB|Function} myTypes.typeC */
+
+export {myTypes};
+//// [file2.js]
+import {myTypes} from './file.js';
+
+/**
+ * @namespace testFnTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const testFnTypes = {
+    // SOME PROPS HERE
+};
+
+/** @typedef {boolean|myTypes.typeC} testFnTypes.input */
+
+/**
+ * @function testFn
+ * @description A test function.
+ * @param {testFnTypes.input} input - Input.
+ * @returns {number|null} Result.
+ */
+function testFn(input) {
+    if (typeof input === 'number') {
+        return 2 * input;
+    } else {
+        return null;
+    }
+}
+
+export {testFn, testFnTypes};
+
+
+
+//// [file.d.ts]
+/**
+ * @namespace myTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+export const myTypes: {
+    [x: string]: any;
+};
+export namespace myTypes {
+    type typeA = string | RegExp | (string | RegExp)[];
+    type typeB = {
+        /**
+         * - Prop 1.
+         */
+        prop1: string | RegExp | (string | RegExp)[];
+        /**
+         * - Prop 2.
+         */
+        prop2: string;
+    };
+    type typeC = Function | typeB;
+}
+//// [file2.d.ts]
+/** @typedef {boolean|myTypes.typeC} testFnTypes.input */
+/**
+ * @function testFn
+ * @description A test function.
+ * @param {testFnTypes.input} input - Input.
+ * @returns {number|null} Result.
+ */
+export function testFn(input: boolean | Function | myTypes.typeB): number | null;
+/**
+ * @namespace testFnTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+export const testFnTypes: {
+    [x: string]: any;
+};
+export namespace testFnTypes {
+    type input = boolean | Function | myTypes.typeB;
+}
+import { myTypes } from "./file.js";

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespace.symbols
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespace.symbols
@@ -1,0 +1,67 @@
+=== tests/cases/conformance/jsdoc/declarations/file.js ===
+/**
+ * @namespace myTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const myTypes = {
+>myTypes : Symbol(myTypes, Decl(file.js, 5, 5), Decl(file.js, 9, 50), Decl(file.js, 12, 12), Decl(file.js, 17, 38))
+
+    // SOME PROPS HERE
+};
+
+/** @typedef {string|RegExp|Array<string|RegExp>} myTypes.typeA */
+
+/**
+ * @typedef myTypes.typeB
+ * @property {myTypes.typeA}    prop1 - Prop 1.
+ * @property {string}           prop2 - Prop 2.
+ */
+
+/** @typedef {myTypes.typeB|Function} myTypes.typeC */
+
+export {myTypes};
+>myTypes : Symbol(myTypes, Decl(file.js, 19, 8))
+
+=== tests/cases/conformance/jsdoc/declarations/file2.js ===
+import {myTypes} from './file.js';
+>myTypes : Symbol(myTypes, Decl(file2.js, 0, 8))
+
+/**
+ * @namespace testFnTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const testFnTypes = {
+>testFnTypes : Symbol(testFnTypes, Decl(file2.js, 7, 5), Decl(file2.js, 11, 37))
+
+    // SOME PROPS HERE
+};
+
+/** @typedef {boolean|myTypes.typeC} testFnTypes.input */
+
+/**
+ * @function testFn
+ * @description A test function.
+ * @param {testFnTypes.input} input - Input.
+ * @returns {number|null} Result.
+ */
+function testFn(input) {
+>testFn : Symbol(testFn, Decl(file2.js, 9, 2))
+>input : Symbol(input, Decl(file2.js, 19, 16))
+
+    if (typeof input === 'number') {
+>input : Symbol(input, Decl(file2.js, 19, 16))
+
+        return 2 * input;
+>input : Symbol(input, Decl(file2.js, 19, 16))
+
+    } else {
+        return null;
+    }
+}
+
+export {testFn, testFnTypes};
+>testFn : Symbol(testFn, Decl(file2.js, 27, 8))
+>testFnTypes : Symbol(testFnTypes, Decl(file2.js, 27, 15))
+

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespace.types
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespace.types
@@ -1,0 +1,75 @@
+=== tests/cases/conformance/jsdoc/declarations/file.js ===
+/**
+ * @namespace myTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const myTypes = {
+>myTypes : { [x: string]: any; }
+>{    // SOME PROPS HERE} : {}
+
+    // SOME PROPS HERE
+};
+
+/** @typedef {string|RegExp|Array<string|RegExp>} myTypes.typeA */
+
+/**
+ * @typedef myTypes.typeB
+ * @property {myTypes.typeA}    prop1 - Prop 1.
+ * @property {string}           prop2 - Prop 2.
+ */
+
+/** @typedef {myTypes.typeB|Function} myTypes.typeC */
+
+export {myTypes};
+>myTypes : { [x: string]: any; }
+
+=== tests/cases/conformance/jsdoc/declarations/file2.js ===
+import {myTypes} from './file.js';
+>myTypes : { [x: string]: any; }
+
+/**
+ * @namespace testFnTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const testFnTypes = {
+>testFnTypes : { [x: string]: any; }
+>{    // SOME PROPS HERE} : {}
+
+    // SOME PROPS HERE
+};
+
+/** @typedef {boolean|myTypes.typeC} testFnTypes.input */
+
+/**
+ * @function testFn
+ * @description A test function.
+ * @param {testFnTypes.input} input - Input.
+ * @returns {number|null} Result.
+ */
+function testFn(input) {
+>testFn : (input: testFnTypes.input) => number | null
+>input : boolean | Function | myTypes.typeB
+
+    if (typeof input === 'number') {
+>typeof input === 'number' : boolean
+>typeof input : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>input : boolean | Function | myTypes.typeB
+>'number' : "number"
+
+        return 2 * input;
+>2 * input : number
+>2 : 2
+>input : never
+
+    } else {
+        return null;
+>null : null
+    }
+}
+
+export {testFn, testFnTypes};
+>testFn : (input: boolean | Function | myTypes.typeB) => number
+>testFnTypes : { [x: string]: any; }
+

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.errors.txt
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.errors.txt
@@ -1,0 +1,55 @@
+tests/cases/conformance/jsdoc/declarations/file2.js(12,31): error TS2694: Namespace 'myTypes' has no exported member 'typeC'.
+
+
+==== tests/cases/conformance/jsdoc/declarations/file2.js (1 errors) ====
+    const {myTypes} = require('./file.js');
+    
+    /**
+     * @namespace testFnTypes
+     * @global
+     * @type {Object<string,*>}
+     */
+    const testFnTypes = {
+        // SOME PROPS HERE
+    };
+    
+    /** @typedef {boolean|myTypes.typeC} testFnTypes.input */
+                                  ~~~~~
+!!! error TS2694: Namespace 'myTypes' has no exported member 'typeC'.
+    
+    /**
+     * @function testFn
+     * @description A test function.
+     * @param {testFnTypes.input} input - Input.
+     * @returns {number|null} Result.
+     */
+    function testFn(input) {
+        if (typeof input === 'number') {
+            return 2 * input;
+        } else {
+            return null;
+        }
+    }
+    
+    module.exports = {testFn, testFnTypes};
+==== tests/cases/conformance/jsdoc/declarations/file.js (0 errors) ====
+    /**
+     * @namespace myTypes
+     * @global
+     * @type {Object<string,*>}
+     */
+    const myTypes = {
+        // SOME PROPS HERE
+    };
+    
+    /** @typedef {string|RegExp|Array<string|RegExp>} myTypes.typeA */
+    
+    /**
+     * @typedef myTypes.typeB
+     * @property {myTypes.typeA}    prop1 - Prop 1.
+     * @property {string}           prop2 - Prop 2.
+     */
+    
+    /** @typedef {myTypes.typeB|Function} myTypes.typeC */
+    
+    exports.myTypes = myTypes;

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.js
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.js
@@ -1,0 +1,79 @@
+//// [tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportAliasExposedWithinNamespaceCjs.ts] ////
+
+//// [file.js]
+/**
+ * @namespace myTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const myTypes = {
+    // SOME PROPS HERE
+};
+
+/** @typedef {string|RegExp|Array<string|RegExp>} myTypes.typeA */
+
+/**
+ * @typedef myTypes.typeB
+ * @property {myTypes.typeA}    prop1 - Prop 1.
+ * @property {string}           prop2 - Prop 2.
+ */
+
+/** @typedef {myTypes.typeB|Function} myTypes.typeC */
+
+exports.myTypes = myTypes;
+//// [file2.js]
+const {myTypes} = require('./file.js');
+
+/**
+ * @namespace testFnTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const testFnTypes = {
+    // SOME PROPS HERE
+};
+
+/** @typedef {boolean|myTypes.typeC} testFnTypes.input */
+
+/**
+ * @function testFn
+ * @description A test function.
+ * @param {testFnTypes.input} input - Input.
+ * @returns {number|null} Result.
+ */
+function testFn(input) {
+    if (typeof input === 'number') {
+        return 2 * input;
+    } else {
+        return null;
+    }
+}
+
+module.exports = {testFn, testFnTypes};
+
+
+
+//// [file.d.ts]
+export var myTypes: {
+    [x: string]: any;
+};
+//// [file2.d.ts]
+/** @typedef {boolean|myTypes.typeC} testFnTypes.input */
+/**
+ * @function testFn
+ * @description A test function.
+ * @param {testFnTypes.input} input - Input.
+ * @returns {number|null} Result.
+ */
+export function testFn(input: any): number | null;
+/**
+ * @namespace testFnTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+export const testFnTypes: {
+    [x: string]: any;
+};
+export namespace testFnTypes {
+    type input = any;
+}

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.symbols
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.symbols
@@ -1,0 +1,75 @@
+=== tests/cases/conformance/jsdoc/declarations/file2.js ===
+const {myTypes} = require('./file.js');
+>myTypes : Symbol(myTypes, Decl(file2.js, 0, 7))
+>require : Symbol(require)
+>'./file.js' : Symbol("tests/cases/conformance/jsdoc/declarations/file", Decl(file.js, 0, 0))
+
+/**
+ * @namespace testFnTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const testFnTypes = {
+>testFnTypes : Symbol(testFnTypes, Decl(file2.js, 7, 5), Decl(file2.js, 11, 37))
+
+    // SOME PROPS HERE
+};
+
+/** @typedef {boolean|myTypes.typeC} testFnTypes.input */
+
+/**
+ * @function testFn
+ * @description A test function.
+ * @param {testFnTypes.input} input - Input.
+ * @returns {number|null} Result.
+ */
+function testFn(input) {
+>testFn : Symbol(testFn, Decl(file2.js, 9, 2))
+>input : Symbol(input, Decl(file2.js, 19, 16))
+
+    if (typeof input === 'number') {
+>input : Symbol(input, Decl(file2.js, 19, 16))
+
+        return 2 * input;
+>input : Symbol(input, Decl(file2.js, 19, 16))
+
+    } else {
+        return null;
+    }
+}
+
+module.exports = {testFn, testFnTypes};
+>module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/file2", Decl(file2.js, 0, 0))
+>module : Symbol(export=, Decl(file2.js, 25, 1))
+>exports : Symbol(export=, Decl(file2.js, 25, 1))
+>testFn : Symbol(testFn, Decl(file2.js, 27, 18))
+>testFnTypes : Symbol(testFnTypes, Decl(file2.js, 27, 25))
+
+=== tests/cases/conformance/jsdoc/declarations/file.js ===
+/**
+ * @namespace myTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const myTypes = {
+>myTypes : Symbol(myTypes, Decl(file.js, 5, 5), Decl(file.js, 9, 50), Decl(file.js, 12, 12), Decl(file.js, 17, 38))
+
+    // SOME PROPS HERE
+};
+
+/** @typedef {string|RegExp|Array<string|RegExp>} myTypes.typeA */
+
+/**
+ * @typedef myTypes.typeB
+ * @property {myTypes.typeA}    prop1 - Prop 1.
+ * @property {string}           prop2 - Prop 2.
+ */
+
+/** @typedef {myTypes.typeB|Function} myTypes.typeC */
+
+exports.myTypes = myTypes;
+>exports.myTypes : Symbol(myTypes, Decl(file.js, 7, 2))
+>exports : Symbol(myTypes, Decl(file.js, 7, 2))
+>myTypes : Symbol(myTypes, Decl(file.js, 7, 2))
+>myTypes : Symbol(myTypes, Decl(file.js, 5, 5), Decl(file.js, 9, 50), Decl(file.js, 12, 12), Decl(file.js, 17, 38))
+

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.types
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.types
@@ -1,0 +1,87 @@
+=== tests/cases/conformance/jsdoc/declarations/file2.js ===
+const {myTypes} = require('./file.js');
+>myTypes : { [x: string]: any; }
+>require('./file.js') : typeof import("tests/cases/conformance/jsdoc/declarations/file")
+>require : any
+>'./file.js' : "./file.js"
+
+/**
+ * @namespace testFnTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const testFnTypes = {
+>testFnTypes : { [x: string]: any; }
+>{    // SOME PROPS HERE} : {}
+
+    // SOME PROPS HERE
+};
+
+/** @typedef {boolean|myTypes.typeC} testFnTypes.input */
+
+/**
+ * @function testFn
+ * @description A test function.
+ * @param {testFnTypes.input} input - Input.
+ * @returns {number|null} Result.
+ */
+function testFn(input) {
+>testFn : (input: testFnTypes.input) => number | null
+>input : any
+
+    if (typeof input === 'number') {
+>typeof input === 'number' : boolean
+>typeof input : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>input : any
+>'number' : "number"
+
+        return 2 * input;
+>2 * input : number
+>2 : 2
+>input : number
+
+    } else {
+        return null;
+>null : null
+    }
+}
+
+module.exports = {testFn, testFnTypes};
+>module.exports = {testFn, testFnTypes} : { testFn: (input: any) => number; testFnTypes: { [x: string]: any; }; }
+>module.exports : { testFn: (input: any) => number; testFnTypes: { [x: string]: any; }; }
+>module : { "\"tests/cases/conformance/jsdoc/declarations/file2\"": { testFn: (input: any) => number; testFnTypes: { [x: string]: any; }; }; }
+>exports : { testFn: (input: any) => number; testFnTypes: { [x: string]: any; }; }
+>{testFn, testFnTypes} : { testFn: (input: any) => number; testFnTypes: { [x: string]: any; }; }
+>testFn : (input: any) => number
+>testFnTypes : { [x: string]: any; }
+
+=== tests/cases/conformance/jsdoc/declarations/file.js ===
+/**
+ * @namespace myTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const myTypes = {
+>myTypes : { [x: string]: any; }
+>{    // SOME PROPS HERE} : {}
+
+    // SOME PROPS HERE
+};
+
+/** @typedef {string|RegExp|Array<string|RegExp>} myTypes.typeA */
+
+/**
+ * @typedef myTypes.typeB
+ * @property {myTypes.typeA}    prop1 - Prop 1.
+ * @property {string}           prop2 - Prop 2.
+ */
+
+/** @typedef {myTypes.typeB|Function} myTypes.typeC */
+
+exports.myTypes = myTypes;
+>exports.myTypes = myTypes : { [x: string]: any; }
+>exports.myTypes : { [x: string]: any; }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/file")
+>myTypes : { [x: string]: any; }
+>myTypes : { [x: string]: any; }
+

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportAliasExposedWithinNamespace.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportAliasExposedWithinNamespace.ts
@@ -1,0 +1,56 @@
+// @declaration: true
+// @emitDeclarationOnly: true
+// @allowJs: true
+// @checkJs: true
+// @module: commonjs
+// @target: es6
+// @filename: file.js
+/**
+ * @namespace myTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const myTypes = {
+    // SOME PROPS HERE
+};
+
+/** @typedef {string|RegExp|Array<string|RegExp>} myTypes.typeA */
+
+/**
+ * @typedef myTypes.typeB
+ * @property {myTypes.typeA}    prop1 - Prop 1.
+ * @property {string}           prop2 - Prop 2.
+ */
+
+/** @typedef {myTypes.typeB|Function} myTypes.typeC */
+
+export {myTypes};
+// @filename: file2.js
+import {myTypes} from './file.js';
+
+/**
+ * @namespace testFnTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const testFnTypes = {
+    // SOME PROPS HERE
+};
+
+/** @typedef {boolean|myTypes.typeC} testFnTypes.input */
+
+/**
+ * @function testFn
+ * @description A test function.
+ * @param {testFnTypes.input} input - Input.
+ * @returns {number|null} Result.
+ */
+function testFn(input) {
+    if (typeof input === 'number') {
+        return 2 * input;
+    } else {
+        return null;
+    }
+}
+
+export {testFn, testFnTypes};

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportAliasExposedWithinNamespaceCjs.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsImportAliasExposedWithinNamespaceCjs.ts
@@ -1,0 +1,56 @@
+// @declaration: true
+// @emitDeclarationOnly: true
+// @allowJs: true
+// @checkJs: true
+// @module: commonjs
+// @target: es6
+// @filename: file.js
+/**
+ * @namespace myTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const myTypes = {
+    // SOME PROPS HERE
+};
+
+/** @typedef {string|RegExp|Array<string|RegExp>} myTypes.typeA */
+
+/**
+ * @typedef myTypes.typeB
+ * @property {myTypes.typeA}    prop1 - Prop 1.
+ * @property {string}           prop2 - Prop 2.
+ */
+
+/** @typedef {myTypes.typeB|Function} myTypes.typeC */
+
+exports.myTypes = myTypes;
+// @filename: file2.js
+const {myTypes} = require('./file.js');
+
+/**
+ * @namespace testFnTypes
+ * @global
+ * @type {Object<string,*>}
+ */
+const testFnTypes = {
+    // SOME PROPS HERE
+};
+
+/** @typedef {boolean|myTypes.typeC} testFnTypes.input */
+
+/**
+ * @function testFn
+ * @description A test function.
+ * @param {testFnTypes.input} input - Input.
+ * @returns {number|null} Result.
+ */
+function testFn(input) {
+    if (typeof input === 'number') {
+        return 2 * input;
+    } else {
+        return null;
+    }
+}
+
+module.exports = {testFn, testFnTypes};


### PR DESCRIPTION
Fixes #37552
