### PR TITLE
Allow assignments to a narrowable reference to be considered narrowable

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -837,7 +837,8 @@ namespace ts {
         function isNarrowableReference(expr: Expression): boolean {
             return expr.kind === SyntaxKind.Identifier || expr.kind === SyntaxKind.ThisKeyword || expr.kind === SyntaxKind.SuperKeyword ||
                 (isPropertyAccessExpression(expr) || isNonNullExpression(expr) || isParenthesizedExpression(expr)) && isNarrowableReference(expr.expression) ||
-                isElementAccessExpression(expr) && isStringOrNumericLiteralLike(expr.argumentExpression) && isNarrowableReference(expr.expression);
+                isElementAccessExpression(expr) && isStringOrNumericLiteralLike(expr.argumentExpression) && isNarrowableReference(expr.expression) ||
+                isAssignmentExpression(expr) && isNarrowableReference(expr.left);
         }
 
         function containsNarrowableReference(expr: Expression): boolean {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -837,8 +837,9 @@ namespace ts {
         function isNarrowableReference(expr: Expression): boolean {
             return expr.kind === SyntaxKind.Identifier || expr.kind === SyntaxKind.ThisKeyword || expr.kind === SyntaxKind.SuperKeyword ||
                 (isPropertyAccessExpression(expr) || isNonNullExpression(expr) || isParenthesizedExpression(expr)) && isNarrowableReference(expr.expression) ||
-                isElementAccessExpression(expr) && isStringOrNumericLiteralLike(expr.argumentExpression) && isNarrowableReference(expr.expression) ||
-                isAssignmentExpression(expr) && isNarrowableReference(expr.left);
+                isElementAccessExpression(expr) && isStringOrNumericLiteralLike(expr.argumentExpression) && isNarrowableReference(expr.expression);
+                //  ||
+                // isAssignmentExpression(expr) && isNarrowableReference(expr.left);
         }
 
         function containsNarrowableReference(expr: Expression): boolean {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -837,9 +837,8 @@ namespace ts {
         function isNarrowableReference(expr: Expression): boolean {
             return expr.kind === SyntaxKind.Identifier || expr.kind === SyntaxKind.ThisKeyword || expr.kind === SyntaxKind.SuperKeyword ||
                 (isPropertyAccessExpression(expr) || isNonNullExpression(expr) || isParenthesizedExpression(expr)) && isNarrowableReference(expr.expression) ||
-                isElementAccessExpression(expr) && isStringOrNumericLiteralLike(expr.argumentExpression) && isNarrowableReference(expr.expression);
-                //  ||
-                // isAssignmentExpression(expr) && isNarrowableReference(expr.left);
+                isElementAccessExpression(expr) && isStringOrNumericLiteralLike(expr.argumentExpression) && isNarrowableReference(expr.expression) ||
+                isAssignmentExpression(expr) && isNarrowableReference(expr.left);
         }
 
         function containsNarrowableReference(expr: Expression): boolean {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20131,11 +20131,11 @@ namespace ts {
                 case SyntaxKind.ParenthesizedExpression:
                 case SyntaxKind.NonNullExpression:
                     return isMatchingReference(source, (target as NonNullExpression | ParenthesizedExpression).expression);
-                // case SyntaxKind.BinaryExpression:
-                //     if (isAssignmentExpression(target)) {
-                //         return isMatchingReference(source, target.left);
-                //     }
-                //     break;
+                case SyntaxKind.BinaryExpression:
+                    if (isAssignmentExpression(target)) {
+                        return isMatchingReference(source, target.left);
+                    }
+                    break;
             }
             switch (source.kind) {
                 case SyntaxKind.Identifier:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20131,6 +20131,11 @@ namespace ts {
                 case SyntaxKind.ParenthesizedExpression:
                 case SyntaxKind.NonNullExpression:
                     return isMatchingReference(source, (target as NonNullExpression | ParenthesizedExpression).expression);
+                case SyntaxKind.BinaryExpression:
+                    if (isAssignmentExpression(target)) {
+                        return isMatchingReference(source, target.left);
+                    }
+                    break;
             }
             switch (source.kind) {
                 case SyntaxKind.Identifier:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20131,11 +20131,11 @@ namespace ts {
                 case SyntaxKind.ParenthesizedExpression:
                 case SyntaxKind.NonNullExpression:
                     return isMatchingReference(source, (target as NonNullExpression | ParenthesizedExpression).expression);
-                case SyntaxKind.BinaryExpression:
-                    if (isAssignmentExpression(target)) {
-                        return isMatchingReference(source, target.left);
-                    }
-                    break;
+                // case SyntaxKind.BinaryExpression:
+                //     if (isAssignmentExpression(target)) {
+                //         return isMatchingReference(source, target.left);
+                //     }
+                //     break;
             }
             switch (source.kind) {
                 case SyntaxKind.Identifier:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20132,10 +20132,7 @@ namespace ts {
                 case SyntaxKind.NonNullExpression:
                     return isMatchingReference(source, (target as NonNullExpression | ParenthesizedExpression).expression);
                 case SyntaxKind.BinaryExpression:
-                    if (isAssignmentExpression(target)) {
-                        return isMatchingReference(source, target.left);
-                    }
-                    break;
+                    return isAssignmentExpression(target) && isMatchingReference(source, target.left);
             }
             switch (source.kind) {
                 case SyntaxKind.Identifier:

--- a/tests/baselines/reference/controlFlowAssignmentExpression.js
+++ b/tests/baselines/reference/controlFlowAssignmentExpression.js
@@ -10,6 +10,13 @@ x = true;
 (x = "", obj).foo = (x = x.length);
 x; // number
 
+// https://github.com/microsoft/TypeScript/issues/35484
+type D = { done: true, value: 1 } | { done: false, value: 2 };
+declare function fn(): D;
+let o: D;
+if ((o = fn()).done) {
+    const y: 1 = o.value;
+}
 
 //// [controlFlowAssignmentExpression.js]
 var x;
@@ -20,3 +27,7 @@ x; // number
 x = true;
 (x = "", obj).foo = (x = x.length);
 x; // number
+var o;
+if ((o = fn()).done) {
+    var y = o.value;
+}

--- a/tests/baselines/reference/controlFlowAssignmentExpression.symbols
+++ b/tests/baselines/reference/controlFlowAssignmentExpression.symbols
@@ -31,3 +31,31 @@ x = true;
 x; // number
 >x : Symbol(x, Decl(controlFlowAssignmentExpression.ts, 0, 3))
 
+// https://github.com/microsoft/TypeScript/issues/35484
+type D = { done: true, value: 1 } | { done: false, value: 2 };
+>D : Symbol(D, Decl(controlFlowAssignmentExpression.ts, 9, 2))
+>done : Symbol(done, Decl(controlFlowAssignmentExpression.ts, 12, 10))
+>value : Symbol(value, Decl(controlFlowAssignmentExpression.ts, 12, 22))
+>done : Symbol(done, Decl(controlFlowAssignmentExpression.ts, 12, 37))
+>value : Symbol(value, Decl(controlFlowAssignmentExpression.ts, 12, 50))
+
+declare function fn(): D;
+>fn : Symbol(fn, Decl(controlFlowAssignmentExpression.ts, 12, 62))
+>D : Symbol(D, Decl(controlFlowAssignmentExpression.ts, 9, 2))
+
+let o: D;
+>o : Symbol(o, Decl(controlFlowAssignmentExpression.ts, 14, 3))
+>D : Symbol(D, Decl(controlFlowAssignmentExpression.ts, 9, 2))
+
+if ((o = fn()).done) {
+>(o = fn()).done : Symbol(done, Decl(controlFlowAssignmentExpression.ts, 12, 10), Decl(controlFlowAssignmentExpression.ts, 12, 37))
+>o : Symbol(o, Decl(controlFlowAssignmentExpression.ts, 14, 3))
+>fn : Symbol(fn, Decl(controlFlowAssignmentExpression.ts, 12, 62))
+>done : Symbol(done, Decl(controlFlowAssignmentExpression.ts, 12, 10), Decl(controlFlowAssignmentExpression.ts, 12, 37))
+
+    const y: 1 = o.value;
+>y : Symbol(y, Decl(controlFlowAssignmentExpression.ts, 16, 9))
+>o.value : Symbol(value, Decl(controlFlowAssignmentExpression.ts, 12, 22))
+>o : Symbol(o, Decl(controlFlowAssignmentExpression.ts, 14, 3))
+>value : Symbol(value, Decl(controlFlowAssignmentExpression.ts, 12, 22))
+}

--- a/tests/baselines/reference/controlFlowAssignmentExpression.types
+++ b/tests/baselines/reference/controlFlowAssignmentExpression.types
@@ -45,3 +45,34 @@ x = true;
 x; // number
 >x : number
 
+// https://github.com/microsoft/TypeScript/issues/35484
+type D = { done: true, value: 1 } | { done: false, value: 2 };
+>D : D
+>done : true
+>true : true
+>value : 1
+>done : false
+>false : false
+>value : 2
+
+declare function fn(): D;
+>fn : () => D
+
+let o: D;
+>o : D
+
+if ((o = fn()).done) {
+>(o = fn()).done : boolean
+>(o = fn()) : D
+>o = fn() : D
+>o : D
+>fn() : D
+>fn : () => D
+>done : boolean
+
+    const y: 1 = o.value;
+>y : 1
+>o.value : 1
+>o : { done: true; value: 1; }
+>value : 1
+}

--- a/tests/cases/conformance/controlFlow/controlFlowAssignmentExpression.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowAssignmentExpression.ts
@@ -8,3 +8,11 @@ x; // number
 x = true;
 (x = "", obj).foo = (x = x.length);
 x; // number
+
+// https://github.com/microsoft/TypeScript/issues/35484
+type D = { done: true, value: 1 } | { done: false, value: 2 };
+declare function fn(): D;
+let o: D;
+if ((o = fn()).done) {
+    const y: 1 = o.value;
+}


### PR DESCRIPTION
This modifies control flow to consider an assignment to be narrowable if the assignment target is a narrowable reference.

Given:
```ts
type D = { done: true, value: 1 } | { done: false, value: 2 };
declare function f(): D;
// (A)
{
  let o: D;
  if (o = f(), o.done) {
    o.value; // '1'
  }
}
 
// (B)
{
  let o: D;
  if ((o = f()).done) {
      o.value; // '1 | 2'
  }
}
```

Prior to this fix, `o.value` in `A` had the type `1` but `o.value` in `B` had the type `1 | 2` because we did not consider `(o = f())` to be narrowable.

This also fixes some discrepancies in the control flow graph formatter used for debugging to handle circular references in loops.

Fixes #35484
