### PR TITLE
Make numeric Array constructors take ArrayLikeBuffer union

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1946,7 +1946,7 @@ interface Int8Array {
 interface Int8ArrayConstructor {
     readonly prototype: Int8Array;
     new(length: number): Int8Array;
-    new(array: ArrayLike<number>): Int8Array;
+    new(array: ArrayLike<number> | ArrayBufferLike): Int8Array;
     new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Int8Array;
 
     /**
@@ -2229,7 +2229,7 @@ interface Uint8Array {
 interface Uint8ArrayConstructor {
     readonly prototype: Uint8Array;
     new(length: number): Uint8Array;
-    new(array: ArrayLike<number>): Uint8Array;
+    new(array: ArrayLike<number> | ArrayBufferLike): Uint8Array;
     new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Uint8Array;
 
     /**
@@ -2511,7 +2511,7 @@ interface Uint8ClampedArray {
 interface Uint8ClampedArrayConstructor {
     readonly prototype: Uint8ClampedArray;
     new(length: number): Uint8ClampedArray;
-    new(array: ArrayLike<number>): Uint8ClampedArray;
+    new(array: ArrayLike<number> | ArrayBufferLike): Uint8ClampedArray;
     new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Uint8ClampedArray;
 
     /**
@@ -2791,7 +2791,7 @@ interface Int16Array {
 interface Int16ArrayConstructor {
     readonly prototype: Int16Array;
     new(length: number): Int16Array;
-    new(array: ArrayLike<number>): Int16Array;
+    new(array: ArrayLike<number> | ArrayBufferLike): Int16Array;
     new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Int16Array;
 
     /**
@@ -3074,7 +3074,7 @@ interface Uint16Array {
 interface Uint16ArrayConstructor {
     readonly prototype: Uint16Array;
     new(length: number): Uint16Array;
-    new(array: ArrayLike<number>): Uint16Array;
+    new(array: ArrayLike<number> | ArrayBufferLike): Uint16Array;
     new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Uint16Array;
 
     /**
@@ -3356,7 +3356,7 @@ interface Int32Array {
 interface Int32ArrayConstructor {
     readonly prototype: Int32Array;
     new(length: number): Int32Array;
-    new(array: ArrayLike<number>): Int32Array;
+    new(array: ArrayLike<number> | ArrayBufferLike): Int32Array;
     new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Int32Array;
 
     /**
@@ -3637,7 +3637,7 @@ interface Uint32Array {
 interface Uint32ArrayConstructor {
     readonly prototype: Uint32Array;
     new(length: number): Uint32Array;
-    new(array: ArrayLike<number>): Uint32Array;
+    new(array: ArrayLike<number> | ArrayBufferLike): Uint32Array;
     new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Uint32Array;
 
     /**
@@ -3919,7 +3919,7 @@ interface Float32Array {
 interface Float32ArrayConstructor {
     readonly prototype: Float32Array;
     new(length: number): Float32Array;
-    new(array: ArrayLike<number>): Float32Array;
+    new(array: ArrayLike<number> | ArrayBufferLike): Float32Array;
     new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Float32Array;
 
     /**
@@ -4193,7 +4193,7 @@ interface Float64Array {
 interface Float64ArrayConstructor {
     readonly prototype: Float64Array;
     new(length: number): Float64Array;
-    new(array: ArrayLike<number>): Float64Array;
+    new(array: ArrayLike<number> | ArrayBufferLike): Float64Array;
     new(buffer: ArrayBufferLike, byteOffset?: number, length?: number): Float64Array;
 
     /**


### PR DESCRIPTION
PR #38449 changed the second overload of the constructor for Int8, Uint8, Int32, Uint32, Int16, Uint16, Float, Float64 -Array so that it no longer includes `ArrayBufferLike`. It's just `ArrayLike<number>`. This is fine except in the case that the caller provides exactly `ArrayLike<number> | ArrayBufferLike`. This PR adds ArrayBufferLike back so that the union is once again accepted.

This avoids a breaking change, in particular in one Microsoft-internal codebase.

