### PR TITLE
Find tagless JSDoc as preceding token

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1217,6 +1217,10 @@ namespace ts {
         }
 
         const children = n.getChildren(sourceFile);
+        if (children.length === 0) {
+            return n;
+        }
+
         const candidate = findRightmostChildNodeWithTokens(children, /*exclusiveStartPosition*/ children.length, sourceFile);
         return candidate && findRightmostToken(candidate, sourceFile);
     }

--- a/tests/cases/fourslash/completionsAfterJSDoc.ts
+++ b/tests/cases/fourslash/completionsAfterJSDoc.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+////export interface Foo {
+////  /** JSDoc */
+////  /**/foo(): void;
+////}
+
+// Should not crash, #35632
+verify.completions({
+  marker: "",
+  isNewIdentifierLocation: true,
+  exact: [{
+    name: "readonly",
+    kind: "keyword",
+    sortText: completion.SortText.GlobalsOrKeywords
+  }]
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #35632

If a JSDoc comment has tags, those tags appear as its children (in the language service). If it doesn’t, it has no children, therefore may itself be the token to the left of the caret.
