### PR TITLE
Add missing 'importName' for private field helpers

### DIFF
--- a/src/compiler/factory/emitHelpers.ts
+++ b/src/compiler/factory/emitHelpers.ts
@@ -843,6 +843,7 @@ namespace ts {
     // Class fields helpers
     export const classPrivateFieldGetHelper: UnscopedEmitHelper = {
         name: "typescript:classPrivateFieldGet",
+        importName: "__classPrivateFieldGet",
         scoped: false,
         text: `
             var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, privateMap) {
@@ -855,6 +856,7 @@ namespace ts {
 
     export const classPrivateFieldSetHelper: UnscopedEmitHelper = {
         name: "typescript:classPrivateFieldSet",
+        importName: "__classPrivateFieldSet",
         scoped: false,
         text: `
             var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (receiver, privateMap, value) {

--- a/tests/baselines/reference/importHelpersES6.js
+++ b/tests/baselines/reference/importHelpersES6.js
@@ -3,7 +3,8 @@
 //// [a.ts]
 declare var dec: any;
 @dec export class A {
-
+    #x: number = 1;
+    async f() { this.#x = await this.#x; }
 }
 
 const o = { a: 1 };
@@ -15,12 +16,21 @@ export declare function __decorate(decorators: Function[], target: any, key?: st
 export declare function __param(paramIndex: number, decorator: Function): Function;
 export declare function __metadata(metadataKey: any, metadataValue: any): Function;
 export declare function __awaiter(thisArg: any, _arguments: any, P: Function, generator: Function): any;
-
+export declare function __classPrivateFieldGet(): any;
+export declare function __classPrivateFieldSet(): any;
 
 //// [a.js]
-import { __decorate } from "tslib";
+var _x;
+import { __awaiter, __classPrivateFieldGet, __classPrivateFieldSet, __decorate } from "tslib";
 let A = class A {
+    constructor() {
+        _x.set(this, 1);
+    }
+    f() {
+        return __awaiter(this, void 0, void 0, function* () { __classPrivateFieldSet(this, _x, yield __classPrivateFieldGet(this, _x)); });
+    }
 };
+_x = new WeakMap();
 A = __decorate([
     dec
 ], A);

--- a/tests/baselines/reference/importHelpersES6.symbols
+++ b/tests/baselines/reference/importHelpersES6.symbols
@@ -6,15 +6,24 @@ declare var dec: any;
 >dec : Symbol(dec, Decl(a.ts, 0, 11))
 >A : Symbol(A, Decl(a.ts, 0, 21))
 
+    #x: number = 1;
+>#x : Symbol(A.#x, Decl(a.ts, 1, 21))
+
+    async f() { this.#x = await this.#x; }
+>f : Symbol(A.f, Decl(a.ts, 2, 19))
+>this.#x : Symbol(A.#x, Decl(a.ts, 1, 21))
+>this : Symbol(A, Decl(a.ts, 0, 21))
+>this.#x : Symbol(A.#x, Decl(a.ts, 1, 21))
+>this : Symbol(A, Decl(a.ts, 0, 21))
 }
 
 const o = { a: 1 };
->o : Symbol(o, Decl(a.ts, 5, 5))
->a : Symbol(a, Decl(a.ts, 5, 11))
+>o : Symbol(o, Decl(a.ts, 6, 5))
+>a : Symbol(a, Decl(a.ts, 6, 11))
 
 const y = { ...o };
->y : Symbol(y, Decl(a.ts, 6, 5))
->o : Symbol(o, Decl(a.ts, 5, 5))
+>y : Symbol(y, Decl(a.ts, 7, 5))
+>o : Symbol(o, Decl(a.ts, 6, 5))
 
 === tests/cases/compiler/tslib.d.ts ===
 export declare function __extends(d: Function, b: Function): void;
@@ -53,4 +62,10 @@ export declare function __awaiter(thisArg: any, _arguments: any, P: Function, ge
 >Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >generator : Symbol(generator, Decl(tslib.d.ts, --, --))
 >Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+export declare function __classPrivateFieldGet(): any;
+>__classPrivateFieldGet : Symbol(__classPrivateFieldGet, Decl(tslib.d.ts, --, --))
+
+export declare function __classPrivateFieldSet(): any;
+>__classPrivateFieldSet : Symbol(__classPrivateFieldSet, Decl(tslib.d.ts, --, --))
 

--- a/tests/baselines/reference/importHelpersES6.types
+++ b/tests/baselines/reference/importHelpersES6.types
@@ -6,6 +6,18 @@ declare var dec: any;
 >dec : any
 >A : A
 
+    #x: number = 1;
+>#x : number
+>1 : 1
+
+    async f() { this.#x = await this.#x; }
+>f : () => Promise<void>
+>this.#x = await this.#x : number
+>this.#x : number
+>this : this
+>await this.#x : number
+>this.#x : number
+>this : this
 }
 
 const o = { a: 1 };
@@ -48,4 +60,10 @@ export declare function __awaiter(thisArg: any, _arguments: any, P: Function, ge
 >_arguments : any
 >P : Function
 >generator : Function
+
+export declare function __classPrivateFieldGet(): any;
+>__classPrivateFieldGet : () => any
+
+export declare function __classPrivateFieldSet(): any;
+>__classPrivateFieldSet : () => any
 

--- a/tests/cases/compiler/importHelpersES6.ts
+++ b/tests/cases/compiler/importHelpersES6.ts
@@ -4,7 +4,8 @@
 // @filename: a.ts
 declare var dec: any;
 @dec export class A {
-
+    #x: number = 1;
+    async f() { this.#x = await this.#x; }
 }
 
 const o = { a: 1 };
@@ -16,3 +17,5 @@ export declare function __decorate(decorators: Function[], target: any, key?: st
 export declare function __param(paramIndex: number, decorator: Function): Function;
 export declare function __metadata(metadataKey: any, metadataValue: any): Function;
 export declare function __awaiter(thisArg: any, _arguments: any, P: Function, generator: Function): any;
+export declare function __classPrivateFieldGet(): any;
+export declare function __classPrivateFieldSet(): any;


### PR DESCRIPTION
Adds `importName` properties for the class private field get/set helpers so that they work correctly with `--importHelpers`.

Fixes #36841
