### PR TITLE
Update CI node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 
 node_js:
   - 'node'
+  - '12'
   - '10'
-  - '8'
 
 env:
   - workerCount=3 timeout=600000


### PR DESCRIPTION
Drop 8, add 14

Devops pipelines still uses the UI so I'll have to change that manually