### PR TITLE
Use isUncalledFunctionReference for aliases too

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -35323,7 +35323,7 @@ namespace ts {
                     error(node, Diagnostics.Re_exporting_a_type_when_the_isolatedModules_flag_is_provided_requires_using_export_type);
                 }
 
-                if (isImportSpecifier(node) && isUncalledFunctionReference(target.valueDeclaration, target)) {
+                if (isImportSpecifier(node) && every(target.declarations, d => !!(getCombinedNodeFlags(d) & NodeFlags.Deprecated))) {
                     errorOrSuggestion(/* isError */ false, node.name, Diagnostics._0_is_deprecated, symbol.escapedName as string);
                 }
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -35323,9 +35323,7 @@ namespace ts {
                     error(node, Diagnostics.Re_exporting_a_type_when_the_isolatedModules_flag_is_provided_requires_using_export_type);
                 }
 
-                if (isImportSpecifier(node) &&
-                    (target.valueDeclaration && target.valueDeclaration.flags & NodeFlags.Deprecated
-                        || every(target.declarations, d => !!(d.flags & NodeFlags.Deprecated)))) {
+                if (isImportSpecifier(node) && isUncalledFunctionReference(target.valueDeclaration, target)) {
                     errorOrSuggestion(/* isError */ false, node.name, Diagnostics._0_is_deprecated, symbol.escapedName as string);
                 }
             }

--- a/tests/cases/fourslash/jsdocDeprecated_suggestion8.ts
+++ b/tests/cases/fourslash/jsdocDeprecated_suggestion8.ts
@@ -1,0 +1,13 @@
+///<reference path="fourslash.ts" />
+
+// @Filename: first.ts
+//// /** @deprecated */
+//// export declare function tap<T>(next: null): void;
+//// export declare function tap<T>(next: T): T;
+// @Filename: second.ts
+//// import { tap } from './first';
+//// tap
+
+goTo.file('second.ts')
+verify.noErrors()
+verify.getSuggestionDiagnostics([]);

--- a/tests/cases/fourslash/jsdocDeprecated_suggestion9.ts
+++ b/tests/cases/fourslash/jsdocDeprecated_suggestion9.ts
@@ -1,0 +1,11 @@
+///<reference path="fourslash.ts" />
+
+// @Filename: first.ts
+//// export class logger { }
+// @Filename: second.ts
+//// import { logger } from './first';
+//// new logger()
+
+goTo.file('second.ts')
+verify.noErrors()
+verify.getSuggestionDiagnostics([]);


### PR DESCRIPTION
Fixes bogus deprecated notices on imports of functions with deprecated overloads, but with some non-deprecated overloads.

This should ship in 4.0 too.

Fixes microsoft/vscode#104238