### PR TITLE
Avoid the double-symbol trick for enums

### DIFF
--- a/tests/baselines/reference/exportedEnumTypeAndValue.symbols
+++ b/tests/baselines/reference/exportedEnumTypeAndValue.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @enum {number} */
+const MyEnum = {
+>MyEnum : Symbol(MyEnum, Decl(def.js, 1, 5), Decl(def.js, 0, 4))
+
+  a: 1,
+>a : Symbol(a, Decl(def.js, 1, 16))
+
+  b: 2
+>b : Symbol(b, Decl(def.js, 2, 7))
+
+};
+export default MyEnum;
+>MyEnum : Symbol(MyEnum, Decl(def.js, 1, 5), Decl(def.js, 0, 4))
+
+=== tests/cases/conformance/jsdoc/use.js ===
+import MyEnum from "./def";
+>MyEnum : Symbol(MyEnum, Decl(use.js, 0, 6))
+
+/** @type {MyEnum} */
+const v = MyEnum.b;
+>v : Symbol(v, Decl(use.js, 3, 5))
+>MyEnum.b : Symbol(b, Decl(def.js, 2, 7))
+>MyEnum : Symbol(MyEnum, Decl(use.js, 0, 6))
+>b : Symbol(b, Decl(def.js, 2, 7))
+

--- a/tests/baselines/reference/exportedEnumTypeAndValue.types
+++ b/tests/baselines/reference/exportedEnumTypeAndValue.types
@@ -1,0 +1,29 @@
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @enum {number} */
+const MyEnum = {
+>MyEnum : { a: number; b: number; }
+>{  a: 1,  b: 2} : { a: number; b: number; }
+
+  a: 1,
+>a : number
+>1 : 1
+
+  b: 2
+>b : number
+>2 : 2
+
+};
+export default MyEnum;
+>MyEnum : number
+
+=== tests/cases/conformance/jsdoc/use.js ===
+import MyEnum from "./def";
+>MyEnum : { a: number; b: number; }
+
+/** @type {MyEnum} */
+const v = MyEnum.b;
+>v : number
+>MyEnum.b : number
+>MyEnum : { a: number; b: number; }
+>b : number
+

--- a/tests/baselines/reference/jsEnumTagOnObjectFrozen.symbols
+++ b/tests/baselines/reference/jsEnumTagOnObjectFrozen.symbols
@@ -55,9 +55,9 @@ const Thing = Object.freeze({
 });
 
 exports.Thing = Thing;
->exports.Thing : Symbol(Thing, Decl(index.js, 4, 3), Decl(index.js, 0, 4))
->exports : Symbol(Thing, Decl(index.js, 4, 3), Decl(index.js, 0, 4))
->Thing : Symbol(Thing, Decl(index.js, 4, 3), Decl(index.js, 0, 4))
+>exports.Thing : Symbol(Thing, Decl(index.js, 4, 3))
+>exports : Symbol(Thing, Decl(index.js, 4, 3))
+>Thing : Symbol(Thing, Decl(index.js, 4, 3))
 >Thing : Symbol(Thing, Decl(index.js, 1, 5), Decl(index.js, 0, 4))
 
 /**

--- a/tests/cases/conformance/jsdoc/exportedEnumTypeAndValue.ts
+++ b/tests/cases/conformance/jsdoc/exportedEnumTypeAndValue.ts
@@ -1,0 +1,17 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: def.js
+/** @enum {number} */
+const MyEnum = {
+  a: 1,
+  b: 2
+};
+export default MyEnum;
+
+// @Filename: use.js
+import MyEnum from "./def";
+
+/** @type {MyEnum} */
+const v = MyEnum.b;

--- a/tests/cases/fourslash/quickInfoJSExport.ts
+++ b/tests/cases/fourslash/quickInfoJSExport.ts
@@ -15,8 +15,7 @@
 //// export { test/**/String };
 
 verify.quickInfoAt("",
-`type testString = string
-(alias) type testString = any
+`(alias) type testString = string
 (alias) const testString: {
     one: string;
     two: string;


### PR DESCRIPTION
Nameless jsdoc typedefs have their exportedness controlled by the
exportedness of the location they pull their name from.

Fixes #33575.
