### PR TITLE
Avoid the double symbol for names that are explicitly exported

### DIFF
--- a/tests/baselines/reference/valueAndType_ExportAs-default.symbols
+++ b/tests/baselines/reference/valueAndType_ExportAs-default.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @typedef {number} X */
+const X = { a: 1, m: 1 };
+>X : Symbol(X, Decl(def.js, 1, 5), Decl(def.js, 0, 4))
+>a : Symbol(a, Decl(def.js, 1, 11))
+>m : Symbol(m, Decl(def.js, 1, 17))
+
+export { X as default };
+>X : Symbol(X, Decl(def.js, 1, 5), Decl(def.js, 0, 4))
+>default : Symbol(default, Decl(def.js, 2, 8))
+
+=== tests/cases/conformance/jsdoc/use.js ===
+import X from "./def";
+>X : Symbol(X, Decl(use.js, 0, 6))
+
+/** @type {X} */
+const n = 1;
+>n : Symbol(n, Decl(use.js, 3, 5))
+

--- a/tests/baselines/reference/valueAndType_ExportAs-default.types
+++ b/tests/baselines/reference/valueAndType_ExportAs-default.types
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @typedef {number} X */
+const X = { a: 1, m: 1 };
+>X : { a: number; m: number; }
+>{ a: 1, m: 1 } : { a: number; m: number; }
+>a : number
+>1 : 1
+>m : number
+>1 : 1
+
+export { X as default };
+>X : { a: number; m: number; }
+>default : { a: number; m: number; }
+
+=== tests/cases/conformance/jsdoc/use.js ===
+import X from "./def";
+>X : { a: number; m: number; }
+
+/** @type {X} */
+const n = 1;
+>n : number
+>1 : 1
+

--- a/tests/baselines/reference/valueAndType_ExportAs.symbols
+++ b/tests/baselines/reference/valueAndType_ExportAs.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @typedef {number} Y */
+const Y = { a: 1, m: 1 };
+>Y : Symbol(Y, Decl(def.js, 1, 5), Decl(def.js, 0, 4))
+>a : Symbol(a, Decl(def.js, 1, 11))
+>m : Symbol(m, Decl(def.js, 1, 17))
+
+export { Y as X };
+>Y : Symbol(Y, Decl(def.js, 1, 5), Decl(def.js, 0, 4))
+>X : Symbol(X, Decl(def.js, 2, 8))
+
+=== tests/cases/conformance/jsdoc/use.js ===
+import { X } from "./def";
+>X : Symbol(X, Decl(use.js, 0, 8))
+
+/** @type {X} */
+const n = 1;
+>n : Symbol(n, Decl(use.js, 3, 5))
+

--- a/tests/baselines/reference/valueAndType_ExportAs.types
+++ b/tests/baselines/reference/valueAndType_ExportAs.types
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @typedef {number} Y */
+const Y = { a: 1, m: 1 };
+>Y : { a: number; m: number; }
+>{ a: 1, m: 1 } : { a: number; m: number; }
+>a : number
+>1 : 1
+>m : number
+>1 : 1
+
+export { Y as X };
+>Y : { a: number; m: number; }
+>X : { a: number; m: number; }
+
+=== tests/cases/conformance/jsdoc/use.js ===
+import { X } from "./def";
+>X : { a: number; m: number; }
+
+/** @type {X} */
+const n = 1;
+>n : number
+>1 : 1
+

--- a/tests/baselines/reference/valueAndType_ExportDefault-enum.symbols
+++ b/tests/baselines/reference/valueAndType_ExportDefault-enum.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @enum {number} */
+const MyEnum = {
+>MyEnum : Symbol(MyEnum, Decl(def.js, 1, 5), Decl(def.js, 0, 4))
+
+  a: 1,
+>a : Symbol(a, Decl(def.js, 1, 16))
+
+  b: 2
+>b : Symbol(b, Decl(def.js, 2, 7))
+
+};
+export default MyEnum;
+>MyEnum : Symbol(MyEnum, Decl(def.js, 1, 5), Decl(def.js, 0, 4))
+
+=== tests/cases/conformance/jsdoc/use.js ===
+import MyEnum from "./def";
+>MyEnum : Symbol(MyEnum, Decl(use.js, 0, 6))
+
+/** @type {MyEnum} */
+const v = MyEnum.b;
+>v : Symbol(v, Decl(use.js, 3, 5))
+>MyEnum.b : Symbol(b, Decl(def.js, 2, 7))
+>MyEnum : Symbol(MyEnum, Decl(use.js, 0, 6))
+>b : Symbol(b, Decl(def.js, 2, 7))
+

--- a/tests/baselines/reference/valueAndType_ExportDefault-enum.types
+++ b/tests/baselines/reference/valueAndType_ExportDefault-enum.types
@@ -1,0 +1,29 @@
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @enum {number} */
+const MyEnum = {
+>MyEnum : { a: number; b: number; }
+>{  a: 1,  b: 2} : { a: number; b: number; }
+
+  a: 1,
+>a : number
+>1 : 1
+
+  b: 2
+>b : number
+>2 : 2
+
+};
+export default MyEnum;
+>MyEnum : number
+
+=== tests/cases/conformance/jsdoc/use.js ===
+import MyEnum from "./def";
+>MyEnum : { a: number; b: number; }
+
+/** @type {MyEnum} */
+const v = MyEnum.b;
+>v : number
+>MyEnum.b : number
+>MyEnum : { a: number; b: number; }
+>b : number
+

--- a/tests/baselines/reference/valueAndType_ExportDefault.symbols
+++ b/tests/baselines/reference/valueAndType_ExportDefault.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @typedef {number} X */
+const X = { a: 1, m: 1 };
+>X : Symbol(X, Decl(def.js, 1, 5), Decl(def.js, 0, 4))
+>a : Symbol(a, Decl(def.js, 1, 11))
+>m : Symbol(m, Decl(def.js, 1, 17))
+
+export default X;
+>X : Symbol(X, Decl(def.js, 1, 5), Decl(def.js, 0, 4))
+
+=== tests/cases/conformance/jsdoc/use.js ===
+import X from "./def";
+>X : Symbol(X, Decl(use.js, 0, 6))
+
+/** @type {X} */
+const n = 1;
+>n : Symbol(n, Decl(use.js, 3, 5))
+

--- a/tests/baselines/reference/valueAndType_ExportDefault.types
+++ b/tests/baselines/reference/valueAndType_ExportDefault.types
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @typedef {number} X */
+const X = { a: 1, m: 1 };
+>X : { a: number; m: number; }
+>{ a: 1, m: 1 } : { a: number; m: number; }
+>a : number
+>1 : 1
+>m : number
+>1 : 1
+
+export default X;
+>X : number
+
+=== tests/cases/conformance/jsdoc/use.js ===
+import X from "./def";
+>X : { a: number; m: number; }
+
+/** @type {X} */
+const n = 1;
+>n : number
+>1 : 1
+

--- a/tests/baselines/reference/valueAndType_ExportDestructure.symbols
+++ b/tests/baselines/reference/valueAndType_ExportDestructure.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @typedef {number} X */
+export const { X, Y } = { X: { a: 1, m: 1 }, Y: "why" };
+>X : Symbol(X, Decl(def.js, 1, 14), Decl(def.js, 0, 4))
+>Y : Symbol(Y, Decl(def.js, 1, 17))
+>X : Symbol(X, Decl(def.js, 1, 25))
+>a : Symbol(a, Decl(def.js, 1, 30))
+>m : Symbol(m, Decl(def.js, 1, 36))
+>Y : Symbol(Y, Decl(def.js, 1, 44))
+
+=== tests/cases/conformance/jsdoc/use.js ===
+import { X } from "./def";
+>X : Symbol(X, Decl(use.js, 0, 8))
+
+/** @type {X} */
+const n = 1;
+>n : Symbol(n, Decl(use.js, 3, 5))
+

--- a/tests/baselines/reference/valueAndType_ExportDestructure.types
+++ b/tests/baselines/reference/valueAndType_ExportDestructure.types
@@ -1,0 +1,24 @@
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @typedef {number} X */
+export const { X, Y } = { X: { a: 1, m: 1 }, Y: "why" };
+>X : { a: number; m: number; }
+>Y : string
+>{ X: { a: 1, m: 1 }, Y: "why" } : { X: { a: number; m: number; }; Y: string; }
+>X : { a: number; m: number; }
+>{ a: 1, m: 1 } : { a: number; m: number; }
+>a : number
+>1 : 1
+>m : number
+>1 : 1
+>Y : string
+>"why" : "why"
+
+=== tests/cases/conformance/jsdoc/use.js ===
+import { X } from "./def";
+>X : { a: number; m: number; }
+
+/** @type {X} */
+const n = 1;
+>n : number
+>1 : 1
+

--- a/tests/baselines/reference/valueAndType_ExportLet.symbols
+++ b/tests/baselines/reference/valueAndType_ExportLet.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @typedef {number} X */
+export let X = { a: 1, m: 1 };
+>X : Symbol(X, Decl(def.js, 1, 10), Decl(def.js, 0, 4))
+>a : Symbol(a, Decl(def.js, 1, 16))
+>m : Symbol(m, Decl(def.js, 1, 22))
+
+=== tests/cases/conformance/jsdoc/use.js ===
+import { X } from "./def";
+>X : Symbol(X, Decl(use.js, 0, 8))
+
+/** @type {X} */
+const n = 1;
+>n : Symbol(n, Decl(use.js, 3, 5))
+

--- a/tests/baselines/reference/valueAndType_ExportLet.types
+++ b/tests/baselines/reference/valueAndType_ExportLet.types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @typedef {number} X */
+export let X = { a: 1, m: 1 };
+>X : { a: number; m: number; }
+>{ a: 1, m: 1 } : { a: number; m: number; }
+>a : number
+>1 : 1
+>m : number
+>1 : 1
+
+=== tests/cases/conformance/jsdoc/use.js ===
+import { X } from "./def";
+>X : { a: number; m: number; }
+
+/** @type {X} */
+const n = 1;
+>n : number
+>1 : 1
+

--- a/tests/baselines/reference/valueAndType_ModuleExports.symbols
+++ b/tests/baselines/reference/valueAndType_ModuleExports.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/jsdoc/use.js ===
+const X = require("./def");
+>X : Symbol(X, Decl(use.js, 0, 5))
+>require : Symbol(require)
+>"./def" : Symbol("tests/cases/conformance/jsdoc/def", Decl(def.js, 0, 0))
+
+/** @type {X} */
+const n = 1;
+>n : Symbol(n, Decl(use.js, 3, 5))
+
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @typedef {number} X */
+const X = { a: 1, m: 1 };
+>X : Symbol(X, Decl(def.js, 1, 5), Decl(def.js, 0, 4))
+>a : Symbol(a, Decl(def.js, 1, 11))
+>m : Symbol(m, Decl(def.js, 1, 17))
+
+module.exports = X;
+>module.exports : Symbol("tests/cases/conformance/jsdoc/def", Decl(def.js, 0, 0))
+>module : Symbol(export=, Decl(def.js, 1, 25))
+>exports : Symbol(export=, Decl(def.js, 1, 25))
+>X : Symbol(X, Decl(def.js, 1, 5), Decl(def.js, 0, 4))
+

--- a/tests/baselines/reference/valueAndType_ModuleExports.types
+++ b/tests/baselines/reference/valueAndType_ModuleExports.types
@@ -1,0 +1,29 @@
+=== tests/cases/conformance/jsdoc/use.js ===
+const X = require("./def");
+>X : { a: number; m: number; }
+>require("./def") : { a: number; m: number; }
+>require : any
+>"./def" : "./def"
+
+/** @type {X} */
+const n = 1;
+>n : error
+>1 : 1
+
+=== tests/cases/conformance/jsdoc/def.js ===
+/** @typedef {number} X */
+const X = { a: 1, m: 1 };
+>X : { a: number; m: number; }
+>{ a: 1, m: 1 } : { a: number; m: number; }
+>a : number
+>1 : 1
+>m : number
+>1 : 1
+
+module.exports = X;
+>module.exports = X : { a: number; m: number; }
+>module.exports : { a: number; m: number; }
+>module : { "\"tests/cases/conformance/jsdoc/def\"": { a: number; m: number; }; }
+>exports : { a: number; m: number; }
+>X : { a: number; m: number; }
+

--- a/tests/cases/conformance/jsdoc/valueAndType_ExportAs-default.ts
+++ b/tests/cases/conformance/jsdoc/valueAndType_ExportAs-default.ts
@@ -1,0 +1,14 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: def.js
+/** @typedef {number} X */
+const X = { a: 1, m: 1 };
+export { X as default };
+
+// @Filename: use.js
+import X from "./def";
+
+/** @type {X} */
+const n = 1;

--- a/tests/cases/conformance/jsdoc/valueAndType_ExportAs.ts
+++ b/tests/cases/conformance/jsdoc/valueAndType_ExportAs.ts
@@ -1,0 +1,14 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: def.js
+/** @typedef {number} Y */
+const Y = { a: 1, m: 1 };
+export { Y as X };
+
+// @Filename: use.js
+import { X } from "./def";
+
+/** @type {X} */
+const n = 1;

--- a/tests/cases/conformance/jsdoc/valueAndType_ExportDefault-enum.ts
+++ b/tests/cases/conformance/jsdoc/valueAndType_ExportDefault-enum.ts
@@ -1,0 +1,17 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: def.js
+/** @enum {number} */
+const MyEnum = {
+  a: 1,
+  b: 2
+};
+export default MyEnum;
+
+// @Filename: use.js
+import MyEnum from "./def";
+
+/** @type {MyEnum} */
+const v = MyEnum.b;

--- a/tests/cases/conformance/jsdoc/valueAndType_ExportDefault.ts
+++ b/tests/cases/conformance/jsdoc/valueAndType_ExportDefault.ts
@@ -1,0 +1,14 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: def.js
+/** @typedef {number} X */
+const X = { a: 1, m: 1 };
+export default X;
+
+// @Filename: use.js
+import X from "./def";
+
+/** @type {X} */
+const n = 1;

--- a/tests/cases/conformance/jsdoc/valueAndType_ExportDestructure.ts
+++ b/tests/cases/conformance/jsdoc/valueAndType_ExportDestructure.ts
@@ -1,0 +1,13 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: def.js
+/** @typedef {number} X */
+export const { X, Y } = { X: { a: 1, m: 1 }, Y: "why" };
+
+// @Filename: use.js
+import { X } from "./def";
+
+/** @type {X} */
+const n = 1;

--- a/tests/cases/conformance/jsdoc/valueAndType_ExportLet.ts
+++ b/tests/cases/conformance/jsdoc/valueAndType_ExportLet.ts
@@ -1,0 +1,13 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: def.js
+/** @typedef {number} X */
+export let X = { a: 1, m: 1 };
+
+// @Filename: use.js
+import { X } from "./def";
+
+/** @type {X} */
+const n = 1;

--- a/tests/cases/conformance/jsdoc/valueAndType_ModuleExports.ts
+++ b/tests/cases/conformance/jsdoc/valueAndType_ModuleExports.ts
@@ -1,0 +1,14 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: def.js
+/** @typedef {number} X */
+const X = { a: 1, m: 1 };
+module.exports = X;
+
+// @Filename: use.js
+const X = require("./def");
+
+/** @type {X} */
+const n = 1;


### PR DESCRIPTION
Fixes #33575.
