### PR TITLE
fix(28516): Abstract methods should not allow `async` modifier

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37940,6 +37940,9 @@ namespace ts {
                             if (flags & ModifierFlags.Private) {
                                 return grammarErrorOnNode(modifier, Diagnostics._0_modifier_cannot_be_used_with_1_modifier, "private", "abstract");
                             }
+                            if (flags & ModifierFlags.Async && lastAsync) {
+                                return grammarErrorOnNode(lastAsync, Diagnostics._0_modifier_cannot_be_used_with_1_modifier, "async", "abstract");
+                            }
                         }
                         if (isNamedDeclaration(node) && node.name.kind === SyntaxKind.PrivateIdentifier) {
                             return grammarErrorOnNode(modifier, Diagnostics._0_modifier_cannot_be_used_with_a_private_identifier, "abstract");
@@ -37957,6 +37960,9 @@ namespace ts {
                         }
                         else if (node.kind === SyntaxKind.Parameter) {
                             return grammarErrorOnNode(modifier, Diagnostics._0_modifier_cannot_appear_on_a_parameter, "async");
+                        }
+                        if (flags & ModifierFlags.Abstract) {
+                            return grammarErrorOnNode(modifier, Diagnostics._0_modifier_cannot_be_used_with_1_modifier, "async", "abstract");
                         }
                         flags |= ModifierFlags.Async;
                         lastAsync = modifier;

--- a/tests/baselines/reference/classAbstractMixedWithModifiers.errors.txt
+++ b/tests/baselines/reference/classAbstractMixedWithModifiers.errors.txt
@@ -3,19 +3,21 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts(9,14): error TS1029: 'protected' modifier must precede 'abstract' modifier.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts(10,14): error TS1243: 'private' modifier cannot be used with 'abstract' modifier.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts(12,14): error TS1243: 'static' modifier cannot be used with 'abstract' modifier.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts(14,12): error TS1243: 'static' modifier cannot be used with 'abstract' modifier.
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts(13,12): error TS1243: 'static' modifier cannot be used with 'abstract' modifier.
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts(15,14): error TS1243: 'async' modifier cannot be used with 'abstract' modifier.
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts(16,5): error TS1243: 'async' modifier cannot be used with 'abstract' modifier.
 
 
-==== tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts (6 errors) ====
+==== tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts (8 errors) ====
     abstract class A {
         abstract foo_a();
-        
+    
         public abstract foo_b();
         protected abstract foo_c();
         private abstract foo_d();
                 ~~~~~~~~
 !!! error TS1243: 'private' modifier cannot be used with 'abstract' modifier.
-        
+    
         abstract public foo_bb();
                  ~~~~~~
 !!! error TS1029: 'public' modifier must precede 'abstract' modifier.
@@ -25,12 +27,19 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
         abstract private foo_dd();
                  ~~~~~~~
 !!! error TS1243: 'private' modifier cannot be used with 'abstract' modifier.
-        
+    
         abstract static foo_d();
                  ~~~~~~
 !!! error TS1243: 'static' modifier cannot be used with 'abstract' modifier.
-        
         static abstract foo_e();
                ~~~~~~~~
 !!! error TS1243: 'static' modifier cannot be used with 'abstract' modifier.
+    
+        abstract async foo_f();
+                 ~~~~~
+!!! error TS1243: 'async' modifier cannot be used with 'abstract' modifier.
+        async abstract foo_g();
+        ~~~~~
+!!! error TS1243: 'async' modifier cannot be used with 'abstract' modifier.
     }
+    

--- a/tests/baselines/reference/classAbstractMixedWithModifiers.js
+++ b/tests/baselines/reference/classAbstractMixedWithModifiers.js
@@ -1,19 +1,22 @@
 //// [classAbstractMixedWithModifiers.ts]
 abstract class A {
     abstract foo_a();
-    
+
     public abstract foo_b();
     protected abstract foo_c();
     private abstract foo_d();
-    
+
     abstract public foo_bb();
     abstract protected foo_cc();
     abstract private foo_dd();
-    
+
     abstract static foo_d();
-    
     static abstract foo_e();
+
+    abstract async foo_f();
+    async abstract foo_g();
 }
+
 
 //// [classAbstractMixedWithModifiers.js]
 var A = /** @class */ (function () {

--- a/tests/baselines/reference/classAbstractMixedWithModifiers.symbols
+++ b/tests/baselines/reference/classAbstractMixedWithModifiers.symbols
@@ -4,7 +4,7 @@ abstract class A {
 
     abstract foo_a();
 >foo_a : Symbol(A.foo_a, Decl(classAbstractMixedWithModifiers.ts, 0, 18))
-    
+
     public abstract foo_b();
 >foo_b : Symbol(A.foo_b, Decl(classAbstractMixedWithModifiers.ts, 1, 21))
 
@@ -13,7 +13,7 @@ abstract class A {
 
     private abstract foo_d();
 >foo_d : Symbol(A.foo_d, Decl(classAbstractMixedWithModifiers.ts, 4, 31))
-    
+
     abstract public foo_bb();
 >foo_bb : Symbol(A.foo_bb, Decl(classAbstractMixedWithModifiers.ts, 5, 29))
 
@@ -22,10 +22,17 @@ abstract class A {
 
     abstract private foo_dd();
 >foo_dd : Symbol(A.foo_dd, Decl(classAbstractMixedWithModifiers.ts, 8, 32))
-    
+
     abstract static foo_d();
 >foo_d : Symbol(A.foo_d, Decl(classAbstractMixedWithModifiers.ts, 9, 30))
-    
+
     static abstract foo_e();
 >foo_e : Symbol(A.foo_e, Decl(classAbstractMixedWithModifiers.ts, 11, 28))
+
+    abstract async foo_f();
+>foo_f : Symbol(A.foo_f, Decl(classAbstractMixedWithModifiers.ts, 12, 28))
+
+    async abstract foo_g();
+>foo_g : Symbol(A.foo_g, Decl(classAbstractMixedWithModifiers.ts, 14, 27))
 }
+

--- a/tests/baselines/reference/classAbstractMixedWithModifiers.types
+++ b/tests/baselines/reference/classAbstractMixedWithModifiers.types
@@ -4,7 +4,7 @@ abstract class A {
 
     abstract foo_a();
 >foo_a : () => any
-    
+
     public abstract foo_b();
 >foo_b : () => any
 
@@ -13,7 +13,7 @@ abstract class A {
 
     private abstract foo_d();
 >foo_d : () => any
-    
+
     abstract public foo_bb();
 >foo_bb : () => any
 
@@ -22,10 +22,17 @@ abstract class A {
 
     abstract private foo_dd();
 >foo_dd : () => any
-    
+
     abstract static foo_d();
 >foo_d : () => any
-    
+
     static abstract foo_e();
 >foo_e : () => any
+
+    abstract async foo_f();
+>foo_f : () => any
+
+    async abstract foo_g();
+>foo_g : () => any
 }
+

--- a/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts
+++ b/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts
@@ -1,15 +1,17 @@
 abstract class A {
     abstract foo_a();
-    
+
     public abstract foo_b();
     protected abstract foo_c();
     private abstract foo_d();
-    
+
     abstract public foo_bb();
     abstract protected foo_cc();
     abstract private foo_dd();
-    
+
     abstract static foo_d();
-    
     static abstract foo_e();
+
+    abstract async foo_f();
+    async abstract foo_g();
 }


### PR DESCRIPTION
Fixes #28516
