### PR TITLE
fix(13503): Crash for `getTypeAtLocation(sourceFile)`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -36582,6 +36582,10 @@ namespace ts {
         }
 
         function getTypeOfNode(node: Node): Type {
+            if (isSourceFile(node) && !isExternalModule(node)) {
+                return errorType;
+            }
+
             if (node.flags & NodeFlags.InWithStatement) {
                 // We cannot answer semantic questions within a with block, do not proceed any further
                 return errorType;

--- a/src/testRunner/unittests/publicApi.ts
+++ b/src/testRunner/unittests/publicApi.ts
@@ -104,4 +104,23 @@ describe("unittests:: Public APIs:: getTypeAtLocation", () => {
         assert.ok(!(type.flags & ts.TypeFlags.Any));
         assert.equal(type, checker.getTypeAtLocation(propertyAccess.name));
     });
+
+    it("works on SourceFile", () => {
+        const content = `const foo = 1;`;
+        const host = new fakes.CompilerHost(vfs.createFromFileSystem(
+            Harness.IO,
+            /*ignoreCase*/ true,
+            { documents: [new documents.TextDocument("/file.ts", content)], cwd: "/" }));
+
+        const program = ts.createProgram({
+            host,
+            rootNames: ["/file.ts"],
+            options: { noLib: true }
+        });
+
+        const checker = program.getTypeChecker();
+        const file = program.getSourceFile("/file.ts")!;
+        const type = checker.getTypeAtLocation(file);
+        assert.equal(type.flags, ts.TypeFlags.Any);
+    });
 });


### PR DESCRIPTION
Fixes #13503