### PR TITLE
QuickInfo of element access expression could shows correct type when it is narrowed.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22006,11 +22006,11 @@ namespace ts {
                 }
             }
 
-            // If location is stringLiteral, it might be argument in ElementAccessExpression, like a["Q"].
-            // Deal it just like identifier/PropertyAccessExpression.
+            // If the location is a StringLiteral, it might be the argument to an ElementAccessExpression (e.g. like foo["bar"])
+            // Deal it the same way as we would with an Identifier or PropertyAccessExpression.
             if (location.kind === SyntaxKind.StringLiteral) {
                 const candidateExpression = location.parent;
-                if (isElementAccessExpression(candidateExpression) && !isAssignmentTarget(candidateExpression)) {
+                if (isElementAccessExpression(candidateExpression) && !isAssignmentTarget(candidateExpression) && candidateExpression.argumentExpression === location) {
                     const type = getTypeOfExpression(candidateExpression);
                     if (getExportSymbolOfValueSymbolIfExported(getNodeLinks(candidateExpression).resolvedSymbol) === symbol) {
                         return type;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22005,6 +22005,19 @@ namespace ts {
                     }
                 }
             }
+
+            // If location is stringLiteral, it might be argument in ElementAccessExpression, like a["Q"].
+            // Deal it just like identifier/PropertyAccessExpression.
+            if (location.kind === SyntaxKind.StringLiteral) {
+                const candidateExpression = location.parent;
+                if (isElementAccessExpression(candidateExpression) && !isAssignmentTarget(candidateExpression)) {
+                    const type = getTypeOfExpression(candidateExpression);
+                    if (getExportSymbolOfValueSymbolIfExported(getNodeLinks(candidateExpression).resolvedSymbol) === symbol) {
+                        return type;
+                    }
+                }
+            }
+
             // The location isn't a reference to the given symbol, meaning we're being asked
             // a hypothetical question of what type the symbol would have if there was a reference
             // to it at the given location. Since we have no control flow information for the

--- a/tests/cases/fourslash/quickInfoElementAccessTypeGuard.ts
+++ b/tests/cases/fourslash/quickInfoElementAccessTypeGuard.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts'/>
+
+//// type T = { p: string | number };
+//// function f(t: T) {
+////     if (typeof t.p === "string") {
+////         t[/**/"p"];    // string, number
+////     }
+//// }
+
+verify.quickInfoAt("", "(property) p: string");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #40013
