### PR TITLE
Add compactDisplay and signDisplay to NumberFormatOptions

### DIFF
--- a/src/lib/es2020.intl.d.ts
+++ b/src/lib/es2020.intl.d.ts
@@ -263,13 +263,17 @@ declare namespace Intl {
     };
 
     interface NumberFormatOptions {
+        compactDisplay?: string;
         notation?: string;
+        signDisplay?: string;
         unit?: string;
         unitDisplay?: string;
     }
 
     interface ResolvedNumberFormatOptions {
+        compactDisplay?: string;
         notation?: string;
+        signDisplay?: string;
         unit?: string;
         unitDisplay?: string;
     }

--- a/tests/lib/lib.d.ts
+++ b/tests/lib/lib.d.ts
@@ -3890,6 +3890,7 @@ declare module Intl {
     interface NumberFormatOptions {
         localeMatcher?: string;
         style?: string;
+        compactDisplay?: string;
         currency?: string;
         currencyDisplay?: string;
         unit?: string;
@@ -3901,12 +3902,14 @@ declare module Intl {
         minimumSignificantDigits?: number;
         maximumSignificantDigits?: number;
         notation?: string;
+        signDisplay?: string;
     }
 
     interface ResolvedNumberFormatOptions {
         locale: string;
         numberingSystem: string;
         style: string;
+        compactDisplay?: string;
         currency?: string;
         currencyDisplay?: string;
         unit?: string;
@@ -3918,6 +3921,7 @@ declare module Intl {
         maximumSignificantDigits?: number;
         useGrouping: boolean;
         notation?: string;
+        signDisplay?: string;
     }
 
     interface NumberFormat {


### PR DESCRIPTION
Fixes #40038 

Add `compactDisplay` and `signDisplay` options to [NumberFormatOptions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/NumberFormat) in `src/lib/es2020.intl.d.ts`
