### PR TITLE
Ensure file, include and exclude specs used are strings 

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5880,13 +5880,14 @@ namespace ts {
         /**
          * Present to report errors (user specified specs), validatedIncludeSpecs are used for file name matching
          */
-        includeSpecs?: readonly string[];
+        includeSpecs: readonly string[] | undefined;
         /**
          * Present to report errors (user specified specs), validatedExcludeSpecs are used for file name matching
          */
-        excludeSpecs?: readonly string[];
-        validatedIncludeSpecs?: readonly string[];
-        validatedExcludeSpecs?: readonly string[];
+        excludeSpecs: readonly string[] | undefined;
+        validatedFilesSpec: readonly string[] | undefined;
+        validatedIncludeSpecs: readonly string[] | undefined;
+        validatedExcludeSpecs: readonly string[] | undefined;
         wildcardDirectories: MapLike<WatchDirectoryFlags>;
     }
 

--- a/src/testRunner/unittests/config/tsconfigParsing.ts
+++ b/src/testRunner/unittests/config/tsconfigParsing.ts
@@ -381,5 +381,36 @@ namespace ts {
             const parsed = getParsedCommandJsonNode(jsonText, "/apath/tsconfig.json", "tests/cases/unittests", ["/apath/a.ts"]);
             assert.isTrue(parsed.errors.length >= 0);
         });
+
+        it("generates errors when files is not string", () => {
+            assertParseFileDiagnostics(
+                JSON.stringify({
+                    files: [{
+                        compilerOptions: {
+                            experimentalDecorators: true,
+                            allowJs: true
+                        }
+                    }]
+                }),
+                "/apath/tsconfig.json",
+                "tests/cases/unittests",
+                ["/apath/a.ts"],
+                Diagnostics.Compiler_option_0_requires_a_value_of_type_1.code,
+                /*noLocation*/ true);
+        });
+
+        it("generates errors when include is not string", () => {
+            assertParseFileDiagnostics(
+                JSON.stringify({
+                    include: [
+                        ["./**/*.ts"]
+                    ]
+                }),
+                "/apath/tsconfig.json",
+                "tests/cases/unittests",
+                ["/apath/a.ts"],
+                Diagnostics.Compiler_option_0_requires_a_value_of_type_1.code,
+                /*noLocation*/ true);
+        });
     });
 }


### PR DESCRIPTION
Fixes #38164, #39856