### PR TITLE
Set stackTraceLimit to 0 in fileSystemEntryExists 

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1662,6 +1662,11 @@ namespace ts {
             }
 
             function fileSystemEntryExists(path: string, entryKind: FileSystemEntryKind): boolean {
+                // Since the error thrown by fs.statSync isn't used, we can avoid collecting a stack trace to improve
+                // the CPU time performance.
+                const originalStackTraceLimit = Error.stackTraceLimit;
+                Error.stackTraceLimit = 0;
+
                 try {
                     const stat = _fs.statSync(path);
                     switch (entryKind) {
@@ -1672,6 +1677,9 @@ namespace ts {
                 }
                 catch (e) {
                     return false;
+                }
+                finally {
+                    Error.stackTraceLimit = originalStackTraceLimit;
                 }
             }
 


### PR DESCRIPTION
The exception thrown by Node.js's fs.statSync function contains a stack trace that can be expensive to compute. Since this exception isn't used by fileSystemEntryExists, we can safely set Error.stackTraceLimit to 0 without a change in behavior.

A significant performance improvement was noticed with this change while profiling tsserver on packages within a proprietary monorepo. Specifically, my team saw high self time percentages for Node.js's `uvException` and `handleErrorFromBinding` internal functions. These functions are executed within `fs.statSync` when it fails to find the given path.

<img width="1468" alt="Screen Shot 2020-08-12 at 4 13 41 PM" src="https://user-images.githubusercontent.com/906558/90183227-220cb800-dd81-11ea-8d61-f41f89481f46.png">

`fs.statSync`: https://github.com/nodejs/node/blob/v14.4.0/lib/fs.js#L1030-L1037
`handleErrorFromBinding`: https://github.com/nodejs/node/blob/v14.4.0/lib/internal/fs/utils.js#L254-L269
`uvException`: https://github.com/nodejs/node/blob/v14.4.0/lib/internal/errors.js#L390-L443

 ## Measurements

After adding `Error.stackTraceLimit = 0`, we saw:

- For a large configured project with 12,565 files, tsserver reached the `projectLoadingFinish` event 48.78% faster. (~46.786s vs ~31.447s)
- For a medium project with 7,064 files, tsserver was 25.75% faster. (~20.897s vs ~16.618s)
- For a small project with 796 files, tsserver was only a negligible 3.00% faster. (~3.545s vs ~3.442)

Measurements were taken on macOS 10.15.6, Node.js 14.4.0, and a recent master commit of TypeScript (`610fa28d`). The average of 3 runs before and after this change were taken.

I would normally include `.cpuprofile` and `isolate-*-*-*.log` files, but can't post them publicly in this case. If there's any other summaries the TypeScript team would be curious about I can report them.

## fs.statSync Misses

Within our monorepo, the `fs.statSync` misses were mostly searches for alternative file extensions of module imports.

- For node_modules imports, a lot of `.ts`/`.tsx` lookups failed until the `.d.ts` file was found.
- Within projects with a lot of JSX files, `.ts` files were looked for before finding the `.tsx` version.
- In the medium scale project mentioned above, a total of 38,515 non-existent files were queried during `createProgram`.