### PR TITLE
don't emit "unused @ts-expect-error" in unchecked js files

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1757,9 +1757,17 @@ namespace ts {
                 return flatDiagnostics;
             }
 
+            const isCheckJs = isCheckJsEnabledForFile(sourceFile, options);
+            const isJs = sourceFile.scriptKind === ScriptKind.JS || sourceFile.scriptKind === ScriptKind.JSX;
+            const isTsNoCheck = sourceFile.checkJsDirective?.enabled === false;
+
             const { diagnostics, directives } = getDiagnosticsWithPrecedingDirectives(sourceFile, sourceFile.commentDirectives, flatDiagnostics);
 
             for (const errorExpectation of directives.getUnusedExpectations()) {
+                // don't report "unused ts-expect-error" in JS files that aren't being type-checked
+                // and also not in files with // @ts-nocheck
+                if (isTsNoCheck || (isJs && !isCheckJs)) continue;
+
                 diagnostics.push(createDiagnosticForRange(sourceFile, errorExpectation.range, Diagnostics.Unused_ts_expect_error_directive));
             }
 

--- a/tests/baselines/reference/ts-expect-error-js.errors.txt
+++ b/tests/baselines/reference/ts-expect-error-js.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/conformance/directives/a.js(3,1): error TS2578: Unused '@ts-expect-error' directive.
+
+
+==== tests/cases/conformance/directives/a.js (1 errors) ====
+    // there should be a "Unused @ts-expect-error" error since js files are being checked
+    
+    // @ts-expect-error
+    ~~~~~~~~~~~~~~~~~~~
+!!! error TS2578: Unused '@ts-expect-error' directive.
+    const a = 1;
+    

--- a/tests/baselines/reference/ts-expect-error-js.symbols
+++ b/tests/baselines/reference/ts-expect-error-js.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/directives/a.js ===
+// there should be a "Unused @ts-expect-error" error since js files are being checked
+
+// @ts-expect-error
+const a = 1;
+>a : Symbol(a, Decl(a.js, 3, 5))
+

--- a/tests/baselines/reference/ts-expect-error-js.types
+++ b/tests/baselines/reference/ts-expect-error-js.types
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/directives/a.js ===
+// there should be a "Unused @ts-expect-error" error since js files are being checked
+
+// @ts-expect-error
+const a = 1;
+>a : 1
+>1 : 1
+

--- a/tests/baselines/reference/ts-expect-error-nocheck-js.symbols
+++ b/tests/baselines/reference/ts-expect-error-nocheck-js.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/directives/a.js ===
+// there should not be a "Unused @ts-expect-error" error since js files are not being checked
+
+// @ts-expect-error
+const a = 1;
+>a : Symbol(a, Decl(a.js, 3, 5))
+

--- a/tests/baselines/reference/ts-expect-error-nocheck-js.types
+++ b/tests/baselines/reference/ts-expect-error-nocheck-js.types
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/directives/a.js ===
+// there should not be a "Unused @ts-expect-error" error since js files are not being checked
+
+// @ts-expect-error
+const a = 1;
+>a : 1
+>1 : 1
+

--- a/tests/baselines/reference/ts-expect-error-nocheck.js
+++ b/tests/baselines/reference/ts-expect-error-nocheck.js
@@ -1,0 +1,14 @@
+//// [ts-expect-error-nocheck.ts]
+// @ts-nocheck
+
+// there should not be a "Unused @ts-expect-error" error due to the // @ts-nocheck
+
+// @ts-expect-error
+const a = 1;
+
+
+//// [ts-expect-error-nocheck.js]
+// @ts-nocheck
+// there should not be a "Unused @ts-expect-error" error due to the // @ts-nocheck
+// @ts-expect-error
+var a = 1;

--- a/tests/baselines/reference/ts-expect-error-nocheck.symbols
+++ b/tests/baselines/reference/ts-expect-error-nocheck.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/directives/ts-expect-error-nocheck.ts ===
+// @ts-nocheck
+
+// there should not be a "Unused @ts-expect-error" error due to the // @ts-nocheck
+
+// @ts-expect-error
+const a = 1;
+>a : Symbol(a, Decl(ts-expect-error-nocheck.ts, 5, 5))
+

--- a/tests/baselines/reference/ts-expect-error-nocheck.types
+++ b/tests/baselines/reference/ts-expect-error-nocheck.types
@@ -1,0 +1,10 @@
+=== tests/cases/conformance/directives/ts-expect-error-nocheck.ts ===
+// @ts-nocheck
+
+// there should not be a "Unused @ts-expect-error" error due to the // @ts-nocheck
+
+// @ts-expect-error
+const a = 1;
+>a : 1
+>1 : 1
+

--- a/tests/cases/conformance/directives/ts-expect-error-js.ts
+++ b/tests/cases/conformance/directives/ts-expect-error-js.ts
@@ -1,0 +1,10 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @fileName: a.js
+
+// there should be a "Unused @ts-expect-error" error since js files are being checked
+
+// @ts-expect-error
+const a = 1;

--- a/tests/cases/conformance/directives/ts-expect-error-nocheck-js.ts
+++ b/tests/cases/conformance/directives/ts-expect-error-nocheck-js.ts
@@ -1,0 +1,10 @@
+// @allowJs: true
+// @checkJs: false
+// @noEmit: true
+
+// @fileName: a.js
+
+// there should not be a "Unused @ts-expect-error" error since js files are not being checked
+
+// @ts-expect-error
+const a = 1;

--- a/tests/cases/conformance/directives/ts-expect-error-nocheck.ts
+++ b/tests/cases/conformance/directives/ts-expect-error-nocheck.ts
@@ -1,0 +1,6 @@
+// @ts-nocheck
+
+// there should not be a "Unused @ts-expect-error" error due to the // @ts-nocheck
+
+// @ts-expect-error
+const a = 1;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #39867

Files with `// @ts-nocheck` should emit absolutely no errors. The same goes for JS files if `checkJs: false`

However, `TS2578: Unused '@ts-expect-error' directive.` is still emitted in files that are not supposed to be typechecked.

This PR changes that behaviour so that error TS2578 is not thrown for files with `// @ts-nocheck` or JS files if `checkJs: false`. Added 3 test cases to confirm that it works. 
