### PR TITLE
Add number parameter to `parseInt` and `parseFloat`

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -38,13 +38,13 @@ declare function eval(x: string): any;
  * If this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.
  * All other strings are considered decimal.
  */
-declare function parseInt(s: string, radix?: number): number;
+declare function parseInt(s: string | number, radix?: number): number;
 
 /**
  * Converts a string to a floating-point number.
  * @param string A string that contains a floating-point number.
  */
-declare function parseFloat(string: string): number;
+declare function parseFloat(string: string | number): number;
 
 /**
  * Returns a Boolean value that indicates whether a value is the reserved value NaN (not a number).


### PR DESCRIPTION
I'm pretty conflicted about this patch. While the [spec](https://tc39.es/ecma262/#sec-parseint-string-radix) says the input must be a `string`, the first thing these functions do is pass the argument to `toString`.  And since **any** `number` will [always](https://tc39.es/ecma262/#sec-tostring) be converted to their [equivalent](https://tc39.es/ecma262/#sec-numeric-types-number-tostring) `string`, this overloading of functions will always be valid.

So even though this `works`, I'm still conflicted.  Because the spec says it takes a `string`, and that's what the current declaration does.  Additionally, if `number` is a reasonable overload then why not any object with a `toString` property?  For example, if `new MyClass().toString() ==='1'`, then would my logic imply `MyClass` is a reasonable type of `s`?  But obviously this is unacceptable because there is no way to know `ToString(new MyClass())` will return a "parseInt-able" string.

While it seems I just delivered a death blow to my patch, I think there's an important distinction here.  While we have no way of knowing what `MyClass.toString` returns, the spec **guarantees** that the return value of `ToString(number)` is a valid input to `parseInt`.  i.e. `parseInt(ToString(num))===num` ∀ num ε [number](https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type).  So that makes this a bit different than needing to include all possible things whose `ToString` could be a "number string".

Workarounds:

1. run `toString` yourself
2. do `parseInt(str as string)`

Right now the latter is what I'm doing.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
