### PR TITLE
Optimize source mapping into external source map sources

### DIFF
--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -13,6 +13,7 @@ namespace ts {
         const rawSources: string[] = [];
         const sources: string[] = [];
         const sourceToSourceIndexMap = new Map<string, number>();
+        const fileNameToSourceIndexMap = new Map<string, number>();
         let sourcesContent: (string | null)[] | undefined;
 
         const names: string[] = [];
@@ -51,6 +52,10 @@ namespace ts {
 
         function addSource(fileName: string) {
             enter();
+            const sourceIndexByFileName = fileNameToSourceIndexMap.get(fileName);
+            if (sourceIndexByFileName !== undefined) {
+                return sourceIndexByFileName;
+            }
             const source = getRelativePathToDirectoryOrUrl(sourcesDirectoryPath,
                 fileName,
                 host.getCurrentDirectory(),
@@ -64,6 +69,7 @@ namespace ts {
                 rawSources.push(fileName);
                 sourceToSourceIndexMap.set(source, sourceIndex);
             }
+            fileNameToSourceIndexMap.set(fileName, sourceIndex);
             exit();
             return sourceIndex;
         }


### PR DESCRIPTION
Fixes #40054

## Timings

| fn                                       | Before  | After | Improvement
| ------------------------- | -------|------|--------|
| emit phase                        | 13.4      | 8.8    | -34% |
| `emitSourcePos`              | 4.8s      | 0.6s  | -87% |
| `setSourceMapSource`    | 4.3s      | 0.1s  | -98% |
