### PR TITLE
Revert "Add '(approximate)' to the beginning of quick info requests in PartialSemantic mode"

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1587,9 +1587,7 @@ namespace ts {
                     kind: ScriptElementKind.unknown,
                     kindModifiers: ScriptElementKindModifier.none,
                     textSpan: createTextSpanFromNode(nodeForQuickInfo, sourceFile),
-                    displayParts: prefixWithApproximation(
-                        typeChecker.runWithCancellationToken(cancellationToken, typeChecker => typeToDisplayParts(typeChecker, type, getContainerNode(nodeForQuickInfo)))
-                    ),
+                    displayParts: typeChecker.runWithCancellationToken(cancellationToken, typeChecker => typeToDisplayParts(typeChecker, type, getContainerNode(nodeForQuickInfo))),
                     documentation: type.symbol ? type.symbol.getDocumentationComment(typeChecker) : undefined,
                     tags: type.symbol ? type.symbol.getJsDocTags() : undefined
                 };
@@ -1602,7 +1600,7 @@ namespace ts {
                 kind: symbolKind,
                 kindModifiers: SymbolDisplay.getSymbolModifiers(symbol),
                 textSpan: createTextSpanFromNode(nodeForQuickInfo, sourceFile),
-                displayParts: prefixWithApproximation(displayParts),
+                displayParts,
                 documentation,
                 tags,
             };
@@ -1630,13 +1628,6 @@ namespace ts {
                 default:
                     return false;
             }
-        }
-
-        function prefixWithApproximation(displayParts: SymbolDisplayPart[]): SymbolDisplayPart[] {
-            if (languageServiceMode === LanguageServiceMode.Semantic) {
-                return displayParts;
-            }
-            return [textPart("(approximation)"), spacePart(), ...displayParts];
         }
 
         /// Goto definition

--- a/src/testRunner/unittests/tsserver/partialSemanticServer.ts
+++ b/src/testRunner/unittests/tsserver/partialSemanticServer.ts
@@ -30,22 +30,6 @@ import { something } from "something";
             return { host, session, file1, file2, file3, something, configFile };
         }
 
-        it("adds '(approximation)' to the description of quick info", () => {
-            const file: File = {
-                path: `${tscWatch.projectRoot}/foo.ts`,
-                content: "export const foo = 100;"
-            };
-            const host = createServerHost([file]);
-            const session = createSession(host, { serverMode: LanguageServiceMode.PartialSemantic, useSingleInferredProject: true });
-            openFilesForSession([file], session);
-            const response = session.executeCommandSeq<protocol.QuickInfoRequest>({
-                command: protocol.CommandTypes.Quickinfo,
-                arguments: protocolFileLocationFromSubstring(file, "foo"),
-            }).response as protocol.QuickInfoResponseBody;
-
-            assert(stringContainsAt(response.displayString, "(approximation)", 0));
-        });
-
         it("open files are added to inferred project even if config file is present and semantic operations succeed", () => {
             const { host, session, file1, file2 } = setup();
             const service = session.getProjectService();


### PR DESCRIPTION
Reverts microsoft/TypeScript#40061 since there were some concerns over whether the editor should do this instead.