### PR TITLE
`Object.keys` fails on generic types

### DIFF
--- a/lib/lib.es2015.core.d.ts
+++ b/lib/lib.es2015.core.d.ts
@@ -322,7 +322,7 @@ interface ObjectConstructor {
      * Returns the names of the enumerable string properties and methods of an object.
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
-    keys(o: {}): string[];
+    keys<T>(o: T): (keyof T)[];
 
     /**
      * Returns true if the values are the same value, false otherwise.


### PR DESCRIPTION
```ts
const clone = <B extends A>(b: B): B => {
    // @ts-ignore
    const clone = (new b.constructor) as B

    for (const key of Object.keys(b)) {
        b[key] // error
    }

    return clone
}
```

The error comes from the fact that `.keys()` returned `string[]`. When working with generic types, TypeScript is unsure that a `string` key will exist within the generic type `B` (not known). TypeScript can only agree if `key` is of type `keyof B`, that explains the change.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
