### PR TITLE
Specified error diagnostic for invalid variable names

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1180,6 +1180,10 @@
         "category": "Error",
         "code": 1388
     },
+    "'{0}' is not allowed as a variable declaration name.": {
+        "category": "Error",
+        "code": 1389
+    },
 
     "The types of '{0}' are incompatible between these types.": {
         "category": "Error",

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2356,7 +2356,7 @@ namespace ts {
 
         // Returns true if we should abort parsing.
         function abortParsingListOrMoveToNextToken(kind: ParsingContext) {
-            parseErrorAtCurrentToken(parsingContextErrors(kind));
+            parseErrorAtCurrentToken(...parsingContextErrors(kind));
             if (isInSomeParsingContext()) {
                 return true;
             }
@@ -2365,33 +2365,37 @@ namespace ts {
             return false;
         }
 
-        function parsingContextErrors(context: ParsingContext): DiagnosticMessage {
+        function parsingContextErrors(context: ParsingContext): [DiagnosticMessage, string?] {
             switch (context) {
-                case ParsingContext.SourceElements: return Diagnostics.Declaration_or_statement_expected;
-                case ParsingContext.BlockStatements: return Diagnostics.Declaration_or_statement_expected;
-                case ParsingContext.SwitchClauses: return Diagnostics.case_or_default_expected;
-                case ParsingContext.SwitchClauseStatements: return Diagnostics.Statement_expected;
+                case ParsingContext.SourceElements: return [Diagnostics.Declaration_or_statement_expected];
+                case ParsingContext.BlockStatements: return [Diagnostics.Declaration_or_statement_expected];
+                case ParsingContext.SwitchClauses: return [Diagnostics.case_or_default_expected];
+                case ParsingContext.SwitchClauseStatements: return [Diagnostics.Statement_expected];
                 case ParsingContext.RestProperties: // fallthrough
-                case ParsingContext.TypeMembers: return Diagnostics.Property_or_signature_expected;
-                case ParsingContext.ClassMembers: return Diagnostics.Unexpected_token_A_constructor_method_accessor_or_property_was_expected;
-                case ParsingContext.EnumMembers: return Diagnostics.Enum_member_expected;
-                case ParsingContext.HeritageClauseElement: return Diagnostics.Expression_expected;
-                case ParsingContext.VariableDeclarations: return Diagnostics.Variable_declaration_expected;
-                case ParsingContext.ObjectBindingElements: return Diagnostics.Property_destructuring_pattern_expected;
-                case ParsingContext.ArrayBindingElements: return Diagnostics.Array_element_destructuring_pattern_expected;
-                case ParsingContext.ArgumentExpressions: return Diagnostics.Argument_expression_expected;
-                case ParsingContext.ObjectLiteralMembers: return Diagnostics.Property_assignment_expected;
-                case ParsingContext.ArrayLiteralMembers: return Diagnostics.Expression_or_comma_expected;
-                case ParsingContext.JSDocParameters: return Diagnostics.Parameter_declaration_expected;
-                case ParsingContext.Parameters: return Diagnostics.Parameter_declaration_expected;
-                case ParsingContext.TypeParameters: return Diagnostics.Type_parameter_declaration_expected;
-                case ParsingContext.TypeArguments: return Diagnostics.Type_argument_expected;
-                case ParsingContext.TupleElementTypes: return Diagnostics.Type_expected;
-                case ParsingContext.HeritageClauses: return Diagnostics.Unexpected_token_expected;
-                case ParsingContext.ImportOrExportSpecifiers: return Diagnostics.Identifier_expected;
-                case ParsingContext.JsxAttributes: return Diagnostics.Identifier_expected;
-                case ParsingContext.JsxChildren: return Diagnostics.Identifier_expected;
-                default: return undefined!; // TODO: GH#18217 `default: Debug.assertNever(context);`
+                case ParsingContext.TypeMembers: return [Diagnostics.Property_or_signature_expected];
+                case ParsingContext.ClassMembers: return [Diagnostics.Unexpected_token_A_constructor_method_accessor_or_property_was_expected];
+                case ParsingContext.EnumMembers: return [Diagnostics.Enum_member_expected];
+                case ParsingContext.HeritageClauseElement: return [Diagnostics.Expression_expected];
+                case ParsingContext.VariableDeclarations:
+                    const tokenString = tokenToString(token());
+                    return tokenString && /\w+/.test(tokenString[0])
+                        ? [Diagnostics._0_is_not_allowed_as_a_variable_declaration_name, tokenString]
+                        : [Diagnostics.Variable_declaration_expected];
+                case ParsingContext.ObjectBindingElements: return [Diagnostics.Property_destructuring_pattern_expected];
+                case ParsingContext.ArrayBindingElements: return [Diagnostics.Array_element_destructuring_pattern_expected];
+                case ParsingContext.ArgumentExpressions: return [Diagnostics.Argument_expression_expected];
+                case ParsingContext.ObjectLiteralMembers: return [Diagnostics.Property_assignment_expected];
+                case ParsingContext.ArrayLiteralMembers: return [Diagnostics.Expression_or_comma_expected];
+                case ParsingContext.JSDocParameters: return [Diagnostics.Parameter_declaration_expected];
+                case ParsingContext.Parameters: return [Diagnostics.Parameter_declaration_expected];
+                case ParsingContext.TypeParameters: return [Diagnostics.Type_parameter_declaration_expected];
+                case ParsingContext.TypeArguments: return [Diagnostics.Type_argument_expected];
+                case ParsingContext.TupleElementTypes: return [Diagnostics.Type_expected];
+                case ParsingContext.HeritageClauses: return [Diagnostics.Unexpected_token_expected];
+                case ParsingContext.ImportOrExportSpecifiers: return [Diagnostics.Identifier_expected];
+                case ParsingContext.JsxAttributes: return [Diagnostics.Identifier_expected];
+                case ParsingContext.JsxChildren: return [Diagnostics.Identifier_expected];
+                default: return [undefined!]; // TODO: GH#18217 `default: Debug.assertNever(context);`
             }
         }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2356,7 +2356,7 @@ namespace ts {
 
         // Returns true if we should abort parsing.
         function abortParsingListOrMoveToNextToken(kind: ParsingContext) {
-            parseErrorAtCurrentToken(...parsingContextErrors(kind));
+            parsingContextErrors(kind);
             if (isInSomeParsingContext()) {
                 return true;
             }
@@ -2365,36 +2365,35 @@ namespace ts {
             return false;
         }
 
-        function parsingContextErrors(context: ParsingContext): [DiagnosticMessage, string?] {
+        function parsingContextErrors(context: ParsingContext) {
             switch (context) {
-                case ParsingContext.SourceElements: return [Diagnostics.Declaration_or_statement_expected];
-                case ParsingContext.BlockStatements: return [Diagnostics.Declaration_or_statement_expected];
-                case ParsingContext.SwitchClauses: return [Diagnostics.case_or_default_expected];
-                case ParsingContext.SwitchClauseStatements: return [Diagnostics.Statement_expected];
+                case ParsingContext.SourceElements: return parseErrorAtCurrentToken(Diagnostics.Declaration_or_statement_expected);
+                case ParsingContext.BlockStatements: return parseErrorAtCurrentToken(Diagnostics.Declaration_or_statement_expected);
+                case ParsingContext.SwitchClauses: return parseErrorAtCurrentToken(Diagnostics.case_or_default_expected);
+                case ParsingContext.SwitchClauseStatements: return parseErrorAtCurrentToken(Diagnostics.Statement_expected);
                 case ParsingContext.RestProperties: // fallthrough
-                case ParsingContext.TypeMembers: return [Diagnostics.Property_or_signature_expected];
-                case ParsingContext.ClassMembers: return [Diagnostics.Unexpected_token_A_constructor_method_accessor_or_property_was_expected];
-                case ParsingContext.EnumMembers: return [Diagnostics.Enum_member_expected];
-                case ParsingContext.HeritageClauseElement: return [Diagnostics.Expression_expected];
+                case ParsingContext.TypeMembers: return parseErrorAtCurrentToken(Diagnostics.Property_or_signature_expected);
+                case ParsingContext.ClassMembers: return parseErrorAtCurrentToken(Diagnostics.Unexpected_token_A_constructor_method_accessor_or_property_was_expected);
+                case ParsingContext.EnumMembers: return parseErrorAtCurrentToken(Diagnostics.Enum_member_expected);
+                case ParsingContext.HeritageClauseElement: return parseErrorAtCurrentToken(Diagnostics.Expression_expected);
                 case ParsingContext.VariableDeclarations:
-                    const tokenString = tokenToString(token());
-                    return tokenString && /\w+/.test(tokenString[0])
-                        ? [Diagnostics._0_is_not_allowed_as_a_variable_declaration_name, tokenString]
-                        : [Diagnostics.Variable_declaration_expected];
-                case ParsingContext.ObjectBindingElements: return [Diagnostics.Property_destructuring_pattern_expected];
-                case ParsingContext.ArrayBindingElements: return [Diagnostics.Array_element_destructuring_pattern_expected];
-                case ParsingContext.ArgumentExpressions: return [Diagnostics.Argument_expression_expected];
-                case ParsingContext.ObjectLiteralMembers: return [Diagnostics.Property_assignment_expected];
-                case ParsingContext.ArrayLiteralMembers: return [Diagnostics.Expression_or_comma_expected];
-                case ParsingContext.JSDocParameters: return [Diagnostics.Parameter_declaration_expected];
-                case ParsingContext.Parameters: return [Diagnostics.Parameter_declaration_expected];
-                case ParsingContext.TypeParameters: return [Diagnostics.Type_parameter_declaration_expected];
-                case ParsingContext.TypeArguments: return [Diagnostics.Type_argument_expected];
-                case ParsingContext.TupleElementTypes: return [Diagnostics.Type_expected];
-                case ParsingContext.HeritageClauses: return [Diagnostics.Unexpected_token_expected];
-                case ParsingContext.ImportOrExportSpecifiers: return [Diagnostics.Identifier_expected];
-                case ParsingContext.JsxAttributes: return [Diagnostics.Identifier_expected];
-                case ParsingContext.JsxChildren: return [Diagnostics.Identifier_expected];
+                    return isKeyword(token())
+                        ? parseErrorAtCurrentToken(Diagnostics._0_is_not_allowed_as_a_variable_declaration_name, tokenToString(token()))
+                        : parseErrorAtCurrentToken(Diagnostics.Variable_declaration_expected);
+                case ParsingContext.ObjectBindingElements: return parseErrorAtCurrentToken(Diagnostics.Property_destructuring_pattern_expected);
+                case ParsingContext.ArrayBindingElements: return parseErrorAtCurrentToken(Diagnostics.Array_element_destructuring_pattern_expected);
+                case ParsingContext.ArgumentExpressions: return parseErrorAtCurrentToken(Diagnostics.Argument_expression_expected);
+                case ParsingContext.ObjectLiteralMembers: return parseErrorAtCurrentToken(Diagnostics.Property_assignment_expected);
+                case ParsingContext.ArrayLiteralMembers: return parseErrorAtCurrentToken(Diagnostics.Expression_or_comma_expected);
+                case ParsingContext.JSDocParameters: return parseErrorAtCurrentToken(Diagnostics.Parameter_declaration_expected);
+                case ParsingContext.Parameters: return parseErrorAtCurrentToken(Diagnostics.Parameter_declaration_expected);
+                case ParsingContext.TypeParameters: return parseErrorAtCurrentToken(Diagnostics.Type_parameter_declaration_expected);
+                case ParsingContext.TypeArguments: return parseErrorAtCurrentToken(Diagnostics.Type_argument_expected);
+                case ParsingContext.TupleElementTypes: return parseErrorAtCurrentToken(Diagnostics.Type_expected);
+                case ParsingContext.HeritageClauses: return parseErrorAtCurrentToken(Diagnostics.Unexpected_token_expected);
+                case ParsingContext.ImportOrExportSpecifiers: return parseErrorAtCurrentToken(Diagnostics.Identifier_expected);
+                case ParsingContext.JsxAttributes: return parseErrorAtCurrentToken(Diagnostics.Identifier_expected);
+                case ParsingContext.JsxChildren: return parseErrorAtCurrentToken(Diagnostics.Identifier_expected);
                 default: return [undefined!]; // TODO: GH#18217 `default: Debug.assertNever(context);`
             }
         }

--- a/tests/baselines/reference/expressionTypeNodeShouldError.errors.txt
+++ b/tests/baselines/reference/expressionTypeNodeShouldError.errors.txt
@@ -1,13 +1,13 @@
 tests/cases/compiler/base.d.ts(1,23): error TS1005: ',' expected.
 tests/cases/compiler/base.d.ts(1,34): error TS1005: ',' expected.
 tests/cases/compiler/boolean.ts(7,23): error TS1005: ',' expected.
-tests/cases/compiler/boolean.ts(7,24): error TS1134: Variable declaration expected.
+tests/cases/compiler/boolean.ts(7,24): error TS1389: 'typeof' is not allowed as a variable declaration name.
 tests/cases/compiler/boolean.ts(12,22): error TS1005: ';' expected.
 tests/cases/compiler/number.ts(7,26): error TS1005: ',' expected.
-tests/cases/compiler/number.ts(7,27): error TS1134: Variable declaration expected.
+tests/cases/compiler/number.ts(7,27): error TS1389: 'typeof' is not allowed as a variable declaration name.
 tests/cases/compiler/number.ts(12,20): error TS1005: ';' expected.
 tests/cases/compiler/string.ts(7,20): error TS1005: ',' expected.
-tests/cases/compiler/string.ts(7,21): error TS1134: Variable declaration expected.
+tests/cases/compiler/string.ts(7,21): error TS1389: 'typeof' is not allowed as a variable declaration name.
 tests/cases/compiler/string.ts(12,19): error TS1005: ';' expected.
 
 
@@ -29,7 +29,7 @@ tests/cases/compiler/string.ts(12,19): error TS1005: ';' expected.
                        ~
 !!! error TS1005: ',' expected.
                         ~~~~~~
-!!! error TS1134: Variable declaration expected.
+!!! error TS1389: 'typeof' is not allowed as a variable declaration name.
         }
     }
     
@@ -49,7 +49,7 @@ tests/cases/compiler/string.ts(12,19): error TS1005: ';' expected.
                              ~
 !!! error TS1005: ',' expected.
                               ~~~~~~
-!!! error TS1134: Variable declaration expected.
+!!! error TS1389: 'typeof' is not allowed as a variable declaration name.
         }
     }
     
@@ -69,7 +69,7 @@ tests/cases/compiler/string.ts(12,19): error TS1005: ';' expected.
                           ~
 !!! error TS1005: ',' expected.
                            ~~~~~~
-!!! error TS1134: Variable declaration expected.
+!!! error TS1389: 'typeof' is not allowed as a variable declaration name.
         }
     }
     

--- a/tests/baselines/reference/getJavaScriptSyntacticDiagnostics02.baseline
+++ b/tests/baselines/reference/getJavaScriptSyntacticDiagnostics02.baseline
@@ -1,7 +1,7 @@
 Syntactic Diagnostics for file '/tests/cases/fourslash/server/getJavaScriptSyntacticDiagnostics02.ts':
 /tests/cases/fourslash/server/b.js(2,8): error TS8010: Type annotations can only be used in TypeScript files.
 /tests/cases/fourslash/server/b.js(3,17): error TS8010: Type annotations can only be used in TypeScript files.
-/tests/cases/fourslash/server/b.js(4,5): error TS1134: Variable declaration expected.
+/tests/cases/fourslash/server/b.js(4,5): error TS1389: 'var' is not allowed as a variable declaration name.
 /tests/cases/fourslash/server/b.js(4,9): error TS1134: Variable declaration expected.
 /tests/cases/fourslash/server/b.js(4,11): error TS1134: Variable declaration expected.
 
@@ -16,7 +16,7 @@ Syntactic Diagnostics for file '/tests/cases/fourslash/server/getJavaScriptSynta
 !!! error TS8010: Type annotations can only be used in TypeScript files.
     var var = "c";
         ~~~
-!!! error TS1134: Variable declaration expected.
+!!! error TS1389: 'var' is not allowed as a variable declaration name.
             ~
 !!! error TS1134: Variable declaration expected.
               ~~~

--- a/tests/baselines/reference/parserInvalidIdentifiersInVariableStatements1.errors.txt
+++ b/tests/baselines/reference/parserInvalidIdentifiersInVariableStatements1.errors.txt
@@ -1,16 +1,16 @@
-tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserInvalidIdentifiersInVariableStatements1.ts(1,5): error TS1134: Variable declaration expected.
-tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserInvalidIdentifiersInVariableStatements1.ts(3,5): error TS1134: Variable declaration expected.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserInvalidIdentifiersInVariableStatements1.ts(1,5): error TS1389: 'export' is not allowed as a variable declaration name.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserInvalidIdentifiersInVariableStatements1.ts(3,5): error TS1389: 'class' is not allowed as a variable declaration name.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserInvalidIdentifiersInVariableStatements1.ts(3,10): error TS1005: '{' expected.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserInvalidIdentifiersInVariableStatements1.ts (3 errors) ====
     var export;
         ~~~~~~
-!!! error TS1134: Variable declaration expected.
+!!! error TS1389: 'export' is not allowed as a variable declaration name.
     var foo;
     var class;
         ~~~~~
-!!! error TS1134: Variable declaration expected.
+!!! error TS1389: 'class' is not allowed as a variable declaration name.
              ~
 !!! error TS1005: '{' expected.
     var bar;

--- a/tests/baselines/reference/reservedWords2.errors.txt
+++ b/tests/baselines/reference/reservedWords2.errors.txt
@@ -8,7 +8,7 @@ tests/cases/compiler/reservedWords2.ts(2,14): error TS1359: Identifier expected.
 tests/cases/compiler/reservedWords2.ts(2,20): error TS1005: '(' expected.
 tests/cases/compiler/reservedWords2.ts(2,20): error TS2304: Cannot find name 'from'.
 tests/cases/compiler/reservedWords2.ts(2,25): error TS1005: ')' expected.
-tests/cases/compiler/reservedWords2.ts(4,5): error TS1134: Variable declaration expected.
+tests/cases/compiler/reservedWords2.ts(4,5): error TS1389: 'typeof' is not allowed as a variable declaration name.
 tests/cases/compiler/reservedWords2.ts(4,12): error TS1109: Expression expected.
 tests/cases/compiler/reservedWords2.ts(5,9): error TS2300: Duplicate identifier '(Missing)'.
 tests/cases/compiler/reservedWords2.ts(5,9): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
@@ -61,7 +61,7 @@ tests/cases/compiler/reservedWords2.ts(12,17): error TS1138: Parameter declarati
     
     var typeof = 10;
         ~~~~~~
-!!! error TS1134: Variable declaration expected.
+!!! error TS1389: 'typeof' is not allowed as a variable declaration name.
                ~
 !!! error TS1109: Expression expected.
     function throw() {}

--- a/tests/baselines/reference/umd-errors.errors.txt
+++ b/tests/baselines/reference/umd-errors.errors.txt
@@ -3,7 +3,7 @@ tests/cases/conformance/externalModules/err2.d.ts(3,2): error TS1316: Global mod
 tests/cases/conformance/externalModules/err3.d.ts(3,1): error TS1184: Modifiers cannot appear here.
 tests/cases/conformance/externalModules/err3.d.ts(4,1): error TS1184: Modifiers cannot appear here.
 tests/cases/conformance/externalModules/err3.d.ts(5,1): error TS1184: Modifiers cannot appear here.
-tests/cases/conformance/externalModules/err3.d.ts(6,7): error TS1134: Variable declaration expected.
+tests/cases/conformance/externalModules/err3.d.ts(6,7): error TS1389: 'export' is not allowed as a variable declaration name.
 tests/cases/conformance/externalModules/err4.d.ts(3,2): error TS1316: Global module exports may only appear at top level.
 tests/cases/conformance/externalModules/err5.ts(3,1): error TS1315: Global module exports may only appear in declaration files.
 
@@ -36,7 +36,7 @@ tests/cases/conformance/externalModules/err5.ts(3,1): error TS1315: Global modul
 !!! error TS1184: Modifiers cannot appear here.
     const export as namespace oo4;
           ~~~~~~
-!!! error TS1134: Variable declaration expected.
+!!! error TS1389: 'export' is not allowed as a variable declaration name.
     
 ==== tests/cases/conformance/externalModules/err4.d.ts (1 errors) ====
     // Illegal, must be at top-level


### PR DESCRIPTION
Fixes #19352

This change is pretty small, despite the unfortunate diff detection: it provides a more specific error message when code erroneously attempts to use a reserved keyword as a variable name.

```diff
const case = 123;
- //  ~~~~ Variable declaration expected.
+ //  ~~~~ 'case' is not allowed as a variable declaration name.
```

This only happens when the attempted variable name starts with a `\w+` character, to avoid printing misleading messages on cases like the last `]` in ` var v = /[]/]/`.

This change is really only half of what should be done to address #19352; IMO the parser should ideally be changed to recognize those invalid variable names as identifiers. That way we wouldn't get multiple error messages per case (e.g. [`const case = 123`](https://www.typescriptlang.org/play?#code/MYewdgzgLgBMCGECmMC8MCMAmAzAbiA)) and emit odd JS. But that's an emitter change so I'll a followup issue if & when this PR is merged, unless directed otherwise.