### PR TITLE
Add unit tests for VersionRange

### DIFF
--- a/src/compiler/semver.ts
+++ b/src/compiler/semver.ts
@@ -84,7 +84,7 @@ namespace ts {
             return compareValues(this.major, other.major)
                 || compareValues(this.minor, other.minor)
                 || compareValues(this.patch, other.patch)
-                || comparePrerelaseIdentifiers(this.prerelease, other.prerelease);
+                || comparePrereleaseIdentifiers(this.prerelease, other.prerelease);
         }
 
         increment(field: "major" | "minor" | "patch") {
@@ -120,7 +120,7 @@ namespace ts {
         };
     }
 
-    function comparePrerelaseIdentifiers(left: readonly string[], right: readonly string[]) {
+    function comparePrereleaseIdentifiers(left: readonly string[], right: readonly string[]) {
         // https://semver.org/#spec-item-11
         // > When major, minor, and patch are equal, a pre-release version has lower precedence
         // > than a normal version.

--- a/src/testRunner/unittests/semver.ts
+++ b/src/testRunner/unittests/semver.ts
@@ -7,22 +7,22 @@ namespace ts {
                     const range = VersionRange.tryParse(version)!;
                     assert(range);
                     for (const g of good) {
-                        assert.isTrue(range.test(g), g)
+                        assert.isTrue(range.test(g), g);
                     }
                     for (const b of bad) {
-                        assert.isFalse(range.test(b), b)
+                        assert.isFalse(range.test(b), b);
                     }
-                }
+                };
             }
-            it("< works", assertVersionRange("<3.8.0", ['3.6', '3.7'], ['3.8', '3.9', '4.0']));
-            it("<= works", assertVersionRange("<=3.8.0", ['3.6', '3.7', '3.8'], ['3.9', '4.0']));
-            it("> works", assertVersionRange(">3.8.0", ['3.9', '4.0'], ['3.6', '3.7', '3.8']));
-            it(">= works", assertVersionRange(">=3.8.0", ['3.8', '3.9', '4.0'], ['3.6', '3.7']));
+            it("< works", assertVersionRange("<3.8.0", ["3.6", "3.7"], ["3.8", "3.9", "4.0"]));
+            it("<= works", assertVersionRange("<=3.8.0", ["3.6", "3.7", "3.8"], ["3.9", "4.0"]));
+            it("> works", assertVersionRange(">3.8.0", ["3.9", "4.0"], ["3.6", "3.7", "3.8"]));
+            it(">= works", assertVersionRange(">=3.8.0", ["3.8", "3.9", "4.0"], ["3.6", "3.7"]));
 
-            it("< works with prerelease", assertVersionRange("<3.8.0-0", ['3.6', '3.7'], ['3.8', '3.9', '4.0']));
-            it("<= works with prerelease", assertVersionRange("<=3.8.0-0", ['3.6', '3.7'], ['3.8', '3.9', '4.0']));
-            it("> works with prerelease", assertVersionRange(">3.8.0-0", ['3.8', '3.9', '4.0'], ['3.6', '3.7']));
-            it(">= works with prerelease", assertVersionRange(">=3.8.0-0", ['3.8', '3.9', '4.0'], ['3.6', '3.7']));
+            it("< works with prerelease", assertVersionRange("<3.8.0-0", ["3.6", "3.7"], ["3.8", "3.9", "4.0"]));
+            it("<= works with prerelease", assertVersionRange("<=3.8.0-0", ["3.6", "3.7"], ["3.8", "3.9", "4.0"]));
+            it("> works with prerelease", assertVersionRange(">3.8.0-0", ["3.8", "3.9", "4.0"], ["3.6", "3.7"]));
+            it(">= works with prerelease", assertVersionRange(">=3.8.0-0", ["3.8", "3.9", "4.0"], ["3.6", "3.7"]));
         });
         describe("Version", () => {
             function assertVersion(version: Version, [major, minor, patch, prerelease, build]: [number, number, number, string[]?, string[]?]) {

--- a/src/testRunner/unittests/semver.ts
+++ b/src/testRunner/unittests/semver.ts
@@ -1,6 +1,29 @@
 namespace ts {
     import theory = Utils.theory;
     describe("unittests:: semver", () => {
+        describe("VersionRange", () => {
+            function assertVersionRange(version: string, good: string[], bad: string[]): () => void {
+                return () => {
+                    const range = VersionRange.tryParse(version)!;
+                    assert(range);
+                    for (const g of good) {
+                        assert.isTrue(range.test(g), g)
+                    }
+                    for (const b of bad) {
+                        assert.isFalse(range.test(b), b)
+                    }
+                }
+            }
+            it("< works", assertVersionRange("<3.8.0", ['3.6', '3.7'], ['3.8', '3.9', '4.0']));
+            it("<= works", assertVersionRange("<=3.8.0", ['3.6', '3.7', '3.8'], ['3.9', '4.0']));
+            it("> works", assertVersionRange(">3.8.0", ['3.9', '4.0'], ['3.6', '3.7', '3.8']));
+            it(">= works", assertVersionRange(">=3.8.0", ['3.8', '3.9', '4.0'], ['3.6', '3.7']));
+
+            it("< works with prerelease", assertVersionRange("<3.8.0-0", ['3.6', '3.7'], ['3.8', '3.9', '4.0']));
+            it("<= works with prerelease", assertVersionRange("<=3.8.0-0", ['3.6', '3.7'], ['3.8', '3.9', '4.0']));
+            it("> works with prerelease", assertVersionRange(">3.8.0-0", ['3.8', '3.9', '4.0'], ['3.6', '3.7']));
+            it(">= works with prerelease", assertVersionRange(">=3.8.0-0", ['3.8', '3.9', '4.0'], ['3.6', '3.7']));
+        });
         describe("Version", () => {
             function assertVersion(version: Version, [major, minor, patch, prerelease, build]: [number, number, number, string[]?, string[]?]) {
                 assert.strictEqual(version.major, major);


### PR DESCRIPTION
Make it easier to understand the intended semantics next time I have to
read this code.

Doesn't fix #40113, since it wasn't a bug in the first place.