### PR TITLE
Handles creating a reasonable AST when destructuring into a parens'd expresssion

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7611,9 +7611,13 @@ namespace ts {
                 const propName = getDestructuringPropertyName(node);
                 if (propName) {
                     const literal = setTextRange(parseNodeFactory.createStringLiteral(propName), node);
-                    const result = setTextRange(parseNodeFactory.createElementAccessExpression(parentAccess, literal), node);
+                    const lhsExpr = isLeftHandSideExpression(parentAccess) ? parentAccess : parseNodeFactory.createParenthesizedExpression(parentAccess);
+                    const result = setTextRange(parseNodeFactory.createElementAccessExpression(lhsExpr, literal), node);
                     setParent(literal, result);
                     setParent(result, node);
+                    if (lhsExpr !== parentAccess) {
+                        setParent(lhsExpr, result);
+                    }
                     result.flowNode = parentAccess.flowNode;
                     return result;
                 }

--- a/tests/baselines/reference/destructuringControlFlowNoCrash.errors.txt
+++ b/tests/baselines/reference/destructuringControlFlowNoCrash.errors.txt
@@ -1,9 +1,12 @@
+error TS2468: Cannot find global value 'Promise'.
 tests/cases/compiler/destructuringControlFlowNoCrash.ts(3,3): error TS2339: Property 'date' does not exist on type '(inspectedElement: any) => number'.
 tests/cases/compiler/destructuringControlFlowNoCrash.ts(10,3): error TS2339: Property 'date2' does not exist on type '(inspectedElement: any) => any'.
 tests/cases/compiler/destructuringControlFlowNoCrash.ts(11,28): error TS1005: '=>' expected.
+tests/cases/compiler/destructuringControlFlowNoCrash.ts(16,25): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
 
 
-==== tests/cases/compiler/destructuringControlFlowNoCrash.ts (3 errors) ====
+!!! error TS2468: Cannot find global value 'Promise'.
+==== tests/cases/compiler/destructuringControlFlowNoCrash.ts (4 errors) ====
     // legal JS, if nonsensical, which also triggers the issue
     const {
       date,
@@ -23,4 +26,9 @@ tests/cases/compiler/destructuringControlFlowNoCrash.ts(11,28): error TS1005: '=
 !!! error TS1005: '=>' expected.
     
     date2.toISOString();
+    
+    // It could also be an async function
+    const { constructor } = async () => {};
+                            ~~~~~~~~~~~~~~
+!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
     

--- a/tests/baselines/reference/destructuringControlFlowNoCrash.errors.txt
+++ b/tests/baselines/reference/destructuringControlFlowNoCrash.errors.txt
@@ -1,0 +1,26 @@
+tests/cases/compiler/destructuringControlFlowNoCrash.ts(3,3): error TS2339: Property 'date' does not exist on type '(inspectedElement: any) => number'.
+tests/cases/compiler/destructuringControlFlowNoCrash.ts(10,3): error TS2339: Property 'date2' does not exist on type '(inspectedElement: any) => any'.
+tests/cases/compiler/destructuringControlFlowNoCrash.ts(11,28): error TS1005: '=>' expected.
+
+
+==== tests/cases/compiler/destructuringControlFlowNoCrash.ts (3 errors) ====
+    // legal JS, if nonsensical, which also triggers the issue
+    const {
+      date,
+      ~~~~
+!!! error TS2339: Property 'date' does not exist on type '(inspectedElement: any) => number'.
+    } = (inspectedElement: any) => 0;
+    
+    date.toISOString();
+    
+    // Working flow code
+    const {
+      date2,
+      ~~~~~
+!!! error TS2339: Property 'date2' does not exist on type '(inspectedElement: any) => any'.
+    } = (inspectedElement: any).props;
+                               ~
+!!! error TS1005: '=>' expected.
+    
+    date2.toISOString();
+    

--- a/tests/baselines/reference/destructuringControlFlowNoCrash.js
+++ b/tests/baselines/reference/destructuringControlFlowNoCrash.js
@@ -13,11 +13,55 @@ const {
 
 date2.toISOString();
 
+// It could also be an async function
+const { constructor } = async () => {};
+
 
 //// [destructuringControlFlowNoCrash.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var _this = this;
 // legal JS, if nonsensical, which also triggers the issue
 var date = function (inspectedElement) { return 0; }.date;
 date.toISOString();
 // Working flow code
 var date2 = function (inspectedElement) { return ; }.date2, props;
 date2.toISOString();
+// It could also be an async function
+var constructor = function () { return __awaiter(_this, void 0, void 0, function () { return __generator(this, function (_a) {
+    return [2 /*return*/];
+}); }); }.constructor;

--- a/tests/baselines/reference/destructuringControlFlowNoCrash.js
+++ b/tests/baselines/reference/destructuringControlFlowNoCrash.js
@@ -1,0 +1,23 @@
+//// [destructuringControlFlowNoCrash.ts]
+// legal JS, if nonsensical, which also triggers the issue
+const {
+  date,
+} = (inspectedElement: any) => 0;
+
+date.toISOString();
+
+// Working flow code
+const {
+  date2,
+} = (inspectedElement: any).props;
+
+date2.toISOString();
+
+
+//// [destructuringControlFlowNoCrash.js]
+// legal JS, if nonsensical, which also triggers the issue
+var date = function (inspectedElement) { return 0; }.date;
+date.toISOString();
+// Working flow code
+var date2 = function (inspectedElement) { return ; }.date2, props;
+date2.toISOString();

--- a/tests/baselines/reference/destructuringControlFlowNoCrash.symbols
+++ b/tests/baselines/reference/destructuringControlFlowNoCrash.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/destructuringControlFlowNoCrash.ts ===
+// legal JS, if nonsensical, which also triggers the issue
+const {
+  date,
+>date : Symbol(date, Decl(destructuringControlFlowNoCrash.ts, 1, 7))
+
+} = (inspectedElement: any) => 0;
+>inspectedElement : Symbol(inspectedElement, Decl(destructuringControlFlowNoCrash.ts, 3, 5))
+
+date.toISOString();
+>date : Symbol(date, Decl(destructuringControlFlowNoCrash.ts, 1, 7))
+
+// Working flow code
+const {
+  date2,
+>date2 : Symbol(date2, Decl(destructuringControlFlowNoCrash.ts, 8, 7))
+
+} = (inspectedElement: any).props;
+>inspectedElement : Symbol(inspectedElement, Decl(destructuringControlFlowNoCrash.ts, 10, 5))
+>props : Symbol(props, Decl(destructuringControlFlowNoCrash.ts, 10, 28))
+
+date2.toISOString();
+>date2 : Symbol(date2, Decl(destructuringControlFlowNoCrash.ts, 8, 7))
+

--- a/tests/baselines/reference/destructuringControlFlowNoCrash.symbols
+++ b/tests/baselines/reference/destructuringControlFlowNoCrash.symbols
@@ -22,3 +22,7 @@ const {
 date2.toISOString();
 >date2 : Symbol(date2, Decl(destructuringControlFlowNoCrash.ts, 8, 7))
 
+// It could also be an async function
+const { constructor } = async () => {};
+>constructor : Symbol(constructor, Decl(destructuringControlFlowNoCrash.ts, 15, 7))
+

--- a/tests/baselines/reference/destructuringControlFlowNoCrash.types
+++ b/tests/baselines/reference/destructuringControlFlowNoCrash.types
@@ -1,0 +1,34 @@
+=== tests/cases/compiler/destructuringControlFlowNoCrash.ts ===
+// legal JS, if nonsensical, which also triggers the issue
+const {
+  date,
+>date : any
+
+} = (inspectedElement: any) => 0;
+>(inspectedElement: any) => 0 : (inspectedElement: any) => number
+>inspectedElement : any
+>0 : 0
+
+date.toISOString();
+>date.toISOString() : any
+>date.toISOString : any
+>date : any
+>toISOString : any
+
+// Working flow code
+const {
+  date2,
+>date2 : any
+
+} = (inspectedElement: any).props;
+>(inspectedElement: any) : (inspectedElement: any) => any
+>inspectedElement : any
+> : any
+>props : any
+
+date2.toISOString();
+>date2.toISOString() : any
+>date2.toISOString : any
+>date2 : any
+>toISOString : any
+

--- a/tests/baselines/reference/destructuringControlFlowNoCrash.types
+++ b/tests/baselines/reference/destructuringControlFlowNoCrash.types
@@ -32,3 +32,8 @@ date2.toISOString();
 >date2 : any
 >toISOString : any
 
+// It could also be an async function
+const { constructor } = async () => {};
+>constructor : Function
+>async () => {} : () => Promise<void>
+

--- a/tests/cases/compiler/destructuringControlFlowNoCrash.ts
+++ b/tests/cases/compiler/destructuringControlFlowNoCrash.ts
@@ -12,3 +12,6 @@ const {
 } = (inspectedElement: any).props;
 
 date2.toISOString();
+
+// It could also be an async function
+const { constructor } = async () => {};

--- a/tests/cases/compiler/destructuringControlFlowNoCrash.ts
+++ b/tests/cases/compiler/destructuringControlFlowNoCrash.ts
@@ -1,0 +1,14 @@
+
+// legal JS, if nonsensical, which also triggers the issue
+const {
+  date,
+} = (inspectedElement: any) => 0;
+
+date.toISOString();
+
+// Working flow code
+const {
+  date2,
+} = (inspectedElement: any).props;
+
+date2.toISOString();


### PR DESCRIPTION
Fixes #39192 - the actual call wasn't the issue, but that it triggered lading a particular test file into memory. This repo with the crash  [uses flow](https://github.com/facebook/react/blob/23595ff593b2e53ddfec2a08e848704d15d84b51/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js#L638), where this is legal syntax, but you can also have legal syntax from it in JS. If a little abstract.

Roughly, this should not crash TS

```ts
const {
  date,
} = (inspectedElement: any) => 0;

date.toISOString();
```