### PR TITLE
Revamp dockerfile for office-ui-fabric to reduce noise

### DIFF
--- a/tests/baselines/reference/docker/office-ui-fabric.log
+++ b/tests/baselines/reference/docker/office-ui-fabric.log
@@ -1,838 +1,853 @@
 Exit Code: 1
 Standard output:
-@fluentui/eslint-plugin: yarn run vX.X.X
-@fluentui/eslint-plugin: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/eslint-plugin: Done in ?s.
-@fluentui/noop: yarn run vX.X.X
-@fluentui/noop: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/noop: Done in ?s.
-@fluentui/web-components: yarn run vX.X.X
-@fluentui/web-components: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/web-components: Done in ?s.
+@microsoft/fast-components-msft: yarn run vX.X.X
+@microsoft/fast-components-msft: $ tsc -p ./tsconfig.json && rollup -c && npm run doc
+@microsoft/fast-components-msft: ┌───────────────────────────────────────────────┐
+@microsoft/fast-components-msft: │                                               │
+@microsoft/fast-components-msft: │   Destination: dist/fast-components-msft.js   │
+@microsoft/fast-components-msft: │   Bundle Size:  490.64 KB                     │
+@microsoft/fast-components-msft: │   Gzipped Size:  50.64 KB                     │
+@microsoft/fast-components-msft: │   Brotli size: 74.92 KB                       │
+@microsoft/fast-components-msft: │                                               │
+@microsoft/fast-components-msft: └───────────────────────────────────────────────┘
+@microsoft/fast-components-msft: ┌───────────────────────────────────────────────────┐
+@microsoft/fast-components-msft: │                                                   │
+@microsoft/fast-components-msft: │   Destination: dist/fast-components-msft.min.js   │
+@microsoft/fast-components-msft: │   Bundle Size:  201.49 KB                         │
+@microsoft/fast-components-msft: │   Gzipped Size:  46.05 KB                         │
+@microsoft/fast-components-msft: │   Brotli size: 39.62 KB                           │
+@microsoft/fast-components-msft: │                                                   │
+@microsoft/fast-components-msft: └───────────────────────────────────────────────────┘
+@microsoft/fast-components-msft: > @microsoft/fast-components-msft@X.X.X doc /office-ui-fabric-react/packages/web-components
+@microsoft/fast-components-msft: > api-extractor run --local
+@microsoft/fast-components-msft: api-extractor 7.7.1  - https://api-extractor.com/
+@microsoft/fast-components-msft: Using configuration from /office-ui-fabric-react/packages/web-components/api-extractor.json
+@microsoft/fast-components-msft: API Extractor completed successfully
+@microsoft/fast-components-msft: Done in ?s.
 @fluentui/ability-attributes: yarn run vX.X.X
-@fluentui/ability-attributes: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/ability-attributes: $ npm run schema && gulp bundle:package:no-umd
+@fluentui/ability-attributes: > @fluentui/ability-attributes@X.X.X schema /office-ui-fabric-react/packages/fluentui/ability-attributes
+@fluentui/ability-attributes: > allyschema -c "process.env.NODE_ENV !== 'production'" schema.json > ./src/schema.ts
+@fluentui/ability-attributes: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
+@fluentui/ability-attributes: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/ability-attributes/gulpfile.ts
 @fluentui/ability-attributes: Done in ?s.
 @fluentui/digest: yarn run vX.X.X
-@fluentui/digest: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/digest: $ just-scripts build
 @fluentui/digest: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/fluentui/digest/tsconfig.json
 @fluentui/digest: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --module esnext --outDir lib --project "/office-ui-fabric-react/packages/fluentui/digest/tsconfig.json"
+@fluentui/digest: [XX:XX:XX XM] ■ Running Webpack
+@fluentui/digest: [XX:XX:XX XM] ■ Webpack Config Path: null
+@fluentui/digest: [XX:XX:XX XM] ■ webpack.config.js not found, skipping webpack
 @fluentui/digest: Done in ?s.
 @uifabric/build: yarn run vX.X.X
-@uifabric/build: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@uifabric/build: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/scripts/tsconfig.json
-@uifabric/build: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/scripts/tsconfig.json"
-@uifabric/build: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/scripts/tsconfig.json
-@uifabric/build: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/scripts/tsconfig.json"
-@uifabric/build: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@uifabric/pr-deploy-site: yarn run vX.X.X
-@uifabric/pr-deploy-site: $ just-scripts ts
-@uifabric/pr-deploy-site: Done in ?s.
+@uifabric/build: $ node ./just-scripts.js no-op
+@uifabric/build: Done in ?s.
 @fluentui/common-styles: yarn run vX.X.X
-@fluentui/common-styles: $ just-scripts ts
+@fluentui/common-styles: $ just-scripts build
+@fluentui/common-styles: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@fluentui/common-styles: [XX:XX:XX XM] ■ Copying [../../node_modules/office-ui-fabric-core/dist/sass/**/*, src/*.scss] to '/office-ui-fabric-react/packages/common-styles/dist/sass'
 @fluentui/common-styles: Done in ?s.
 @uifabric/example-data: yarn run vX.X.X
-@uifabric/example-data: $ just-scripts ts
+@uifabric/example-data: $ just-scripts build
+@uifabric/example-data: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
 @uifabric/example-data: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/example-data/tsconfig.json
 @uifabric/example-data: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/example-data/tsconfig.json"
 @uifabric/example-data: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/example-data/tsconfig.json
 @uifabric/example-data: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/example-data/tsconfig.json"
+@uifabric/example-data: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/example-data/lib/index.d.ts'
 @uifabric/example-data: Done in ?s.
 @fluentui/keyboard-key: yarn run vX.X.X
-@fluentui/keyboard-key: $ just-scripts ts
+@fluentui/keyboard-key: $ just-scripts build
+@fluentui/keyboard-key: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
 @fluentui/keyboard-key: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/keyboard-key/tsconfig.json
 @fluentui/keyboard-key: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/keyboard-key/tsconfig.json"
 @fluentui/keyboard-key: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/keyboard-key/tsconfig.json
 @fluentui/keyboard-key: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/keyboard-key/tsconfig.json"
+@fluentui/keyboard-key: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/keyboard-key/lib/index.d.ts'
 @fluentui/keyboard-key: Done in ?s.
 @uifabric/migration: yarn run vX.X.X
-@uifabric/migration: $ just-scripts ts
-@uifabric/migration: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/migration/tsconfig.json
-@uifabric/migration: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/migration/tsconfig.json"
-@uifabric/migration: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/migration/tsconfig.json
-@uifabric/migration: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/migration/tsconfig.json"
+@uifabric/migration: $ just-scripts build
+@uifabric/migration: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@uifabric/migration: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/packages/migration/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/migration/tsconfig.json
+@uifabric/migration: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/packages/migration/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module commonjs --project "/office-ui-fabric-react/packages/migration/tsconfig.json"
 @uifabric/migration: Done in ?s.
 @uifabric/monaco-editor: yarn run vX.X.X
-@uifabric/monaco-editor: $ just-scripts ts
+@uifabric/monaco-editor: $ just-scripts build
+@uifabric/monaco-editor: [XX:XX:XX XM] ■ Removing [esm, lib, lib-commonjs]
 @uifabric/monaco-editor: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/monaco-editor/tsconfig.json
 @uifabric/monaco-editor: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/monaco-editor/tsconfig.json"
 @uifabric/monaco-editor: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/monaco-editor/tsconfig.json
 @uifabric/monaco-editor: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/monaco-editor/tsconfig.json"
 @uifabric/monaco-editor: Done in ?s.
 @fluentui/react-conformance: yarn run vX.X.X
-@fluentui/react-conformance: $ just-scripts ts
+@fluentui/react-conformance: $ just-scripts build
+@fluentui/react-conformance: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
 @fluentui/react-conformance: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-conformance/tsconfig.json
-@fluentui/react-conformance: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-conformance/tsconfig.json"
-@fluentui/react-conformance: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-conformance/tsconfig.json
-@fluentui/react-conformance: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-conformance/tsconfig.json"
+@fluentui/react-conformance: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module commonjs --project "/office-ui-fabric-react/packages/react-conformance/tsconfig.json"
 @fluentui/react-conformance: Done in ?s.
 @uifabric/set-version: yarn run vX.X.X
-@uifabric/set-version: $ just-scripts ts
+@uifabric/set-version: $ just-scripts build
+@uifabric/set-version: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
 @uifabric/set-version: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/set-version/tsconfig.json
 @uifabric/set-version: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/set-version/tsconfig.json"
 @uifabric/set-version: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/set-version/tsconfig.json
 @uifabric/set-version: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/set-version/tsconfig.json"
 @uifabric/set-version: Done in ?s.
 @uifabric/webpack-utils: yarn run vX.X.X
-@uifabric/webpack-utils: $ just-scripts ts
+@uifabric/webpack-utils: $ just-scripts build
+@uifabric/webpack-utils: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
 @uifabric/webpack-utils: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/webpack-utils/tsconfig.json
-@uifabric/webpack-utils: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/webpack-utils/tsconfig.json"
-@uifabric/webpack-utils: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/webpack-utils/tsconfig.json
-@uifabric/webpack-utils: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/webpack-utils/tsconfig.json"
-@uifabric/webpack-utils: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@uifabric/webpack-utils: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module commonjs --project "/office-ui-fabric-react/packages/webpack-utils/tsconfig.json"
+@uifabric/webpack-utils: Done in ?s.
 @fluentui/docs-components: yarn run vX.X.X
-@fluentui/docs-components: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/docs-components: $ gulp bundle:package:no-umd
+@fluentui/docs-components: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
+@fluentui/docs-components: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/docs-components/gulpfile.ts
 @fluentui/docs-components: Done in ?s.
 @fluentui/react-component-event-listener: yarn run vX.X.X
-@fluentui/react-component-event-listener: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/react-component-event-listener: $ gulp bundle:package:no-umd
+@fluentui/react-component-event-listener: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
+@fluentui/react-component-event-listener: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-component-event-listener/gulpfile.ts
 @fluentui/react-component-event-listener: Done in ?s.
 @fluentui/react-component-nesting-registry: yarn run vX.X.X
-@fluentui/react-component-nesting-registry: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/react-component-nesting-registry: $ gulp bundle:package:no-umd
+@fluentui/react-component-nesting-registry: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
+@fluentui/react-component-nesting-registry: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-component-nesting-registry/gulpfile.ts
 @fluentui/react-component-nesting-registry: Done in ?s.
 @fluentui/react-component-ref: yarn run vX.X.X
-@fluentui/react-component-ref: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/react-component-ref: $ gulp bundle:package:no-umd
+@fluentui/react-component-ref: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
+@fluentui/react-component-ref: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-component-ref/gulpfile.ts
 @fluentui/react-component-ref: Done in ?s.
 @fluentui/react-context-selector: yarn run vX.X.X
-@fluentui/react-context-selector: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/react-context-selector: $ gulp bundle:package:no-umd
+@fluentui/react-context-selector: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
+@fluentui/react-context-selector: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-context-selector/gulpfile.ts
 @fluentui/react-context-selector: Done in ?s.
 @fluentui/react-proptypes: yarn run vX.X.X
-@fluentui/react-proptypes: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/react-proptypes: $ gulp bundle:package:no-umd
+@fluentui/react-proptypes: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
+@fluentui/react-proptypes: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-proptypes/gulpfile.ts
 @fluentui/react-proptypes: Done in ?s.
 @fluentui/state: yarn run vX.X.X
-@fluentui/state: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/state: $ gulp bundle:package:no-umd
+@fluentui/state: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
+@fluentui/state: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/state/gulpfile.ts
 @fluentui/state: Done in ?s.
 @fluentui/styles: yarn run vX.X.X
-@fluentui/styles: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/styles: $ gulp bundle:package:no-umd
+@fluentui/styles: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
+@fluentui/styles: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/styles/gulpfile.ts
 @fluentui/styles: Done in ?s.
 @fluentui/accessibility: yarn run vX.X.X
-@fluentui/accessibility: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/accessibility: $ gulp bundle:package:no-umd
+@fluentui/accessibility: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
+@fluentui/accessibility: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/accessibility/gulpfile.ts
 @fluentui/accessibility: Done in ?s.
 @fluentui/date-time-utilities: yarn run vX.X.X
-@fluentui/date-time-utilities: $ just-scripts ts
+@fluentui/date-time-utilities: $ just-scripts build
+@fluentui/date-time-utilities: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
 @fluentui/date-time-utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/date-time-utilities/tsconfig.json
 @fluentui/date-time-utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/date-time-utilities/tsconfig.json"
 @fluentui/date-time-utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/date-time-utilities/tsconfig.json
 @fluentui/date-time-utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/date-time-utilities/tsconfig.json"
+@fluentui/date-time-utilities: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/date-time-utilities/lib/index.d.ts'
 @fluentui/date-time-utilities: Done in ?s.
 @uifabric/merge-styles: yarn run vX.X.X
-@uifabric/merge-styles: $ just-scripts ts
+@uifabric/merge-styles: $ just-scripts build
+@uifabric/merge-styles: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
 @uifabric/merge-styles: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/merge-styles/tsconfig.json
 @uifabric/merge-styles: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/merge-styles/tsconfig.json"
 @uifabric/merge-styles: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/merge-styles/tsconfig.json
 @uifabric/merge-styles: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/merge-styles/tsconfig.json"
-@uifabric/merge-styles: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@uifabric/merge-styles: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/merge-styles/lib/index.d.ts'
+@uifabric/merge-styles: Done in ?s.
+@fluentui/react-flex: yarn run vX.X.X
+@fluentui/react-flex: $ just-scripts build
+@fluentui/react-flex: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@fluentui/react-flex: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-flex/tsconfig.json
+@fluentui/react-flex: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-flex/tsconfig.json"
+@fluentui/react-flex: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-flex/tsconfig.json
+@fluentui/react-flex: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-flex/tsconfig.json"
+@fluentui/react-flex: Done in ?s.
 @fluentui/react-northstar-styles-renderer: yarn run vX.X.X
-@fluentui/react-northstar-styles-renderer: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/react-northstar-styles-renderer: $ gulp bundle:package:no-umd
+@fluentui/react-northstar-styles-renderer: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
+@fluentui/react-northstar-styles-renderer: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-northstar-styles-renderer/gulpfile.ts
 @fluentui/react-northstar-styles-renderer: Done in ?s.
 @uifabric/jest-serializer-merge-styles: yarn run vX.X.X
-@uifabric/jest-serializer-merge-styles: $ just-scripts ts
+@uifabric/jest-serializer-merge-styles: $ just-scripts build
+@uifabric/jest-serializer-merge-styles: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
 @uifabric/jest-serializer-merge-styles: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/jest-serializer-merge-styles/tsconfig.json
 @uifabric/jest-serializer-merge-styles: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/jest-serializer-merge-styles/tsconfig.json"
 @uifabric/jest-serializer-merge-styles: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/jest-serializer-merge-styles/tsconfig.json
 @uifabric/jest-serializer-merge-styles: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/jest-serializer-merge-styles/tsconfig.json"
 @uifabric/jest-serializer-merge-styles: Done in ?s.
 @fluentui/react-northstar-emotion-renderer: yarn run vX.X.X
-@fluentui/react-northstar-emotion-renderer: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/react-northstar-emotion-renderer: $ gulp bundle:package:no-umd
+@fluentui/react-northstar-emotion-renderer: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
+@fluentui/react-northstar-emotion-renderer: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-northstar-emotion-renderer/gulpfile.ts
 @fluentui/react-northstar-emotion-renderer: Done in ?s.
 @fluentui/react-northstar-fela-renderer: yarn run vX.X.X
-@fluentui/react-northstar-fela-renderer: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/react-northstar-fela-renderer: $ gulp bundle:package:no-umd
+@fluentui/react-northstar-fela-renderer: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
+@fluentui/react-northstar-fela-renderer: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-northstar-fela-renderer/gulpfile.ts
 @fluentui/react-northstar-fela-renderer: Done in ?s.
 @fluentui/react-stylesheets: yarn run vX.X.X
-@fluentui/react-stylesheets: $ just-scripts ts
+@fluentui/react-stylesheets: $ just-scripts build
+@fluentui/react-stylesheets: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
 @fluentui/react-stylesheets: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-stylesheets/tsconfig.json
 @fluentui/react-stylesheets: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-stylesheets/tsconfig.json"
 @fluentui/react-stylesheets: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-stylesheets/tsconfig.json
 @fluentui/react-stylesheets: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-stylesheets/tsconfig.json"
+@fluentui/react-stylesheets: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/react-stylesheets/lib/index.d.ts'
 @fluentui/react-stylesheets: Done in ?s.
-@fluentui/react-utilities: yarn run vX.X.X
-@fluentui/react-utilities: $ just-scripts ts
-@fluentui/react-utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-utilities/tsconfig.json
-@fluentui/react-utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-utilities/tsconfig.json"
-@fluentui/react-utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-utilities/tsconfig.json
-@fluentui/react-utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-utilities/tsconfig.json"
-@fluentui/react-utilities: Done in ?s.
 @uifabric/test-utilities: yarn run vX.X.X
-@uifabric/test-utilities: $ just-scripts ts
+@uifabric/test-utilities: $ just-scripts build
+@uifabric/test-utilities: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
 @uifabric/test-utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/test-utilities/tsconfig.json
 @uifabric/test-utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/test-utilities/tsconfig.json"
 @uifabric/test-utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/test-utilities/tsconfig.json
 @uifabric/test-utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/test-utilities/tsconfig.json"
 @uifabric/test-utilities: Done in ?s.
-@fluentui/react-window-provider: yarn run vX.X.X
-@fluentui/react-window-provider: $ just-scripts ts
-@fluentui/react-window-provider: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-window-provider/tsconfig.json
-@fluentui/react-window-provider: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-window-provider/tsconfig.json"
-@fluentui/react-window-provider: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-window-provider/tsconfig.json
-@fluentui/react-window-provider: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-window-provider/tsconfig.json"
-@fluentui/react-window-provider: Done in ?s.
 @uifabric/utilities: yarn run vX.X.X
-@uifabric/utilities: $ just-scripts ts
+@uifabric/utilities: $ just-scripts build
+@uifabric/utilities: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
 @uifabric/utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/utilities/tsconfig.json
 @uifabric/utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/utilities/tsconfig.json"
 @uifabric/utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/utilities/tsconfig.json
 @uifabric/utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/utilities/tsconfig.json"
-@uifabric/utilities: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@uifabric/utilities: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/utilities/lib/index.d.ts'
+@uifabric/utilities: Done in ?s.
 @fluentui/react-compose: yarn run vX.X.X
-@fluentui/react-compose: $ just-scripts ts
+@fluentui/react-compose: $ just-scripts build
+@fluentui/react-compose: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
 @fluentui/react-compose: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-compose/tsconfig.json
 @fluentui/react-compose: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-compose/tsconfig.json"
 @fluentui/react-compose: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-compose/tsconfig.json
 @fluentui/react-compose: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-compose/tsconfig.json"
+@fluentui/react-compose: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/react-compose/lib/index.d.ts'
 @fluentui/react-compose: Done in ?s.
 @uifabric/react-hooks: yarn run vX.X.X
-@uifabric/react-hooks: $ just-scripts ts
+@uifabric/react-hooks: $ just-scripts build
+@uifabric/react-hooks: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
 @uifabric/react-hooks: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-hooks/tsconfig.json
 @uifabric/react-hooks: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-hooks/tsconfig.json"
 @uifabric/react-hooks: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-hooks/tsconfig.json
 @uifabric/react-hooks: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-hooks/tsconfig.json"
+@uifabric/react-hooks: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/react-hooks/lib/index.d.ts'
 @uifabric/react-hooks: Done in ?s.
 @fluentui/react-icons: yarn run vX.X.X
-@fluentui/react-icons: $ just-scripts ts
+@fluentui/react-icons: $ just-scripts build
+@fluentui/react-icons: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
 @fluentui/react-icons: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-icons/tsconfig.json
 @fluentui/react-icons: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-icons/tsconfig.json"
 @fluentui/react-icons: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-icons/tsconfig.json
 @fluentui/react-icons: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-icons/tsconfig.json"
 @fluentui/react-icons: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@uifabric/styling: yarn run vX.X.X
-@uifabric/styling: $ just-scripts ts
-@uifabric/styling: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/styling/tsconfig.json
-@uifabric/styling: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/styling/tsconfig.json"
-@uifabric/styling: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/styling/tsconfig.json
-@uifabric/styling: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/styling/tsconfig.json"
-@uifabric/styling: Done in ?s.
-@fluentui/react-bindings: yarn run vX.X.X
-@fluentui/react-bindings: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/react-bindings: Done in ?s.
-@uifabric/file-type-icons: yarn run vX.X.X
-@uifabric/file-type-icons: $ just-scripts ts
-@uifabric/file-type-icons: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/file-type-icons/tsconfig.json
-@uifabric/file-type-icons: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/file-type-icons/tsconfig.json"
-@uifabric/file-type-icons: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/file-type-icons/tsconfig.json
-@uifabric/file-type-icons: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/file-type-icons/tsconfig.json"
-@uifabric/file-type-icons: Done in ?s.
-@uifabric/foundation: yarn run vX.X.X
-@uifabric/foundation: $ just-scripts ts
-@uifabric/foundation: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/foundation/tsconfig.json
-@uifabric/foundation: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/foundation/tsconfig.json"
-@uifabric/foundation: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/foundation/tsconfig.json
-@uifabric/foundation: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/foundation/tsconfig.json"
-@uifabric/foundation: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@uifabric/icons: yarn run vX.X.X
-@uifabric/icons: $ just-scripts ts
-@uifabric/icons: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/icons/tsconfig.json
-@uifabric/icons: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/icons/tsconfig.json"
-@uifabric/icons: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/icons/tsconfig.json
-@uifabric/icons: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/icons/tsconfig.json"
-@uifabric/icons: Done in ?s.
-@fluentui/react-focus: yarn run vX.X.X
-@fluentui/react-focus: $ just-scripts ts
-@fluentui/react-focus: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-focus/tsconfig.json
-@fluentui/react-focus: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-focus/tsconfig.json"
-@fluentui/react-focus: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-focus/tsconfig.json
-@fluentui/react-focus: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-focus/tsconfig.json"
-@fluentui/react-focus: Done in ?s.
-@fluentui/react-theme-provider: yarn run vX.X.X
-@fluentui/react-theme-provider: $ just-scripts ts
-@fluentui/react-theme-provider: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-theme-provider/tsconfig.json
-@fluentui/react-theme-provider: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-theme-provider/tsconfig.json"
-@fluentui/react-theme-provider: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-theme-provider/tsconfig.json
-@fluentui/react-theme-provider: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-theme-provider/tsconfig.json"
-@fluentui/react-theme-provider: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@fluentui/react-icons-northstar: yarn run vX.X.X
-@fluentui/react-icons-northstar: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/react-icons-northstar: Done in ?s.
-@fluentui/react-telemetry: yarn run vX.X.X
-@fluentui/react-telemetry: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/react-telemetry: Done in ?s.
-office-ui-fabric-react: yarn run vX.X.X
-office-ui-fabric-react: $ just-scripts ts
-office-ui-fabric-react: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/office-ui-fabric-react/tsconfig.json
-office-ui-fabric-react: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/office-ui-fabric-react/tsconfig.json"
-office-ui-fabric-react: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/office-ui-fabric-react/tsconfig.json
-office-ui-fabric-react: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/office-ui-fabric-react/tsconfig.json"
-office-ui-fabric-react: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@fluentui/react-image: yarn run vX.X.X
-@fluentui/react-image: $ just-scripts ts
-@fluentui/react-image: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-image/tsconfig.json
-@fluentui/react-image: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-image/tsconfig.json"
-@fluentui/react-image: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-image/tsconfig.json
-@fluentui/react-image: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-image/tsconfig.json"
-@fluentui/react-image: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@fluentui/react-northstar: yarn run vX.X.X
-@fluentui/react-northstar: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/react-northstar: Done in ?s.
-server-rendered-app: yarn run vX.X.X
-server-rendered-app: $ just-scripts ts
-server-rendered-app: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/server-rendered-app/tsconfig.json
-server-rendered-app: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/server-rendered-app/tsconfig.json"
-server-rendered-app: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/server-rendered-app/tsconfig.json
-server-rendered-app: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/server-rendered-app/tsconfig.json"
-server-rendered-app: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-todo-app: yarn run vX.X.X
-todo-app: $ just-scripts ts
-todo-app: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/todo-app/tsconfig.json
-todo-app: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/todo-app/tsconfig.json"
-todo-app: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/todo-app/tsconfig.json
-todo-app: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/todo-app/tsconfig.json"
-todo-app: Done in ?s.
-@uifabric/azure-themes: yarn run vX.X.X
-@uifabric/azure-themes: $ just-scripts ts
-@uifabric/azure-themes: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/azure-themes/tsconfig.json
-@uifabric/azure-themes: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/azure-themes/tsconfig.json"
-@uifabric/azure-themes: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/azure-themes/tsconfig.json
-@uifabric/azure-themes: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/azure-themes/tsconfig.json"
-@uifabric/azure-themes: Done in ?s.
-@fluentui/codemods: yarn run vX.X.X
-@fluentui/codemods: $ just-scripts ts
-@fluentui/codemods: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/codemods/tsconfig.json
-@fluentui/codemods: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/codemods/tsconfig.json"
-@fluentui/codemods: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/codemods/tsconfig.json
-@fluentui/codemods: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/codemods/tsconfig.json"
-@fluentui/codemods: Done in ?s.
-@fluentui/react: yarn run vX.X.X
-@fluentui/react: $ just-scripts ts
-@fluentui/react: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react/tsconfig.json
-@fluentui/react: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react/tsconfig.json"
-@fluentui/react: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react/tsconfig.json
-@fluentui/react: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react/tsconfig.json"
-@fluentui/react: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@uifabric/tsx-editor: yarn run vX.X.X
-@uifabric/tsx-editor: $ just-scripts ts
-@uifabric/tsx-editor: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/tsx-editor/tsconfig.json
-@uifabric/tsx-editor: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/tsx-editor/tsconfig.json"
-@uifabric/tsx-editor: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/tsx-editor/tsconfig.json
-@uifabric/tsx-editor: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/tsx-editor/tsconfig.json"
-@uifabric/tsx-editor: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@uifabric/variants: yarn run vX.X.X
-@uifabric/variants: $ just-scripts ts
-@uifabric/variants: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/variants/tsconfig.json
-@uifabric/variants: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/variants/tsconfig.json"
-@uifabric/variants: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/variants/tsconfig.json
-@uifabric/variants: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/variants/tsconfig.json"
-@uifabric/variants: Done in ?s.
-@fluentui/circulars-test: yarn run vX.X.X
-@fluentui/circulars-test: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/circulars-test: Done in ?s.
-@fluentui/code-sandbox: yarn run vX.X.X
-@fluentui/code-sandbox: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/code-sandbox: Done in ?s.
-@fluentui/e2e: yarn run vX.X.X
-@fluentui/e2e: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/e2e: Done in ?s.
-@fluentui/local-sandbox: yarn run vX.X.X
-@fluentui/local-sandbox: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/local-sandbox: Done in ?s.
-@fluentui/perf-test: yarn run vX.X.X
-@fluentui/perf-test: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/perf-test: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/fluentui/perf-test/tsconfig.json
-@fluentui/perf-test: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/fluentui/perf-test/tsconfig.json"
-@fluentui/perf-test: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/fluentui/perf-test/tsconfig.json
-@fluentui/perf-test: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/fluentui/perf-test/tsconfig.json"
-@fluentui/perf-test: Done in ?s.
-@fluentui/projects-test: yarn run vX.X.X
-@fluentui/projects-test: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/projects-test: Done in ?s.
-@fluentui/react-builder: yarn run vX.X.X
-@fluentui/react-builder: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/react-builder: Done in ?s.
-codesandbox-react-template: yarn run vX.X.X
-codesandbox-react-template: $ just-scripts ts
-codesandbox-react-template: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/codesandbox-react-template/tsconfig.json
-codesandbox-react-template: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/codesandbox-react-template/tsconfig.json"
-codesandbox-react-template: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/codesandbox-react-template/tsconfig.json
-codesandbox-react-template: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/codesandbox-react-template/tsconfig.json"
-codesandbox-react-template: Done in ?s.
-@uifabric/fluent-theme: yarn run vX.X.X
-@uifabric/fluent-theme: $ just-scripts ts
-@uifabric/fluent-theme: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/fluent-theme/tsconfig.json
-@uifabric/fluent-theme: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/fluent-theme/tsconfig.json"
-@uifabric/fluent-theme: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/fluent-theme/tsconfig.json
-@uifabric/fluent-theme: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/fluent-theme/tsconfig.json"
-@uifabric/fluent-theme: Done in ?s.
-@uifabric/mdl2-theme: yarn run vX.X.X
-@uifabric/mdl2-theme: $ just-scripts ts
-@uifabric/mdl2-theme: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/mdl2-theme/tsconfig.json
-@uifabric/mdl2-theme: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/mdl2-theme/tsconfig.json"
-@uifabric/mdl2-theme: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/mdl2-theme/tsconfig.json
-@uifabric/mdl2-theme: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/mdl2-theme/tsconfig.json"
-@uifabric/mdl2-theme: Done in ?s.
-@uifabric/theme-samples: yarn run vX.X.X
-@uifabric/theme-samples: $ just-scripts ts
-@uifabric/theme-samples: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/theme-samples/tsconfig.json
-@uifabric/theme-samples: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/theme-samples/tsconfig.json"
-@uifabric/theme-samples: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/theme-samples/tsconfig.json
-@uifabric/theme-samples: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/theme-samples/tsconfig.json"
-@uifabric/theme-samples: Done in ?s.
-codesandbox-react-northstar-template: yarn run vX.X.X
-codesandbox-react-northstar-template: $ just-scripts ts
-codesandbox-react-northstar-template: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/codesandbox-react-northstar-template/tsconfig.json
-codesandbox-react-northstar-template: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/codesandbox-react-northstar-template/tsconfig.json"
-codesandbox-react-northstar-template: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/codesandbox-react-northstar-template/tsconfig.json
-codesandbox-react-northstar-template: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/codesandbox-react-northstar-template/tsconfig.json"
-codesandbox-react-northstar-template: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@fluentui/docs: yarn run vX.X.X
-@fluentui/docs: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/docs: Done in ?s.
-@uifabric/example-app-base: yarn run vX.X.X
-@uifabric/example-app-base: $ just-scripts ts
-@uifabric/example-app-base: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/example-app-base/tsconfig.json
-@uifabric/example-app-base: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/example-app-base/tsconfig.json"
-@uifabric/example-app-base: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/example-app-base/tsconfig.json
-@uifabric/example-app-base: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/example-app-base/tsconfig.json"
-@uifabric/example-app-base: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@fluentui/storybook: yarn run vX.X.X
-@fluentui/storybook: $ just-scripts ts
-@fluentui/storybook: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/storybook/tsconfig.json
-@fluentui/storybook: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/storybook/tsconfig.json"
-@fluentui/storybook: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/storybook/tsconfig.json
-@fluentui/storybook: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/storybook/tsconfig.json"
-@fluentui/storybook: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@fluentui/perf: yarn run vX.X.X
-@fluentui/perf: $ /office-ui-fabric-react/node_modules/.bin/just ts
-@fluentui/perf: Done in ?s.
-dom-tests: yarn run vX.X.X
-dom-tests: $ just-scripts ts
-dom-tests: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/dom-tests/tsconfig.json
-dom-tests: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/dom-tests/tsconfig.json"
-dom-tests: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/dom-tests/tsconfig.json
-dom-tests: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/dom-tests/tsconfig.json"
-dom-tests: Done in ?s.
-@uifabric/charting: yarn run vX.X.X
-@uifabric/charting: $ just-scripts ts
-@uifabric/charting: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/charting/tsconfig.json
-@uifabric/charting: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/charting/tsconfig.json"
-@uifabric/charting: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/charting/tsconfig.json
-@uifabric/charting: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/charting/tsconfig.json"
-@uifabric/charting: Done in ?s.
-@uifabric/date-time: yarn run vX.X.X
-@uifabric/date-time: $ just-scripts ts
-@uifabric/date-time: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/date-time/tsconfig.json
-@uifabric/date-time: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/date-time/tsconfig.json"
-@uifabric/date-time: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/date-time/tsconfig.json
-@uifabric/date-time: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/date-time/tsconfig.json"
-@uifabric/date-time: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@uifabric/experiments: yarn run vX.X.X
-@uifabric/experiments: $ just-scripts ts
-@uifabric/experiments: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/experiments/tsconfig.json
-@uifabric/experiments: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/experiments/tsconfig.json"
-@uifabric/experiments: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/experiments/tsconfig.json
-@uifabric/experiments: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/experiments/tsconfig.json"
-@uifabric/experiments: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@uifabric/lists: yarn run vX.X.X
-@uifabric/lists: $ just-scripts ts
-@uifabric/lists: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/lists/tsconfig.json
-@uifabric/lists: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/lists/tsconfig.json"
-@uifabric/lists: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/lists/tsconfig.json
-@uifabric/lists: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/lists/tsconfig.json"
-@uifabric/lists: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@uifabric/react-cards: yarn run vX.X.X
-@uifabric/react-cards: $ just-scripts ts
-@uifabric/react-cards: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-cards/tsconfig.json
-@uifabric/react-cards: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-cards/tsconfig.json"
-@uifabric/react-cards: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-cards/tsconfig.json
-@uifabric/react-cards: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-cards/tsconfig.json"
-@uifabric/react-cards: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@fluentui/react-avatar: yarn run vX.X.X
-@fluentui/react-avatar: $ just-scripts ts
-@fluentui/react-avatar: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-avatar/tsconfig.json
-@fluentui/react-avatar: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-avatar/tsconfig.json"
-@fluentui/react-avatar: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-avatar/tsconfig.json
-@fluentui/react-avatar: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-avatar/tsconfig.json"
-@fluentui/react-avatar: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@fluentui/react-button: yarn run vX.X.X
-@fluentui/react-button: $ just-scripts ts
-@fluentui/react-button: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-button/tsconfig.json
-@fluentui/react-button: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-button/tsconfig.json"
-@fluentui/react-button: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-button/tsconfig.json
-@fluentui/react-button: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-button/tsconfig.json"
-@fluentui/react-button: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@fluentui/react-tabs: yarn run vX.X.X
-@fluentui/react-tabs: $ just-scripts ts
-@fluentui/react-tabs: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-tabs/tsconfig.json
-@fluentui/react-tabs: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-tabs/tsconfig.json"
-@fluentui/react-tabs: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-tabs/tsconfig.json
-@fluentui/react-tabs: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-tabs/tsconfig.json"
-@fluentui/react-tabs: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-theming-designer: yarn run vX.X.X
-theming-designer: $ just-scripts ts
-theming-designer: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/theming-designer/tsconfig.json
-theming-designer: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/theming-designer/tsconfig.json"
-theming-designer: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/theming-designer/tsconfig.json
-theming-designer: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/theming-designer/tsconfig.json"
-theming-designer: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@uifabric/api-docs: yarn run vX.X.X
-@uifabric/api-docs: $ just-scripts ts
-@uifabric/api-docs: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/api-docs/tsconfig.json
-@uifabric/api-docs: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/api-docs/tsconfig.json"
-@uifabric/api-docs: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/api-docs/tsconfig.json
-@uifabric/api-docs: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/api-docs/tsconfig.json"
-@uifabric/api-docs: Done in ?s.
-@fluentui/react-flex: yarn run vX.X.X
-@fluentui/react-flex: $ just-scripts ts
-@fluentui/react-flex: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-flex/tsconfig.json
-@fluentui/react-flex: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-flex/tsconfig.json"
-@fluentui/react-flex: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-flex/tsconfig.json
-@fluentui/react-flex: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-flex/tsconfig.json"
-@fluentui/react-flex: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@fluentui/react-next: yarn run vX.X.X
-@fluentui/react-next: $ just-scripts ts
-@fluentui/react-next: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-next/tsconfig.json
-@fluentui/react-next: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-next/tsconfig.json"
-@fluentui/react-next: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-next/tsconfig.json
-@fluentui/react-next: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-next/tsconfig.json"
-@fluentui/react-next: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@uifabric/fabric-website-resources: yarn run vX.X.X
-@uifabric/fabric-website-resources: $ just-scripts ts
-@uifabric/fabric-website-resources: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/fabric-website-resources/tsconfig.json
-@uifabric/fabric-website-resources: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/fabric-website-resources/tsconfig.json"
-@uifabric/fabric-website-resources: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/fabric-website-resources/tsconfig.json
-@uifabric/fabric-website-resources: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/fabric-website-resources/tsconfig.json"
-@uifabric/fabric-website-resources: Done in ?s.
-codesandbox-react-next-template: yarn run vX.X.X
-codesandbox-react-next-template: $ just-scripts ts
-codesandbox-react-next-template: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/codesandbox-react-next-template/tsconfig.json
-codesandbox-react-next-template: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/codesandbox-react-next-template/tsconfig.json"
-codesandbox-react-next-template: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/codesandbox-react-next-template/tsconfig.json
-codesandbox-react-next-template: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/codesandbox-react-next-template/tsconfig.json"
-codesandbox-react-next-template: Done in ?s.
-perf-test: yarn run vX.X.X
-perf-test: $ just-scripts ts
-perf-test: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/perf-test/tsconfig.json
-perf-test: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/perf-test/tsconfig.json"
-perf-test: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/perf-test/tsconfig.json
-perf-test: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/perf-test/tsconfig.json"
-perf-test: Done in ?s.
-test-bundles: yarn run vX.X.X
-test-bundles: $ just-scripts ts
-test-bundles: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/test-bundles/tsconfig.json
-test-bundles: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/test-bundles/tsconfig.json"
-test-bundles: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/test-bundles/tsconfig.json
-test-bundles: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/test-bundles/tsconfig.json"
-test-bundles: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-vr-tests: yarn run vX.X.X
-vr-tests: $ just-scripts ts
-vr-tests: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/vr-tests/tsconfig.json
-vr-tests: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/vr-tests/tsconfig.json"
-vr-tests: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/vr-tests/tsconfig.json
-vr-tests: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/vr-tests/tsconfig.json"
-vr-tests: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-a11y-tests: yarn run vX.X.X
-a11y-tests: $ just-scripts ts
-a11y-tests: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/a11y-tests/tsconfig.json
-a11y-tests: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/a11y-tests/tsconfig.json"
-a11y-tests: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/a11y-tests/tsconfig.json
-a11y-tests: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/a11y-tests/tsconfig.json"
-a11y-tests: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-@uifabric/fabric-website: yarn run vX.X.X
-@uifabric/fabric-website: $ just-scripts ts
-@uifabric/fabric-website: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/fabric-website/tsconfig.json
-@uifabric/fabric-website: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/fabric-website/tsconfig.json"
-@uifabric/fabric-website: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/fabric-website/tsconfig.json
-@uifabric/fabric-website: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/fabric-website/tsconfig.json"
-@uifabric/fabric-website: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
-ssr-tests: yarn run vX.X.X
-ssr-tests: $ just-scripts ts
-ssr-tests: Done in ?s.
-@fluentui/examples: yarn run vX.X.X
-@fluentui/examples: $ just-scripts ts
-@fluentui/examples: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/examples/tsconfig.json
-@fluentui/examples: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/examples/tsconfig.json"
-@fluentui/examples: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/examples/tsconfig.json
-@fluentui/examples: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/examples/tsconfig.json"
-@fluentui/examples: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
 
 
 
 Standard error:
-@fluentui/eslint-plugin: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/eslint-plugin: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/noop: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/noop: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/web-components: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/web-components: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/ability-attributes: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/ability-attributes: [XX:XX:XX XM] x Command not defined: ts
-@uifabric/build: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@uifabric/build: [XX:XX:XX XM] x ------------------------------------
-@uifabric/build: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/scripts/tsconfig.json"
-@uifabric/build:     at ChildProcess.exithandler (child_process.js:303:12)
-@uifabric/build:     at ChildProcess.emit (events.js:315:20)
-@uifabric/build:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@uifabric/build:     at maybeClose (internal/child_process.js:1026:16)
-@uifabric/build:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@uifabric/build: [XX:XX:XX XM] x stdout:
-@uifabric/build: [XX:XX:XX XM] x create-package/plop-templates-node/just.config.ts:1:9 - error TS2451: Cannot redeclare block-scoped variable 'preset'.
-@uifabric/build: 1 const { preset, just } = require('@uifabric/build');
-@uifabric/build:           ~~~~~~
-@uifabric/build:   create-package/plop-templates-react/just.config.ts:1:9
-@uifabric/build:     1 const { preset } = require('@uifabric/build');
-@uifabric/build:               ~~~~~~
-@uifabric/build:     'preset' was also declared here.
-@uifabric/build:   tasks/preset.ts:1:7
-@uifabric/build:     1 const preset = require('../just.config');
-@uifabric/build:             ~~~~~~
-@uifabric/build:     and here.
-@uifabric/build: create-package/plop-templates-node/just.config.ts:2:9 - error TS2451: Cannot redeclare block-scoped variable 'task'.
-@uifabric/build: 2 const { task } = just;
-@uifabric/build:           ~~~~
-@uifabric/build:   just.config.ts:3:9
-@uifabric/build:     3 const { task, series, parallel, condition, option, argv, addResolvePath, resolveCwd } = require('just-scripts');
-@uifabric/build:               ~~~~
-@uifabric/build:     'task' was also declared here.
-@uifabric/build: create-package/plop-templates-react/just.config.ts:1:9 - error TS2451: Cannot redeclare block-scoped variable 'preset'.
-@uifabric/build: 1 const { preset } = require('@uifabric/build');
-@uifabric/build:           ~~~~~~
-@uifabric/build:   create-package/plop-templates-node/just.config.ts:1:9
-@uifabric/build:     1 const { preset, just } = require('@uifabric/build');
-@uifabric/build:               ~~~~~~
-@uifabric/build:     'preset' was also declared here.
-@uifabric/build: create-package/plop-templates-react/src/version.ts:3:28 - error TS2307: Cannot find module '@uifabric/set-version' or its corresponding type declarations.
-@uifabric/build: 3 import { setVersion } from '@uifabric/set-version';
-@uifabric/build:                              ~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/build: exec-sync.js:4:7 - error TS6133: 'chalk' is declared but its value is never read.
-@uifabric/build: 4 const chalk = require('chalk').default;
-@uifabric/build:         ~~~~~
-@uifabric/build: exec-sync.js:21:13 - error TS2304: Cannot find name 'chalk'.
-@uifabric/build: 21   logStatus(chalk.gray('Executing: ') + chalk.cyan(displayName || cmd));
-@uifabric/build:                ~~~~~
-@uifabric/build: exec-sync.js:21:41 - error TS2304: Cannot find name 'chalk'.
-@uifabric/build: 21   logStatus(chalk.gray('Executing: ') + chalk.cyan(displayName || cmd));
-@uifabric/build:                                            ~~~~~
-@uifabric/build: exec.js:4:7 - error TS6133: 'chalk' is declared but its value is never read.
-@uifabric/build: 4 const chalk = require('chalk').default;
-@uifabric/build:         ~~~~~
-@uifabric/build: exec.js:28:13 - error TS2304: Cannot find name 'chalk'.
-@uifabric/build: 28   logStatus(chalk.gray('Executing: ') + chalk.cyan(displayName || cmd));
-@uifabric/build:                ~~~~~
-@uifabric/build: exec.js:28:41 - error TS2304: Cannot find name 'chalk'.
-@uifabric/build: 28   logStatus(chalk.gray('Executing: ') + chalk.cyan(displayName || cmd));
-@uifabric/build:                                            ~~~~~
-@uifabric/build: gulp/plugins/util/getComponentInfo.ts:139:9 - error TS2322: Type 'Tag[]' is not assignable to type '{ title: string; description: string; type: null; name: string; }[]'.
-@uifabric/build:   Type 'Tag' is not assignable to type '{ title: string; description: string; type: null; name: string; }'.
-@uifabric/build:     Types of property 'type' are incompatible.
-@uifabric/build:       Type 'Type' is not assignable to type 'null'.
-@uifabric/build:         Type 'AllLiteral' is not assignable to type 'null'.
-@uifabric/build: 139         tags,
-@uifabric/build:             ~~~~
-@uifabric/build:   gulp/plugins/util/docs-types.ts:49:3
-@uifabric/build:     49   tags: {
-@uifabric/build:          ~~~~
-@uifabric/build:     The expected type comes from property 'tags' which is declared here on type 'ComponentProp'
-@uifabric/build: gulp/tasks/test-projects/cra/App.tsx:16:8 - error TS2307: Cannot find module '@fluentui/react-northstar' or its corresponding type declarations.
-@uifabric/build: 16 } from '@fluentui/react-northstar';
-@uifabric/build:           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/build: gulp/tasks/test-projects/typings/index.tsx:1:27 - error TS2307: Cannot find module '@fluentui/react-northstar' or its corresponding type declarations.
-@uifabric/build: 1 import * as FluentUI from '@fluentui/react-northstar';
-@uifabric/build:                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/build: index.js:1:1 - error TS9006: Declaration emit for this file requires using private name 'CssLoaderOptions' from module '"/office-ui-fabric-react/node_modules/just-scripts/lib/webpack/overlays/stylesOverlay"'. An explicit type annotation may unblock declaration emit.
-@uifabric/build: 1 const just = require('just-scripts');
-@uifabric/build:   ~~~~~
-@uifabric/build: index.js:1:1 - error TS9006: Declaration emit for this file requires using private name 'PrettierTaskOptions' from module '"/office-ui-fabric-react/node_modules/just-scripts/lib/tasks/prettierTask"'. An explicit type annotation may unblock declaration emit.
-@uifabric/build: 1 const just = require('just-scripts');
-@uifabric/build:   ~~~~~
-@uifabric/build: just.config.ts:3:9 - error TS2451: Cannot redeclare block-scoped variable 'task'.
-@uifabric/build: 3 const { task, series, parallel, condition, option, argv, addResolvePath, resolveCwd } = require('just-scripts');
-@uifabric/build:           ~~~~
-@uifabric/build:   create-package/plop-templates-node/just.config.ts:2:9
-@uifabric/build:     2 const { task } = just;
-@uifabric/build:               ~~~~
-@uifabric/build:     'task' was also declared here.
-@uifabric/build: lint-staged/auto-convert-change-files.js:3:7 - error TS6133: 'chalk' is declared but its value is never read.
-@uifabric/build: 3 const chalk = require('chalk').default;
-@uifabric/build:         ~~~~~
-@uifabric/build: lint-staged/auto-convert-change-files.js:8:16 - error TS2304: Cannot find name 'chalk'.
-@uifabric/build: 8   console.warn(chalk.red('Legacy change file(s) detected. Auto-converting these to the new format.'));
-@uifabric/build:                  ~~~~~
-@uifabric/build: lint-staged/auto-convert-change-files.js:13:16 - error TS2304: Cannot find name 'chalk'.
-@uifabric/build: 13   console.warn(chalk.green('Changes are completed for you. Please run git commit again!'));
-@uifabric/build:                   ~~~~~
-@uifabric/build: lint-staged/auto-convert-change-files.js:15:5 - error TS2304: Cannot find name 'chalk'.
-@uifabric/build: 15     chalk.cyan('In the future, please use "npm run change" to generate change files instead of "rush change"'),
-@uifabric/build:        ~~~~~
-@uifabric/build: monorepo/findRepoDeps.js:51:18 - error TS2569: Type 'Set<string>' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators.
-@uifabric/build: 51   repoDeps = [...result].map(dep => packageInfo[dep]);
-@uifabric/build:                     ~~~~~~
-@uifabric/build: publish-beta.js:4:7 - error TS6133: 'chalk' is declared but its value is never read.
-@uifabric/build: 4 const chalk = require('chalk').default;
-@uifabric/build:         ~~~~~
-@uifabric/build: publish-beta.js:18:12 - error TS1212: Identifier expected. 'package' is a reserved word in strict mode.
-@uifabric/build: 18 for (const package of packages) {
-@uifabric/build:               ~~~~~~~
-@uifabric/build: publish-beta.js:19:53 - error TS1212: Identifier expected. 'package' is a reserved word in strict mode.
-@uifabric/build: 19   const packagePath = path.resolve(__dirname, '..', package.packagePath);
-@uifabric/build:                                                        ~~~~~~~
-@uifabric/build: publish-beta.js:21:29 - error TS2304: Cannot find name 'chalk'.
-@uifabric/build: 21   console.log(`Publishing ${chalk.magenta(package.packageName)} in ${packagePath}`);
-@uifabric/build:                                ~~~~~
-@uifabric/build: publish-beta.js:21:43 - error TS1212: Identifier expected. 'package' is a reserved word in strict mode.
-@uifabric/build: 21   console.log(`Publishing ${chalk.magenta(package.packageName)} in ${packagePath}`);
-@uifabric/build:                                              ~~~~~~~
-@uifabric/build: screener/screener.config.js:29:7 - error TS6133: 'config' is declared but its value is never read.
-@uifabric/build: 29 const config = require('../config').default;
-@uifabric/build:          ~~~~~~
-@uifabric/build: screener/screener.config.js:31:9 - error TS2339: Property 'compilerOptions' does not exist on type 'typeof Electron'.
-@uifabric/build: 31 const { compilerOptions } = require(config.paths.docs('tsconfig.json'));
-@uifabric/build:            ~~~~~~~~~~~~~~~
-@uifabric/build: screener/screener.config.js:31:37 - error TS2304: Cannot find name 'config'.
-@uifabric/build: 31 const { compilerOptions } = require(config.paths.docs('tsconfig.json'));
-@uifabric/build:                                        ~~~~~~
-@uifabric/build: screener/screener.config.js:34:12 - error TS2304: Cannot find name 'config'.
-@uifabric/build: 34   baseUrl: config.path_base,
-@uifabric/build:               ~~~~~~
-@uifabric/build: screener/screener.config.js:48:14 - error TS2304: Cannot find name 'config'.
-@uifabric/build: 48     host: `${config.server_host}:${config.server_port}`,
-@uifabric/build:                 ~~~~~~
-@uifabric/build: screener/screener.config.js:48:36 - error TS2304: Cannot find name 'config'.
-@uifabric/build: 48     host: `${config.server_host}:${config.server_port}`,
-@uifabric/build:                                       ~~~~~~
-@uifabric/build: tasks/lint-imports.js:33:9 - error TS6133: 'chalk' is declared but its value is never read.
-@uifabric/build: 33   const chalk = require('chalk').default;
-@uifabric/build:            ~~~~~
-@uifabric/build: tasks/lint-imports.js:361:26 - error TS2304: Cannot find name 'chalk'.
-@uifabric/build: 361         console.error(`${chalk.red('ERROR')}: ${errorGroup.count} ${errorMessages[groupName]}`);
-@uifabric/build:                              ~~~~~
-@uifabric/build: tasks/lint-imports.js:366:34 - error TS2304: Cannot find name 'chalk'.
-@uifabric/build: 366             console.error(`    ${chalk.inverse(importPath)}`);
-@uifabric/build:                                      ~~~~~
-@uifabric/build: tasks/preset.ts:1:7 - error TS2451: Cannot redeclare block-scoped variable 'preset'.
-@uifabric/build: 1 const preset = require('../just.config');
-@uifabric/build:         ~~~~~~
-@uifabric/build:   create-package/plop-templates-node/just.config.ts:1:9
-@uifabric/build:     1 const { preset, just } = require('@uifabric/build');
-@uifabric/build:               ~~~~~~
-@uifabric/build:     'preset' was also declared here.
-@uifabric/build: update-package-versions.js:11:7 - error TS6133: 'path' is declared but its value is never read.
-@uifabric/build: 11 const path = require('path');
-@uifabric/build:          ~~~~
-@uifabric/build: update-package-versions.js:13:7 - error TS6133: 'chalk' is declared but its value is never read.
-@uifabric/build: 13 const chalk = require('chalk').default;
-@uifabric/build:          ~~~~~
-@uifabric/build: update-package-versions.js:43:27 - error TS2304: Cannot find name 'chalk'.
-@uifabric/build: 43   console.log(`Updating ${chalk.magenta(name)} from ${chalk.grey(packageJson.version)} to ${chalk.green(newVersion)}.`);
-@uifabric/build:                              ~~~~~
-@uifabric/build: update-package-versions.js:43:55 - error TS2304: Cannot find name 'chalk'.
-@uifabric/build: 43   console.log(`Updating ${chalk.magenta(name)} from ${chalk.grey(packageJson.version)} to ${chalk.green(newVersion)}.`);
-@uifabric/build:                                                          ~~~~~
-@uifabric/build: update-package-versions.js:43:93 - error TS2304: Cannot find name 'chalk'.
-@uifabric/build: 43   console.log(`Updating ${chalk.magenta(name)} from ${chalk.grey(packageJson.version)} to ${chalk.green(newVersion)}.`);
-@uifabric/build:                                                                                                ~~~~~
-@uifabric/build: update-package-versions.js:47:12 - error TS1250: Function declarations are not allowed inside blocks in strict mode when targeting 'ES3' or 'ES5'.
-@uifabric/build: 47   function updateDependencies(deps) {
-@uifabric/build:               ~~~~~~~~~~~~~~~~~~
-@uifabric/build: Found 42 errors.
-@uifabric/build: [XX:XX:XX XM] x ------------------------------------
-@uifabric/build: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@uifabric/build: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@uifabric/build: error Command failed with exit code 1.
-@uifabric/webpack-utils: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@uifabric/webpack-utils: [XX:XX:XX XM] x ------------------------------------
-@uifabric/webpack-utils: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/webpack-utils/tsconfig.json"
-@uifabric/webpack-utils:     at ChildProcess.exithandler (child_process.js:303:12)
-@uifabric/webpack-utils:     at ChildProcess.emit (events.js:315:20)
-@uifabric/webpack-utils:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@uifabric/webpack-utils:     at maybeClose (internal/child_process.js:1026:16)
-@uifabric/webpack-utils:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@uifabric/webpack-utils: [XX:XX:XX XM] x stdout:
-@uifabric/webpack-utils: [XX:XX:XX XM] x src/fabricAsyncLoaderInclude.ts:7:1 - error TS1203: Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.
-@uifabric/webpack-utils: 7 export = (input: string) =>
-@uifabric/webpack-utils:   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/webpack-utils: 8   input.match(/office-ui-fabric-react[\\/]lib[\\/]components[\\/]ContextualMenu[\\/]ContextualMenu.js/) ||
-@uifabric/webpack-utils:   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/webpack-utils: 9   input.match(/office-ui-fabric-react[\\/]lib[\\/]components[\\/]Callout[\\/]Callout.js/);
-@uifabric/webpack-utils:   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/webpack-utils: Found 1 error.
-@uifabric/webpack-utils: [XX:XX:XX XM] x ------------------------------------
-@uifabric/webpack-utils: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@uifabric/webpack-utils: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@uifabric/webpack-utils: error Command failed with exit code 1.
-@fluentui/docs-components: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/docs-components: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/react-component-event-listener: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/react-component-event-listener: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/react-component-nesting-registry: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/react-component-nesting-registry: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/react-component-ref: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/react-component-ref: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/react-context-selector: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/react-context-selector: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/react-proptypes: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/react-proptypes: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/state: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/state: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/styles: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/styles: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/accessibility: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/accessibility: [XX:XX:XX XM] x Command not defined: ts
-@uifabric/merge-styles: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@uifabric/merge-styles: [XX:XX:XX XM] x ------------------------------------
-@uifabric/merge-styles: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/merge-styles/tsconfig.json"
-@uifabric/merge-styles:     at ChildProcess.exithandler (child_process.js:303:12)
-@uifabric/merge-styles:     at ChildProcess.emit (events.js:315:20)
-@uifabric/merge-styles:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@uifabric/merge-styles:     at maybeClose (internal/child_process.js:1026:16)
-@uifabric/merge-styles:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@uifabric/merge-styles: [XX:XX:XX XM] x stdout:
-@uifabric/merge-styles: [XX:XX:XX XM] x src/mergeStyleSets.test.ts:168:15 - error TS2310: Type 'ISubComponentStyles' recursively references itself as a base type.
-@uifabric/merge-styles: 168     interface ISubComponentStyles extends IStyleSet<ISubComponentStyles> {
-@uifabric/merge-styles:                   ~~~~~~~~~~~~~~~~~~~
-@uifabric/merge-styles: src/mergeStyleSets.test.ts:176:15 - error TS2310: Type 'IStyles' recursively references itself as a base type.
-@uifabric/merge-styles: 176     interface IStyles extends IStyleSet<IStyles> {
-@uifabric/merge-styles:                   ~~~~~~~
-@uifabric/merge-styles: Found 2 errors.
-@uifabric/merge-styles: [XX:XX:XX XM] x ------------------------------------
-@uifabric/merge-styles: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@uifabric/merge-styles: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@uifabric/merge-styles: error Command failed with exit code 1.
-@fluentui/react-northstar-styles-renderer: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/react-northstar-styles-renderer: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/react-northstar-emotion-renderer: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/react-northstar-emotion-renderer: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/react-northstar-fela-renderer: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/react-northstar-fela-renderer: [XX:XX:XX XM] x Command not defined: ts
-@uifabric/utilities: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@uifabric/utilities: [XX:XX:XX XM] x ------------------------------------
-@uifabric/utilities: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/utilities/tsconfig.json"
-@uifabric/utilities:     at ChildProcess.exithandler (child_process.js:303:12)
-@uifabric/utilities:     at ChildProcess.emit (events.js:315:20)
-@uifabric/utilities:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@uifabric/utilities:     at maybeClose (internal/child_process.js:1026:16)
-@uifabric/utilities:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@uifabric/utilities: [XX:XX:XX XM] x stdout:
-@uifabric/utilities: [XX:XX:XX XM] x src/AutoScroll.ts:143:14 - error TS2790: The operand of a 'delete' operator must be optional.
-@uifabric/utilities: 143       delete this._timeoutId;
-@uifabric/utilities:                  ~~~~~~~~~~~~~~~
-@uifabric/utilities: src/dom/getRect.ts:19:16 - error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
-@uifabric/utilities: 19     } else if ((element as HTMLElement).getBoundingClientRect) {
-@uifabric/utilities:                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/utilities: src/object.ts:9:11 - error TS2339: Property 'hasOwnProperty' does not exist on type 'TA'.
-@uifabric/utilities: 9     if (a.hasOwnProperty(propName)) {
-@uifabric/utilities:             ~~~~~~~~~~~~~~
-@uifabric/utilities: src/object.ts:10:14 - error TS2339: Property 'hasOwnProperty' does not exist on type 'TB'.
-@uifabric/utilities: 10       if (!b.hasOwnProperty(propName) || b[propName] !== a[propName]) {
-@uifabric/utilities:                 ~~~~~~~~~~~~~~
-@uifabric/utilities: src/object.ts:10:42 - error TS2536: Type 'Extract<keyof TA, string>' cannot be used to index type 'TB'.
-@uifabric/utilities: 10       if (!b.hasOwnProperty(propName) || b[propName] !== a[propName]) {
-@uifabric/utilities:                                             ~~~~~~~~~~~
-@uifabric/utilities: src/object.ts:16:11 - error TS2339: Property 'hasOwnProperty' does not exist on type 'TB'.
-@uifabric/utilities: 16     if (b.hasOwnProperty(propName)) {
-@uifabric/utilities:              ~~~~~~~~~~~~~~
-@uifabric/utilities: src/object.ts:17:14 - error TS2339: Property 'hasOwnProperty' does not exist on type 'TA'.
-@uifabric/utilities: 17       if (!a.hasOwnProperty(propName)) {
-@uifabric/utilities:                 ~~~~~~~~~~~~~~
-@uifabric/utilities: Found 7 errors.
-@uifabric/utilities: [XX:XX:XX XM] x ------------------------------------
-@uifabric/utilities: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@uifabric/utilities: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@uifabric/utilities: error Command failed with exit code 1.
+info cli using local version of lerna
+@microsoft/fast-components-msft: src/index-rollup.ts → dist/fast-components-msft.js, dist/fast-components-msft.min.js...
+@microsoft/fast-components-msft: created dist/fast-components-msft.js, dist/fast-components-msft.min.js in ?s
+@microsoft/fast-components-msft: npm WARN lifecycle The node binary used for scripts is  but npm is using /usr/local/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
+@fluentui/ability-attributes: npm WARN lifecycle The node binary used for scripts is  but npm is using /usr/local/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
+@uifabric/build: warning package.json: "dependencies" has dependency "typescript" with range "3.7.2" that collides with a dependency in "devDependencies" of the same name with version "../typescript.tgz"
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@uifabric/build: (Use `node --trace-warnings ...` to show where the warning was created)
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@uifabric/build: (node:166) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@fluentui/common-styles: (Use `node --trace-warnings ...` to show where the warning was created)
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@uifabric/example-data: (Use `node --trace-warnings ...` to show where the warning was created)
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@uifabric/example-data: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@fluentui/keyboard-key: (Use `node --trace-warnings ...` to show where the warning was created)
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@fluentui/keyboard-key: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@uifabric/migration: (Use `node --trace-warnings ...` to show where the warning was created)
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@uifabric/migration: (node:286) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@uifabric/monaco-editor: (Use `node --trace-warnings ...` to show where the warning was created)
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@fluentui/react-conformance: (Use `node --trace-warnings ...` to show where the warning was created)
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@uifabric/set-version: (Use `node --trace-warnings ...` to show where the warning was created)
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@uifabric/set-version: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@uifabric/webpack-utils: (Use `node --trace-warnings ...` to show where the warning was created)
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@fluentui/date-time-utilities: (Use `node --trace-warnings ...` to show where the warning was created)
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@fluentui/date-time-utilities: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@uifabric/merge-styles: (Use `node --trace-warnings ...` to show where the warning was created)
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@uifabric/merge-styles: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@fluentui/react-flex: (Use `node --trace-warnings ...` to show where the warning was created)
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@fluentui/react-flex: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (Use `node --trace-warnings ...` to show where the warning was created)
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@uifabric/jest-serializer-merge-styles: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@fluentui/react-stylesheets: (Use `node --trace-warnings ...` to show where the warning was created)
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@fluentui/react-stylesheets: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@uifabric/test-utilities: (Use `node --trace-warnings ...` to show where the warning was created)
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@uifabric/utilities: (Use `node --trace-warnings ...` to show where the warning was created)
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@uifabric/utilities: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@fluentui/react-compose: (Use `node --trace-warnings ...` to show where the warning was created)
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@fluentui/react-compose: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@uifabric/react-hooks: (Use `node --trace-warnings ...` to show where the warning was created)
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@uifabric/react-hooks: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
+@fluentui/react-icons: (Use `node --trace-warnings ...` to show where the warning was created)
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
+@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
+@fluentui/react-icons: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
 @fluentui/react-icons: [XX:XX:XX XM] x Error detected while running 'ts:esm'
 @fluentui/react-icons: [XX:XX:XX XM] x ------------------------------------
 @fluentui/react-icons: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-icons/tsconfig.json"
-@fluentui/react-icons:     at ChildProcess.exithandler (child_process.js:303:12)
-@fluentui/react-icons:     at ChildProcess.emit (events.js:315:20)
-@fluentui/react-icons:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@fluentui/react-icons:     at maybeClose (internal/child_process.js:1026:16)
-@fluentui/react-icons:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@fluentui/react-icons:     at ChildProcess.exithandler (child_process.js:308:12)
+@fluentui/react-icons:     at ChildProcess.emit (events.js:314:20)
+@fluentui/react-icons:     at ChildProcess.EventEmitter.emit (domain.js:548:15)
+@fluentui/react-icons:     at maybeClose (internal/child_process.js:1051:16)
+@fluentui/react-icons:     at Process.ChildProcess._handle.onexit (internal/child_process.js:287:5)
+@fluentui/react-icons:     at Process.callbackTrampoline (internal/async_hooks.js:129:14)
 @fluentui/react-icons: [XX:XX:XX XM] x stdout:
-@fluentui/react-icons: [XX:XX:XX XM] x src/utils/createSvgIcon.ts:3:26 - error TS2307: Cannot find module './SvgIcon.scss' or its corresponding type declarations.
+@fluentui/react-icons: [XX:XX:XX XM] x src/utils/createSvgIcon.ts:3:26 - error TS2307: Cannot find module './SvgIcon.scss'.
 @fluentui/react-icons: 3 import * as classes from './SvgIcon.scss';
 @fluentui/react-icons:                            ~~~~~~~~~~~~~~~~
 @fluentui/react-icons: Found 1 error.
@@ -840,1637 +855,4 @@ Standard error:
 @fluentui/react-icons: [XX:XX:XX XM] x Error previously detected. See above for error messages.
 @fluentui/react-icons: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
 @fluentui/react-icons: error Command failed with exit code 1.
-@fluentui/react-bindings: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/react-bindings: [XX:XX:XX XM] x Command not defined: ts
-@uifabric/foundation: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
-@uifabric/foundation: [XX:XX:XX XM] x ------------------------------------
-@uifabric/foundation: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/foundation/tsconfig.json"
-@uifabric/foundation:     at ChildProcess.exithandler (child_process.js:303:12)
-@uifabric/foundation:     at ChildProcess.emit (events.js:315:20)
-@uifabric/foundation:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@uifabric/foundation:     at maybeClose (internal/child_process.js:1026:16)
-@uifabric/foundation:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@uifabric/foundation: [XX:XX:XX XM] x stdout:
-@uifabric/foundation: [XX:XX:XX XM] x src/createComponent.tsx:81:23 - error TS2352: Conversion of type 'TComponentProps & { styles: IConcatenatedStyleSet<any>; tokens: TTokens; _defaultStyles: IConcatenatedStyleSet<any>; theme: ITheme; className?: string | undefined; }' to type 'TViewProps & IDefaultSlotProps<any>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
-@uifabric/foundation:   Type 'TComponentProps & { styles: IConcatenatedStyleSet<any>; tokens: TTokens; _defaultStyles: IConcatenatedStyleSet<any>; theme: ITheme; className?: string | undefined; }' is not comparable to type 'TViewProps'.
-@uifabric/foundation:     'TComponentProps & { styles: IConcatenatedStyleSet<any>; tokens: TTokens; _defaultStyles: IConcatenatedStyleSet<any>; theme: ITheme; className?: string | undefined; }' is assignable to the constraint of type 'TViewProps', but 'TViewProps' could be instantiated with a different subtype of constraint 'object'.
-@uifabric/foundation:  81     const viewProps = {
-@uifabric/foundation:                           ~
-@uifabric/foundation:  82       ...componentProps,
-@uifabric/foundation:     ~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/foundation: ... 
-@uifabric/foundation:  86       theme,
-@uifabric/foundation:     ~~~~~~~~~~~~
-@uifabric/foundation:  87     } as TViewProps & IDefaultSlotProps<any>;
-@uifabric/foundation:     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/foundation: Found 1 error.
-@uifabric/foundation: [XX:XX:XX XM] x ------------------------------------
-@uifabric/foundation: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@uifabric/foundation: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
-@uifabric/foundation: error Command failed with exit code 1.
-@fluentui/react-theme-provider: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
-@fluentui/react-theme-provider: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react-theme-provider: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-theme-provider/tsconfig.json"
-@fluentui/react-theme-provider:     at ChildProcess.exithandler (child_process.js:303:12)
-@fluentui/react-theme-provider:     at ChildProcess.emit (events.js:315:20)
-@fluentui/react-theme-provider:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@fluentui/react-theme-provider:     at maybeClose (internal/child_process.js:1026:16)
-@fluentui/react-theme-provider:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@fluentui/react-theme-provider: [XX:XX:XX XM] x stdout:
-@fluentui/react-theme-provider: [XX:XX:XX XM] x src/ThemeProvider.tsx:48:45 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-theme-provider: 48     const rootClass = cx(className, classes.root) || undefined;
-@fluentui/react-theme-provider:                                                ~~~~
-@fluentui/react-theme-provider: Found 1 error.
-@fluentui/react-theme-provider: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react-theme-provider: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@fluentui/react-theme-provider: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
-@fluentui/react-theme-provider: error Command failed with exit code 1.
-@fluentui/react-icons-northstar: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/react-icons-northstar: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/react-telemetry: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/react-telemetry: [XX:XX:XX XM] x Command not defined: ts
-office-ui-fabric-react: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
-office-ui-fabric-react: [XX:XX:XX XM] x ------------------------------------
-office-ui-fabric-react: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/office-ui-fabric-react/tsconfig.json"
-office-ui-fabric-react:     at ChildProcess.exithandler (child_process.js:303:12)
-office-ui-fabric-react:     at ChildProcess.emit (events.js:315:20)
-office-ui-fabric-react:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-office-ui-fabric-react:     at maybeClose (internal/child_process.js:1026:16)
-office-ui-fabric-react:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-office-ui-fabric-react: [XX:XX:XX XM] x stdout:
-office-ui-fabric-react: [XX:XX:XX XM] x src/components/ChoiceGroup/ChoiceGroup.base.tsx:147:19 - error TS2783: 'key' is specified more than once, so this usage will be overwritten.
-office-ui-fabric-react: 147                   key={option.key}
-office-ui-fabric-react:                       ~~~~~~~~~~~~~~~~
-office-ui-fabric-react:   src/components/ChoiceGroup/ChoiceGroup.base.tsx:151:19
-office-ui-fabric-react:     151                   {...innerOptionProps}
-office-ui-fabric-react:                           ~~~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react:     This spread always overwrites this property.
-office-ui-fabric-react: src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx:82:38 - error TS2554: Expected 1 arguments, but got 2.
-office-ui-fabric-react: 82           {onRenderField(this.props, this._onRenderField)}
-office-ui-fabric-react:                                         ~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/ComboBox/ComboBox.tsx:415:13 - error TS2554: Expected 1 arguments, but got 2.
-office-ui-fabric-react: 415             this._onRenderContainer,
-office-ui-fabric-react:                 ~~~~~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/DetailsList/DetailsColumn.base.tsx:194:14 - error TS2790: The operand of a 'delete' operator must be optional.
-office-ui-fabric-react: 194       delete this._dragDropSubscription;
-office-ui-fabric-react:                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/DetailsList/DetailsColumn.base.tsx:208:14 - error TS2790: The operand of a 'delete' operator must be optional.
-office-ui-fabric-react: 208       delete this._dragDropSubscription;
-office-ui-fabric-react:                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/DetailsList/DetailsHeader.base.tsx:130:14 - error TS2790: The operand of a 'delete' operator must be optional.
-office-ui-fabric-react: 130       delete this._subscriptionObject;
-office-ui-fabric-react:                  ~~~~~~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/DetailsList/DetailsHeader.base.tsx:152:14 - error TS2790: The operand of a 'delete' operator must be optional.
-office-ui-fabric-react: 152       delete this._subscriptionObject;
-office-ui-fabric-react:                  ~~~~~~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/DetailsList/DetailsRow.base.tsx:110:16 - error TS2790: The operand of a 'delete' operator must be optional.
-office-ui-fabric-react: 110         delete this._dragDropSubscription;
-office-ui-fabric-react:                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/DetailsList/DetailsRow.base.tsx:148:14 - error TS2790: The operand of a 'delete' operator must be optional.
-office-ui-fabric-react: 148       delete this._dragDropSubscription;
-office-ui-fabric-react:                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx:12:72 - error TS2339: Property 'peoplePickerPersonaContent' does not exist on type 'typeof import("*.scss")'.
-office-ui-fabric-react: 12     <div className={css('ms-PeoplePicker-personaContent', stylesImport.peoplePickerPersonaContent)}>
-office-ui-fabric-react:                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx:16:64 - error TS2339: Property 'peoplePickerPersona' does not exist on type 'typeof import("*.scss")'.
-office-ui-fabric-react: 16         className={css('ms-PeoplePicker-Persona', stylesImport.peoplePickerPersona)}
-office-ui-fabric-react:                                                                   ~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/FocusTrapZone/FocusTrapZone.tsx:106:12 - error TS2790: The operand of a 'delete' operator must be optional.
-office-ui-fabric-react: 106     delete this._previouslyFocusedElementOutsideTrapZone;
-office-ui-fabric-react:                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/GroupedList/GroupedListSection.tsx:174:16 - error TS2790: The operand of a 'delete' operator must be optional.
-office-ui-fabric-react: 174         delete this._dragDropSubscription;
-office-ui-fabric-react:                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/List/List.tsx:340:12 - error TS2790: The operand of a 'delete' operator must be optional.
-office-ui-fabric-react: 340     delete this._scrollElement;
-office-ui-fabric-react:                ~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/MarqueeSelection/MarqueeSelection.base.tsx:88:12 - error TS2790: The operand of a 'delete' operator must be optional.
-office-ui-fabric-react: 88     delete this._scrollableParent;
-office-ui-fabric-react:               ~~~~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/MarqueeSelection/MarqueeSelection.base.tsx:89:12 - error TS2790: The operand of a 'delete' operator must be optional.
-office-ui-fabric-react: 89     delete this._scrollableSurface;
-office-ui-fabric-react:               ~~~~~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/Persona/Persona.deprecated.test.tsx:113:13 - error TS2322: Type 'ReactWrapper<HTMLAttributes, any, Component<{}, {}, any>>' is not assignable to type 'ReactWrapper<ImgHTMLAttributes<any>, any, Component<{}, {}, any>>'.
-office-ui-fabric-react:   Type 'HTMLAttributes' is not assignable to type 'ImgHTMLAttributes<any>'.
-office-ui-fabric-react:     Types of property 'crossOrigin' are incompatible.
-office-ui-fabric-react:       Type 'string | undefined' is not assignable to type '"" | "anonymous" | "use-credentials" | undefined'.
-office-ui-fabric-react:         Type 'string' is not assignable to type '"" | "anonymous" | "use-credentials" | undefined'.
-office-ui-fabric-react: 113       const image: ReactWrapper<React.ImgHTMLAttributes<any>, any> = wrapper.find('ImageBase');
-office-ui-fabric-react:                 ~~~~~
-office-ui-fabric-react: src/components/Persona/Persona.deprecated.test.tsx:120:13 - error TS2322: Type 'ReactWrapper<HTMLAttributes, any, Component<{}, {}, any>>' is not assignable to type 'ReactWrapper<ImgHTMLAttributes<any>, any, Component<{}, {}, any>>'.
-office-ui-fabric-react: 120       const image: ReactWrapper<React.ImgHTMLAttributes<any>, any> = wrapper.find('ImageBase');
-office-ui-fabric-react:                 ~~~~~
-office-ui-fabric-react: src/components/Persona/Persona.test.tsx:190:13 - error TS2322: Type 'ReactWrapper<HTMLAttributes, any, Component<{}, {}, any>>' is not assignable to type 'ReactWrapper<ImgHTMLAttributes<any>, any, Component<{}, {}, any>>'.
-office-ui-fabric-react: 190       const image: ReactWrapper<React.ImgHTMLAttributes<any>, any> = wrapper.find('ImageBase');
-office-ui-fabric-react:                 ~~~~~
-office-ui-fabric-react: src/components/Persona/Persona.test.tsx:197:13 - error TS2322: Type 'ReactWrapper<HTMLAttributes, any, Component<{}, {}, any>>' is not assignable to type 'ReactWrapper<ImgHTMLAttributes<any>, any, Component<{}, {}, any>>'.
-office-ui-fabric-react: 197       const image: ReactWrapper<React.ImgHTMLAttributes<any>, any> = wrapper.find('ImageBase');
-office-ui-fabric-react:                 ~~~~~
-office-ui-fabric-react: src/components/Popup/Popup.tsx:75:12 - error TS2790: The operand of a 'delete' operator must be optional.
-office-ui-fabric-react: 75     delete this._originalFocusedElement;
-office-ui-fabric-react:               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-office-ui-fabric-react: src/components/TextField/TextField.types.ts:327:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-office-ui-fabric-react: 327 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-office-ui-fabric-react:                      ~~~~~~~~~~~~~~~~
-office-ui-fabric-react: Found 22 errors.
-office-ui-fabric-react: [XX:XX:XX XM] x ------------------------------------
-office-ui-fabric-react: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-office-ui-fabric-react: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
-office-ui-fabric-react: error Command failed with exit code 1.
-@fluentui/react-image: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@fluentui/react-image: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react-image: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-image/tsconfig.json"
-@fluentui/react-image:     at ChildProcess.exithandler (child_process.js:303:12)
-@fluentui/react-image:     at ChildProcess.emit (events.js:315:20)
-@fluentui/react-image:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@fluentui/react-image:     at maybeClose (internal/child_process.js:1026:16)
-@fluentui/react-image:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@fluentui/react-image: [XX:XX:XX XM] x stdout:
-@fluentui/react-image: [XX:XX:XX XM] x src/components/Image/Image.stories.tsx:12:57 - error TS2339: Property 'hStack' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-image: 12   return <div {...rest} className={horizontal ? classes.hStack : classes.vStack} />;
-@fluentui/react-image:                                                            ~~~~~~
-@fluentui/react-image: src/components/Image/Image.stories.tsx:12:74 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-image: 12   return <div {...rest} className={horizontal ? classes.hStack : classes.vStack} />;
-@fluentui/react-image:                                                                             ~~~~~~
-@fluentui/react-image: src/components/Image/Image.tsx:9:44 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
-@fluentui/react-image:   Property 'styles' is incompatible with index signature.
-@fluentui/react-image:     Type '{ [className: string]: string; }' is not assignable to type 'string'.
-@fluentui/react-image: 9 export const useImageClasses = makeClasses(classes);
-@fluentui/react-image:                                              ~~~~~~~
-@fluentui/react-image: Found 3 errors.
-@fluentui/react-image: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react-image: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@fluentui/react-image: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@fluentui/react-image: error Command failed with exit code 1.
-@fluentui/react-northstar: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/react-northstar: [XX:XX:XX XM] x Command not defined: ts
-server-rendered-app: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-server-rendered-app: [XX:XX:XX XM] x ------------------------------------
-server-rendered-app: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/server-rendered-app/tsconfig.json"
-server-rendered-app:     at ChildProcess.exithandler (child_process.js:303:12)
-server-rendered-app:     at ChildProcess.emit (events.js:315:20)
-server-rendered-app:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-server-rendered-app:     at maybeClose (internal/child_process.js:1026:16)
-server-rendered-app:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-server-rendered-app: [XX:XX:XX XM] x stdout:
-server-rendered-app: [XX:XX:XX XM] x ../../packages/office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-server-rendered-app: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-server-rendered-app:                      ~~~~~~~~~~~~~~~~
-server-rendered-app: Found 1 error.
-server-rendered-app: [XX:XX:XX XM] x ------------------------------------
-server-rendered-app: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-server-rendered-app: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-server-rendered-app: error Command failed with exit code 1.
-@fluentui/react: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@fluentui/react: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react/tsconfig.json"
-@fluentui/react:     at ChildProcess.exithandler (child_process.js:303:12)
-@fluentui/react:     at ChildProcess.emit (events.js:315:20)
-@fluentui/react:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@fluentui/react:     at maybeClose (internal/child_process.js:1026:16)
-@fluentui/react:     at Socket.<anonymous> (internal/child_process.js:441:11)
-@fluentui/react:     at Socket.emit (events.js:315:20)
-@fluentui/react:     at Socket.EventEmitter.emit (domain.js:547:15)
-@fluentui/react:     at Pipe.<anonymous> (net.js:674:12)
-@fluentui/react: [XX:XX:XX XM] x stdout:
-@fluentui/react: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-@fluentui/react: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-@fluentui/react:                      ~~~~~~~~~~~~~~~~
-@fluentui/react: Found 1 error.
-@fluentui/react: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@fluentui/react: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@fluentui/react: error Command failed with exit code 1.
-@uifabric/tsx-editor: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@uifabric/tsx-editor: [XX:XX:XX XM] x ------------------------------------
-@uifabric/tsx-editor: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/tsx-editor/tsconfig.json"
-@uifabric/tsx-editor:     at ChildProcess.exithandler (child_process.js:303:12)
-@uifabric/tsx-editor:     at ChildProcess.emit (events.js:315:20)
-@uifabric/tsx-editor:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@uifabric/tsx-editor:     at maybeClose (internal/child_process.js:1026:16)
-@uifabric/tsx-editor:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@uifabric/tsx-editor: [XX:XX:XX XM] x stdout:
-@uifabric/tsx-editor: [XX:XX:XX XM] x ../monaco-editor/monaco-typescript.d.ts:8:25 - error TS2307: Cannot find module '@uifabric/monaco-editor' or its corresponding type declarations.
-@uifabric/tsx-editor: 8 import * as monaco from '@uifabric/monaco-editor';
-@uifabric/tsx-editor:                           ~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/tsx-editor: ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-@uifabric/tsx-editor: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-@uifabric/tsx-editor:                      ~~~~~~~~~~~~~~~~
-@uifabric/tsx-editor: src/components/Editor.tsx:1:25 - error TS2307: Cannot find module '@uifabric/monaco-editor' or its corresponding type declarations.
-@uifabric/tsx-editor: 1 import * as monaco from '@uifabric/monaco-editor';
-@uifabric/tsx-editor:                           ~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/tsx-editor: src/components/TsxEditor.tsx:3:25 - error TS2307: Cannot find module '@uifabric/monaco-editor' or its corresponding type declarations.
-@uifabric/tsx-editor: 3 import * as monaco from '@uifabric/monaco-editor';
-@uifabric/tsx-editor:                           ~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/tsx-editor: src/interfaces/monaco.ts:5:25 - error TS2307: Cannot find module '@uifabric/monaco-editor/esm/vs/editor/editor.api' or its corresponding type declarations.
-@uifabric/tsx-editor: 5 import * as monaco from '@uifabric/monaco-editor/esm/vs/editor/editor.api';
-@uifabric/tsx-editor:                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/tsx-editor: src/transpiler/transpile.ts:2:25 - error TS2307: Cannot find module '@uifabric/monaco-editor' or its corresponding type declarations.
-@uifabric/tsx-editor: 2 import * as monaco from '@uifabric/monaco-editor';
-@uifabric/tsx-editor:                           ~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/tsx-editor: src/transpiler/transpile.ts:26:11 - error TS7006: Parameter 'worker' implicitly has an 'any' type.
-@uifabric/tsx-editor: 26     .then(worker => {
-@uifabric/tsx-editor:              ~~~~~~
-@uifabric/tsx-editor: src/transpiler/transpile.ts:31:62 - error TS7006: Parameter 'syntacticDiagnostics' implicitly has an 'any' type.
-@uifabric/tsx-editor: 31         return worker.getSyntacticDiagnostics(filename).then(syntacticDiagnostics => {
-@uifabric/tsx-editor:                                                                 ~~~~~~~~~~~~~~~~~~~~
-@uifabric/tsx-editor: src/transpiler/transpile.ts:32:62 - error TS7006: Parameter 'd' implicitly has an 'any' type.
-@uifabric/tsx-editor: 32           syntacticDiagnostics = syntacticDiagnostics.filter(d => d.category === 1 /*error*/);
-@uifabric/tsx-editor:                                                                 ~
-@uifabric/tsx-editor: src/transpiler/transpile.ts:50:12 - error TS7006: Parameter 'ex' implicitly has an 'any' type.
-@uifabric/tsx-editor: 50     .catch(ex => {
-@uifabric/tsx-editor:               ~~
-@uifabric/tsx-editor: src/utilities/getQueryParam.test.ts:7:12 - error TS2790: The operand of a 'delete' operator must be optional.
-@uifabric/tsx-editor: 7     delete window.location;
-@uifabric/tsx-editor:              ~~~~~~~~~~~~~~~
-@uifabric/tsx-editor: Found 11 errors.
-@uifabric/tsx-editor: [XX:XX:XX XM] x ------------------------------------
-@uifabric/tsx-editor: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@uifabric/tsx-editor: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@uifabric/tsx-editor: error Command failed with exit code 1.
-@fluentui/circulars-test: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/circulars-test: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/code-sandbox: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/code-sandbox: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/e2e: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/e2e: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/local-sandbox: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/local-sandbox: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/projects-test: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/projects-test: [XX:XX:XX XM] x Command not defined: ts
-@fluentui/react-builder: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/react-builder: [XX:XX:XX XM] x Command not defined: ts
-codesandbox-react-northstar-template: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
-codesandbox-react-northstar-template: [XX:XX:XX XM] x ------------------------------------
-codesandbox-react-northstar-template: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/codesandbox-react-northstar-template/tsconfig.json"
-codesandbox-react-northstar-template:     at ChildProcess.exithandler (child_process.js:303:12)
-codesandbox-react-northstar-template:     at ChildProcess.emit (events.js:315:20)
-codesandbox-react-northstar-template:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-codesandbox-react-northstar-template:     at maybeClose (internal/child_process.js:1026:16)
-codesandbox-react-northstar-template:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-codesandbox-react-northstar-template: [XX:XX:XX XM] x stdout:
-codesandbox-react-northstar-template: [XX:XX:XX XM] x src/index.tsx:15:8 - error TS2307: Cannot find module '@fluentui/react-northstar' or its corresponding type declarations.
-codesandbox-react-northstar-template: 15 } from '@fluentui/react-northstar';
-codesandbox-react-northstar-template:           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-codesandbox-react-northstar-template: src/index.tsx:16:28 - error TS2307: Cannot find module '@fluentui/code-sandbox' or its corresponding type declarations.
-codesandbox-react-northstar-template: 16 import { SandboxApp } from '@fluentui/code-sandbox';
-codesandbox-react-northstar-template:                               ~~~~~~~~~~~~~~~~~~~~~~~~
-codesandbox-react-northstar-template: Found 2 errors.
-codesandbox-react-northstar-template: [XX:XX:XX XM] x ------------------------------------
-codesandbox-react-northstar-template: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-codesandbox-react-northstar-template: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
-codesandbox-react-northstar-template: error Command failed with exit code 1.
-@fluentui/docs: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/docs: [XX:XX:XX XM] x Command not defined: ts
-@uifabric/example-app-base: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@uifabric/example-app-base: [XX:XX:XX XM] x ------------------------------------
-@uifabric/example-app-base: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/example-app-base/tsconfig.json"
-@uifabric/example-app-base:     at ChildProcess.exithandler (child_process.js:303:12)
-@uifabric/example-app-base:     at ChildProcess.emit (events.js:315:20)
-@uifabric/example-app-base:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@uifabric/example-app-base:     at maybeClose (internal/child_process.js:1026:16)
-@uifabric/example-app-base:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@uifabric/example-app-base: [XX:XX:XX XM] x stdout:
-@uifabric/example-app-base: [XX:XX:XX XM] x src/components/Page/Page.tsx:21:25 - error TS2307: Cannot find module './Page.module.scss' or its corresponding type declarations.
-@uifabric/example-app-base: 21 import * as styles from './Page.module.scss';
-@uifabric/example-app-base:                            ~~~~~~~~~~~~~~~~~~~~
-@uifabric/example-app-base: src/components/Page/sections/BestPracticesSection.tsx:7:25 - error TS2307: Cannot find module '../Page.module.scss' or its corresponding type declarations.
-@uifabric/example-app-base: 7 import * as styles from '../Page.module.scss';
-@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
-@uifabric/example-app-base: src/components/Page/sections/ExamplesSection.tsx:4:25 - error TS2307: Cannot find module '../Page.module.scss' or its corresponding type declarations.
-@uifabric/example-app-base: 4 import * as styles from '../Page.module.scss';
-@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
-@uifabric/example-app-base: src/components/Page/sections/FeedbackSection.tsx:5:25 - error TS2307: Cannot find module '../Page.module.scss' or its corresponding type declarations.
-@uifabric/example-app-base: 5 import * as styles from '../Page.module.scss';
-@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
-@uifabric/example-app-base: src/components/Page/sections/ImplementationSection.tsx:5:25 - error TS2307: Cannot find module '../Page.module.scss' or its corresponding type declarations.
-@uifabric/example-app-base: 5 import * as styles from '../Page.module.scss';
-@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
-@uifabric/example-app-base: src/components/Page/sections/MarkdownSection.tsx:7:25 - error TS2307: Cannot find module '../Page.module.scss' or its corresponding type declarations.
-@uifabric/example-app-base: 7 import * as styles from '../Page.module.scss';
-@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
-@uifabric/example-app-base: src/components/Page/sections/OtherPageSection.tsx:4:25 - error TS2307: Cannot find module '../Page.module.scss' or its corresponding type declarations.
-@uifabric/example-app-base: 4 import * as styles from '../Page.module.scss';
-@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
-@uifabric/example-app-base: src/components/Page/sections/OverviewSection.tsx:4:25 - error TS2307: Cannot find module '../Page.module.scss' or its corresponding type declarations.
-@uifabric/example-app-base: 4 import * as styles from '../Page.module.scss';
-@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
-@uifabric/example-app-base: src/components/PlatformPicker/PlatformPicker.tsx:12:25 - error TS2307: Cannot find module './PlatformPicker.module.scss' or its corresponding type declarations.
-@uifabric/example-app-base: 12 import * as styles from './PlatformPicker.module.scss';
-@uifabric/example-app-base:                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/example-app-base: src/components/Table/Table.tsx:4:25 - error TS2307: Cannot find module './Table.module.scss' or its corresponding type declarations.
-@uifabric/example-app-base: 4 import * as styles from './Table.module.scss';
-@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
-@uifabric/example-app-base: src/components/TopNav/TopNav.tsx:7:25 - error TS2307: Cannot find module './TopNav.module.scss' or its corresponding type declarations.
-@uifabric/example-app-base: 7 import * as styles from './TopNav.module.scss';
-@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/example-app-base: src/components/Video/Video.tsx:4:25 - error TS2307: Cannot find module './Video.module.scss' or its corresponding type declarations.
-@uifabric/example-app-base: 4 import * as styles from './Video.module.scss';
-@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
-@uifabric/example-app-base: src/utilities/createDemoApp.tsx:52:71 - error TS2783: 'appDefinition' is specified more than once, so this usage will be overwritten.
-@uifabric/example-app-base: 52     const App: React.FunctionComponent<IAppProps> = props => <AppBase appDefinition={appDefinition} {...props} />;
-@uifabric/example-app-base:                                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/example-app-base:   src/utilities/createDemoApp.tsx:52:101
-@uifabric/example-app-base:     52     const App: React.FunctionComponent<IAppProps> = props => <AppBase appDefinition={appDefinition} {...props} />;
-@uifabric/example-app-base:                                                                                                            ~~~~~~~~~~
-@uifabric/example-app-base:     This spread always overwrites this property.
-@uifabric/example-app-base: Found 13 errors.
-@uifabric/example-app-base: [XX:XX:XX XM] x ------------------------------------
-@uifabric/example-app-base: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@uifabric/example-app-base: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@uifabric/example-app-base: error Command failed with exit code 1.
-@fluentui/storybook: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@fluentui/storybook: [XX:XX:XX XM] x ------------------------------------
-@fluentui/storybook: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/storybook/tsconfig.json"
-@fluentui/storybook:     at ChildProcess.exithandler (child_process.js:303:12)
-@fluentui/storybook:     at ChildProcess.emit (events.js:315:20)
-@fluentui/storybook:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@fluentui/storybook:     at maybeClose (internal/child_process.js:1026:16)
-@fluentui/storybook:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@fluentui/storybook: [XX:XX:XX XM] x stdout:
-@fluentui/storybook: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-@fluentui/storybook: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-@fluentui/storybook:                      ~~~~~~~~~~~~~~~~
-@fluentui/storybook: Found 1 error.
-@fluentui/storybook: [XX:XX:XX XM] x ------------------------------------
-@fluentui/storybook: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@fluentui/storybook: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@fluentui/storybook: error Command failed with exit code 1.
-@fluentui/perf: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
-@fluentui/perf: [XX:XX:XX XM] x Command not defined: ts
-@uifabric/date-time: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
-@uifabric/date-time: [XX:XX:XX XM] x ------------------------------------
-@uifabric/date-time: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/date-time/tsconfig.json"
-@uifabric/date-time:     at ChildProcess.exithandler (child_process.js:303:12)
-@uifabric/date-time:     at ChildProcess.emit (events.js:315:20)
-@uifabric/date-time:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@uifabric/date-time:     at maybeClose (internal/child_process.js:1026:16)
-@uifabric/date-time:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@uifabric/date-time: [XX:XX:XX XM] x stdout:
-@uifabric/date-time: [XX:XX:XX XM] x src/components/Calendar/examples/Calendar.Inline.ContiguousWorkWeekDays.Example.tsx:30:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 30       <div className={styles.wrapper}>
-@uifabric/date-time:                                 ~~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.CustomDayCellRef.Example.tsx:28:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 28       <div className={styles.wrapper}>
-@uifabric/date-time:                                 ~~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.DateBoundaries.Example.tsx:27:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 27       <div className={styles.wrapper}>
-@uifabric/date-time:                                 ~~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.MonthOnly.Example.tsx:30:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 30       <div className={styles.wrapper}>
-@uifabric/date-time:                                 ~~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.MonthSelection.Example.tsx:34:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 34       <div className={styles.wrapper}>
-@uifabric/date-time:                                 ~~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.MonthSelection.Example.tsx:54:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 54           <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
-@uifabric/date-time:                                               ~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.MonthSelection.Example.tsx:55:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 55           <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
-@uifabric/date-time:                                               ~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.MultidayDayView.Example.tsx:35:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 35       <div className={styles.wrapper}>
-@uifabric/date-time:                                 ~~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.MultidayDayView.Example.tsx:59:31 - error TS2339: Property 'dropdown' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 59             className={styles.dropdown}
-@uifabric/date-time:                                  ~~~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.NonContiguousWorkWeekDays.Example.tsx:30:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 30       <div className={styles.wrapper}>
-@uifabric/date-time:                                 ~~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.OverlayedMonthPicker.Example.tsx:21:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 21       <div className={styles.wrapper}>
-@uifabric/date-time:                                 ~~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.SixWeeks.tsx:21:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 21       <div className={styles.wrapper}>
-@uifabric/date-time:                                 ~~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.WeekNumbers.Example.tsx:21:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 21       <div className={styles.wrapper}>
-@uifabric/date-time:                                 ~~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.WeekSelection.Example.tsx:34:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 34       <div className={styles.wrapper}>
-@uifabric/date-time:                                 ~~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.WeekSelection.Example.tsx:54:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 54           <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
-@uifabric/date-time:                                               ~~~~~~
-@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.WeekSelection.Example.tsx:55:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 55           <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
-@uifabric/date-time:                                               ~~~~~~
-@uifabric/date-time: src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx:22:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 22       <div className={styles.wrapper}>
-@uifabric/date-time:                                 ~~~~~~~
-@uifabric/date-time: src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx:34:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 34           <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
-@uifabric/date-time:                                               ~~~~~~
-@uifabric/date-time: src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx:35:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 35           <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
-@uifabric/date-time:                                               ~~~~~~
-@uifabric/date-time: src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Expandable.Example.tsx:27:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 27       <div className={styles.wrapper}>
-@uifabric/date-time:                                 ~~~~~~~
-@uifabric/date-time: src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Expandable.Example.tsx:34:31 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 34             className={styles.button}
-@uifabric/date-time:                                  ~~~~~~
-@uifabric/date-time: src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Expandable.Example.tsx:49:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 49           <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
-@uifabric/date-time:                                               ~~~~~~
-@uifabric/date-time: src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Expandable.Example.tsx:50:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
-@uifabric/date-time: 50           <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
-@uifabric/date-time:                                               ~~~~~~
-@uifabric/date-time: ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-@uifabric/date-time: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-@uifabric/date-time:                      ~~~~~~~~~~~~~~~~
-@uifabric/date-time: ../tsx-editor/lib/interfaces/monaco.d.ts:1:25 - error TS2307: Cannot find module '@uifabric/monaco-editor/esm/vs/editor/editor.api' or its corresponding type declarations.
-@uifabric/date-time: 1 import * as monaco from '@uifabric/monaco-editor/esm/vs/editor/editor.api';
-@uifabric/date-time:                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/date-time: Found 25 errors.
-@uifabric/date-time: [XX:XX:XX XM] x ------------------------------------
-@uifabric/date-time: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@uifabric/date-time: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
-@uifabric/date-time: error Command failed with exit code 1.
-@uifabric/experiments: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@uifabric/experiments: [XX:XX:XX XM] x ------------------------------------
-@uifabric/experiments: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/experiments/tsconfig.json"
-@uifabric/experiments:     at ChildProcess.exithandler (child_process.js:303:12)
-@uifabric/experiments:     at ChildProcess.emit (events.js:315:20)
-@uifabric/experiments:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@uifabric/experiments:     at maybeClose (internal/child_process.js:1026:16)
-@uifabric/experiments:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@uifabric/experiments: [XX:XX:XX XM] x stdout:
-@uifabric/experiments: [XX:XX:XX XM] x src/components/FloatingSuggestions/FloatingPeopleSuggestions/defaults/DefaultPeopleSuggestionsItem.tsx:12:72 - error TS2339: Property 'peoplePickerPersonaContent' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 12     <div className={css('ms-PeoplePicker-personaContent', stylesImport.peoplePickerPersonaContent)}>
-@uifabric/experiments:                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/experiments: src/components/FloatingSuggestions/FloatingPeopleSuggestions/defaults/DefaultPeopleSuggestionsItem.tsx:16:64 - error TS2339: Property 'peoplePickerPersona' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 16         className={css('ms-PeoplePicker-Persona', stylesImport.peoplePickerPersona)}
-@uifabric/experiments:                                                                   ~~~~~~~~~~~~~~~~~~~
-@uifabric/experiments: src/components/FloatingSuggestions/FloatingSuggestions.tsx:202:27 - error TS2339: Property 'callout' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 202         className={styles.callout}
-@uifabric/experiments:                               ~~~~~~~
-@uifabric/experiments: src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx:75:102 - error TS2339: Property 'editingContainer' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 75       <span aria-labelledby={'editingItemPersona-' + itemId} className={css('ms-EditingItem', styles.editingContainer)}>
-@uifabric/experiments:                                                                                                         ~~~~~~~~~~~~~~~~
-@uifabric/experiments: src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx:86:29 - error TS2339: Property 'editingInput' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 86           className={styles.editingInput}
-@uifabric/experiments:                                ~~~~~~~~~~~~
-@uifabric/experiments: src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx:135:9 - error TS2322: Type 'ComponentType<TriggerProps<unknown>>' is not assignable to type 'ComponentClass<ISelectedItemProps<IPersonaProps & BaseSelectedItem>, any> | FunctionComponent<ISelectedItemProps<IPersonaProps & BaseSelectedItem>> | undefined'.
-@uifabric/experiments:   Type 'ComponentClass<TriggerProps<unknown>, any>' is not assignable to type 'ComponentClass<ISelectedItemProps<IPersonaProps & BaseSelectedItem>, any> | FunctionComponent<ISelectedItemProps<IPersonaProps & BaseSelectedItem>> | undefined'.
-@uifabric/experiments:     Type 'ComponentClass<TriggerProps<unknown>, any>' is not assignable to type 'ComponentClass<ISelectedItemProps<IPersonaProps & BaseSelectedItem>, any>'.
-@uifabric/experiments:       Types of property 'propTypes' are incompatible.
-@uifabric/experiments:         Type 'WeakValidationMap<TriggerProps<unknown>> | undefined' is not assignable to type 'WeakValidationMap<ISelectedItemProps<IPersonaProps & BaseSelectedItem>> | undefined'.
-@uifabric/experiments:           Type 'WeakValidationMap<TriggerProps<unknown>>' is not assignable to type 'WeakValidationMap<ISelectedItemProps<IPersonaProps & BaseSelectedItem>>'.
-@uifabric/experiments:             Types of property 'item' are incompatible.
-@uifabric/experiments:               Type 'Validator<unknown> | undefined' is not assignable to type 'Validator<IPersonaProps & BaseSelectedItem> | undefined'.
-@uifabric/experiments:                 Type 'Validator<unknown>' is not assignable to type 'Validator<IPersonaProps & BaseSelectedItem>'.
-@uifabric/experiments:                   Type 'unknown' is not assignable to type 'IPersonaProps & BaseSelectedItem'.
-@uifabric/experiments:                     Type 'unknown' is not assignable to type 'IPersonaProps'.
-@uifabric/experiments: 135         onRenderItem={SelectedItem}
-@uifabric/experiments:             ~~~~~~~~~~~~
-@uifabric/experiments:   src/components/SelectedItemsList/SelectedItemsList.types.ts:75:3
-@uifabric/experiments:     75   onRenderItem?: React.ComponentType<ISelectedItemProps<T>>;
-@uifabric/experiments:          ~~~~~~~~~~~~
-@uifabric/experiments:     The expected type comes from property 'onRenderItem' which is declared here on type 'IntrinsicAttributes & Pick<ISelectedPeopleListProps<IPersonaProps & BaseSelectedItem>, "onChange" | ... 12 more ... | "canRemoveItem"> & RefAttributes<...>'
-@uifabric/experiments: src/components/StaticList/StaticList.tsx:14:37 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 14       { className: css(stylesImport.root, className) },
-@uifabric/experiments:                                        ~~~~
-@uifabric/experiments: src/components/Tile/Tile.tsx:175:97 - error TS2339: Property 'label' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 175           <span key="label" id={this._labelId} className={css('ms-Tile-label', TileStylesModule.label)}>
-@uifabric/experiments:                                                                                                     ~~~~~
-@uifabric/experiments: src/components/Tile/Tile.tsx:253:68 - error TS2339: Property 'description' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 253             className={css('ms-Tile-description', TileStylesModule.description)}
-@uifabric/experiments:                                                                        ~~~~~~~~~~~
-@uifabric/experiments: src/components/Tile/examples/Tile.Folder.Example.tsx:85:56 - error TS2339: Property 'tileFolder' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 85           <span className={css(TileExampleStylesModule.tileFolder)}>
-@uifabric/experiments:                                                           ~~~~~~~~~~
-@uifabric/experiments: src/components/Tile/examples/Tile.Media.Example.tsx:21:50 - error TS2339: Property 'activityBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 21         <span className={TileExampleStylesModule.activityBlock}>
-@uifabric/experiments:                                                     ~~~~~~~~~~~~~
-@uifabric/experiments: src/components/Tile/examples/Tile.Media.Example.tsx:41:50 - error TS2339: Property 'activityBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 41         <span className={TileExampleStylesModule.activityBlock}>
-@uifabric/experiments:                                                     ~~~~~~~~~~~~~
-@uifabric/experiments: src/components/Tile/examples/Tile.Media.Example.tsx:61:50 - error TS2339: Property 'activityBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 61         <span className={TileExampleStylesModule.activityBlock}>
-@uifabric/experiments:                                                     ~~~~~~~~~~~~~
-@uifabric/experiments: src/components/Tile/examples/Tile.Media.Example.tsx:81:50 - error TS2339: Property 'activityBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 81         <span className={TileExampleStylesModule.activityBlock}>
-@uifabric/experiments:                                                     ~~~~~~~~~~~~~
-@uifabric/experiments: src/components/VirtualizedList/examples/VirtualizedList.Basic.Example.tsx:33:72 - error TS2339: Property 'fixedHeight' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 33         <ScrollContainer className={VirtualizedListExampleStylesModule.fixedHeight}>
-@uifabric/experiments:                                                                           ~~~~~~~~~~~
-@uifabric/experiments: src/components/VirtualizedList/examples/VirtualizedList.Basic2.Example.tsx:39:98 - error TS2339: Property 'fixedHeight' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 39         <ScrollContainer scrollDebounceDelay={200} className={VirtualizedListExampleStylesModule.fixedHeight}>
-@uifabric/experiments:                                                                                                     ~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signal.tsx:15:83 - error TS2339: Property 'signal' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 15     <span aria-label={props.ariaLabel} {...spanProps} className={css(SignalStyles.signal, className)}>
-@uifabric/experiments:                                                                                      ~~~~~~
-@uifabric/experiments: src/components/signals/SignalField.tsx:24:27 - error TS2339: Property 'signalField' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 24         SignalFieldStyles.signalField,
-@uifabric/experiments:                              ~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/SignalField.tsx:26:30 - error TS2339: Property 'wide' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 26           [SignalFieldStyles.wide]: signalsFieldMode === 'wide',
-@uifabric/experiments:                                 ~~~~
-@uifabric/experiments: src/components/signals/SignalField.tsx:27:30 - error TS2339: Property 'compact' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 27           [SignalFieldStyles.compact]: signalsFieldMode === 'compact',
-@uifabric/experiments:                                 ~~~~~~~
-@uifabric/experiments: src/components/signals/SignalField.tsx:33:42 - error TS2339: Property 'signalFieldValue' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 33       <span className={SignalFieldStyles.signalFieldValue}>{props.children}</span>
-@uifabric/experiments:                                             ~~~~~~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:13:60 - error TS2339: Property 'youCheckedOut' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 13   return <IconSignal {...props} signalClass={SignalsStyles.youCheckedOut} iconName="checkedoutbyyou12" />;
-@uifabric/experiments:                                                               ~~~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:17:60 - error TS2339: Property 'blocked' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 17   return <IconSignal {...props} signalClass={SignalsStyles.blocked} iconName="blocked12" />;
-@uifabric/experiments:                                                               ~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:24:34 - error TS2339: Property 'missingMetadata' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 24       signalClass={SignalsStyles.missingMetadata}
-@uifabric/experiments:                                     ~~~~~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:31:60 - error TS2339: Property 'warning' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 31   return <IconSignal {...props} signalClass={SignalsStyles.warning} iconName="warning12" />;
-@uifabric/experiments:                                                               ~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:35:60 - error TS2339: Property 'awaitingApproval' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 35   return <IconSignal {...props} signalClass={SignalsStyles.awaitingApproval} iconName="clock" />;
-@uifabric/experiments:                                                               ~~~~~~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:39:60 - error TS2339: Property 'trending' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 39   return <IconSignal {...props} signalClass={SignalsStyles.trending} iconName="market" />;
-@uifabric/experiments:                                                               ~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:43:60 - error TS2339: Property 'someoneCheckedOut' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 43   return <IconSignal {...props} signalClass={SignalsStyles.someoneCheckedOut} iconName="checkedoutbyother12" />;
-@uifabric/experiments:                                                               ~~~~~~~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:47:60 - error TS2339: Property 'record' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 47   return <IconSignal {...props} signalClass={SignalsStyles.record} iconName="lock" />;
-@uifabric/experiments:                                                               ~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:51:60 - error TS2339: Property 'needsRepublishing' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 51   return <IconSignal {...props} signalClass={SignalsStyles.needsRepublishing} iconName="readingmode" />;
-@uifabric/experiments:                                                               ~~~~~~~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:55:60 - error TS2339: Property 'itemScheduled' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 55   return <IconSignal {...props} signalClass={SignalsStyles.itemScheduled} iconName="datetime2" />;
-@uifabric/experiments:                                                               ~~~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:65:54 - error TS2339: Property 'signal' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 65     <span {...spanProps} className={css(SignalStyles.signal, SignalsStyles.newSignal)}>
-@uifabric/experiments:                                                         ~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:65:76 - error TS2339: Property 'newSignal' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 65     <span {...spanProps} className={css(SignalStyles.signal, SignalsStyles.newSignal)}>
-@uifabric/experiments:                                                                               ~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:66:70 - error TS2339: Property 'newIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 66       <Icon ariaLabel={props.ariaLabel} className={css(SignalsStyles.newIcon)} iconName="glimmer" />
-@uifabric/experiments:                                                                         ~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:77:58 - error TS2339: Property 'liveEdit' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 77   return <Signal className={css(className, SignalsStyles.liveEdit)} {...spanProps} />;
-@uifabric/experiments:                                                             ~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:81:60 - error TS2339: Property 'mention' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 81   return <IconSignal {...props} signalClass={SignalsStyles.mention} iconName="accounts" />;
-@uifabric/experiments:                                                               ~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:91:42 - error TS2339: Property 'comments' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 91     <Signal className={css(SignalsStyles.comments, className)} {...spanProps}>
-@uifabric/experiments:                                             ~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:92:70 - error TS2339: Property 'commentsIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 92       <Icon ariaLabel={props.ariaLabel} className={css(SignalsStyles.commentsIcon)} iconName="MessageFill" />
-@uifabric/experiments:                                                                         ~~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:93:54 - error TS2339: Property 'commentsCount' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 93       {children ? <span className={css(SignalsStyles.commentsCount)}>{children}</span> : null}
-@uifabric/experiments:                                                         ~~~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:102:60 - error TS2339: Property 'unseenReply' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 102   return <IconSignal {...props} signalClass={SignalsStyles.unseenReply} iconName="commentprevious" />;
-@uifabric/experiments:                                                                ~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:106:60 - error TS2339: Property 'unseenEdit' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 106   return <IconSignal {...props} signalClass={SignalsStyles.unseenEdit} iconName="edit" />;
-@uifabric/experiments:                                                                ~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:110:60 - error TS2339: Property 'readOnly' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 110   return <IconSignal {...props} signalClass={SignalsStyles.readOnly} iconName="uneditablesolid12" />;
-@uifabric/experiments:                                                                ~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:114:60 - error TS2339: Property 'emailed' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 114   return <IconSignal {...props} signalClass={SignalsStyles.emailed} iconName="mail" />;
-@uifabric/experiments:                                                                ~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:118:60 - error TS2339: Property 'shared' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 118   return <IconSignal {...props} signalClass={SignalsStyles.shared} iconName="people" />;
-@uifabric/experiments:                                                                ~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:122:60 - error TS2339: Property 'folder' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 122   return <IconSignal {...props} signalClass={SignalsStyles.folder} iconName="TVMonitor" />;
-@uifabric/experiments:                                                                ~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:126:60 - error TS2339: Property 'folder' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 126   return <IconSignal {...props} signalClass={SignalsStyles.folder} iconName="Page" />;
-@uifabric/experiments:                                                                ~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:130:60 - error TS2339: Property 'folder' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 130   return <IconSignal {...props} signalClass={SignalsStyles.folder} iconName="Photo2" />;
-@uifabric/experiments:                                                                ~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:134:60 - error TS2339: Property 'malwareDetected' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 134   return <IconSignal {...props} signalClass={SignalsStyles.malwareDetected} iconName="BlockedSiteSolid12" />;
-@uifabric/experiments:                                                                ~~~~~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:143:60 - error TS2339: Property 'external' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 143   return <IconSignal {...props} signalClass={SignalsStyles.external} iconName="Globe" />;
-@uifabric/experiments:                                                                ~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:147:60 - error TS2339: Property 'bookmarkOutline' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 147   return <IconSignal {...props} signalClass={SignalsStyles.bookmarkOutline} iconName="SingleBookmark" />;
-@uifabric/experiments:                                                                ~~~~~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:151:60 - error TS2339: Property 'bookmarkFilled' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 151   return <IconSignal {...props} signalClass={SignalsStyles.bookmarkFilled} iconName="SingleBookmarkSolid" />;
-@uifabric/experiments:                                                                ~~~~~~~~~~~~~~
-@uifabric/experiments: src/components/signals/Signals.tsx:169:82 - error TS2339: Property 'signal' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 169     <Icon {...spanProps} ariaLabel={props.ariaLabel} className={css(SignalStyles.signal, signalClass, className)} />
-@uifabric/experiments:                                                                                      ~~~~~~
-@uifabric/experiments: src/utilities/scrolling/ScrollContainer.tsx:76:68 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
-@uifabric/experiments: 76         className={css('ms-ScrollContainer', ScrollContainerStyles.root, className)}
-@uifabric/experiments:                                                                       ~~~~
-@uifabric/experiments: Found 53 errors.
-@uifabric/experiments: [XX:XX:XX XM] x ------------------------------------
-@uifabric/experiments: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@uifabric/experiments: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@uifabric/experiments: error Command failed with exit code 1.
-@uifabric/lists: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@uifabric/lists: [XX:XX:XX XM] x ------------------------------------
-@uifabric/lists: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/lists/tsconfig.json"
-@uifabric/lists:     at ChildProcess.exithandler (child_process.js:303:12)
-@uifabric/lists:     at ChildProcess.emit (events.js:315:20)
-@uifabric/lists:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@uifabric/lists:     at maybeClose (internal/child_process.js:1026:16)
-@uifabric/lists:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@uifabric/lists: [XX:XX:XX XM] x stdout:
-@uifabric/lists: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-@uifabric/lists: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-@uifabric/lists:                      ~~~~~~~~~~~~~~~~
-@uifabric/lists: ../tsx-editor/lib/interfaces/monaco.d.ts:1:25 - error TS2307: Cannot find module '@uifabric/monaco-editor/esm/vs/editor/editor.api' or its corresponding type declarations.
-@uifabric/lists: 1 import * as monaco from '@uifabric/monaco-editor/esm/vs/editor/editor.api';
-@uifabric/lists:                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/lists: Found 2 errors.
-@uifabric/lists: [XX:XX:XX XM] x ------------------------------------
-@uifabric/lists: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@uifabric/lists: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@uifabric/lists: error Command failed with exit code 1.
-@uifabric/react-cards: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@uifabric/react-cards: [XX:XX:XX XM] x ------------------------------------
-@uifabric/react-cards: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-cards/tsconfig.json"
-@uifabric/react-cards:     at ChildProcess.exithandler (child_process.js:303:12)
-@uifabric/react-cards:     at ChildProcess.emit (events.js:315:20)
-@uifabric/react-cards:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@uifabric/react-cards:     at maybeClose (internal/child_process.js:1026:16)
-@uifabric/react-cards:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@uifabric/react-cards: [XX:XX:XX XM] x stdout:
-@uifabric/react-cards: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-@uifabric/react-cards: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-@uifabric/react-cards:                      ~~~~~~~~~~~~~~~~
-@uifabric/react-cards: ../tsx-editor/lib/interfaces/monaco.d.ts:1:25 - error TS2307: Cannot find module '@uifabric/monaco-editor/esm/vs/editor/editor.api' or its corresponding type declarations.
-@uifabric/react-cards: 1 import * as monaco from '@uifabric/monaco-editor/esm/vs/editor/editor.api';
-@uifabric/react-cards:                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@uifabric/react-cards: Found 2 errors.
-@uifabric/react-cards: [XX:XX:XX XM] x ------------------------------------
-@uifabric/react-cards: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@uifabric/react-cards: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@uifabric/react-cards: error Command failed with exit code 1.
-@fluentui/react-avatar: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@fluentui/react-avatar: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react-avatar: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-avatar/tsconfig.json"
-@fluentui/react-avatar:     at ChildProcess.exithandler (child_process.js:303:12)
-@fluentui/react-avatar:     at ChildProcess.emit (events.js:315:20)
-@fluentui/react-avatar:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@fluentui/react-avatar:     at maybeClose (internal/child_process.js:1026:16)
-@fluentui/react-avatar:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@fluentui/react-avatar: [XX:XX:XX XM] x stdout:
-@fluentui/react-avatar: [XX:XX:XX XM] x src/components/Avatar/Avatar.tsx:10:38 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
-@fluentui/react-avatar: 10 const useAvatarClasses = makeClasses(classes);
-@fluentui/react-avatar:                                         ~~~~~~~
-@fluentui/react-avatar: src/components/Status/Status.tsx:8:45 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
-@fluentui/react-avatar:   Property 'styles' is incompatible with index signature.
-@fluentui/react-avatar:     Type '{ [className: string]: string; }' is not assignable to type 'string'.
-@fluentui/react-avatar: 8 export const useStatusClasses = makeClasses(classes);
-@fluentui/react-avatar:                                               ~~~~~~~
-@fluentui/react-avatar: src/components/utils/StoryExample.tsx:5:27 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-avatar: 5   <div className={classes.root}>
-@fluentui/react-avatar:                             ~~~~
-@fluentui/react-avatar: src/components/utils/StoryExample.tsx:7:29 - error TS2339: Property 'content' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-avatar: 7     <div className={classes.content}>{children}</div>
-@fluentui/react-avatar:                               ~~~~~~~
-@fluentui/react-avatar: Found 4 errors.
-@fluentui/react-avatar: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react-avatar: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@fluentui/react-avatar: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@fluentui/react-avatar: error Command failed with exit code 1.
-@fluentui/react-button: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
-@fluentui/react-button: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react-button: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-button/tsconfig.json"
-@fluentui/react-button:     at ChildProcess.exithandler (child_process.js:303:12)
-@fluentui/react-button:     at ChildProcess.emit (events.js:315:20)
-@fluentui/react-button:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@fluentui/react-button:     at maybeClose (internal/child_process.js:1026:16)
-@fluentui/react-button:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@fluentui/react-button: [XX:XX:XX XM] x stdout:
-@fluentui/react-button: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-@fluentui/react-button: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-@fluentui/react-button:                      ~~~~~~~~~~~~~~~~
-@fluentui/react-button: src/components/Button/Button.stories.tsx:12:57 - error TS2339: Property 'hStack' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-button: 12   return <div {...rest} className={horizontal ? classes.hStack : classes.vStack} />;
-@fluentui/react-button:                                                            ~~~~~~
-@fluentui/react-button: src/components/Button/Button.stories.tsx:12:74 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-button: 12   return <div {...rest} className={horizontal ? classes.hStack : classes.vStack} />;
-@fluentui/react-button:                                                                             ~~~~~~
-@fluentui/react-button: src/components/Button/Button.stories.tsx:19:88 - error TS2339: Property 'text' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-button: 19 const Text = (props: React.PropsWithChildren<{}>) => <h2 {...props} className={classes.text} />;
-@fluentui/react-button:                                                                                           ~~~~
-@fluentui/react-button: src/components/Button/Button.tsx:10:45 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
-@fluentui/react-button:   Property 'styles' is incompatible with index signature.
-@fluentui/react-button:     Type '{ [className: string]: string; }' is not assignable to type 'string'.
-@fluentui/react-button: 10 export const useButtonClasses = makeClasses(classes);
-@fluentui/react-button:                                                ~~~~~~~
-@fluentui/react-button: src/components/MenuButton/MenuButton.stories.tsx:21:27 - error TS2339: Property 'hStack' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-button: 21   <div className={classes.hStack}>
-@fluentui/react-button:                              ~~~~~~
-@fluentui/react-button: src/components/MenuButton/MenuButton.stories.tsx:46:29 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-button: 46     <div className={classes.vStack}>
-@fluentui/react-button:                                ~~~~~~
-@fluentui/react-button: src/components/MenuButton/MenuButton.stories.tsx:68:29 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-button: 68     <div className={classes.vStack}>
-@fluentui/react-button:                                ~~~~~~
-@fluentui/react-button: src/components/MenuButton/MenuButton.tsx:11:49 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
-@fluentui/react-button: 11 export const useMenuButtonClasses = makeClasses(classes);
-@fluentui/react-button:                                                    ~~~~~~~
-@fluentui/react-button: src/components/SplitButton/SplitButton.stories.tsx:21:27 - error TS2339: Property 'hStack' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-button: 21   <div className={classes.hStack}>
-@fluentui/react-button:                              ~~~~~~
-@fluentui/react-button: src/components/SplitButton/SplitButton.stories.tsx:46:29 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-button: 46     <div className={classes.vStack}>
-@fluentui/react-button:                                ~~~~~~
-@fluentui/react-button: src/components/SplitButton/SplitButton.stories.tsx:68:29 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-button: 68     <div className={classes.vStack}>
-@fluentui/react-button:                                ~~~~~~
-@fluentui/react-button: src/components/SplitButton/SplitButton.tsx:12:50 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
-@fluentui/react-button: 12 export const useSplitButtonClasses = makeClasses(classes);
-@fluentui/react-button:                                                     ~~~~~~~
-@fluentui/react-button: src/components/ToggleButton/ToggleButton.stories.tsx:8:27 - error TS2339: Property 'hStack' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-button: 8   <div className={classes.hStack}>
-@fluentui/react-button:                             ~~~~~~
-@fluentui/react-button: src/components/ToggleButton/ToggleButton.stories.tsx:33:29 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-button: 33     <div className={classes.vStack}>
-@fluentui/react-button:                                ~~~~~~
-@fluentui/react-button: src/components/ToggleButton/ToggleButton.stories.tsx:52:29 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-button: 52     <div className={classes.vStack}>
-@fluentui/react-button:                                ~~~~~~
-@fluentui/react-button: src/components/ToggleButton/ToggleButton.stories.tsx:61:29 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-button: 61     <div className={classes.vStack}>
-@fluentui/react-button:                                ~~~~~~
-@fluentui/react-button: src/components/ToggleButton/ToggleButton.tsx:10:51 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
-@fluentui/react-button: 10 export const useToggleButtonClasses = makeClasses(toggleButtonClasses);
-@fluentui/react-button:                                                      ~~~~~~~~~~~~~~~~~~~
-@fluentui/react-button: Found 18 errors.
-@fluentui/react-button: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react-button: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@fluentui/react-button: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
-@fluentui/react-button: error Command failed with exit code 1.
-@fluentui/react-tabs: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@fluentui/react-tabs: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react-tabs: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-tabs/tsconfig.json"
-@fluentui/react-tabs:     at ChildProcess.exithandler (child_process.js:303:12)
-@fluentui/react-tabs:     at ChildProcess.emit (events.js:315:20)
-@fluentui/react-tabs:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@fluentui/react-tabs:     at maybeClose (internal/child_process.js:1026:16)
-@fluentui/react-tabs:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@fluentui/react-tabs: [XX:XX:XX XM] x stdout:
-@fluentui/react-tabs: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-@fluentui/react-tabs: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-@fluentui/react-tabs:                      ~~~~~~~~~~~~~~~~
-@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:27:39 - error TS2339: Property 'linkSize_large' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-tabs: 27       linkSize === 'large' && classes.linkSize_large,
-@fluentui/react-tabs:                                          ~~~~~~~~~~~~~~
-@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:28:40 - error TS2339: Property 'linkFormat_tabs' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-tabs: 28       linkFormat === 'tabs' && classes.linkFormat_tabs,
-@fluentui/react-tabs:                                           ~~~~~~~~~~~~~~~
-@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:34:17 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-tabs: 34         classes.root,
-@fluentui/react-tabs:                    ~~~~
-@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:40:25 - error TS2339: Property 'link' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-tabs: 40       link: css(classes.link, globalClassNames.link, ...modifierClasses),
-@fluentui/react-tabs:                            ~~~~
-@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:41:31 - error TS2339: Property 'linkInMenu' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-tabs: 41       linkInMenu: css(classes.linkInMenu, globalClassNames.linkInMenu, ...modifierClasses),
-@fluentui/react-tabs:                                  ~~~~~~~~~~
-@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:43:35 - error TS2339: Property 'linkIsSelected' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-tabs: 43       linkIsSelected: css(classes.linkIsSelected, globalClassNames.linkIsSelected),
-@fluentui/react-tabs:                                      ~~~~~~~~~~~~~~
-@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:44:32 - error TS2339: Property 'linkContent' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-tabs: 44       linkContent: css(classes.linkContent, globalClassNames.linkContent, ...modifierClasses),
-@fluentui/react-tabs:                                   ~~~~~~~~~~~
-@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:45:25 - error TS2339: Property 'text' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-tabs: 45       text: css(classes.text, globalClassNames.text, ...modifierClasses),
-@fluentui/react-tabs:                            ~~~~
-@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:46:26 - error TS2339: Property 'count' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-tabs: 46       count: css(classes.count, globalClassNames.count, ...modifierClasses),
-@fluentui/react-tabs:                             ~~~~~
-@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:48:34 - error TS2339: Property 'itemContainer' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-tabs: 48       itemContainer: css(classes.itemContainer, ...modifierClasses),
-@fluentui/react-tabs:                                     ~~~~~~~~~~~~~
-@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:49:39 - error TS2339: Property 'overflowMenuButton' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-tabs: 49       overflowMenuButton: css(classes.overflowMenuButton, globalClassNames.overflowMenuButton, ...modifierClasses),
-@fluentui/react-tabs:                                          ~~~~~~~~~~~~~~~~~~
-@fluentui/react-tabs: Found 12 errors.
-@fluentui/react-tabs: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react-tabs: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@fluentui/react-tabs: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@fluentui/react-tabs: error Command failed with exit code 1.
-theming-designer: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-theming-designer: [XX:XX:XX XM] x ------------------------------------
-theming-designer: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/theming-designer/tsconfig.json"
-theming-designer:     at ChildProcess.exithandler (child_process.js:303:12)
-theming-designer:     at ChildProcess.emit (events.js:315:20)
-theming-designer:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-theming-designer:     at maybeClose (internal/child_process.js:1026:16)
-theming-designer:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-theming-designer: [XX:XX:XX XM] x stdout:
-theming-designer: [XX:XX:XX XM] x ../../packages/office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-theming-designer: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-theming-designer:                      ~~~~~~~~~~~~~~~~
-theming-designer: ../../packages/tsx-editor/lib/interfaces/monaco.d.ts:1:25 - error TS2307: Cannot find module '@uifabric/monaco-editor/esm/vs/editor/editor.api' or its corresponding type declarations.
-theming-designer: 1 import * as monaco from '@uifabric/monaco-editor/esm/vs/editor/editor.api';
-theming-designer:                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-theming-designer: Found 2 errors.
-theming-designer: [XX:XX:XX XM] x ------------------------------------
-theming-designer: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-theming-designer: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-theming-designer: error Command failed with exit code 1.
-@fluentui/react-flex: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@fluentui/react-flex: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react-flex: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-flex/tsconfig.json"
-@fluentui/react-flex:     at ChildProcess.exithandler (child_process.js:303:12)
-@fluentui/react-flex:     at ChildProcess.emit (events.js:315:20)
-@fluentui/react-flex:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@fluentui/react-flex:     at maybeClose (internal/child_process.js:1026:16)
-@fluentui/react-flex:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@fluentui/react-flex: [XX:XX:XX XM] x stdout:
-@fluentui/react-flex: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-@fluentui/react-flex: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-@fluentui/react-flex:                      ~~~~~~~~~~~~~~~~
-@fluentui/react-flex: src/components/Flex/Flex.tsx:22:34 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
-@fluentui/react-flex:   Property 'styles' is incompatible with index signature.
-@fluentui/react-flex:     Type '{ [className: string]: string; }' is not assignable to type 'string'.
-@fluentui/react-flex: 22     classes: createClassResolver(classes),
-@fluentui/react-flex:                                     ~~~~~~~
-@fluentui/react-flex: src/components/FlexItem/FlexItem.tsx:20:34 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
-@fluentui/react-flex: 20     classes: createClassResolver(classes),
-@fluentui/react-flex:                                     ~~~~~~~
-@fluentui/react-flex: Found 3 errors.
-@fluentui/react-flex: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react-flex: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@fluentui/react-flex: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@fluentui/react-flex: error Command failed with exit code 1.
-@fluentui/react-next: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
-@fluentui/react-next: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react-next: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-next/tsconfig.json"
-@fluentui/react-next:     at ChildProcess.exithandler (child_process.js:303:12)
-@fluentui/react-next:     at ChildProcess.emit (events.js:315:20)
-@fluentui/react-next:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@fluentui/react-next:     at maybeClose (internal/child_process.js:1026:16)
-@fluentui/react-next:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@fluentui/react-next: [XX:XX:XX XM] x stdout:
-@fluentui/react-next: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-@fluentui/react-next: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-@fluentui/react-next:                      ~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx:147:19 - error TS2783: 'key' is specified more than once, so this usage will be overwritten.
-@fluentui/react-next: 147                   key={option.key}
-@fluentui/react-next:                       ~~~~~~~~~~~~~~~~
-@fluentui/react-next:   ../office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx:151:19
-@fluentui/react-next:     151                   {...innerOptionProps}
-@fluentui/react-next:                           ~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next:     This spread always overwrites this property.
-@fluentui/react-next: ../office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx:82:38 - error TS2554: Expected 1 arguments, but got 2.
-@fluentui/react-next: 82           {onRenderField(this.props, this._onRenderField)}
-@fluentui/react-next:                                         ~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx:415:13 - error TS2554: Expected 1 arguments, but got 2.
-@fluentui/react-next: 415             this._onRenderContainer,
-@fluentui/react-next:                 ~~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx:194:14 - error TS2790: The operand of a 'delete' operator must be optional.
-@fluentui/react-next: 194       delete this._dragDropSubscription;
-@fluentui/react-next:                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx:208:14 - error TS2790: The operand of a 'delete' operator must be optional.
-@fluentui/react-next: 208       delete this._dragDropSubscription;
-@fluentui/react-next:                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx:130:14 - error TS2790: The operand of a 'delete' operator must be optional.
-@fluentui/react-next: 130       delete this._subscriptionObject;
-@fluentui/react-next:                  ~~~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx:152:14 - error TS2790: The operand of a 'delete' operator must be optional.
-@fluentui/react-next: 152       delete this._subscriptionObject;
-@fluentui/react-next:                  ~~~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx:110:16 - error TS2790: The operand of a 'delete' operator must be optional.
-@fluentui/react-next: 110         delete this._dragDropSubscription;
-@fluentui/react-next:                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx:148:14 - error TS2790: The operand of a 'delete' operator must be optional.
-@fluentui/react-next: 148       delete this._dragDropSubscription;
-@fluentui/react-next:                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx:12:72 - error TS2339: Property 'peoplePickerPersonaContent' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 12     <div className={css('ms-PeoplePicker-personaContent', stylesImport.peoplePickerPersonaContent)}>
-@fluentui/react-next:                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx:16:64 - error TS2339: Property 'peoplePickerPersona' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 16         className={css('ms-PeoplePicker-Persona', stylesImport.peoplePickerPersona)}
-@fluentui/react-next:                                                                   ~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx:106:12 - error TS2790: The operand of a 'delete' operator must be optional.
-@fluentui/react-next: 106     delete this._previouslyFocusedElementOutsideTrapZone;
-@fluentui/react-next:                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx:174:16 - error TS2790: The operand of a 'delete' operator must be optional.
-@fluentui/react-next: 174         delete this._dragDropSubscription;
-@fluentui/react-next:                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/List/List.tsx:340:12 - error TS2790: The operand of a 'delete' operator must be optional.
-@fluentui/react-next: 340     delete this._scrollElement;
-@fluentui/react-next:                ~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx:88:12 - error TS2790: The operand of a 'delete' operator must be optional.
-@fluentui/react-next: 88     delete this._scrollableParent;
-@fluentui/react-next:               ~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx:89:12 - error TS2790: The operand of a 'delete' operator must be optional.
-@fluentui/react-next: 89     delete this._scrollableSurface;
-@fluentui/react-next:               ~~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/Popup/Popup.tsx:75:12 - error TS2790: The operand of a 'delete' operator must be optional.
-@fluentui/react-next: 75     delete this._originalFocusedElement;
-@fluentui/react-next:               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: ../office-ui-fabric-react/src/components/TextField/TextField.types.ts:327:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-@fluentui/react-next: 327 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-@fluentui/react-next:                      ~~~~~~~~~~~~~~~~
-@fluentui/react-next: src/components/Checkbox/useCheckboxClasses.tsx:15:50 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
-@fluentui/react-next:   Property 'styles' is incompatible with index signature.
-@fluentui/react-next:     Type '{ [className: string]: string; }' is not assignable to type 'string'.
-@fluentui/react-next: 15 const defaultClassResolver = createClassResolver(classes);
-@fluentui/react-next:                                                     ~~~~~~~
-@fluentui/react-next: src/components/ComboBox/ComboBox.tsx:417:13 - error TS2554: Expected 1 arguments, but got 2.
-@fluentui/react-next: 417             this._onRenderContainer,
-@fluentui/react-next:                 ~~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx:28:35 - error TS2339: Property 'iconContainer' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 28           <span className={styles.iconContainer}>
-@fluentui/react-next:                                      ~~~~~~~~~~~~~
-@fluentui/react-next: src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx:29:65 - error TS2339: Property 'logoFillIcon' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 29             <Icon iconName={'WordLogoFill16'} className={styles.logoFillIcon} />
-@fluentui/react-next:                                                                    ~~~~~~~~~~~~
-@fluentui/react-next: src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx:30:61 - error TS2339: Property 'logoIcon' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 30             <Icon iconName={'WordLogo16'} className={styles.logoIcon} />
-@fluentui/react-next:                                                                ~~~~~~~~
-@fluentui/react-next: src/components/FocusTrapZone/FocusTrapZone.tsx:90:12 - error TS2790: The operand of a 'delete' operator must be optional.
-@fluentui/react-next: 90     delete this._previouslyFocusedElementOutsideTrapZone;
-@fluentui/react-next:               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@fluentui/react-next: src/components/Link/Link.tsx:16:56 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 16     const propControlledClasses = [isButton && classes.button, isDisabled && classes.disabled];
-@fluentui/react-next:                                                           ~~~~~~
-@fluentui/react-next: src/components/Link/Link.tsx:16:86 - error TS2339: Property 'disabled' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 16     const propControlledClasses = [isButton && classes.button, isDisabled && classes.disabled];
-@fluentui/react-next:                                                                                         ~~~~~~~~
-@fluentui/react-next: src/components/Link/Link.tsx:21:36 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 21       root: css(className, classes.root, globalClassNames.root, ...rootStaticClasses, ...propControlledClasses),
-@fluentui/react-next:                                       ~~~~
-@fluentui/react-next: src/components/Persona/Persona.test.tsx:188:13 - error TS2322: Type 'ReactWrapper<HTMLAttributes, any, Component<{}, {}, any>>' is not assignable to type 'ReactWrapper<ImgHTMLAttributes<unknown>, unknown, Component<{}, {}, any>>'.
-@fluentui/react-next:   Type 'HTMLAttributes' is not assignable to type 'ImgHTMLAttributes<unknown>'.
-@fluentui/react-next:     Types of property 'crossOrigin' are incompatible.
-@fluentui/react-next:       Type 'string | undefined' is not assignable to type '"" | "anonymous" | "use-credentials" | undefined'.
-@fluentui/react-next:         Type 'string' is not assignable to type '"" | "anonymous" | "use-credentials" | undefined'.
-@fluentui/react-next: 188       const image: ReactWrapper<React.ImgHTMLAttributes<unknown>, unknown> = wrapper.find('ImageBase');
-@fluentui/react-next:                 ~~~~~
-@fluentui/react-next: src/components/Persona/Persona.test.tsx:195:13 - error TS2322: Type 'ReactWrapper<HTMLAttributes, any, Component<{}, {}, any>>' is not assignable to type 'ReactWrapper<ImgHTMLAttributes<unknown>, unknown, Component<{}, {}, any>>'.
-@fluentui/react-next: 195       const image: ReactWrapper<React.ImgHTMLAttributes<unknown>, unknown> = wrapper.find('ImageBase');
-@fluentui/react-next:                 ~~~~~
-@fluentui/react-next: src/components/Slider/Slider.tsx:39:27 - error TS2339: Property 'disabled' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 39       disabled && classes.disabled,
-@fluentui/react-next:                              ~~~~~~~~
-@fluentui/react-next: src/components/Slider/Slider.tsx:40:27 - error TS2339: Property 'vertical' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 40       vertical && classes.vertical,
-@fluentui/react-next:                              ~~~~~~~~
-@fluentui/react-next: src/components/Slider/Slider.tsx:47:36 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 47       root: css(className, classes.root, globalClassNames.root, ...propClasses),
-@fluentui/react-next:                                       ~~~~
-@fluentui/react-next: src/components/Slider/Slider.tsx:48:30 - error TS2339: Property 'container' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 48       container: css(classes.container, globalClassNames.container, ...propClasses),
-@fluentui/react-next:                                 ~~~~~~~~~
-@fluentui/react-next: src/components/Slider/Slider.tsx:49:29 - error TS2339: Property 'slideBox' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 49       slideBox: css(classes.slideBox, globalClassNames.slideBox, ...propClasses),
-@fluentui/react-next:                                ~~~~~~~~
-@fluentui/react-next: src/components/Slider/Slider.tsx:50:25 - error TS2339: Property 'line' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 50       line: css(classes.line, globalClassNames.line, ...propClasses),
-@fluentui/react-next:                            ~~~~
-@fluentui/react-next: src/components/Slider/Slider.tsx:51:26 - error TS2339: Property 'thumb' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 51       thumb: css(classes.thumb, globalClassNames.thumb, ...propClasses),
-@fluentui/react-next:                             ~~~~~
-@fluentui/react-next: src/components/Slider/Slider.tsx:52:34 - error TS2339: Property 'activeSection' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 52       activeSection: css(classes.activeSection, globalClassNames.activeSection, ...propClasses),
-@fluentui/react-next:                                     ~~~~~~~~~~~~~
-@fluentui/react-next: src/components/Slider/Slider.tsx:53:36 - error TS2339: Property 'inactiveSection' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 53       inactiveSection: css(classes.inactiveSection, globalClassNames.inactiveSection, ...propClasses),
-@fluentui/react-next:                                       ~~~~~~~~~~~~~~~
-@fluentui/react-next: src/components/Slider/Slider.tsx:54:34 - error TS2339: Property 'lineContainer' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 54       lineContainer: css(classes.lineContainer, ...propClasses),
-@fluentui/react-next:                                     ~~~~~~~~~~~~~
-@fluentui/react-next: src/components/Slider/Slider.tsx:55:31 - error TS2339: Property 'valueLabel' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 55       valueLabel: css(classes.valueLabel, globalClassNames.valueLabel, ...propClasses),
-@fluentui/react-next:                                  ~~~~~~~~~~
-@fluentui/react-next: src/components/Slider/Slider.tsx:56:31 - error TS2339: Property 'titleLabel' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 56       titleLabel: css(classes.titleLabel, titleLabelClassName, ...propClasses),
-@fluentui/react-next:                                  ~~~~~~~~~~
-@fluentui/react-next: src/components/Slider/Slider.tsx:58:29 - error TS2339: Property 'zeroTick' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 58       zeroTick: css(classes.zeroTick, globalClassNames.zeroTick, ...propClasses),
-@fluentui/react-next:                                ~~~~~~~~
-@fluentui/react-next: src/components/TextField/TextField.types.ts:328:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-@fluentui/react-next: 328 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-@fluentui/react-next:                      ~~~~~~~~~~~~~~~~
-@fluentui/react-next: src/components/Toggle/Toggle.tsx:31:26 - error TS2339: Property 'checked' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 31       checked && classes.checked,
-@fluentui/react-next:                             ~~~~~~~
-@fluentui/react-next: src/components/Toggle/Toggle.tsx:32:27 - error TS2339: Property 'disabled' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 32       disabled && classes.disabled,
-@fluentui/react-next:                              ~~~~~~~~
-@fluentui/react-next: src/components/Toggle/Toggle.tsx:33:30 - error TS2339: Property 'inlineLabel' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 33       inlineLabel && classes.inlineLabel,
-@fluentui/react-next:                                 ~~~~~~~~~~~
-@fluentui/react-next: src/components/Toggle/Toggle.tsx:34:31 - error TS2339: Property 'onOffMissing' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 34       onOffMissing && classes.onOffMissing,
-@fluentui/react-next:                                  ~~~~~~~~~~~~
-@fluentui/react-next: src/components/Toggle/Toggle.tsx:40:36 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 40       root: css(className, classes.root, globalClassNames.root, ...rootStaticClasses, ...propControlledClasses),
-@fluentui/react-next:                                       ~~~~
-@fluentui/react-next: src/components/Toggle/Toggle.tsx:41:26 - error TS2339: Property 'label' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 41       label: css(classes.label, globalClassNames.label, ...propControlledClasses),
-@fluentui/react-next:                             ~~~~~
-@fluentui/react-next: src/components/Toggle/Toggle.tsx:42:30 - error TS2339: Property 'container' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 42       container: css(classes.container, globalClassNames.container, ...propControlledClasses),
-@fluentui/react-next:                                 ~~~~~~~~~
-@fluentui/react-next: src/components/Toggle/Toggle.tsx:43:25 - error TS2339: Property 'pill' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 43       pill: css(classes.pill, globalClassNames.pill, ...propControlledClasses),
-@fluentui/react-next:                            ~~~~
-@fluentui/react-next: src/components/Toggle/Toggle.tsx:44:26 - error TS2339: Property 'thumb' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 44       thumb: css(classes.thumb, globalClassNames.thumb, ...propControlledClasses),
-@fluentui/react-next:                             ~~~~~
-@fluentui/react-next: src/components/Toggle/Toggle.tsx:45:25 - error TS2339: Property 'text' does not exist on type 'typeof import("*.scss")'.
-@fluentui/react-next: 45       text: css(classes.text, globalClassNames.text, ...propControlledClasses),
-@fluentui/react-next:                            ~~~~
-@fluentui/react-next: Found 54 errors.
-@fluentui/react-next: [XX:XX:XX XM] x ------------------------------------
-@fluentui/react-next: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@fluentui/react-next: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
-@fluentui/react-next: error Command failed with exit code 1.
-test-bundles: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
-test-bundles: [XX:XX:XX XM] x ------------------------------------
-test-bundles: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/test-bundles/tsconfig.json"
-test-bundles:     at ChildProcess.exithandler (child_process.js:303:12)
-test-bundles:     at ChildProcess.emit (events.js:315:20)
-test-bundles:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-test-bundles:     at maybeClose (internal/child_process.js:1026:16)
-test-bundles:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-test-bundles: [XX:XX:XX XM] x stdout:
-test-bundles: [XX:XX:XX XM] x ../../packages/office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-test-bundles: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-test-bundles:                      ~~~~~~~~~~~~~~~~
-test-bundles: Found 1 error.
-test-bundles: [XX:XX:XX XM] x ------------------------------------
-test-bundles: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-test-bundles: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
-test-bundles: error Command failed with exit code 1.
-vr-tests: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
-vr-tests: [XX:XX:XX XM] x ------------------------------------
-vr-tests: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/vr-tests/tsconfig.json"
-vr-tests:     at ChildProcess.exithandler (child_process.js:303:12)
-vr-tests:     at ChildProcess.emit (events.js:315:20)
-vr-tests:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-vr-tests:     at maybeClose (internal/child_process.js:1026:16)
-vr-tests:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-vr-tests: [XX:XX:XX XM] x stdout:
-vr-tests: [XX:XX:XX XM] x ../../packages/office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-vr-tests: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-vr-tests:                      ~~~~~~~~~~~~~~~~
-vr-tests: ../../packages/react-next/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-vr-tests: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-vr-tests:                      ~~~~~~~~~~~~~~~~
-vr-tests: Found 2 errors.
-vr-tests: [XX:XX:XX XM] x ------------------------------------
-vr-tests: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-vr-tests: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
-vr-tests: error Command failed with exit code 1.
-a11y-tests: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-a11y-tests: [XX:XX:XX XM] x ------------------------------------
-a11y-tests: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/a11y-tests/tsconfig.json"
-a11y-tests:     at ChildProcess.exithandler (child_process.js:303:12)
-a11y-tests:     at ChildProcess.emit (events.js:315:20)
-a11y-tests:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-a11y-tests:     at maybeClose (internal/child_process.js:1026:16)
-a11y-tests:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-a11y-tests: [XX:XX:XX XM] x stdout:
-a11y-tests: [XX:XX:XX XM] x ../../packages/office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-a11y-tests: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-a11y-tests:                      ~~~~~~~~~~~~~~~~
-a11y-tests: Found 1 error.
-a11y-tests: [XX:XX:XX XM] x ------------------------------------
-a11y-tests: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-a11y-tests: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-a11y-tests: error Command failed with exit code 1.
-@uifabric/fabric-website: [XX:XX:XX XM] x Error detected while running 'ts:esm'
-@uifabric/fabric-website: [XX:XX:XX XM] x ------------------------------------
-@uifabric/fabric-website: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/fabric-website/tsconfig.json"
-@uifabric/fabric-website:     at ChildProcess.exithandler (child_process.js:303:12)
-@uifabric/fabric-website:     at ChildProcess.emit (events.js:315:20)
-@uifabric/fabric-website:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@uifabric/fabric-website:     at maybeClose (internal/child_process.js:1026:16)
-@uifabric/fabric-website:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@uifabric/fabric-website: [XX:XX:XX XM] x stdout:
-@uifabric/fabric-website: [XX:XX:XX XM] x src/components/Nav/Nav.tsx:73:35 - error TS2339: Property 'navWrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 73     return <div className={styles.navWrapper}>{this._renderPageNav(pages)}</div>;
-@uifabric/fabric-website:                                      ~~~~~~~~~~
-@uifabric/fabric-website: src/components/Nav/Nav.tsx:90:34 - error TS2339: Property 'nav' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 90           <nav className={styles.nav} role="navigation">
-@uifabric/fabric-website:                                     ~~~
-@uifabric/fabric-website: src/components/Nav/Nav.tsx:115:33 - error TS2339: Property 'links' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 115       <ul className={css(styles.links, isSubMenu && styles.isSubMenu)} aria-label="Main website navigation">
-@uifabric/fabric-website:                                     ~~~~~
-@uifabric/fabric-website: src/components/Nav/Nav.tsx:115:60 - error TS2339: Property 'isSubMenu' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 115       <ul className={css(styles.links, isSubMenu && styles.isSubMenu)} aria-label="Main website navigation">
-@uifabric/fabric-website:                                                                ~~~~~~~~~
-@uifabric/fabric-website: src/components/Nav/Nav.tsx:137:56 - error TS2339: Property 'matchesFilter' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 137         const highlightMatch = <span className={styles.matchesFilter}>{match}</span>;
-@uifabric/fabric-website:                                                            ~~~~~~~~~~~~~
-@uifabric/fabric-website: src/components/Nav/Nav.tsx:151:18 - error TS2339: Property 'link' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 151           styles.link,
-@uifabric/fabric-website:                      ~~~~
-@uifabric/fabric-website: src/components/Nav/Nav.tsx:152:44 - error TS2339: Property 'isActive' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 152           isPageActive(page.url) && styles.isActive,
-@uifabric/fabric-website:                                                ~~~~~~~~
-@uifabric/fabric-website: src/components/Nav/Nav.tsx:153:42 - error TS2339: Property 'hasActiveChild' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 153           hasActiveChild(page) && styles.hasActiveChild,
-@uifabric/fabric-website:                                              ~~~~~~~~~~~~~~
-@uifabric/fabric-website: src/components/Nav/Nav.tsx:154:37 - error TS2339: Property 'isHomePage' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 154           page.isHomePage && styles.isHomePage,
-@uifabric/fabric-website:                                         ~~~~~~~~~~
-@uifabric/fabric-website: src/components/Nav/Nav.tsx:167:91 - error TS2339: Property 'externalIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 167             {page.isExternal && <Icon iconName="NavigateExternalInline" className={styles.externalIcon} />}
-@uifabric/fabric-website:                                                                                               ~~~~~~~~~~~~
-@uifabric/fabric-website: src/components/Nav/Nav.tsx:189:45 - error TS2339: Property 'section' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 189         <li key={key} className={css(styles.section, hasActiveChild(page) && styles.hasActiveChild)}>
-@uifabric/fabric-website:                                                 ~~~~~~~
-@uifabric/fabric-website: src/components/Nav/Nav.tsx:189:85 - error TS2339: Property 'hasActiveChild' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 189         <li key={key} className={css(styles.section, hasActiveChild(page) && styles.hasActiveChild)}>
-@uifabric/fabric-website:                                                                                         ~~~~~~~~~~~~~~
-@uifabric/fabric-website: src/components/Nav/Nav.tsx:257:30 - error TS2339: Property 'searchBoxWrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 257       <div className={styles.searchBoxWrapper}>
-@uifabric/fabric-website:                                  ~~~~~~~~~~~~~~~~
-@uifabric/fabric-website: src/components/Nav/Nav.tsx:259:29 - error TS2339: Property 'searchBox' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 259           className={styles.searchBox}
-@uifabric/fabric-website:                                 ~~~~~~~~~
-@uifabric/fabric-website: src/components/Nav/Nav.tsx:269:29 - error TS2339: Property 'filterButton' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 269           className={styles.filterButton}
-@uifabric/fabric-website:                                 ~~~~~~~~~~~~
-@uifabric/fabric-website: src/components/Site/Site.tsx:157:41 - error TS2339: Property 'siteRoot' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 157       <div key="site" className={styles.siteRoot}>
-@uifabric/fabric-website:                                             ~~~~~~~~
-@uifabric/fabric-website: src/components/Site/Site.tsx:160:36 - error TS2339: Property 'siteWrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 160         <div className={css(styles.siteWrapper, isContentFullBleed && styles.fullWidth)}>
-@uifabric/fabric-website:                                        ~~~~~~~~~~~
-@uifabric/fabric-website: src/components/Site/Site.tsx:160:78 - error TS2339: Property 'fullWidth' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 160         <div className={css(styles.siteWrapper, isContentFullBleed && styles.fullWidth)}>
-@uifabric/fabric-website:                                                                                  ~~~~~~~~~
-@uifabric/fabric-website: src/components/Site/Site.tsx:163:31 - error TS2339: Property 'siteContent' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 163             className={styles.siteContent}
-@uifabric/fabric-website:                                   ~~~~~~~~~~~
-@uifabric/fabric-website: src/components/Site/Site.tsx:280:32 - error TS2339: Property 'siteNavScrollWrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 280         <div className={styles.siteNavScrollWrapper}>
-@uifabric/fabric-website:                                    ~~~~~~~~~~~~~~~~~~~~
-@uifabric/fabric-website: src/components/Site/Site.tsx:282:36 - error TS2339: Property 'siteNavWrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 282             <div className={styles.siteNavWrapper}>
-@uifabric/fabric-website:                                        ~~~~~~~~~~~~~~
-@uifabric/fabric-website: src/components/Site/Site.tsx:283:38 - error TS2339: Property 'siteNavHeader' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 283               <div className={styles.siteNavHeader}>{this._renderPlatformPicker()}</div>
-@uifabric/fabric-website:                                          ~~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/ControlsPage/ControlsPage.tsx:37:41 - error TS2339: Property 'uListFlex' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 37               <ul className={PageStyles.uListFlex}>
-@uifabric/fabric-website:                                            ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/ControlsPage/ControlsPage.tsx:43:61 - error TS2339: Property 'uThird' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 43                     <li key={url} className={css(PageStyles.uThird)}>
-@uifabric/fabric-website:                                                                ~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:23:39 - error TS2339: Property 'cardWrapper' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 23       sectionWrapperClassName={styles.cardWrapper}
-@uifabric/fabric-website:                                          ~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:33:29 - error TS2339: Property 'card' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 33           className: styles.card,
-@uifabric/fabric-website:                                ~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:35:73 - error TS2339: Property 'cardLink' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 35             <Link href="#/styles/web/colors/products" className={styles.cardLink}>
-@uifabric/fabric-website:                                                                            ~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:36:38 - error TS2339: Property 'cardContent' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 36               <div className={styles.cardContent}>
-@uifabric/fabric-website:                                         ~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:37:71 - error TS2339: Property 'cardTitle' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 37                 <MarkdownHeader as="h2" id="colors" className={styles.cardTitle}>
-@uifabric/fabric-website:                                                                          ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:40:58 - error TS2339: Property 'cardIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 40                 <Icon iconName="Color" className={styles.cardIcon} />
-@uifabric/fabric-website:                                                             ~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:46:29 - error TS2339: Property 'card' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 46           className: styles.card,
-@uifabric/fabric-website:                                ~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:48:67 - error TS2339: Property 'cardLink' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 48             <Link href="#/styles/web/elevation" className={styles.cardLink}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:49:38 - error TS2339: Property 'cardContent' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 49               <div className={styles.cardContent}>
-@uifabric/fabric-website:                                         ~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:50:74 - error TS2339: Property 'cardTitle' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 50                 <MarkdownHeader as="h2" id="elevation" className={styles.cardTitle}>
-@uifabric/fabric-website:                                                                             ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:53:72 - error TS2339: Property 'cardIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 53                 <Icon iconName="ArrangeSendBackward" className={styles.cardIcon} />
-@uifabric/fabric-website:                                                                           ~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:59:29 - error TS2339: Property 'card' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 59           className: styles.card,
-@uifabric/fabric-website:                                ~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:61:63 - error TS2339: Property 'cardLink' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 61             <Link href="#/styles/web/icons" className={styles.cardLink}>
-@uifabric/fabric-website:                                                                  ~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:62:38 - error TS2339: Property 'cardContent' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 62               <div className={styles.cardContent}>
-@uifabric/fabric-website:                                         ~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:63:76 - error TS2339: Property 'cardTitle' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 63                 <MarkdownHeader as="h2" id="iconography" className={styles.cardTitle}>
-@uifabric/fabric-website:                                                                               ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:66:68 - error TS2339: Property 'cardIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 66                 <Icon iconName="EmojiTabSymbols" className={styles.cardIcon} />
-@uifabric/fabric-website:                                                                       ~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:72:29 - error TS2339: Property 'card' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 72           className: styles.card,
-@uifabric/fabric-website:                                ~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:74:64 - error TS2339: Property 'cardLink' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 74             <Link href="#/styles/web/layout" className={styles.cardLink}>
-@uifabric/fabric-website:                                                                   ~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:75:38 - error TS2339: Property 'cardContent' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 75               <div className={styles.cardContent}>
-@uifabric/fabric-website:                                         ~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:76:71 - error TS2339: Property 'cardTitle' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 76                 <MarkdownHeader as="h2" id="layout" className={styles.cardTitle}>
-@uifabric/fabric-website:                                                                          ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:79:58 - error TS2339: Property 'cardIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 79                 <Icon iconName="Tiles" className={styles.cardIcon} />
-@uifabric/fabric-website:                                                             ~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:85:29 - error TS2339: Property 'card' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 85           className: styles.card,
-@uifabric/fabric-website:                                ~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:87:64 - error TS2339: Property 'cardLink' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 87             <Link href="#/styles/web/motion" className={styles.cardLink}>
-@uifabric/fabric-website:                                                                   ~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:88:38 - error TS2339: Property 'cardContent' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 88               <div className={styles.cardContent}>
-@uifabric/fabric-website:                                         ~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:89:71 - error TS2339: Property 'cardTitle' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 89                 <MarkdownHeader as="h2" id="motion" className={styles.cardTitle}>
-@uifabric/fabric-website:                                                                          ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:92:63 - error TS2339: Property 'cardIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 92                 <Icon iconName="MiniExpand" className={styles.cardIcon} />
-@uifabric/fabric-website:                                                                  ~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:98:29 - error TS2339: Property 'card' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 98           className: styles.card,
-@uifabric/fabric-website:                                ~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:100:68 - error TS2339: Property 'cardLink' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 100             <Link href="#/styles/web/typography" className={styles.cardLink}>
-@uifabric/fabric-website:                                                                        ~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:101:38 - error TS2339: Property 'cardContent' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 101               <div className={styles.cardContent}>
-@uifabric/fabric-website:                                          ~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:102:75 - error TS2339: Property 'cardTitle' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 102                 <MarkdownHeader as="h2" id="typography" className={styles.cardTitle}>
-@uifabric/fabric-website:                                                                               ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:105:61 - error TS2339: Property 'cardIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 105                 <Icon iconName="FontSize" className={styles.cardIcon} />
-@uifabric/fabric-website:                                                                 ~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:111:29 - error TS2339: Property 'card' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 111           className: styles.card,
-@uifabric/fabric-website:                                 ~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:113:70 - error TS2339: Property 'cardLink' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 113             <Link href="#/styles/web/localization" className={styles.cardLink}>
-@uifabric/fabric-website:                                                                          ~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:114:38 - error TS2339: Property 'cardContent' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 114               <div className={styles.cardContent}>
-@uifabric/fabric-website:                                          ~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:115:77 - error TS2339: Property 'cardTitle' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 115                 <MarkdownHeader as="h2" id="localization" className={styles.cardTitle}>
-@uifabric/fabric-website:                                                                                 ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:118:58 - error TS2339: Property 'cardIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 118                 <Icon iconName="World" className={styles.cardIcon} />
-@uifabric/fabric-website:                                                              ~~~~~~~~
-@uifabric/fabric-website: src/pages/PageTemplates/TemplatePage/TemplatePage.tsx:101:33 - error TS2339: Property 'customSection' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 101           className: css(styles.customSection, 'customGlobalClassName', platform === 'web' && 'falseyGlobalClassName'),
-@uifabric/fabric-website:                                     ~~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/ElevationPage/ElevationPage.tsx:112:37 - error TS2339: Property 'usageList' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 112               <ul className={styles.usageList}>
-@uifabric/fabric-website:                                         ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/ElevationPage/ElevationPage.tsx:114:53 - error TS2339: Property 'usageListItem' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 114                   <li key={index} className={styles.usageListItem}>
-@uifabric/fabric-website:                                                         ~~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/ElevationPage/ElevationPage.tsx:122:42 - error TS2339: Property 'example' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 122               <div className={css(styles.example, styles.compact, `ms-depth-${row.level}`)}>
-@uifabric/fabric-website:                                              ~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/ElevationPage/ElevationPage.tsx:122:58 - error TS2339: Property 'compact' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 122               <div className={css(styles.example, styles.compact, `ms-depth-${row.level}`)}>
-@uifabric/fabric-website:                                                              ~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/ElevationPage/ElevationPage.tsx:123:41 - error TS2339: Property 'caption' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 123                 <span className={styles.caption}>Depth {row.level}</span>
-@uifabric/fabric-website:                                             ~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/FabricIconsPage/FabricIconsPage.tsx:48:73 - error TS2339: Property 'iconGrid' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 48               <PivotItem headerText="Fluent UI React" className={styles.iconGrid}>
-@uifabric/fabric-website:                                                                            ~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/FabricIconsPage/FabricIconsPage.tsx:51:69 - error TS2339: Property 'iconGrid' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 51               <PivotItem headerText="Fabric Core" className={styles.iconGrid}>
-@uifabric/fabric-website:                                                                        ~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:60:43 - error TS2339: Property 'exampleIcons' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 60                     <ul className={styles.exampleIcons}>
-@uifabric/fabric-website:                                              ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:64:45 - error TS2339: Property 'productIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 64                           className={styles.productIcon}
-@uifabric/fabric-website:                                                ~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:71:45 - error TS2339: Property 'productIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 71                           className={styles.productIcon}
-@uifabric/fabric-website:                                                ~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:78:45 - error TS2339: Property 'productIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 78                           className={styles.productIcon}
-@uifabric/fabric-website:                                                ~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:103:41 - error TS2339: Property 'exampleIcons' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 103                   <ul className={styles.exampleIcons}>
-@uifabric/fabric-website:                                             ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:142:37 - error TS2339: Property 'iconList' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 142               <ul className={styles.iconList}>
-@uifabric/fabric-website:                                         ~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:147:41 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 147                       className={styles.icon}
-@uifabric/fabric-website:                                             ~~~~
-@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:150:45 - error TS2339: Property 'iconName' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 150                     <span className={styles.iconName}>{icon.name}</span>
-@uifabric/fabric-website:                                                 ~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:64:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 64                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:65:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 65                     <div className={styles.demoBlock}>1</div>
-@uifabric/fabric-website:                                               ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:67:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 67                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:68:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 68                     <div className={styles.demoBlock}>1</div>
-@uifabric/fabric-website:                                               ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:70:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 70                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:71:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 71                     <div className={styles.demoBlock}>1</div>
-@uifabric/fabric-website:                                               ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:73:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 73                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:74:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 74                     <div className={styles.demoBlock}>1</div>
-@uifabric/fabric-website:                                               ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:76:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 76                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:77:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 77                     <div className={styles.demoBlock}>1</div>
-@uifabric/fabric-website:                                               ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:79:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 79                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:80:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 80                     <div className={styles.demoBlock}>1</div>
-@uifabric/fabric-website:                                               ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:82:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 82                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:83:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 83                     <div className={styles.demoBlock}>1</div>
-@uifabric/fabric-website:                                               ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:85:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 85                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:86:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 86                     <div className={styles.demoBlock}>1</div>
-@uifabric/fabric-website:                                               ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:88:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 88                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:89:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 89                     <div className={styles.demoBlock}>1</div>
-@uifabric/fabric-website:                                               ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:91:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 91                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:92:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 92                     <div className={styles.demoBlock}>1</div>
-@uifabric/fabric-website:                                               ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:94:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 94                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:95:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 95                     <div className={styles.demoBlock}>1</div>
-@uifabric/fabric-website:                                               ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:97:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 97                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:98:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 98                     <div className={styles.demoBlock}>1</div>
-@uifabric/fabric-website:                                               ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:102:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 102                   <div className={'ms-Grid-col ms-sm2 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:103:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 103                     <div className={styles.demoBlock}>2</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:105:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 105                   <div className={'ms-Grid-col ms-sm2 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:106:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 106                     <div className={styles.demoBlock}>2</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:108:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 108                   <div className={'ms-Grid-col ms-sm2 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:109:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 109                     <div className={styles.demoBlock}>2</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:111:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 111                   <div className={'ms-Grid-col ms-sm2 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:112:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 112                     <div className={styles.demoBlock}>2</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:114:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 114                   <div className={'ms-Grid-col ms-sm2 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:115:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 115                     <div className={styles.demoBlock}>2</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:117:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 117                   <div className={'ms-Grid-col ms-sm2 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:118:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 118                     <div className={styles.demoBlock}>2</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:122:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 122                   <div className={'ms-Grid-col ms-sm3 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:123:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 123                     <div className={styles.demoBlock}>3</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:125:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 125                   <div className={'ms-Grid-col ms-sm3 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:126:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 126                     <div className={styles.demoBlock}>3</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:128:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 128                   <div className={'ms-Grid-col ms-sm3 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:129:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 129                     <div className={styles.demoBlock}>3</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:131:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 131                   <div className={'ms-Grid-col ms-sm3 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:132:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 132                     <div className={styles.demoBlock}>3</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:136:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 136                   <div className={'ms-Grid-col ms-sm4 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:137:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 137                     <div className={styles.demoBlock}>4</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:139:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 139                   <div className={'ms-Grid-col ms-sm4 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:140:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 140                     <div className={styles.demoBlock}>4</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:142:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 142                   <div className={'ms-Grid-col ms-sm4 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:143:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 143                     <div className={styles.demoBlock}>4</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:147:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 147                   <div className={'ms-Grid-col ms-sm6 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:148:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 148                     <div className={styles.demoBlock}>6</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:150:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 150                   <div className={'ms-Grid-col ms-sm6 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:151:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 151                     <div className={styles.demoBlock}>6</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:155:67 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 155                   <div className={'ms-Grid-col ms-sm12 ' + styles.demoBlockCol}>
-@uifabric/fabric-website:                                                                       ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:156:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 156                     <div className={styles.demoBlock}>12</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:188:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 188                     <div className={styles.demoBlock}>Visible on smaller screens</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:191:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 191                     <div className={styles.demoBlock}>Visible on larger screens</div>
-@uifabric/fabric-website:                                                ~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LocalizationPage/LocalizationPage.tsx:48:37 - error TS2339: Property 'directionalIcons' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 48               <ul className={styles.directionalIcons}>
-@uifabric/fabric-website:                                        ~~~~~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LocalizationPage/LocalizationPage.tsx:50:41 - error TS2339: Property 'directionalIconPair' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 50                   <li className={styles.directionalIconPair} key={pairIndex}>
-@uifabric/fabric-website:                                            ~~~~~~~~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LocalizationPage/LocalizationPage.tsx:51:44 - error TS2339: Property 'directionalIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 51                     <div className={styles.directionalIcon}>
-@uifabric/fabric-website:                                               ~~~~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/LocalizationPage/LocalizationPage.tsx:55:44 - error TS2339: Property 'directionalIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 55                     <div className={styles.directionalIcon}>
-@uifabric/fabric-website:                                               ~~~~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:62:43 - error TS2339: Property 'exampleIcons' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 62                     <ul className={styles.exampleIcons}>
-@uifabric/fabric-website:                                              ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:66:45 - error TS2339: Property 'productIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 66                           className={styles.productIcon}
-@uifabric/fabric-website:                                                ~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:73:45 - error TS2339: Property 'productIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 73                           className={styles.productIcon}
-@uifabric/fabric-website:                                                ~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:80:45 - error TS2339: Property 'productIcon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 80                           className={styles.productIcon}
-@uifabric/fabric-website:                                                ~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:105:41 - error TS2339: Property 'exampleIcons' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 105                   <ul className={styles.exampleIcons}>
-@uifabric/fabric-website:                                             ~~~~~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:175:37 - error TS2339: Property 'iconList' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 175               <ul className={styles.iconList}>
-@uifabric/fabric-website:                                         ~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:183:41 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 183                       className={styles.icon}
-@uifabric/fabric-website:                                             ~~~~
-@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:185:45 - error TS2339: Property 'iconName' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 185                     <span className={styles.iconName}>{icon.name}</span>
-@uifabric/fabric-website:                                                 ~~~~~~~~
-@uifabric/fabric-website: src/pages/Styles/TypographyPage/TypographyPage.tsx:137:42 - error TS2339: Property 'example' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 137               <div className={css(styles.example, `ms-fontSize-${row.size}`)}>
-@uifabric/fabric-website:                                              ~~~~~~~
-@uifabric/fabric-website: src/root.tsx:19:39 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 19       className: platformPickerStyles.icon,
-@uifabric/fabric-website:                                          ~~~~
-@uifabric/fabric-website: src/root.tsx:22:39 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 22       className: platformPickerStyles.icon,
-@uifabric/fabric-website:                                          ~~~~
-@uifabric/fabric-website: src/root.tsx:25:39 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 25       className: platformPickerStyles.icon,
-@uifabric/fabric-website:                                          ~~~~
-@uifabric/fabric-website: src/root.tsx:28:39 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 28       className: platformPickerStyles.icon,
-@uifabric/fabric-website:                                          ~~~~
-@uifabric/fabric-website: src/root.tsx:31:39 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 31       className: platformPickerStyles.icon,
-@uifabric/fabric-website:                                          ~~~~
-@uifabric/fabric-website: src/root.tsx:34:39 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 34       className: platformPickerStyles.icon,
-@uifabric/fabric-website:                                          ~~~~
-@uifabric/fabric-website: src/utilities/svgIcons.tsx:16:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 16   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
-@uifabric/fabric-website:                                 ~~~~
-@uifabric/fabric-website: src/utilities/svgIcons.tsx:49:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 49   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
-@uifabric/fabric-website:                                 ~~~~
-@uifabric/fabric-website: src/utilities/svgIcons.tsx:67:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 67   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
-@uifabric/fabric-website:                                 ~~~~
-@uifabric/fabric-website: src/utilities/svgIcons.tsx:91:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 91   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
-@uifabric/fabric-website:                                 ~~~~
-@uifabric/fabric-website: src/utilities/svgIcons.tsx:126:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 126   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
-@uifabric/fabric-website:                                  ~~~~
-@uifabric/fabric-website: src/utilities/svgIcons.tsx:158:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 158   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
-@uifabric/fabric-website:                                  ~~~~
-@uifabric/fabric-website: src/utilities/svgIconsColor.tsx:9:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 9   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
-@uifabric/fabric-website:                                ~~~~
-@uifabric/fabric-website: src/utilities/svgIconsColor.tsx:81:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 81   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
-@uifabric/fabric-website:                                 ~~~~
-@uifabric/fabric-website: src/utilities/svgIconsColor.tsx:126:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 126   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
-@uifabric/fabric-website:                                  ~~~~
-@uifabric/fabric-website: src/utilities/svgIconsColor.tsx:202:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 202   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
-@uifabric/fabric-website:                                  ~~~~
-@uifabric/fabric-website: src/utilities/svgIconsColor.tsx:285:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 285   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
-@uifabric/fabric-website:                                  ~~~~
-@uifabric/fabric-website: src/utilities/svgIconsColor.tsx:348:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
-@uifabric/fabric-website: 348   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
-@uifabric/fabric-website:                                  ~~~~
-@uifabric/fabric-website: Found 165 errors.
-@uifabric/fabric-website: [XX:XX:XX XM] x ------------------------------------
-@uifabric/fabric-website: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@uifabric/fabric-website: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
-@uifabric/fabric-website: error Command failed with exit code 1.
-@fluentui/examples: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
-@fluentui/examples: [XX:XX:XX XM] x ------------------------------------
-@fluentui/examples: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/examples/tsconfig.json"
-@fluentui/examples:     at ChildProcess.exithandler (child_process.js:303:12)
-@fluentui/examples:     at ChildProcess.emit (events.js:315:20)
-@fluentui/examples:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
-@fluentui/examples:     at maybeClose (internal/child_process.js:1026:16)
-@fluentui/examples:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
-@fluentui/examples: [XX:XX:XX XM] x stdout:
-@fluentui/examples: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
-@fluentui/examples: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
-@fluentui/examples:                      ~~~~~~~~~~~~~~~~
-@fluentui/examples: Found 1 error.
-@fluentui/examples: [XX:XX:XX XM] x ------------------------------------
-@fluentui/examples: [XX:XX:XX XM] x Error previously detected. See above for error messages.
-@fluentui/examples: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
-@fluentui/examples: error Command failed with exit code 1.
-lerna ERR! Received non-zero exit code 1 during execution
+lerna ERR! yarn run build exited 1 in '@fluentui/react-icons'

--- a/tests/baselines/reference/docker/office-ui-fabric.log
+++ b/tests/baselines/reference/docker/office-ui-fabric.log
@@ -1,853 +1,838 @@
 Exit Code: 1
 Standard output:
-@microsoft/fast-components-msft: yarn run vX.X.X
-@microsoft/fast-components-msft: $ tsc -p ./tsconfig.json && rollup -c && npm run doc
-@microsoft/fast-components-msft: ┌───────────────────────────────────────────────┐
-@microsoft/fast-components-msft: │                                               │
-@microsoft/fast-components-msft: │   Destination: dist/fast-components-msft.js   │
-@microsoft/fast-components-msft: │   Bundle Size:  490.64 KB                     │
-@microsoft/fast-components-msft: │   Gzipped Size:  50.64 KB                     │
-@microsoft/fast-components-msft: │   Brotli size: 74.92 KB                       │
-@microsoft/fast-components-msft: │                                               │
-@microsoft/fast-components-msft: └───────────────────────────────────────────────┘
-@microsoft/fast-components-msft: ┌───────────────────────────────────────────────────┐
-@microsoft/fast-components-msft: │                                                   │
-@microsoft/fast-components-msft: │   Destination: dist/fast-components-msft.min.js   │
-@microsoft/fast-components-msft: │   Bundle Size:  201.49 KB                         │
-@microsoft/fast-components-msft: │   Gzipped Size:  46.05 KB                         │
-@microsoft/fast-components-msft: │   Brotli size: 39.62 KB                           │
-@microsoft/fast-components-msft: │                                                   │
-@microsoft/fast-components-msft: └───────────────────────────────────────────────────┘
-@microsoft/fast-components-msft: > @microsoft/fast-components-msft@X.X.X doc /office-ui-fabric-react/packages/web-components
-@microsoft/fast-components-msft: > api-extractor run --local
-@microsoft/fast-components-msft: api-extractor 7.7.1  - https://api-extractor.com/
-@microsoft/fast-components-msft: Using configuration from /office-ui-fabric-react/packages/web-components/api-extractor.json
-@microsoft/fast-components-msft: API Extractor completed successfully
-@microsoft/fast-components-msft: Done in ?s.
+@fluentui/eslint-plugin: yarn run vX.X.X
+@fluentui/eslint-plugin: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/eslint-plugin: Done in ?s.
+@fluentui/noop: yarn run vX.X.X
+@fluentui/noop: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/noop: Done in ?s.
+@fluentui/web-components: yarn run vX.X.X
+@fluentui/web-components: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/web-components: Done in ?s.
 @fluentui/ability-attributes: yarn run vX.X.X
-@fluentui/ability-attributes: $ npm run schema && gulp bundle:package:no-umd
-@fluentui/ability-attributes: > @fluentui/ability-attributes@X.X.X schema /office-ui-fabric-react/packages/fluentui/ability-attributes
-@fluentui/ability-attributes: > allyschema -c "process.env.NODE_ENV !== 'production'" schema.json > ./src/schema.ts
-@fluentui/ability-attributes: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
-@fluentui/ability-attributes: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/ability-attributes/gulpfile.ts
+@fluentui/ability-attributes: $ /office-ui-fabric-react/node_modules/.bin/just ts
 @fluentui/ability-attributes: Done in ?s.
 @fluentui/digest: yarn run vX.X.X
-@fluentui/digest: $ just-scripts build
+@fluentui/digest: $ /office-ui-fabric-react/node_modules/.bin/just ts
 @fluentui/digest: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/fluentui/digest/tsconfig.json
 @fluentui/digest: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --module esnext --outDir lib --project "/office-ui-fabric-react/packages/fluentui/digest/tsconfig.json"
-@fluentui/digest: [XX:XX:XX XM] ■ Running Webpack
-@fluentui/digest: [XX:XX:XX XM] ■ Webpack Config Path: null
-@fluentui/digest: [XX:XX:XX XM] ■ webpack.config.js not found, skipping webpack
 @fluentui/digest: Done in ?s.
 @uifabric/build: yarn run vX.X.X
-@uifabric/build: $ node ./just-scripts.js no-op
-@uifabric/build: Done in ?s.
+@uifabric/build: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@uifabric/build: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/scripts/tsconfig.json
+@uifabric/build: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/scripts/tsconfig.json"
+@uifabric/build: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/scripts/tsconfig.json
+@uifabric/build: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/scripts/tsconfig.json"
+@uifabric/build: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@uifabric/pr-deploy-site: yarn run vX.X.X
+@uifabric/pr-deploy-site: $ just-scripts ts
+@uifabric/pr-deploy-site: Done in ?s.
 @fluentui/common-styles: yarn run vX.X.X
-@fluentui/common-styles: $ just-scripts build
-@fluentui/common-styles: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
-@fluentui/common-styles: [XX:XX:XX XM] ■ Copying [../../node_modules/office-ui-fabric-core/dist/sass/**/*, src/*.scss] to '/office-ui-fabric-react/packages/common-styles/dist/sass'
+@fluentui/common-styles: $ just-scripts ts
 @fluentui/common-styles: Done in ?s.
 @uifabric/example-data: yarn run vX.X.X
-@uifabric/example-data: $ just-scripts build
-@uifabric/example-data: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@uifabric/example-data: $ just-scripts ts
 @uifabric/example-data: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/example-data/tsconfig.json
 @uifabric/example-data: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/example-data/tsconfig.json"
 @uifabric/example-data: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/example-data/tsconfig.json
 @uifabric/example-data: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/example-data/tsconfig.json"
-@uifabric/example-data: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/example-data/lib/index.d.ts'
 @uifabric/example-data: Done in ?s.
 @fluentui/keyboard-key: yarn run vX.X.X
-@fluentui/keyboard-key: $ just-scripts build
-@fluentui/keyboard-key: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@fluentui/keyboard-key: $ just-scripts ts
 @fluentui/keyboard-key: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/keyboard-key/tsconfig.json
 @fluentui/keyboard-key: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/keyboard-key/tsconfig.json"
 @fluentui/keyboard-key: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/keyboard-key/tsconfig.json
 @fluentui/keyboard-key: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/keyboard-key/tsconfig.json"
-@fluentui/keyboard-key: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/keyboard-key/lib/index.d.ts'
 @fluentui/keyboard-key: Done in ?s.
 @uifabric/migration: yarn run vX.X.X
-@uifabric/migration: $ just-scripts build
-@uifabric/migration: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
-@uifabric/migration: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/packages/migration/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/migration/tsconfig.json
-@uifabric/migration: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/packages/migration/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module commonjs --project "/office-ui-fabric-react/packages/migration/tsconfig.json"
+@uifabric/migration: $ just-scripts ts
+@uifabric/migration: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/migration/tsconfig.json
+@uifabric/migration: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/migration/tsconfig.json"
+@uifabric/migration: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/migration/tsconfig.json
+@uifabric/migration: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/migration/tsconfig.json"
 @uifabric/migration: Done in ?s.
 @uifabric/monaco-editor: yarn run vX.X.X
-@uifabric/monaco-editor: $ just-scripts build
-@uifabric/monaco-editor: [XX:XX:XX XM] ■ Removing [esm, lib, lib-commonjs]
+@uifabric/monaco-editor: $ just-scripts ts
 @uifabric/monaco-editor: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/monaco-editor/tsconfig.json
 @uifabric/monaco-editor: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/monaco-editor/tsconfig.json"
 @uifabric/monaco-editor: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/monaco-editor/tsconfig.json
 @uifabric/monaco-editor: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/monaco-editor/tsconfig.json"
 @uifabric/monaco-editor: Done in ?s.
 @fluentui/react-conformance: yarn run vX.X.X
-@fluentui/react-conformance: $ just-scripts build
-@fluentui/react-conformance: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@fluentui/react-conformance: $ just-scripts ts
 @fluentui/react-conformance: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-conformance/tsconfig.json
-@fluentui/react-conformance: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module commonjs --project "/office-ui-fabric-react/packages/react-conformance/tsconfig.json"
+@fluentui/react-conformance: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-conformance/tsconfig.json"
+@fluentui/react-conformance: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-conformance/tsconfig.json
+@fluentui/react-conformance: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-conformance/tsconfig.json"
 @fluentui/react-conformance: Done in ?s.
 @uifabric/set-version: yarn run vX.X.X
-@uifabric/set-version: $ just-scripts build
-@uifabric/set-version: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@uifabric/set-version: $ just-scripts ts
 @uifabric/set-version: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/set-version/tsconfig.json
 @uifabric/set-version: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/set-version/tsconfig.json"
 @uifabric/set-version: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/set-version/tsconfig.json
 @uifabric/set-version: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/set-version/tsconfig.json"
 @uifabric/set-version: Done in ?s.
 @uifabric/webpack-utils: yarn run vX.X.X
-@uifabric/webpack-utils: $ just-scripts build
-@uifabric/webpack-utils: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@uifabric/webpack-utils: $ just-scripts ts
 @uifabric/webpack-utils: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/webpack-utils/tsconfig.json
-@uifabric/webpack-utils: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module commonjs --project "/office-ui-fabric-react/packages/webpack-utils/tsconfig.json"
-@uifabric/webpack-utils: Done in ?s.
+@uifabric/webpack-utils: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/webpack-utils/tsconfig.json"
+@uifabric/webpack-utils: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/webpack-utils/tsconfig.json
+@uifabric/webpack-utils: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/webpack-utils/tsconfig.json"
+@uifabric/webpack-utils: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
 @fluentui/docs-components: yarn run vX.X.X
-@fluentui/docs-components: $ gulp bundle:package:no-umd
-@fluentui/docs-components: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
-@fluentui/docs-components: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/docs-components/gulpfile.ts
+@fluentui/docs-components: $ /office-ui-fabric-react/node_modules/.bin/just ts
 @fluentui/docs-components: Done in ?s.
 @fluentui/react-component-event-listener: yarn run vX.X.X
-@fluentui/react-component-event-listener: $ gulp bundle:package:no-umd
-@fluentui/react-component-event-listener: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
-@fluentui/react-component-event-listener: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-component-event-listener/gulpfile.ts
+@fluentui/react-component-event-listener: $ /office-ui-fabric-react/node_modules/.bin/just ts
 @fluentui/react-component-event-listener: Done in ?s.
 @fluentui/react-component-nesting-registry: yarn run vX.X.X
-@fluentui/react-component-nesting-registry: $ gulp bundle:package:no-umd
-@fluentui/react-component-nesting-registry: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
-@fluentui/react-component-nesting-registry: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-component-nesting-registry/gulpfile.ts
+@fluentui/react-component-nesting-registry: $ /office-ui-fabric-react/node_modules/.bin/just ts
 @fluentui/react-component-nesting-registry: Done in ?s.
 @fluentui/react-component-ref: yarn run vX.X.X
-@fluentui/react-component-ref: $ gulp bundle:package:no-umd
-@fluentui/react-component-ref: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
-@fluentui/react-component-ref: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-component-ref/gulpfile.ts
+@fluentui/react-component-ref: $ /office-ui-fabric-react/node_modules/.bin/just ts
 @fluentui/react-component-ref: Done in ?s.
 @fluentui/react-context-selector: yarn run vX.X.X
-@fluentui/react-context-selector: $ gulp bundle:package:no-umd
-@fluentui/react-context-selector: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
-@fluentui/react-context-selector: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-context-selector/gulpfile.ts
+@fluentui/react-context-selector: $ /office-ui-fabric-react/node_modules/.bin/just ts
 @fluentui/react-context-selector: Done in ?s.
 @fluentui/react-proptypes: yarn run vX.X.X
-@fluentui/react-proptypes: $ gulp bundle:package:no-umd
-@fluentui/react-proptypes: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
-@fluentui/react-proptypes: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-proptypes/gulpfile.ts
+@fluentui/react-proptypes: $ /office-ui-fabric-react/node_modules/.bin/just ts
 @fluentui/react-proptypes: Done in ?s.
 @fluentui/state: yarn run vX.X.X
-@fluentui/state: $ gulp bundle:package:no-umd
-@fluentui/state: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
-@fluentui/state: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/state/gulpfile.ts
+@fluentui/state: $ /office-ui-fabric-react/node_modules/.bin/just ts
 @fluentui/state: Done in ?s.
 @fluentui/styles: yarn run vX.X.X
-@fluentui/styles: $ gulp bundle:package:no-umd
-@fluentui/styles: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
-@fluentui/styles: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/styles/gulpfile.ts
+@fluentui/styles: $ /office-ui-fabric-react/node_modules/.bin/just ts
 @fluentui/styles: Done in ?s.
 @fluentui/accessibility: yarn run vX.X.X
-@fluentui/accessibility: $ gulp bundle:package:no-umd
-@fluentui/accessibility: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
-@fluentui/accessibility: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/accessibility/gulpfile.ts
+@fluentui/accessibility: $ /office-ui-fabric-react/node_modules/.bin/just ts
 @fluentui/accessibility: Done in ?s.
 @fluentui/date-time-utilities: yarn run vX.X.X
-@fluentui/date-time-utilities: $ just-scripts build
-@fluentui/date-time-utilities: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@fluentui/date-time-utilities: $ just-scripts ts
 @fluentui/date-time-utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/date-time-utilities/tsconfig.json
 @fluentui/date-time-utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/date-time-utilities/tsconfig.json"
 @fluentui/date-time-utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/date-time-utilities/tsconfig.json
 @fluentui/date-time-utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/date-time-utilities/tsconfig.json"
-@fluentui/date-time-utilities: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/date-time-utilities/lib/index.d.ts'
 @fluentui/date-time-utilities: Done in ?s.
 @uifabric/merge-styles: yarn run vX.X.X
-@uifabric/merge-styles: $ just-scripts build
-@uifabric/merge-styles: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@uifabric/merge-styles: $ just-scripts ts
 @uifabric/merge-styles: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/merge-styles/tsconfig.json
 @uifabric/merge-styles: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/merge-styles/tsconfig.json"
 @uifabric/merge-styles: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/merge-styles/tsconfig.json
 @uifabric/merge-styles: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/merge-styles/tsconfig.json"
-@uifabric/merge-styles: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/merge-styles/lib/index.d.ts'
-@uifabric/merge-styles: Done in ?s.
-@fluentui/react-flex: yarn run vX.X.X
-@fluentui/react-flex: $ just-scripts build
-@fluentui/react-flex: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
-@fluentui/react-flex: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-flex/tsconfig.json
-@fluentui/react-flex: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-flex/tsconfig.json"
-@fluentui/react-flex: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-flex/tsconfig.json
-@fluentui/react-flex: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-flex/tsconfig.json"
-@fluentui/react-flex: Done in ?s.
+@uifabric/merge-styles: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
 @fluentui/react-northstar-styles-renderer: yarn run vX.X.X
-@fluentui/react-northstar-styles-renderer: $ gulp bundle:package:no-umd
-@fluentui/react-northstar-styles-renderer: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
-@fluentui/react-northstar-styles-renderer: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-northstar-styles-renderer/gulpfile.ts
+@fluentui/react-northstar-styles-renderer: $ /office-ui-fabric-react/node_modules/.bin/just ts
 @fluentui/react-northstar-styles-renderer: Done in ?s.
 @uifabric/jest-serializer-merge-styles: yarn run vX.X.X
-@uifabric/jest-serializer-merge-styles: $ just-scripts build
-@uifabric/jest-serializer-merge-styles: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@uifabric/jest-serializer-merge-styles: $ just-scripts ts
 @uifabric/jest-serializer-merge-styles: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/jest-serializer-merge-styles/tsconfig.json
 @uifabric/jest-serializer-merge-styles: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/jest-serializer-merge-styles/tsconfig.json"
 @uifabric/jest-serializer-merge-styles: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/jest-serializer-merge-styles/tsconfig.json
 @uifabric/jest-serializer-merge-styles: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/jest-serializer-merge-styles/tsconfig.json"
 @uifabric/jest-serializer-merge-styles: Done in ?s.
 @fluentui/react-northstar-emotion-renderer: yarn run vX.X.X
-@fluentui/react-northstar-emotion-renderer: $ gulp bundle:package:no-umd
-@fluentui/react-northstar-emotion-renderer: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
-@fluentui/react-northstar-emotion-renderer: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-northstar-emotion-renderer/gulpfile.ts
+@fluentui/react-northstar-emotion-renderer: $ /office-ui-fabric-react/node_modules/.bin/just ts
 @fluentui/react-northstar-emotion-renderer: Done in ?s.
 @fluentui/react-northstar-fela-renderer: yarn run vX.X.X
-@fluentui/react-northstar-fela-renderer: $ gulp bundle:package:no-umd
-@fluentui/react-northstar-fela-renderer: [XX:XX:XX] Requiring external module @uifabric/build/babel/register
-@fluentui/react-northstar-fela-renderer: [XX:XX:XX] Using gulpfile /office-ui-fabric-react/packages/fluentui/react-northstar-fela-renderer/gulpfile.ts
+@fluentui/react-northstar-fela-renderer: $ /office-ui-fabric-react/node_modules/.bin/just ts
 @fluentui/react-northstar-fela-renderer: Done in ?s.
 @fluentui/react-stylesheets: yarn run vX.X.X
-@fluentui/react-stylesheets: $ just-scripts build
-@fluentui/react-stylesheets: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@fluentui/react-stylesheets: $ just-scripts ts
 @fluentui/react-stylesheets: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-stylesheets/tsconfig.json
 @fluentui/react-stylesheets: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-stylesheets/tsconfig.json"
 @fluentui/react-stylesheets: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-stylesheets/tsconfig.json
 @fluentui/react-stylesheets: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-stylesheets/tsconfig.json"
-@fluentui/react-stylesheets: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/react-stylesheets/lib/index.d.ts'
 @fluentui/react-stylesheets: Done in ?s.
+@fluentui/react-utilities: yarn run vX.X.X
+@fluentui/react-utilities: $ just-scripts ts
+@fluentui/react-utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-utilities/tsconfig.json
+@fluentui/react-utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-utilities/tsconfig.json"
+@fluentui/react-utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-utilities/tsconfig.json
+@fluentui/react-utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-utilities/tsconfig.json"
+@fluentui/react-utilities: Done in ?s.
 @uifabric/test-utilities: yarn run vX.X.X
-@uifabric/test-utilities: $ just-scripts build
-@uifabric/test-utilities: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@uifabric/test-utilities: $ just-scripts ts
 @uifabric/test-utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/test-utilities/tsconfig.json
 @uifabric/test-utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/test-utilities/tsconfig.json"
 @uifabric/test-utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/test-utilities/tsconfig.json
 @uifabric/test-utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/test-utilities/tsconfig.json"
 @uifabric/test-utilities: Done in ?s.
+@fluentui/react-window-provider: yarn run vX.X.X
+@fluentui/react-window-provider: $ just-scripts ts
+@fluentui/react-window-provider: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-window-provider/tsconfig.json
+@fluentui/react-window-provider: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-window-provider/tsconfig.json"
+@fluentui/react-window-provider: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-window-provider/tsconfig.json
+@fluentui/react-window-provider: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-window-provider/tsconfig.json"
+@fluentui/react-window-provider: Done in ?s.
 @uifabric/utilities: yarn run vX.X.X
-@uifabric/utilities: $ just-scripts build
-@uifabric/utilities: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@uifabric/utilities: $ just-scripts ts
 @uifabric/utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/utilities/tsconfig.json
 @uifabric/utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/utilities/tsconfig.json"
 @uifabric/utilities: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/utilities/tsconfig.json
 @uifabric/utilities: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/utilities/tsconfig.json"
-@uifabric/utilities: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/utilities/lib/index.d.ts'
-@uifabric/utilities: Done in ?s.
+@uifabric/utilities: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
 @fluentui/react-compose: yarn run vX.X.X
-@fluentui/react-compose: $ just-scripts build
-@fluentui/react-compose: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@fluentui/react-compose: $ just-scripts ts
 @fluentui/react-compose: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-compose/tsconfig.json
 @fluentui/react-compose: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-compose/tsconfig.json"
 @fluentui/react-compose: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-compose/tsconfig.json
 @fluentui/react-compose: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-compose/tsconfig.json"
-@fluentui/react-compose: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/react-compose/lib/index.d.ts'
 @fluentui/react-compose: Done in ?s.
 @uifabric/react-hooks: yarn run vX.X.X
-@uifabric/react-hooks: $ just-scripts build
-@uifabric/react-hooks: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@uifabric/react-hooks: $ just-scripts ts
 @uifabric/react-hooks: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-hooks/tsconfig.json
 @uifabric/react-hooks: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-hooks/tsconfig.json"
 @uifabric/react-hooks: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-hooks/tsconfig.json
 @uifabric/react-hooks: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-hooks/tsconfig.json"
-@uifabric/react-hooks: [XX:XX:XX XM] ■ Extracting Public API surface from '/office-ui-fabric-react/packages/react-hooks/lib/index.d.ts'
 @uifabric/react-hooks: Done in ?s.
 @fluentui/react-icons: yarn run vX.X.X
-@fluentui/react-icons: $ just-scripts build
-@fluentui/react-icons: [XX:XX:XX XM] ■ Removing [lib, temp, dist, lib-amd, lib-commonjs, lib-es2015, coverage, src/**/*.scss.ts]
+@fluentui/react-icons: $ just-scripts ts
 @fluentui/react-icons: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-icons/tsconfig.json
 @fluentui/react-icons: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-icons/tsconfig.json"
 @fluentui/react-icons: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-icons/tsconfig.json
 @fluentui/react-icons: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-icons/tsconfig.json"
 @fluentui/react-icons: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@uifabric/styling: yarn run vX.X.X
+@uifabric/styling: $ just-scripts ts
+@uifabric/styling: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/styling/tsconfig.json
+@uifabric/styling: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/styling/tsconfig.json"
+@uifabric/styling: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/styling/tsconfig.json
+@uifabric/styling: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/styling/tsconfig.json"
+@uifabric/styling: Done in ?s.
+@fluentui/react-bindings: yarn run vX.X.X
+@fluentui/react-bindings: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/react-bindings: Done in ?s.
+@uifabric/file-type-icons: yarn run vX.X.X
+@uifabric/file-type-icons: $ just-scripts ts
+@uifabric/file-type-icons: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/file-type-icons/tsconfig.json
+@uifabric/file-type-icons: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/file-type-icons/tsconfig.json"
+@uifabric/file-type-icons: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/file-type-icons/tsconfig.json
+@uifabric/file-type-icons: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/file-type-icons/tsconfig.json"
+@uifabric/file-type-icons: Done in ?s.
+@uifabric/foundation: yarn run vX.X.X
+@uifabric/foundation: $ just-scripts ts
+@uifabric/foundation: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/foundation/tsconfig.json
+@uifabric/foundation: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/foundation/tsconfig.json"
+@uifabric/foundation: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/foundation/tsconfig.json
+@uifabric/foundation: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/foundation/tsconfig.json"
+@uifabric/foundation: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@uifabric/icons: yarn run vX.X.X
+@uifabric/icons: $ just-scripts ts
+@uifabric/icons: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/icons/tsconfig.json
+@uifabric/icons: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/icons/tsconfig.json"
+@uifabric/icons: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/icons/tsconfig.json
+@uifabric/icons: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/icons/tsconfig.json"
+@uifabric/icons: Done in ?s.
+@fluentui/react-focus: yarn run vX.X.X
+@fluentui/react-focus: $ just-scripts ts
+@fluentui/react-focus: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-focus/tsconfig.json
+@fluentui/react-focus: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-focus/tsconfig.json"
+@fluentui/react-focus: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-focus/tsconfig.json
+@fluentui/react-focus: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-focus/tsconfig.json"
+@fluentui/react-focus: Done in ?s.
+@fluentui/react-theme-provider: yarn run vX.X.X
+@fluentui/react-theme-provider: $ just-scripts ts
+@fluentui/react-theme-provider: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-theme-provider/tsconfig.json
+@fluentui/react-theme-provider: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-theme-provider/tsconfig.json"
+@fluentui/react-theme-provider: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-theme-provider/tsconfig.json
+@fluentui/react-theme-provider: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-theme-provider/tsconfig.json"
+@fluentui/react-theme-provider: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@fluentui/react-icons-northstar: yarn run vX.X.X
+@fluentui/react-icons-northstar: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/react-icons-northstar: Done in ?s.
+@fluentui/react-telemetry: yarn run vX.X.X
+@fluentui/react-telemetry: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/react-telemetry: Done in ?s.
+office-ui-fabric-react: yarn run vX.X.X
+office-ui-fabric-react: $ just-scripts ts
+office-ui-fabric-react: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/office-ui-fabric-react/tsconfig.json
+office-ui-fabric-react: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/office-ui-fabric-react/tsconfig.json"
+office-ui-fabric-react: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/office-ui-fabric-react/tsconfig.json
+office-ui-fabric-react: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/office-ui-fabric-react/tsconfig.json"
+office-ui-fabric-react: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@fluentui/react-image: yarn run vX.X.X
+@fluentui/react-image: $ just-scripts ts
+@fluentui/react-image: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-image/tsconfig.json
+@fluentui/react-image: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-image/tsconfig.json"
+@fluentui/react-image: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-image/tsconfig.json
+@fluentui/react-image: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-image/tsconfig.json"
+@fluentui/react-image: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@fluentui/react-northstar: yarn run vX.X.X
+@fluentui/react-northstar: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/react-northstar: Done in ?s.
+server-rendered-app: yarn run vX.X.X
+server-rendered-app: $ just-scripts ts
+server-rendered-app: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/server-rendered-app/tsconfig.json
+server-rendered-app: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/server-rendered-app/tsconfig.json"
+server-rendered-app: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/server-rendered-app/tsconfig.json
+server-rendered-app: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/server-rendered-app/tsconfig.json"
+server-rendered-app: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+todo-app: yarn run vX.X.X
+todo-app: $ just-scripts ts
+todo-app: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/todo-app/tsconfig.json
+todo-app: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/todo-app/tsconfig.json"
+todo-app: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/todo-app/tsconfig.json
+todo-app: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/todo-app/tsconfig.json"
+todo-app: Done in ?s.
+@uifabric/azure-themes: yarn run vX.X.X
+@uifabric/azure-themes: $ just-scripts ts
+@uifabric/azure-themes: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/azure-themes/tsconfig.json
+@uifabric/azure-themes: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/azure-themes/tsconfig.json"
+@uifabric/azure-themes: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/azure-themes/tsconfig.json
+@uifabric/azure-themes: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/azure-themes/tsconfig.json"
+@uifabric/azure-themes: Done in ?s.
+@fluentui/codemods: yarn run vX.X.X
+@fluentui/codemods: $ just-scripts ts
+@fluentui/codemods: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/codemods/tsconfig.json
+@fluentui/codemods: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/codemods/tsconfig.json"
+@fluentui/codemods: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/codemods/tsconfig.json
+@fluentui/codemods: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/codemods/tsconfig.json"
+@fluentui/codemods: Done in ?s.
+@fluentui/react: yarn run vX.X.X
+@fluentui/react: $ just-scripts ts
+@fluentui/react: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react/tsconfig.json
+@fluentui/react: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react/tsconfig.json"
+@fluentui/react: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react/tsconfig.json
+@fluentui/react: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react/tsconfig.json"
+@fluentui/react: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@uifabric/tsx-editor: yarn run vX.X.X
+@uifabric/tsx-editor: $ just-scripts ts
+@uifabric/tsx-editor: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/tsx-editor/tsconfig.json
+@uifabric/tsx-editor: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/tsx-editor/tsconfig.json"
+@uifabric/tsx-editor: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/tsx-editor/tsconfig.json
+@uifabric/tsx-editor: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/tsx-editor/tsconfig.json"
+@uifabric/tsx-editor: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@uifabric/variants: yarn run vX.X.X
+@uifabric/variants: $ just-scripts ts
+@uifabric/variants: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/variants/tsconfig.json
+@uifabric/variants: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/variants/tsconfig.json"
+@uifabric/variants: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/variants/tsconfig.json
+@uifabric/variants: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/variants/tsconfig.json"
+@uifabric/variants: Done in ?s.
+@fluentui/circulars-test: yarn run vX.X.X
+@fluentui/circulars-test: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/circulars-test: Done in ?s.
+@fluentui/code-sandbox: yarn run vX.X.X
+@fluentui/code-sandbox: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/code-sandbox: Done in ?s.
+@fluentui/e2e: yarn run vX.X.X
+@fluentui/e2e: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/e2e: Done in ?s.
+@fluentui/local-sandbox: yarn run vX.X.X
+@fluentui/local-sandbox: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/local-sandbox: Done in ?s.
+@fluentui/perf-test: yarn run vX.X.X
+@fluentui/perf-test: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/perf-test: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/fluentui/perf-test/tsconfig.json
+@fluentui/perf-test: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/fluentui/perf-test/tsconfig.json"
+@fluentui/perf-test: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/fluentui/perf-test/tsconfig.json
+@fluentui/perf-test: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/fluentui/perf-test/tsconfig.json"
+@fluentui/perf-test: Done in ?s.
+@fluentui/projects-test: yarn run vX.X.X
+@fluentui/projects-test: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/projects-test: Done in ?s.
+@fluentui/react-builder: yarn run vX.X.X
+@fluentui/react-builder: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/react-builder: Done in ?s.
+codesandbox-react-template: yarn run vX.X.X
+codesandbox-react-template: $ just-scripts ts
+codesandbox-react-template: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/codesandbox-react-template/tsconfig.json
+codesandbox-react-template: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/codesandbox-react-template/tsconfig.json"
+codesandbox-react-template: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/codesandbox-react-template/tsconfig.json
+codesandbox-react-template: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/codesandbox-react-template/tsconfig.json"
+codesandbox-react-template: Done in ?s.
+@uifabric/fluent-theme: yarn run vX.X.X
+@uifabric/fluent-theme: $ just-scripts ts
+@uifabric/fluent-theme: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/fluent-theme/tsconfig.json
+@uifabric/fluent-theme: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/fluent-theme/tsconfig.json"
+@uifabric/fluent-theme: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/fluent-theme/tsconfig.json
+@uifabric/fluent-theme: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/fluent-theme/tsconfig.json"
+@uifabric/fluent-theme: Done in ?s.
+@uifabric/mdl2-theme: yarn run vX.X.X
+@uifabric/mdl2-theme: $ just-scripts ts
+@uifabric/mdl2-theme: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/mdl2-theme/tsconfig.json
+@uifabric/mdl2-theme: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/mdl2-theme/tsconfig.json"
+@uifabric/mdl2-theme: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/mdl2-theme/tsconfig.json
+@uifabric/mdl2-theme: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/mdl2-theme/tsconfig.json"
+@uifabric/mdl2-theme: Done in ?s.
+@uifabric/theme-samples: yarn run vX.X.X
+@uifabric/theme-samples: $ just-scripts ts
+@uifabric/theme-samples: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/theme-samples/tsconfig.json
+@uifabric/theme-samples: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/theme-samples/tsconfig.json"
+@uifabric/theme-samples: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/theme-samples/tsconfig.json
+@uifabric/theme-samples: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/theme-samples/tsconfig.json"
+@uifabric/theme-samples: Done in ?s.
+codesandbox-react-northstar-template: yarn run vX.X.X
+codesandbox-react-northstar-template: $ just-scripts ts
+codesandbox-react-northstar-template: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/codesandbox-react-northstar-template/tsconfig.json
+codesandbox-react-northstar-template: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/codesandbox-react-northstar-template/tsconfig.json"
+codesandbox-react-northstar-template: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/codesandbox-react-northstar-template/tsconfig.json
+codesandbox-react-northstar-template: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/codesandbox-react-northstar-template/tsconfig.json"
+codesandbox-react-northstar-template: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@fluentui/docs: yarn run vX.X.X
+@fluentui/docs: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/docs: Done in ?s.
+@uifabric/example-app-base: yarn run vX.X.X
+@uifabric/example-app-base: $ just-scripts ts
+@uifabric/example-app-base: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/example-app-base/tsconfig.json
+@uifabric/example-app-base: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/example-app-base/tsconfig.json"
+@uifabric/example-app-base: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/example-app-base/tsconfig.json
+@uifabric/example-app-base: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/example-app-base/tsconfig.json"
+@uifabric/example-app-base: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@fluentui/storybook: yarn run vX.X.X
+@fluentui/storybook: $ just-scripts ts
+@fluentui/storybook: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/storybook/tsconfig.json
+@fluentui/storybook: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/storybook/tsconfig.json"
+@fluentui/storybook: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/storybook/tsconfig.json
+@fluentui/storybook: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/storybook/tsconfig.json"
+@fluentui/storybook: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@fluentui/perf: yarn run vX.X.X
+@fluentui/perf: $ /office-ui-fabric-react/node_modules/.bin/just ts
+@fluentui/perf: Done in ?s.
+dom-tests: yarn run vX.X.X
+dom-tests: $ just-scripts ts
+dom-tests: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/dom-tests/tsconfig.json
+dom-tests: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/dom-tests/tsconfig.json"
+dom-tests: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/dom-tests/tsconfig.json
+dom-tests: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/dom-tests/tsconfig.json"
+dom-tests: Done in ?s.
+@uifabric/charting: yarn run vX.X.X
+@uifabric/charting: $ just-scripts ts
+@uifabric/charting: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/charting/tsconfig.json
+@uifabric/charting: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/charting/tsconfig.json"
+@uifabric/charting: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/charting/tsconfig.json
+@uifabric/charting: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/charting/tsconfig.json"
+@uifabric/charting: Done in ?s.
+@uifabric/date-time: yarn run vX.X.X
+@uifabric/date-time: $ just-scripts ts
+@uifabric/date-time: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/date-time/tsconfig.json
+@uifabric/date-time: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/date-time/tsconfig.json"
+@uifabric/date-time: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/date-time/tsconfig.json
+@uifabric/date-time: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/date-time/tsconfig.json"
+@uifabric/date-time: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@uifabric/experiments: yarn run vX.X.X
+@uifabric/experiments: $ just-scripts ts
+@uifabric/experiments: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/experiments/tsconfig.json
+@uifabric/experiments: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/experiments/tsconfig.json"
+@uifabric/experiments: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/experiments/tsconfig.json
+@uifabric/experiments: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/experiments/tsconfig.json"
+@uifabric/experiments: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@uifabric/lists: yarn run vX.X.X
+@uifabric/lists: $ just-scripts ts
+@uifabric/lists: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/lists/tsconfig.json
+@uifabric/lists: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/lists/tsconfig.json"
+@uifabric/lists: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/lists/tsconfig.json
+@uifabric/lists: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/lists/tsconfig.json"
+@uifabric/lists: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@uifabric/react-cards: yarn run vX.X.X
+@uifabric/react-cards: $ just-scripts ts
+@uifabric/react-cards: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-cards/tsconfig.json
+@uifabric/react-cards: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-cards/tsconfig.json"
+@uifabric/react-cards: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-cards/tsconfig.json
+@uifabric/react-cards: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-cards/tsconfig.json"
+@uifabric/react-cards: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@fluentui/react-avatar: yarn run vX.X.X
+@fluentui/react-avatar: $ just-scripts ts
+@fluentui/react-avatar: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-avatar/tsconfig.json
+@fluentui/react-avatar: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-avatar/tsconfig.json"
+@fluentui/react-avatar: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-avatar/tsconfig.json
+@fluentui/react-avatar: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-avatar/tsconfig.json"
+@fluentui/react-avatar: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@fluentui/react-button: yarn run vX.X.X
+@fluentui/react-button: $ just-scripts ts
+@fluentui/react-button: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-button/tsconfig.json
+@fluentui/react-button: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-button/tsconfig.json"
+@fluentui/react-button: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-button/tsconfig.json
+@fluentui/react-button: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-button/tsconfig.json"
+@fluentui/react-button: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@fluentui/react-tabs: yarn run vX.X.X
+@fluentui/react-tabs: $ just-scripts ts
+@fluentui/react-tabs: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-tabs/tsconfig.json
+@fluentui/react-tabs: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-tabs/tsconfig.json"
+@fluentui/react-tabs: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-tabs/tsconfig.json
+@fluentui/react-tabs: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-tabs/tsconfig.json"
+@fluentui/react-tabs: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+theming-designer: yarn run vX.X.X
+theming-designer: $ just-scripts ts
+theming-designer: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/theming-designer/tsconfig.json
+theming-designer: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/theming-designer/tsconfig.json"
+theming-designer: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/theming-designer/tsconfig.json
+theming-designer: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/theming-designer/tsconfig.json"
+theming-designer: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@uifabric/api-docs: yarn run vX.X.X
+@uifabric/api-docs: $ just-scripts ts
+@uifabric/api-docs: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/api-docs/tsconfig.json
+@uifabric/api-docs: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/api-docs/tsconfig.json"
+@uifabric/api-docs: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/api-docs/tsconfig.json
+@uifabric/api-docs: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/api-docs/tsconfig.json"
+@uifabric/api-docs: Done in ?s.
+@fluentui/react-flex: yarn run vX.X.X
+@fluentui/react-flex: $ just-scripts ts
+@fluentui/react-flex: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-flex/tsconfig.json
+@fluentui/react-flex: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-flex/tsconfig.json"
+@fluentui/react-flex: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-flex/tsconfig.json
+@fluentui/react-flex: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-flex/tsconfig.json"
+@fluentui/react-flex: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@fluentui/react-next: yarn run vX.X.X
+@fluentui/react-next: $ just-scripts ts
+@fluentui/react-next: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-next/tsconfig.json
+@fluentui/react-next: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-next/tsconfig.json"
+@fluentui/react-next: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/react-next/tsconfig.json
+@fluentui/react-next: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-next/tsconfig.json"
+@fluentui/react-next: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@uifabric/fabric-website-resources: yarn run vX.X.X
+@uifabric/fabric-website-resources: $ just-scripts ts
+@uifabric/fabric-website-resources: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/fabric-website-resources/tsconfig.json
+@uifabric/fabric-website-resources: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/fabric-website-resources/tsconfig.json"
+@uifabric/fabric-website-resources: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/fabric-website-resources/tsconfig.json
+@uifabric/fabric-website-resources: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/fabric-website-resources/tsconfig.json"
+@uifabric/fabric-website-resources: Done in ?s.
+codesandbox-react-next-template: yarn run vX.X.X
+codesandbox-react-next-template: $ just-scripts ts
+codesandbox-react-next-template: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/codesandbox-react-next-template/tsconfig.json
+codesandbox-react-next-template: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/codesandbox-react-next-template/tsconfig.json"
+codesandbox-react-next-template: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/codesandbox-react-next-template/tsconfig.json
+codesandbox-react-next-template: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/codesandbox-react-next-template/tsconfig.json"
+codesandbox-react-next-template: Done in ?s.
+perf-test: yarn run vX.X.X
+perf-test: $ just-scripts ts
+perf-test: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/perf-test/tsconfig.json
+perf-test: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/perf-test/tsconfig.json"
+perf-test: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/perf-test/tsconfig.json
+perf-test: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/perf-test/tsconfig.json"
+perf-test: Done in ?s.
+test-bundles: yarn run vX.X.X
+test-bundles: $ just-scripts ts
+test-bundles: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/test-bundles/tsconfig.json
+test-bundles: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/test-bundles/tsconfig.json"
+test-bundles: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/test-bundles/tsconfig.json
+test-bundles: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/test-bundles/tsconfig.json"
+test-bundles: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+vr-tests: yarn run vX.X.X
+vr-tests: $ just-scripts ts
+vr-tests: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/vr-tests/tsconfig.json
+vr-tests: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/vr-tests/tsconfig.json"
+vr-tests: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/vr-tests/tsconfig.json
+vr-tests: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/vr-tests/tsconfig.json"
+vr-tests: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+a11y-tests: yarn run vX.X.X
+a11y-tests: $ just-scripts ts
+a11y-tests: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/a11y-tests/tsconfig.json
+a11y-tests: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/a11y-tests/tsconfig.json"
+a11y-tests: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/a11y-tests/tsconfig.json
+a11y-tests: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/a11y-tests/tsconfig.json"
+a11y-tests: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+@uifabric/fabric-website: yarn run vX.X.X
+@uifabric/fabric-website: $ just-scripts ts
+@uifabric/fabric-website: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/fabric-website/tsconfig.json
+@uifabric/fabric-website: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/fabric-website/tsconfig.json"
+@uifabric/fabric-website: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/apps/fabric-website/tsconfig.json
+@uifabric/fabric-website: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/fabric-website/tsconfig.json"
+@uifabric/fabric-website: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+ssr-tests: yarn run vX.X.X
+ssr-tests: $ just-scripts ts
+ssr-tests: Done in ?s.
+@fluentui/examples: yarn run vX.X.X
+@fluentui/examples: $ just-scripts ts
+@fluentui/examples: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/examples/tsconfig.json
+@fluentui/examples: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/examples/tsconfig.json"
+@fluentui/examples: [XX:XX:XX XM] ■ Running /office-ui-fabric-react/node_modules/typescript/lib/tsc.js with /office-ui-fabric-react/packages/examples/tsconfig.json
+@fluentui/examples: [XX:XX:XX XM] ■ Executing: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/examples/tsconfig.json"
+@fluentui/examples: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
 
 
 
 Standard error:
-info cli using local version of lerna
-@microsoft/fast-components-msft: src/index-rollup.ts → dist/fast-components-msft.js, dist/fast-components-msft.min.js...
-@microsoft/fast-components-msft: created dist/fast-components-msft.js, dist/fast-components-msft.min.js in ?s
-@microsoft/fast-components-msft: npm WARN lifecycle The node binary used for scripts is  but npm is using /usr/local/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
-@fluentui/ability-attributes: npm WARN lifecycle The node binary used for scripts is  but npm is using /usr/local/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
-@uifabric/build: warning package.json: "dependencies" has dependency "typescript" with range "3.7.2" that collides with a dependency in "devDependencies" of the same name with version "../typescript.tgz"
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@uifabric/build: (Use `node --trace-warnings ...` to show where the warning was created)
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@uifabric/build: (node:166) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@fluentui/common-styles: (Use `node --trace-warnings ...` to show where the warning was created)
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@fluentui/common-styles: (node:185) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@uifabric/example-data: (Use `node --trace-warnings ...` to show where the warning was created)
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@uifabric/example-data: (node:208) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@uifabric/example-data: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@fluentui/keyboard-key: (Use `node --trace-warnings ...` to show where the warning was created)
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@fluentui/keyboard-key: (node:247) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@fluentui/keyboard-key: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@uifabric/migration: (Use `node --trace-warnings ...` to show where the warning was created)
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@uifabric/migration: (node:286) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@uifabric/monaco-editor: (Use `node --trace-warnings ...` to show where the warning was created)
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@uifabric/monaco-editor: (node:317) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@fluentui/react-conformance: (Use `node --trace-warnings ...` to show where the warning was created)
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@fluentui/react-conformance: (node:356) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@uifabric/set-version: (Use `node --trace-warnings ...` to show where the warning was created)
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@uifabric/set-version: (node:387) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@uifabric/set-version: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@uifabric/webpack-utils: (Use `node --trace-warnings ...` to show where the warning was created)
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@uifabric/webpack-utils: (node:426) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@fluentui/date-time-utilities: (Use `node --trace-warnings ...` to show where the warning was created)
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@fluentui/date-time-utilities: (node:736) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@fluentui/date-time-utilities: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@uifabric/merge-styles: (Use `node --trace-warnings ...` to show where the warning was created)
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@uifabric/merge-styles: (node:775) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@uifabric/merge-styles: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@fluentui/react-flex: (Use `node --trace-warnings ...` to show where the warning was created)
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@fluentui/react-flex: (node:814) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@fluentui/react-flex: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (Use `node --trace-warnings ...` to show where the warning was created)
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: (node:884) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@uifabric/jest-serializer-merge-styles: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@fluentui/react-stylesheets: (Use `node --trace-warnings ...` to show where the warning was created)
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@fluentui/react-stylesheets: (node:985) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@fluentui/react-stylesheets: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@uifabric/test-utilities: (Use `node --trace-warnings ...` to show where the warning was created)
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@uifabric/test-utilities: (node:1024) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@uifabric/utilities: (Use `node --trace-warnings ...` to show where the warning was created)
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@uifabric/utilities: (node:1063) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@uifabric/utilities: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@fluentui/react-compose: (Use `node --trace-warnings ...` to show where the warning was created)
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@fluentui/react-compose: (node:1102) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@fluentui/react-compose: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@uifabric/react-hooks: (Use `node --trace-warnings ...` to show where the warning was created)
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@uifabric/react-hooks: (node:1141) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@uifabric/react-hooks: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
-@fluentui/react-icons: (Use `node --trace-warnings ...` to show where the warning was created)
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
-@fluentui/react-icons: (node:1180) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
-@fluentui/react-icons: [XX:XX:XX XM] ▲ One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect
+@fluentui/eslint-plugin: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/eslint-plugin: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/noop: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/noop: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/web-components: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/web-components: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/ability-attributes: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/ability-attributes: [XX:XX:XX XM] x Command not defined: ts
+@uifabric/build: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@uifabric/build: [XX:XX:XX XM] x ------------------------------------
+@uifabric/build: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/scripts/tsconfig.json"
+@uifabric/build:     at ChildProcess.exithandler (child_process.js:303:12)
+@uifabric/build:     at ChildProcess.emit (events.js:315:20)
+@uifabric/build:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@uifabric/build:     at maybeClose (internal/child_process.js:1026:16)
+@uifabric/build:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@uifabric/build: [XX:XX:XX XM] x stdout:
+@uifabric/build: [XX:XX:XX XM] x create-package/plop-templates-node/just.config.ts:1:9 - error TS2451: Cannot redeclare block-scoped variable 'preset'.
+@uifabric/build: 1 const { preset, just } = require('@uifabric/build');
+@uifabric/build:           ~~~~~~
+@uifabric/build:   create-package/plop-templates-react/just.config.ts:1:9
+@uifabric/build:     1 const { preset } = require('@uifabric/build');
+@uifabric/build:               ~~~~~~
+@uifabric/build:     'preset' was also declared here.
+@uifabric/build:   tasks/preset.ts:1:7
+@uifabric/build:     1 const preset = require('../just.config');
+@uifabric/build:             ~~~~~~
+@uifabric/build:     and here.
+@uifabric/build: create-package/plop-templates-node/just.config.ts:2:9 - error TS2451: Cannot redeclare block-scoped variable 'task'.
+@uifabric/build: 2 const { task } = just;
+@uifabric/build:           ~~~~
+@uifabric/build:   just.config.ts:3:9
+@uifabric/build:     3 const { task, series, parallel, condition, option, argv, addResolvePath, resolveCwd } = require('just-scripts');
+@uifabric/build:               ~~~~
+@uifabric/build:     'task' was also declared here.
+@uifabric/build: create-package/plop-templates-react/just.config.ts:1:9 - error TS2451: Cannot redeclare block-scoped variable 'preset'.
+@uifabric/build: 1 const { preset } = require('@uifabric/build');
+@uifabric/build:           ~~~~~~
+@uifabric/build:   create-package/plop-templates-node/just.config.ts:1:9
+@uifabric/build:     1 const { preset, just } = require('@uifabric/build');
+@uifabric/build:               ~~~~~~
+@uifabric/build:     'preset' was also declared here.
+@uifabric/build: create-package/plop-templates-react/src/version.ts:3:28 - error TS2307: Cannot find module '@uifabric/set-version' or its corresponding type declarations.
+@uifabric/build: 3 import { setVersion } from '@uifabric/set-version';
+@uifabric/build:                              ~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/build: exec-sync.js:4:7 - error TS6133: 'chalk' is declared but its value is never read.
+@uifabric/build: 4 const chalk = require('chalk').default;
+@uifabric/build:         ~~~~~
+@uifabric/build: exec-sync.js:21:13 - error TS2304: Cannot find name 'chalk'.
+@uifabric/build: 21   logStatus(chalk.gray('Executing: ') + chalk.cyan(displayName || cmd));
+@uifabric/build:                ~~~~~
+@uifabric/build: exec-sync.js:21:41 - error TS2304: Cannot find name 'chalk'.
+@uifabric/build: 21   logStatus(chalk.gray('Executing: ') + chalk.cyan(displayName || cmd));
+@uifabric/build:                                            ~~~~~
+@uifabric/build: exec.js:4:7 - error TS6133: 'chalk' is declared but its value is never read.
+@uifabric/build: 4 const chalk = require('chalk').default;
+@uifabric/build:         ~~~~~
+@uifabric/build: exec.js:28:13 - error TS2304: Cannot find name 'chalk'.
+@uifabric/build: 28   logStatus(chalk.gray('Executing: ') + chalk.cyan(displayName || cmd));
+@uifabric/build:                ~~~~~
+@uifabric/build: exec.js:28:41 - error TS2304: Cannot find name 'chalk'.
+@uifabric/build: 28   logStatus(chalk.gray('Executing: ') + chalk.cyan(displayName || cmd));
+@uifabric/build:                                            ~~~~~
+@uifabric/build: gulp/plugins/util/getComponentInfo.ts:139:9 - error TS2322: Type 'Tag[]' is not assignable to type '{ title: string; description: string; type: null; name: string; }[]'.
+@uifabric/build:   Type 'Tag' is not assignable to type '{ title: string; description: string; type: null; name: string; }'.
+@uifabric/build:     Types of property 'type' are incompatible.
+@uifabric/build:       Type 'Type' is not assignable to type 'null'.
+@uifabric/build:         Type 'AllLiteral' is not assignable to type 'null'.
+@uifabric/build: 139         tags,
+@uifabric/build:             ~~~~
+@uifabric/build:   gulp/plugins/util/docs-types.ts:49:3
+@uifabric/build:     49   tags: {
+@uifabric/build:          ~~~~
+@uifabric/build:     The expected type comes from property 'tags' which is declared here on type 'ComponentProp'
+@uifabric/build: gulp/tasks/test-projects/cra/App.tsx:16:8 - error TS2307: Cannot find module '@fluentui/react-northstar' or its corresponding type declarations.
+@uifabric/build: 16 } from '@fluentui/react-northstar';
+@uifabric/build:           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/build: gulp/tasks/test-projects/typings/index.tsx:1:27 - error TS2307: Cannot find module '@fluentui/react-northstar' or its corresponding type declarations.
+@uifabric/build: 1 import * as FluentUI from '@fluentui/react-northstar';
+@uifabric/build:                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/build: index.js:1:1 - error TS9006: Declaration emit for this file requires using private name 'CssLoaderOptions' from module '"/office-ui-fabric-react/node_modules/just-scripts/lib/webpack/overlays/stylesOverlay"'. An explicit type annotation may unblock declaration emit.
+@uifabric/build: 1 const just = require('just-scripts');
+@uifabric/build:   ~~~~~
+@uifabric/build: index.js:1:1 - error TS9006: Declaration emit for this file requires using private name 'PrettierTaskOptions' from module '"/office-ui-fabric-react/node_modules/just-scripts/lib/tasks/prettierTask"'. An explicit type annotation may unblock declaration emit.
+@uifabric/build: 1 const just = require('just-scripts');
+@uifabric/build:   ~~~~~
+@uifabric/build: just.config.ts:3:9 - error TS2451: Cannot redeclare block-scoped variable 'task'.
+@uifabric/build: 3 const { task, series, parallel, condition, option, argv, addResolvePath, resolveCwd } = require('just-scripts');
+@uifabric/build:           ~~~~
+@uifabric/build:   create-package/plop-templates-node/just.config.ts:2:9
+@uifabric/build:     2 const { task } = just;
+@uifabric/build:               ~~~~
+@uifabric/build:     'task' was also declared here.
+@uifabric/build: lint-staged/auto-convert-change-files.js:3:7 - error TS6133: 'chalk' is declared but its value is never read.
+@uifabric/build: 3 const chalk = require('chalk').default;
+@uifabric/build:         ~~~~~
+@uifabric/build: lint-staged/auto-convert-change-files.js:8:16 - error TS2304: Cannot find name 'chalk'.
+@uifabric/build: 8   console.warn(chalk.red('Legacy change file(s) detected. Auto-converting these to the new format.'));
+@uifabric/build:                  ~~~~~
+@uifabric/build: lint-staged/auto-convert-change-files.js:13:16 - error TS2304: Cannot find name 'chalk'.
+@uifabric/build: 13   console.warn(chalk.green('Changes are completed for you. Please run git commit again!'));
+@uifabric/build:                   ~~~~~
+@uifabric/build: lint-staged/auto-convert-change-files.js:15:5 - error TS2304: Cannot find name 'chalk'.
+@uifabric/build: 15     chalk.cyan('In the future, please use "npm run change" to generate change files instead of "rush change"'),
+@uifabric/build:        ~~~~~
+@uifabric/build: monorepo/findRepoDeps.js:51:18 - error TS2569: Type 'Set<string>' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators.
+@uifabric/build: 51   repoDeps = [...result].map(dep => packageInfo[dep]);
+@uifabric/build:                     ~~~~~~
+@uifabric/build: publish-beta.js:4:7 - error TS6133: 'chalk' is declared but its value is never read.
+@uifabric/build: 4 const chalk = require('chalk').default;
+@uifabric/build:         ~~~~~
+@uifabric/build: publish-beta.js:18:12 - error TS1212: Identifier expected. 'package' is a reserved word in strict mode.
+@uifabric/build: 18 for (const package of packages) {
+@uifabric/build:               ~~~~~~~
+@uifabric/build: publish-beta.js:19:53 - error TS1212: Identifier expected. 'package' is a reserved word in strict mode.
+@uifabric/build: 19   const packagePath = path.resolve(__dirname, '..', package.packagePath);
+@uifabric/build:                                                        ~~~~~~~
+@uifabric/build: publish-beta.js:21:29 - error TS2304: Cannot find name 'chalk'.
+@uifabric/build: 21   console.log(`Publishing ${chalk.magenta(package.packageName)} in ${packagePath}`);
+@uifabric/build:                                ~~~~~
+@uifabric/build: publish-beta.js:21:43 - error TS1212: Identifier expected. 'package' is a reserved word in strict mode.
+@uifabric/build: 21   console.log(`Publishing ${chalk.magenta(package.packageName)} in ${packagePath}`);
+@uifabric/build:                                              ~~~~~~~
+@uifabric/build: screener/screener.config.js:29:7 - error TS6133: 'config' is declared but its value is never read.
+@uifabric/build: 29 const config = require('../config').default;
+@uifabric/build:          ~~~~~~
+@uifabric/build: screener/screener.config.js:31:9 - error TS2339: Property 'compilerOptions' does not exist on type 'typeof Electron'.
+@uifabric/build: 31 const { compilerOptions } = require(config.paths.docs('tsconfig.json'));
+@uifabric/build:            ~~~~~~~~~~~~~~~
+@uifabric/build: screener/screener.config.js:31:37 - error TS2304: Cannot find name 'config'.
+@uifabric/build: 31 const { compilerOptions } = require(config.paths.docs('tsconfig.json'));
+@uifabric/build:                                        ~~~~~~
+@uifabric/build: screener/screener.config.js:34:12 - error TS2304: Cannot find name 'config'.
+@uifabric/build: 34   baseUrl: config.path_base,
+@uifabric/build:               ~~~~~~
+@uifabric/build: screener/screener.config.js:48:14 - error TS2304: Cannot find name 'config'.
+@uifabric/build: 48     host: `${config.server_host}:${config.server_port}`,
+@uifabric/build:                 ~~~~~~
+@uifabric/build: screener/screener.config.js:48:36 - error TS2304: Cannot find name 'config'.
+@uifabric/build: 48     host: `${config.server_host}:${config.server_port}`,
+@uifabric/build:                                       ~~~~~~
+@uifabric/build: tasks/lint-imports.js:33:9 - error TS6133: 'chalk' is declared but its value is never read.
+@uifabric/build: 33   const chalk = require('chalk').default;
+@uifabric/build:            ~~~~~
+@uifabric/build: tasks/lint-imports.js:361:26 - error TS2304: Cannot find name 'chalk'.
+@uifabric/build: 361         console.error(`${chalk.red('ERROR')}: ${errorGroup.count} ${errorMessages[groupName]}`);
+@uifabric/build:                              ~~~~~
+@uifabric/build: tasks/lint-imports.js:366:34 - error TS2304: Cannot find name 'chalk'.
+@uifabric/build: 366             console.error(`    ${chalk.inverse(importPath)}`);
+@uifabric/build:                                      ~~~~~
+@uifabric/build: tasks/preset.ts:1:7 - error TS2451: Cannot redeclare block-scoped variable 'preset'.
+@uifabric/build: 1 const preset = require('../just.config');
+@uifabric/build:         ~~~~~~
+@uifabric/build:   create-package/plop-templates-node/just.config.ts:1:9
+@uifabric/build:     1 const { preset, just } = require('@uifabric/build');
+@uifabric/build:               ~~~~~~
+@uifabric/build:     'preset' was also declared here.
+@uifabric/build: update-package-versions.js:11:7 - error TS6133: 'path' is declared but its value is never read.
+@uifabric/build: 11 const path = require('path');
+@uifabric/build:          ~~~~
+@uifabric/build: update-package-versions.js:13:7 - error TS6133: 'chalk' is declared but its value is never read.
+@uifabric/build: 13 const chalk = require('chalk').default;
+@uifabric/build:          ~~~~~
+@uifabric/build: update-package-versions.js:43:27 - error TS2304: Cannot find name 'chalk'.
+@uifabric/build: 43   console.log(`Updating ${chalk.magenta(name)} from ${chalk.grey(packageJson.version)} to ${chalk.green(newVersion)}.`);
+@uifabric/build:                              ~~~~~
+@uifabric/build: update-package-versions.js:43:55 - error TS2304: Cannot find name 'chalk'.
+@uifabric/build: 43   console.log(`Updating ${chalk.magenta(name)} from ${chalk.grey(packageJson.version)} to ${chalk.green(newVersion)}.`);
+@uifabric/build:                                                          ~~~~~
+@uifabric/build: update-package-versions.js:43:93 - error TS2304: Cannot find name 'chalk'.
+@uifabric/build: 43   console.log(`Updating ${chalk.magenta(name)} from ${chalk.grey(packageJson.version)} to ${chalk.green(newVersion)}.`);
+@uifabric/build:                                                                                                ~~~~~
+@uifabric/build: update-package-versions.js:47:12 - error TS1250: Function declarations are not allowed inside blocks in strict mode when targeting 'ES3' or 'ES5'.
+@uifabric/build: 47   function updateDependencies(deps) {
+@uifabric/build:               ~~~~~~~~~~~~~~~~~~
+@uifabric/build: Found 42 errors.
+@uifabric/build: [XX:XX:XX XM] x ------------------------------------
+@uifabric/build: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@uifabric/build: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@uifabric/build: error Command failed with exit code 1.
+@uifabric/webpack-utils: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@uifabric/webpack-utils: [XX:XX:XX XM] x ------------------------------------
+@uifabric/webpack-utils: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/webpack-utils/tsconfig.json"
+@uifabric/webpack-utils:     at ChildProcess.exithandler (child_process.js:303:12)
+@uifabric/webpack-utils:     at ChildProcess.emit (events.js:315:20)
+@uifabric/webpack-utils:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@uifabric/webpack-utils:     at maybeClose (internal/child_process.js:1026:16)
+@uifabric/webpack-utils:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@uifabric/webpack-utils: [XX:XX:XX XM] x stdout:
+@uifabric/webpack-utils: [XX:XX:XX XM] x src/fabricAsyncLoaderInclude.ts:7:1 - error TS1203: Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.
+@uifabric/webpack-utils: 7 export = (input: string) =>
+@uifabric/webpack-utils:   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/webpack-utils: 8   input.match(/office-ui-fabric-react[\\/]lib[\\/]components[\\/]ContextualMenu[\\/]ContextualMenu.js/) ||
+@uifabric/webpack-utils:   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/webpack-utils: 9   input.match(/office-ui-fabric-react[\\/]lib[\\/]components[\\/]Callout[\\/]Callout.js/);
+@uifabric/webpack-utils:   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/webpack-utils: Found 1 error.
+@uifabric/webpack-utils: [XX:XX:XX XM] x ------------------------------------
+@uifabric/webpack-utils: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@uifabric/webpack-utils: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@uifabric/webpack-utils: error Command failed with exit code 1.
+@fluentui/docs-components: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/docs-components: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/react-component-event-listener: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/react-component-event-listener: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/react-component-nesting-registry: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/react-component-nesting-registry: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/react-component-ref: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/react-component-ref: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/react-context-selector: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/react-context-selector: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/react-proptypes: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/react-proptypes: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/state: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/state: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/styles: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/styles: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/accessibility: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/accessibility: [XX:XX:XX XM] x Command not defined: ts
+@uifabric/merge-styles: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@uifabric/merge-styles: [XX:XX:XX XM] x ------------------------------------
+@uifabric/merge-styles: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/merge-styles/tsconfig.json"
+@uifabric/merge-styles:     at ChildProcess.exithandler (child_process.js:303:12)
+@uifabric/merge-styles:     at ChildProcess.emit (events.js:315:20)
+@uifabric/merge-styles:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@uifabric/merge-styles:     at maybeClose (internal/child_process.js:1026:16)
+@uifabric/merge-styles:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@uifabric/merge-styles: [XX:XX:XX XM] x stdout:
+@uifabric/merge-styles: [XX:XX:XX XM] x src/mergeStyleSets.test.ts:168:15 - error TS2310: Type 'ISubComponentStyles' recursively references itself as a base type.
+@uifabric/merge-styles: 168     interface ISubComponentStyles extends IStyleSet<ISubComponentStyles> {
+@uifabric/merge-styles:                   ~~~~~~~~~~~~~~~~~~~
+@uifabric/merge-styles: src/mergeStyleSets.test.ts:176:15 - error TS2310: Type 'IStyles' recursively references itself as a base type.
+@uifabric/merge-styles: 176     interface IStyles extends IStyleSet<IStyles> {
+@uifabric/merge-styles:                   ~~~~~~~
+@uifabric/merge-styles: Found 2 errors.
+@uifabric/merge-styles: [XX:XX:XX XM] x ------------------------------------
+@uifabric/merge-styles: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@uifabric/merge-styles: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@uifabric/merge-styles: error Command failed with exit code 1.
+@fluentui/react-northstar-styles-renderer: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/react-northstar-styles-renderer: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/react-northstar-emotion-renderer: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/react-northstar-emotion-renderer: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/react-northstar-fela-renderer: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/react-northstar-fela-renderer: [XX:XX:XX XM] x Command not defined: ts
+@uifabric/utilities: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@uifabric/utilities: [XX:XX:XX XM] x ------------------------------------
+@uifabric/utilities: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/utilities/tsconfig.json"
+@uifabric/utilities:     at ChildProcess.exithandler (child_process.js:303:12)
+@uifabric/utilities:     at ChildProcess.emit (events.js:315:20)
+@uifabric/utilities:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@uifabric/utilities:     at maybeClose (internal/child_process.js:1026:16)
+@uifabric/utilities:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@uifabric/utilities: [XX:XX:XX XM] x stdout:
+@uifabric/utilities: [XX:XX:XX XM] x src/AutoScroll.ts:143:14 - error TS2790: The operand of a 'delete' operator must be optional.
+@uifabric/utilities: 143       delete this._timeoutId;
+@uifabric/utilities:                  ~~~~~~~~~~~~~~~
+@uifabric/utilities: src/dom/getRect.ts:19:16 - error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+@uifabric/utilities: 19     } else if ((element as HTMLElement).getBoundingClientRect) {
+@uifabric/utilities:                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/utilities: src/object.ts:9:11 - error TS2339: Property 'hasOwnProperty' does not exist on type 'TA'.
+@uifabric/utilities: 9     if (a.hasOwnProperty(propName)) {
+@uifabric/utilities:             ~~~~~~~~~~~~~~
+@uifabric/utilities: src/object.ts:10:14 - error TS2339: Property 'hasOwnProperty' does not exist on type 'TB'.
+@uifabric/utilities: 10       if (!b.hasOwnProperty(propName) || b[propName] !== a[propName]) {
+@uifabric/utilities:                 ~~~~~~~~~~~~~~
+@uifabric/utilities: src/object.ts:10:42 - error TS2536: Type 'Extract<keyof TA, string>' cannot be used to index type 'TB'.
+@uifabric/utilities: 10       if (!b.hasOwnProperty(propName) || b[propName] !== a[propName]) {
+@uifabric/utilities:                                             ~~~~~~~~~~~
+@uifabric/utilities: src/object.ts:16:11 - error TS2339: Property 'hasOwnProperty' does not exist on type 'TB'.
+@uifabric/utilities: 16     if (b.hasOwnProperty(propName)) {
+@uifabric/utilities:              ~~~~~~~~~~~~~~
+@uifabric/utilities: src/object.ts:17:14 - error TS2339: Property 'hasOwnProperty' does not exist on type 'TA'.
+@uifabric/utilities: 17       if (!a.hasOwnProperty(propName)) {
+@uifabric/utilities:                 ~~~~~~~~~~~~~~
+@uifabric/utilities: Found 7 errors.
+@uifabric/utilities: [XX:XX:XX XM] x ------------------------------------
+@uifabric/utilities: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@uifabric/utilities: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@uifabric/utilities: error Command failed with exit code 1.
 @fluentui/react-icons: [XX:XX:XX XM] x Error detected while running 'ts:esm'
 @fluentui/react-icons: [XX:XX:XX XM] x ------------------------------------
 @fluentui/react-icons: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-icons/tsconfig.json"
-@fluentui/react-icons:     at ChildProcess.exithandler (child_process.js:308:12)
-@fluentui/react-icons:     at ChildProcess.emit (events.js:314:20)
-@fluentui/react-icons:     at ChildProcess.EventEmitter.emit (domain.js:548:15)
-@fluentui/react-icons:     at maybeClose (internal/child_process.js:1051:16)
-@fluentui/react-icons:     at Process.ChildProcess._handle.onexit (internal/child_process.js:287:5)
-@fluentui/react-icons:     at Process.callbackTrampoline (internal/async_hooks.js:129:14)
+@fluentui/react-icons:     at ChildProcess.exithandler (child_process.js:303:12)
+@fluentui/react-icons:     at ChildProcess.emit (events.js:315:20)
+@fluentui/react-icons:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@fluentui/react-icons:     at maybeClose (internal/child_process.js:1026:16)
+@fluentui/react-icons:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
 @fluentui/react-icons: [XX:XX:XX XM] x stdout:
-@fluentui/react-icons: [XX:XX:XX XM] x src/utils/createSvgIcon.ts:3:26 - error TS2307: Cannot find module './SvgIcon.scss'.
+@fluentui/react-icons: [XX:XX:XX XM] x src/utils/createSvgIcon.ts:3:26 - error TS2307: Cannot find module './SvgIcon.scss' or its corresponding type declarations.
 @fluentui/react-icons: 3 import * as classes from './SvgIcon.scss';
 @fluentui/react-icons:                            ~~~~~~~~~~~~~~~~
 @fluentui/react-icons: Found 1 error.
@@ -855,4 +840,1637 @@ info cli using local version of lerna
 @fluentui/react-icons: [XX:XX:XX XM] x Error previously detected. See above for error messages.
 @fluentui/react-icons: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
 @fluentui/react-icons: error Command failed with exit code 1.
-lerna ERR! yarn run build exited 1 in '@fluentui/react-icons'
+@fluentui/react-bindings: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/react-bindings: [XX:XX:XX XM] x Command not defined: ts
+@uifabric/foundation: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
+@uifabric/foundation: [XX:XX:XX XM] x ------------------------------------
+@uifabric/foundation: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/foundation/tsconfig.json"
+@uifabric/foundation:     at ChildProcess.exithandler (child_process.js:303:12)
+@uifabric/foundation:     at ChildProcess.emit (events.js:315:20)
+@uifabric/foundation:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@uifabric/foundation:     at maybeClose (internal/child_process.js:1026:16)
+@uifabric/foundation:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@uifabric/foundation: [XX:XX:XX XM] x stdout:
+@uifabric/foundation: [XX:XX:XX XM] x src/createComponent.tsx:81:23 - error TS2352: Conversion of type 'TComponentProps & { styles: IConcatenatedStyleSet<any>; tokens: TTokens; _defaultStyles: IConcatenatedStyleSet<any>; theme: ITheme; className?: string | undefined; }' to type 'TViewProps & IDefaultSlotProps<any>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+@uifabric/foundation:   Type 'TComponentProps & { styles: IConcatenatedStyleSet<any>; tokens: TTokens; _defaultStyles: IConcatenatedStyleSet<any>; theme: ITheme; className?: string | undefined; }' is not comparable to type 'TViewProps'.
+@uifabric/foundation:     'TComponentProps & { styles: IConcatenatedStyleSet<any>; tokens: TTokens; _defaultStyles: IConcatenatedStyleSet<any>; theme: ITheme; className?: string | undefined; }' is assignable to the constraint of type 'TViewProps', but 'TViewProps' could be instantiated with a different subtype of constraint 'object'.
+@uifabric/foundation:  81     const viewProps = {
+@uifabric/foundation:                           ~
+@uifabric/foundation:  82       ...componentProps,
+@uifabric/foundation:     ~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/foundation: ... 
+@uifabric/foundation:  86       theme,
+@uifabric/foundation:     ~~~~~~~~~~~~
+@uifabric/foundation:  87     } as TViewProps & IDefaultSlotProps<any>;
+@uifabric/foundation:     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/foundation: Found 1 error.
+@uifabric/foundation: [XX:XX:XX XM] x ------------------------------------
+@uifabric/foundation: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@uifabric/foundation: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
+@uifabric/foundation: error Command failed with exit code 1.
+@fluentui/react-theme-provider: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
+@fluentui/react-theme-provider: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react-theme-provider: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-theme-provider/tsconfig.json"
+@fluentui/react-theme-provider:     at ChildProcess.exithandler (child_process.js:303:12)
+@fluentui/react-theme-provider:     at ChildProcess.emit (events.js:315:20)
+@fluentui/react-theme-provider:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@fluentui/react-theme-provider:     at maybeClose (internal/child_process.js:1026:16)
+@fluentui/react-theme-provider:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@fluentui/react-theme-provider: [XX:XX:XX XM] x stdout:
+@fluentui/react-theme-provider: [XX:XX:XX XM] x src/ThemeProvider.tsx:48:45 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-theme-provider: 48     const rootClass = cx(className, classes.root) || undefined;
+@fluentui/react-theme-provider:                                                ~~~~
+@fluentui/react-theme-provider: Found 1 error.
+@fluentui/react-theme-provider: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react-theme-provider: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@fluentui/react-theme-provider: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
+@fluentui/react-theme-provider: error Command failed with exit code 1.
+@fluentui/react-icons-northstar: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/react-icons-northstar: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/react-telemetry: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/react-telemetry: [XX:XX:XX XM] x Command not defined: ts
+office-ui-fabric-react: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
+office-ui-fabric-react: [XX:XX:XX XM] x ------------------------------------
+office-ui-fabric-react: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/office-ui-fabric-react/tsconfig.json"
+office-ui-fabric-react:     at ChildProcess.exithandler (child_process.js:303:12)
+office-ui-fabric-react:     at ChildProcess.emit (events.js:315:20)
+office-ui-fabric-react:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+office-ui-fabric-react:     at maybeClose (internal/child_process.js:1026:16)
+office-ui-fabric-react:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+office-ui-fabric-react: [XX:XX:XX XM] x stdout:
+office-ui-fabric-react: [XX:XX:XX XM] x src/components/ChoiceGroup/ChoiceGroup.base.tsx:147:19 - error TS2783: 'key' is specified more than once, so this usage will be overwritten.
+office-ui-fabric-react: 147                   key={option.key}
+office-ui-fabric-react:                       ~~~~~~~~~~~~~~~~
+office-ui-fabric-react:   src/components/ChoiceGroup/ChoiceGroup.base.tsx:151:19
+office-ui-fabric-react:     151                   {...innerOptionProps}
+office-ui-fabric-react:                           ~~~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react:     This spread always overwrites this property.
+office-ui-fabric-react: src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx:82:38 - error TS2554: Expected 1 arguments, but got 2.
+office-ui-fabric-react: 82           {onRenderField(this.props, this._onRenderField)}
+office-ui-fabric-react:                                         ~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/ComboBox/ComboBox.tsx:415:13 - error TS2554: Expected 1 arguments, but got 2.
+office-ui-fabric-react: 415             this._onRenderContainer,
+office-ui-fabric-react:                 ~~~~~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/DetailsList/DetailsColumn.base.tsx:194:14 - error TS2790: The operand of a 'delete' operator must be optional.
+office-ui-fabric-react: 194       delete this._dragDropSubscription;
+office-ui-fabric-react:                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/DetailsList/DetailsColumn.base.tsx:208:14 - error TS2790: The operand of a 'delete' operator must be optional.
+office-ui-fabric-react: 208       delete this._dragDropSubscription;
+office-ui-fabric-react:                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/DetailsList/DetailsHeader.base.tsx:130:14 - error TS2790: The operand of a 'delete' operator must be optional.
+office-ui-fabric-react: 130       delete this._subscriptionObject;
+office-ui-fabric-react:                  ~~~~~~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/DetailsList/DetailsHeader.base.tsx:152:14 - error TS2790: The operand of a 'delete' operator must be optional.
+office-ui-fabric-react: 152       delete this._subscriptionObject;
+office-ui-fabric-react:                  ~~~~~~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/DetailsList/DetailsRow.base.tsx:110:16 - error TS2790: The operand of a 'delete' operator must be optional.
+office-ui-fabric-react: 110         delete this._dragDropSubscription;
+office-ui-fabric-react:                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/DetailsList/DetailsRow.base.tsx:148:14 - error TS2790: The operand of a 'delete' operator must be optional.
+office-ui-fabric-react: 148       delete this._dragDropSubscription;
+office-ui-fabric-react:                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx:12:72 - error TS2339: Property 'peoplePickerPersonaContent' does not exist on type 'typeof import("*.scss")'.
+office-ui-fabric-react: 12     <div className={css('ms-PeoplePicker-personaContent', stylesImport.peoplePickerPersonaContent)}>
+office-ui-fabric-react:                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx:16:64 - error TS2339: Property 'peoplePickerPersona' does not exist on type 'typeof import("*.scss")'.
+office-ui-fabric-react: 16         className={css('ms-PeoplePicker-Persona', stylesImport.peoplePickerPersona)}
+office-ui-fabric-react:                                                                   ~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/FocusTrapZone/FocusTrapZone.tsx:106:12 - error TS2790: The operand of a 'delete' operator must be optional.
+office-ui-fabric-react: 106     delete this._previouslyFocusedElementOutsideTrapZone;
+office-ui-fabric-react:                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/GroupedList/GroupedListSection.tsx:174:16 - error TS2790: The operand of a 'delete' operator must be optional.
+office-ui-fabric-react: 174         delete this._dragDropSubscription;
+office-ui-fabric-react:                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/List/List.tsx:340:12 - error TS2790: The operand of a 'delete' operator must be optional.
+office-ui-fabric-react: 340     delete this._scrollElement;
+office-ui-fabric-react:                ~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/MarqueeSelection/MarqueeSelection.base.tsx:88:12 - error TS2790: The operand of a 'delete' operator must be optional.
+office-ui-fabric-react: 88     delete this._scrollableParent;
+office-ui-fabric-react:               ~~~~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/MarqueeSelection/MarqueeSelection.base.tsx:89:12 - error TS2790: The operand of a 'delete' operator must be optional.
+office-ui-fabric-react: 89     delete this._scrollableSurface;
+office-ui-fabric-react:               ~~~~~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/Persona/Persona.deprecated.test.tsx:113:13 - error TS2322: Type 'ReactWrapper<HTMLAttributes, any, Component<{}, {}, any>>' is not assignable to type 'ReactWrapper<ImgHTMLAttributes<any>, any, Component<{}, {}, any>>'.
+office-ui-fabric-react:   Type 'HTMLAttributes' is not assignable to type 'ImgHTMLAttributes<any>'.
+office-ui-fabric-react:     Types of property 'crossOrigin' are incompatible.
+office-ui-fabric-react:       Type 'string | undefined' is not assignable to type '"" | "anonymous" | "use-credentials" | undefined'.
+office-ui-fabric-react:         Type 'string' is not assignable to type '"" | "anonymous" | "use-credentials" | undefined'.
+office-ui-fabric-react: 113       const image: ReactWrapper<React.ImgHTMLAttributes<any>, any> = wrapper.find('ImageBase');
+office-ui-fabric-react:                 ~~~~~
+office-ui-fabric-react: src/components/Persona/Persona.deprecated.test.tsx:120:13 - error TS2322: Type 'ReactWrapper<HTMLAttributes, any, Component<{}, {}, any>>' is not assignable to type 'ReactWrapper<ImgHTMLAttributes<any>, any, Component<{}, {}, any>>'.
+office-ui-fabric-react: 120       const image: ReactWrapper<React.ImgHTMLAttributes<any>, any> = wrapper.find('ImageBase');
+office-ui-fabric-react:                 ~~~~~
+office-ui-fabric-react: src/components/Persona/Persona.test.tsx:190:13 - error TS2322: Type 'ReactWrapper<HTMLAttributes, any, Component<{}, {}, any>>' is not assignable to type 'ReactWrapper<ImgHTMLAttributes<any>, any, Component<{}, {}, any>>'.
+office-ui-fabric-react: 190       const image: ReactWrapper<React.ImgHTMLAttributes<any>, any> = wrapper.find('ImageBase');
+office-ui-fabric-react:                 ~~~~~
+office-ui-fabric-react: src/components/Persona/Persona.test.tsx:197:13 - error TS2322: Type 'ReactWrapper<HTMLAttributes, any, Component<{}, {}, any>>' is not assignable to type 'ReactWrapper<ImgHTMLAttributes<any>, any, Component<{}, {}, any>>'.
+office-ui-fabric-react: 197       const image: ReactWrapper<React.ImgHTMLAttributes<any>, any> = wrapper.find('ImageBase');
+office-ui-fabric-react:                 ~~~~~
+office-ui-fabric-react: src/components/Popup/Popup.tsx:75:12 - error TS2790: The operand of a 'delete' operator must be optional.
+office-ui-fabric-react: 75     delete this._originalFocusedElement;
+office-ui-fabric-react:               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+office-ui-fabric-react: src/components/TextField/TextField.types.ts:327:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+office-ui-fabric-react: 327 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+office-ui-fabric-react:                      ~~~~~~~~~~~~~~~~
+office-ui-fabric-react: Found 22 errors.
+office-ui-fabric-react: [XX:XX:XX XM] x ------------------------------------
+office-ui-fabric-react: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+office-ui-fabric-react: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
+office-ui-fabric-react: error Command failed with exit code 1.
+@fluentui/react-image: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@fluentui/react-image: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react-image: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-image/tsconfig.json"
+@fluentui/react-image:     at ChildProcess.exithandler (child_process.js:303:12)
+@fluentui/react-image:     at ChildProcess.emit (events.js:315:20)
+@fluentui/react-image:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@fluentui/react-image:     at maybeClose (internal/child_process.js:1026:16)
+@fluentui/react-image:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@fluentui/react-image: [XX:XX:XX XM] x stdout:
+@fluentui/react-image: [XX:XX:XX XM] x src/components/Image/Image.stories.tsx:12:57 - error TS2339: Property 'hStack' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-image: 12   return <div {...rest} className={horizontal ? classes.hStack : classes.vStack} />;
+@fluentui/react-image:                                                            ~~~~~~
+@fluentui/react-image: src/components/Image/Image.stories.tsx:12:74 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-image: 12   return <div {...rest} className={horizontal ? classes.hStack : classes.vStack} />;
+@fluentui/react-image:                                                                             ~~~~~~
+@fluentui/react-image: src/components/Image/Image.tsx:9:44 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
+@fluentui/react-image:   Property 'styles' is incompatible with index signature.
+@fluentui/react-image:     Type '{ [className: string]: string; }' is not assignable to type 'string'.
+@fluentui/react-image: 9 export const useImageClasses = makeClasses(classes);
+@fluentui/react-image:                                              ~~~~~~~
+@fluentui/react-image: Found 3 errors.
+@fluentui/react-image: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react-image: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@fluentui/react-image: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@fluentui/react-image: error Command failed with exit code 1.
+@fluentui/react-northstar: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/react-northstar: [XX:XX:XX XM] x Command not defined: ts
+server-rendered-app: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+server-rendered-app: [XX:XX:XX XM] x ------------------------------------
+server-rendered-app: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/server-rendered-app/tsconfig.json"
+server-rendered-app:     at ChildProcess.exithandler (child_process.js:303:12)
+server-rendered-app:     at ChildProcess.emit (events.js:315:20)
+server-rendered-app:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+server-rendered-app:     at maybeClose (internal/child_process.js:1026:16)
+server-rendered-app:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+server-rendered-app: [XX:XX:XX XM] x stdout:
+server-rendered-app: [XX:XX:XX XM] x ../../packages/office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+server-rendered-app: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+server-rendered-app:                      ~~~~~~~~~~~~~~~~
+server-rendered-app: Found 1 error.
+server-rendered-app: [XX:XX:XX XM] x ------------------------------------
+server-rendered-app: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+server-rendered-app: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+server-rendered-app: error Command failed with exit code 1.
+@fluentui/react: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@fluentui/react: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react/tsconfig.json"
+@fluentui/react:     at ChildProcess.exithandler (child_process.js:303:12)
+@fluentui/react:     at ChildProcess.emit (events.js:315:20)
+@fluentui/react:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@fluentui/react:     at maybeClose (internal/child_process.js:1026:16)
+@fluentui/react:     at Socket.<anonymous> (internal/child_process.js:441:11)
+@fluentui/react:     at Socket.emit (events.js:315:20)
+@fluentui/react:     at Socket.EventEmitter.emit (domain.js:547:15)
+@fluentui/react:     at Pipe.<anonymous> (net.js:674:12)
+@fluentui/react: [XX:XX:XX XM] x stdout:
+@fluentui/react: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+@fluentui/react: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+@fluentui/react:                      ~~~~~~~~~~~~~~~~
+@fluentui/react: Found 1 error.
+@fluentui/react: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@fluentui/react: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@fluentui/react: error Command failed with exit code 1.
+@uifabric/tsx-editor: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@uifabric/tsx-editor: [XX:XX:XX XM] x ------------------------------------
+@uifabric/tsx-editor: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/tsx-editor/tsconfig.json"
+@uifabric/tsx-editor:     at ChildProcess.exithandler (child_process.js:303:12)
+@uifabric/tsx-editor:     at ChildProcess.emit (events.js:315:20)
+@uifabric/tsx-editor:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@uifabric/tsx-editor:     at maybeClose (internal/child_process.js:1026:16)
+@uifabric/tsx-editor:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@uifabric/tsx-editor: [XX:XX:XX XM] x stdout:
+@uifabric/tsx-editor: [XX:XX:XX XM] x ../monaco-editor/monaco-typescript.d.ts:8:25 - error TS2307: Cannot find module '@uifabric/monaco-editor' or its corresponding type declarations.
+@uifabric/tsx-editor: 8 import * as monaco from '@uifabric/monaco-editor';
+@uifabric/tsx-editor:                           ~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/tsx-editor: ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+@uifabric/tsx-editor: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+@uifabric/tsx-editor:                      ~~~~~~~~~~~~~~~~
+@uifabric/tsx-editor: src/components/Editor.tsx:1:25 - error TS2307: Cannot find module '@uifabric/monaco-editor' or its corresponding type declarations.
+@uifabric/tsx-editor: 1 import * as monaco from '@uifabric/monaco-editor';
+@uifabric/tsx-editor:                           ~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/tsx-editor: src/components/TsxEditor.tsx:3:25 - error TS2307: Cannot find module '@uifabric/monaco-editor' or its corresponding type declarations.
+@uifabric/tsx-editor: 3 import * as monaco from '@uifabric/monaco-editor';
+@uifabric/tsx-editor:                           ~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/tsx-editor: src/interfaces/monaco.ts:5:25 - error TS2307: Cannot find module '@uifabric/monaco-editor/esm/vs/editor/editor.api' or its corresponding type declarations.
+@uifabric/tsx-editor: 5 import * as monaco from '@uifabric/monaco-editor/esm/vs/editor/editor.api';
+@uifabric/tsx-editor:                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/tsx-editor: src/transpiler/transpile.ts:2:25 - error TS2307: Cannot find module '@uifabric/monaco-editor' or its corresponding type declarations.
+@uifabric/tsx-editor: 2 import * as monaco from '@uifabric/monaco-editor';
+@uifabric/tsx-editor:                           ~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/tsx-editor: src/transpiler/transpile.ts:26:11 - error TS7006: Parameter 'worker' implicitly has an 'any' type.
+@uifabric/tsx-editor: 26     .then(worker => {
+@uifabric/tsx-editor:              ~~~~~~
+@uifabric/tsx-editor: src/transpiler/transpile.ts:31:62 - error TS7006: Parameter 'syntacticDiagnostics' implicitly has an 'any' type.
+@uifabric/tsx-editor: 31         return worker.getSyntacticDiagnostics(filename).then(syntacticDiagnostics => {
+@uifabric/tsx-editor:                                                                 ~~~~~~~~~~~~~~~~~~~~
+@uifabric/tsx-editor: src/transpiler/transpile.ts:32:62 - error TS7006: Parameter 'd' implicitly has an 'any' type.
+@uifabric/tsx-editor: 32           syntacticDiagnostics = syntacticDiagnostics.filter(d => d.category === 1 /*error*/);
+@uifabric/tsx-editor:                                                                 ~
+@uifabric/tsx-editor: src/transpiler/transpile.ts:50:12 - error TS7006: Parameter 'ex' implicitly has an 'any' type.
+@uifabric/tsx-editor: 50     .catch(ex => {
+@uifabric/tsx-editor:               ~~
+@uifabric/tsx-editor: src/utilities/getQueryParam.test.ts:7:12 - error TS2790: The operand of a 'delete' operator must be optional.
+@uifabric/tsx-editor: 7     delete window.location;
+@uifabric/tsx-editor:              ~~~~~~~~~~~~~~~
+@uifabric/tsx-editor: Found 11 errors.
+@uifabric/tsx-editor: [XX:XX:XX XM] x ------------------------------------
+@uifabric/tsx-editor: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@uifabric/tsx-editor: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@uifabric/tsx-editor: error Command failed with exit code 1.
+@fluentui/circulars-test: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/circulars-test: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/code-sandbox: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/code-sandbox: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/e2e: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/e2e: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/local-sandbox: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/local-sandbox: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/projects-test: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/projects-test: [XX:XX:XX XM] x Command not defined: ts
+@fluentui/react-builder: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/react-builder: [XX:XX:XX XM] x Command not defined: ts
+codesandbox-react-northstar-template: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
+codesandbox-react-northstar-template: [XX:XX:XX XM] x ------------------------------------
+codesandbox-react-northstar-template: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/codesandbox-react-northstar-template/tsconfig.json"
+codesandbox-react-northstar-template:     at ChildProcess.exithandler (child_process.js:303:12)
+codesandbox-react-northstar-template:     at ChildProcess.emit (events.js:315:20)
+codesandbox-react-northstar-template:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+codesandbox-react-northstar-template:     at maybeClose (internal/child_process.js:1026:16)
+codesandbox-react-northstar-template:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+codesandbox-react-northstar-template: [XX:XX:XX XM] x stdout:
+codesandbox-react-northstar-template: [XX:XX:XX XM] x src/index.tsx:15:8 - error TS2307: Cannot find module '@fluentui/react-northstar' or its corresponding type declarations.
+codesandbox-react-northstar-template: 15 } from '@fluentui/react-northstar';
+codesandbox-react-northstar-template:           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+codesandbox-react-northstar-template: src/index.tsx:16:28 - error TS2307: Cannot find module '@fluentui/code-sandbox' or its corresponding type declarations.
+codesandbox-react-northstar-template: 16 import { SandboxApp } from '@fluentui/code-sandbox';
+codesandbox-react-northstar-template:                               ~~~~~~~~~~~~~~~~~~~~~~~~
+codesandbox-react-northstar-template: Found 2 errors.
+codesandbox-react-northstar-template: [XX:XX:XX XM] x ------------------------------------
+codesandbox-react-northstar-template: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+codesandbox-react-northstar-template: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
+codesandbox-react-northstar-template: error Command failed with exit code 1.
+@fluentui/docs: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/docs: [XX:XX:XX XM] x Command not defined: ts
+@uifabric/example-app-base: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@uifabric/example-app-base: [XX:XX:XX XM] x ------------------------------------
+@uifabric/example-app-base: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/example-app-base/tsconfig.json"
+@uifabric/example-app-base:     at ChildProcess.exithandler (child_process.js:303:12)
+@uifabric/example-app-base:     at ChildProcess.emit (events.js:315:20)
+@uifabric/example-app-base:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@uifabric/example-app-base:     at maybeClose (internal/child_process.js:1026:16)
+@uifabric/example-app-base:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@uifabric/example-app-base: [XX:XX:XX XM] x stdout:
+@uifabric/example-app-base: [XX:XX:XX XM] x src/components/Page/Page.tsx:21:25 - error TS2307: Cannot find module './Page.module.scss' or its corresponding type declarations.
+@uifabric/example-app-base: 21 import * as styles from './Page.module.scss';
+@uifabric/example-app-base:                            ~~~~~~~~~~~~~~~~~~~~
+@uifabric/example-app-base: src/components/Page/sections/BestPracticesSection.tsx:7:25 - error TS2307: Cannot find module '../Page.module.scss' or its corresponding type declarations.
+@uifabric/example-app-base: 7 import * as styles from '../Page.module.scss';
+@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
+@uifabric/example-app-base: src/components/Page/sections/ExamplesSection.tsx:4:25 - error TS2307: Cannot find module '../Page.module.scss' or its corresponding type declarations.
+@uifabric/example-app-base: 4 import * as styles from '../Page.module.scss';
+@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
+@uifabric/example-app-base: src/components/Page/sections/FeedbackSection.tsx:5:25 - error TS2307: Cannot find module '../Page.module.scss' or its corresponding type declarations.
+@uifabric/example-app-base: 5 import * as styles from '../Page.module.scss';
+@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
+@uifabric/example-app-base: src/components/Page/sections/ImplementationSection.tsx:5:25 - error TS2307: Cannot find module '../Page.module.scss' or its corresponding type declarations.
+@uifabric/example-app-base: 5 import * as styles from '../Page.module.scss';
+@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
+@uifabric/example-app-base: src/components/Page/sections/MarkdownSection.tsx:7:25 - error TS2307: Cannot find module '../Page.module.scss' or its corresponding type declarations.
+@uifabric/example-app-base: 7 import * as styles from '../Page.module.scss';
+@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
+@uifabric/example-app-base: src/components/Page/sections/OtherPageSection.tsx:4:25 - error TS2307: Cannot find module '../Page.module.scss' or its corresponding type declarations.
+@uifabric/example-app-base: 4 import * as styles from '../Page.module.scss';
+@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
+@uifabric/example-app-base: src/components/Page/sections/OverviewSection.tsx:4:25 - error TS2307: Cannot find module '../Page.module.scss' or its corresponding type declarations.
+@uifabric/example-app-base: 4 import * as styles from '../Page.module.scss';
+@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
+@uifabric/example-app-base: src/components/PlatformPicker/PlatformPicker.tsx:12:25 - error TS2307: Cannot find module './PlatformPicker.module.scss' or its corresponding type declarations.
+@uifabric/example-app-base: 12 import * as styles from './PlatformPicker.module.scss';
+@uifabric/example-app-base:                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/example-app-base: src/components/Table/Table.tsx:4:25 - error TS2307: Cannot find module './Table.module.scss' or its corresponding type declarations.
+@uifabric/example-app-base: 4 import * as styles from './Table.module.scss';
+@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
+@uifabric/example-app-base: src/components/TopNav/TopNav.tsx:7:25 - error TS2307: Cannot find module './TopNav.module.scss' or its corresponding type declarations.
+@uifabric/example-app-base: 7 import * as styles from './TopNav.module.scss';
+@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/example-app-base: src/components/Video/Video.tsx:4:25 - error TS2307: Cannot find module './Video.module.scss' or its corresponding type declarations.
+@uifabric/example-app-base: 4 import * as styles from './Video.module.scss';
+@uifabric/example-app-base:                           ~~~~~~~~~~~~~~~~~~~~~
+@uifabric/example-app-base: src/utilities/createDemoApp.tsx:52:71 - error TS2783: 'appDefinition' is specified more than once, so this usage will be overwritten.
+@uifabric/example-app-base: 52     const App: React.FunctionComponent<IAppProps> = props => <AppBase appDefinition={appDefinition} {...props} />;
+@uifabric/example-app-base:                                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/example-app-base:   src/utilities/createDemoApp.tsx:52:101
+@uifabric/example-app-base:     52     const App: React.FunctionComponent<IAppProps> = props => <AppBase appDefinition={appDefinition} {...props} />;
+@uifabric/example-app-base:                                                                                                            ~~~~~~~~~~
+@uifabric/example-app-base:     This spread always overwrites this property.
+@uifabric/example-app-base: Found 13 errors.
+@uifabric/example-app-base: [XX:XX:XX XM] x ------------------------------------
+@uifabric/example-app-base: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@uifabric/example-app-base: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@uifabric/example-app-base: error Command failed with exit code 1.
+@fluentui/storybook: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@fluentui/storybook: [XX:XX:XX XM] x ------------------------------------
+@fluentui/storybook: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/storybook/tsconfig.json"
+@fluentui/storybook:     at ChildProcess.exithandler (child_process.js:303:12)
+@fluentui/storybook:     at ChildProcess.emit (events.js:315:20)
+@fluentui/storybook:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@fluentui/storybook:     at maybeClose (internal/child_process.js:1026:16)
+@fluentui/storybook:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@fluentui/storybook: [XX:XX:XX XM] x stdout:
+@fluentui/storybook: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+@fluentui/storybook: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+@fluentui/storybook:                      ~~~~~~~~~~~~~~~~
+@fluentui/storybook: Found 1 error.
+@fluentui/storybook: [XX:XX:XX XM] x ------------------------------------
+@fluentui/storybook: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@fluentui/storybook: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@fluentui/storybook: error Command failed with exit code 1.
+@fluentui/perf: [XX:XX:XX XM] x Cannot find config file "null". Please create a file called "just.config.js" in the root of the project next to "package.json".
+@fluentui/perf: [XX:XX:XX XM] x Command not defined: ts
+@uifabric/date-time: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
+@uifabric/date-time: [XX:XX:XX XM] x ------------------------------------
+@uifabric/date-time: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/date-time/tsconfig.json"
+@uifabric/date-time:     at ChildProcess.exithandler (child_process.js:303:12)
+@uifabric/date-time:     at ChildProcess.emit (events.js:315:20)
+@uifabric/date-time:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@uifabric/date-time:     at maybeClose (internal/child_process.js:1026:16)
+@uifabric/date-time:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@uifabric/date-time: [XX:XX:XX XM] x stdout:
+@uifabric/date-time: [XX:XX:XX XM] x src/components/Calendar/examples/Calendar.Inline.ContiguousWorkWeekDays.Example.tsx:30:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 30       <div className={styles.wrapper}>
+@uifabric/date-time:                                 ~~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.CustomDayCellRef.Example.tsx:28:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 28       <div className={styles.wrapper}>
+@uifabric/date-time:                                 ~~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.DateBoundaries.Example.tsx:27:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 27       <div className={styles.wrapper}>
+@uifabric/date-time:                                 ~~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.MonthOnly.Example.tsx:30:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 30       <div className={styles.wrapper}>
+@uifabric/date-time:                                 ~~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.MonthSelection.Example.tsx:34:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 34       <div className={styles.wrapper}>
+@uifabric/date-time:                                 ~~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.MonthSelection.Example.tsx:54:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 54           <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
+@uifabric/date-time:                                               ~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.MonthSelection.Example.tsx:55:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 55           <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
+@uifabric/date-time:                                               ~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.MultidayDayView.Example.tsx:35:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 35       <div className={styles.wrapper}>
+@uifabric/date-time:                                 ~~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.MultidayDayView.Example.tsx:59:31 - error TS2339: Property 'dropdown' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 59             className={styles.dropdown}
+@uifabric/date-time:                                  ~~~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.NonContiguousWorkWeekDays.Example.tsx:30:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 30       <div className={styles.wrapper}>
+@uifabric/date-time:                                 ~~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.OverlayedMonthPicker.Example.tsx:21:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 21       <div className={styles.wrapper}>
+@uifabric/date-time:                                 ~~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.SixWeeks.tsx:21:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 21       <div className={styles.wrapper}>
+@uifabric/date-time:                                 ~~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.WeekNumbers.Example.tsx:21:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 21       <div className={styles.wrapper}>
+@uifabric/date-time:                                 ~~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.WeekSelection.Example.tsx:34:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 34       <div className={styles.wrapper}>
+@uifabric/date-time:                                 ~~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.WeekSelection.Example.tsx:54:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 54           <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
+@uifabric/date-time:                                               ~~~~~~
+@uifabric/date-time: src/components/Calendar/examples/Calendar.Inline.WeekSelection.Example.tsx:55:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 55           <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
+@uifabric/date-time:                                               ~~~~~~
+@uifabric/date-time: src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx:22:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 22       <div className={styles.wrapper}>
+@uifabric/date-time:                                 ~~~~~~~
+@uifabric/date-time: src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx:34:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 34           <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
+@uifabric/date-time:                                               ~~~~~~
+@uifabric/date-time: src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx:35:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 35           <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
+@uifabric/date-time:                                               ~~~~~~
+@uifabric/date-time: src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Expandable.Example.tsx:27:30 - error TS2339: Property 'wrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 27       <div className={styles.wrapper}>
+@uifabric/date-time:                                 ~~~~~~~
+@uifabric/date-time: src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Expandable.Example.tsx:34:31 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 34             className={styles.button}
+@uifabric/date-time:                                  ~~~~~~
+@uifabric/date-time: src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Expandable.Example.tsx:49:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 49           <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
+@uifabric/date-time:                                               ~~~~~~
+@uifabric/date-time: src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Expandable.Example.tsx:50:44 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
+@uifabric/date-time: 50           <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
+@uifabric/date-time:                                               ~~~~~~
+@uifabric/date-time: ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+@uifabric/date-time: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+@uifabric/date-time:                      ~~~~~~~~~~~~~~~~
+@uifabric/date-time: ../tsx-editor/lib/interfaces/monaco.d.ts:1:25 - error TS2307: Cannot find module '@uifabric/monaco-editor/esm/vs/editor/editor.api' or its corresponding type declarations.
+@uifabric/date-time: 1 import * as monaco from '@uifabric/monaco-editor/esm/vs/editor/editor.api';
+@uifabric/date-time:                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/date-time: Found 25 errors.
+@uifabric/date-time: [XX:XX:XX XM] x ------------------------------------
+@uifabric/date-time: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@uifabric/date-time: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
+@uifabric/date-time: error Command failed with exit code 1.
+@uifabric/experiments: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@uifabric/experiments: [XX:XX:XX XM] x ------------------------------------
+@uifabric/experiments: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/experiments/tsconfig.json"
+@uifabric/experiments:     at ChildProcess.exithandler (child_process.js:303:12)
+@uifabric/experiments:     at ChildProcess.emit (events.js:315:20)
+@uifabric/experiments:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@uifabric/experiments:     at maybeClose (internal/child_process.js:1026:16)
+@uifabric/experiments:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@uifabric/experiments: [XX:XX:XX XM] x stdout:
+@uifabric/experiments: [XX:XX:XX XM] x src/components/FloatingSuggestions/FloatingPeopleSuggestions/defaults/DefaultPeopleSuggestionsItem.tsx:12:72 - error TS2339: Property 'peoplePickerPersonaContent' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 12     <div className={css('ms-PeoplePicker-personaContent', stylesImport.peoplePickerPersonaContent)}>
+@uifabric/experiments:                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/experiments: src/components/FloatingSuggestions/FloatingPeopleSuggestions/defaults/DefaultPeopleSuggestionsItem.tsx:16:64 - error TS2339: Property 'peoplePickerPersona' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 16         className={css('ms-PeoplePicker-Persona', stylesImport.peoplePickerPersona)}
+@uifabric/experiments:                                                                   ~~~~~~~~~~~~~~~~~~~
+@uifabric/experiments: src/components/FloatingSuggestions/FloatingSuggestions.tsx:202:27 - error TS2339: Property 'callout' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 202         className={styles.callout}
+@uifabric/experiments:                               ~~~~~~~
+@uifabric/experiments: src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx:75:102 - error TS2339: Property 'editingContainer' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 75       <span aria-labelledby={'editingItemPersona-' + itemId} className={css('ms-EditingItem', styles.editingContainer)}>
+@uifabric/experiments:                                                                                                         ~~~~~~~~~~~~~~~~
+@uifabric/experiments: src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx:86:29 - error TS2339: Property 'editingInput' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 86           className={styles.editingInput}
+@uifabric/experiments:                                ~~~~~~~~~~~~
+@uifabric/experiments: src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx:135:9 - error TS2322: Type 'ComponentType<TriggerProps<unknown>>' is not assignable to type 'ComponentClass<ISelectedItemProps<IPersonaProps & BaseSelectedItem>, any> | FunctionComponent<ISelectedItemProps<IPersonaProps & BaseSelectedItem>> | undefined'.
+@uifabric/experiments:   Type 'ComponentClass<TriggerProps<unknown>, any>' is not assignable to type 'ComponentClass<ISelectedItemProps<IPersonaProps & BaseSelectedItem>, any> | FunctionComponent<ISelectedItemProps<IPersonaProps & BaseSelectedItem>> | undefined'.
+@uifabric/experiments:     Type 'ComponentClass<TriggerProps<unknown>, any>' is not assignable to type 'ComponentClass<ISelectedItemProps<IPersonaProps & BaseSelectedItem>, any>'.
+@uifabric/experiments:       Types of property 'propTypes' are incompatible.
+@uifabric/experiments:         Type 'WeakValidationMap<TriggerProps<unknown>> | undefined' is not assignable to type 'WeakValidationMap<ISelectedItemProps<IPersonaProps & BaseSelectedItem>> | undefined'.
+@uifabric/experiments:           Type 'WeakValidationMap<TriggerProps<unknown>>' is not assignable to type 'WeakValidationMap<ISelectedItemProps<IPersonaProps & BaseSelectedItem>>'.
+@uifabric/experiments:             Types of property 'item' are incompatible.
+@uifabric/experiments:               Type 'Validator<unknown> | undefined' is not assignable to type 'Validator<IPersonaProps & BaseSelectedItem> | undefined'.
+@uifabric/experiments:                 Type 'Validator<unknown>' is not assignable to type 'Validator<IPersonaProps & BaseSelectedItem>'.
+@uifabric/experiments:                   Type 'unknown' is not assignable to type 'IPersonaProps & BaseSelectedItem'.
+@uifabric/experiments:                     Type 'unknown' is not assignable to type 'IPersonaProps'.
+@uifabric/experiments: 135         onRenderItem={SelectedItem}
+@uifabric/experiments:             ~~~~~~~~~~~~
+@uifabric/experiments:   src/components/SelectedItemsList/SelectedItemsList.types.ts:75:3
+@uifabric/experiments:     75   onRenderItem?: React.ComponentType<ISelectedItemProps<T>>;
+@uifabric/experiments:          ~~~~~~~~~~~~
+@uifabric/experiments:     The expected type comes from property 'onRenderItem' which is declared here on type 'IntrinsicAttributes & Pick<ISelectedPeopleListProps<IPersonaProps & BaseSelectedItem>, "onChange" | ... 12 more ... | "canRemoveItem"> & RefAttributes<...>'
+@uifabric/experiments: src/components/StaticList/StaticList.tsx:14:37 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 14       { className: css(stylesImport.root, className) },
+@uifabric/experiments:                                        ~~~~
+@uifabric/experiments: src/components/Tile/Tile.tsx:175:97 - error TS2339: Property 'label' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 175           <span key="label" id={this._labelId} className={css('ms-Tile-label', TileStylesModule.label)}>
+@uifabric/experiments:                                                                                                     ~~~~~
+@uifabric/experiments: src/components/Tile/Tile.tsx:253:68 - error TS2339: Property 'description' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 253             className={css('ms-Tile-description', TileStylesModule.description)}
+@uifabric/experiments:                                                                        ~~~~~~~~~~~
+@uifabric/experiments: src/components/Tile/examples/Tile.Folder.Example.tsx:85:56 - error TS2339: Property 'tileFolder' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 85           <span className={css(TileExampleStylesModule.tileFolder)}>
+@uifabric/experiments:                                                           ~~~~~~~~~~
+@uifabric/experiments: src/components/Tile/examples/Tile.Media.Example.tsx:21:50 - error TS2339: Property 'activityBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 21         <span className={TileExampleStylesModule.activityBlock}>
+@uifabric/experiments:                                                     ~~~~~~~~~~~~~
+@uifabric/experiments: src/components/Tile/examples/Tile.Media.Example.tsx:41:50 - error TS2339: Property 'activityBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 41         <span className={TileExampleStylesModule.activityBlock}>
+@uifabric/experiments:                                                     ~~~~~~~~~~~~~
+@uifabric/experiments: src/components/Tile/examples/Tile.Media.Example.tsx:61:50 - error TS2339: Property 'activityBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 61         <span className={TileExampleStylesModule.activityBlock}>
+@uifabric/experiments:                                                     ~~~~~~~~~~~~~
+@uifabric/experiments: src/components/Tile/examples/Tile.Media.Example.tsx:81:50 - error TS2339: Property 'activityBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 81         <span className={TileExampleStylesModule.activityBlock}>
+@uifabric/experiments:                                                     ~~~~~~~~~~~~~
+@uifabric/experiments: src/components/VirtualizedList/examples/VirtualizedList.Basic.Example.tsx:33:72 - error TS2339: Property 'fixedHeight' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 33         <ScrollContainer className={VirtualizedListExampleStylesModule.fixedHeight}>
+@uifabric/experiments:                                                                           ~~~~~~~~~~~
+@uifabric/experiments: src/components/VirtualizedList/examples/VirtualizedList.Basic2.Example.tsx:39:98 - error TS2339: Property 'fixedHeight' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 39         <ScrollContainer scrollDebounceDelay={200} className={VirtualizedListExampleStylesModule.fixedHeight}>
+@uifabric/experiments:                                                                                                     ~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signal.tsx:15:83 - error TS2339: Property 'signal' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 15     <span aria-label={props.ariaLabel} {...spanProps} className={css(SignalStyles.signal, className)}>
+@uifabric/experiments:                                                                                      ~~~~~~
+@uifabric/experiments: src/components/signals/SignalField.tsx:24:27 - error TS2339: Property 'signalField' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 24         SignalFieldStyles.signalField,
+@uifabric/experiments:                              ~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/SignalField.tsx:26:30 - error TS2339: Property 'wide' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 26           [SignalFieldStyles.wide]: signalsFieldMode === 'wide',
+@uifabric/experiments:                                 ~~~~
+@uifabric/experiments: src/components/signals/SignalField.tsx:27:30 - error TS2339: Property 'compact' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 27           [SignalFieldStyles.compact]: signalsFieldMode === 'compact',
+@uifabric/experiments:                                 ~~~~~~~
+@uifabric/experiments: src/components/signals/SignalField.tsx:33:42 - error TS2339: Property 'signalFieldValue' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 33       <span className={SignalFieldStyles.signalFieldValue}>{props.children}</span>
+@uifabric/experiments:                                             ~~~~~~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:13:60 - error TS2339: Property 'youCheckedOut' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 13   return <IconSignal {...props} signalClass={SignalsStyles.youCheckedOut} iconName="checkedoutbyyou12" />;
+@uifabric/experiments:                                                               ~~~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:17:60 - error TS2339: Property 'blocked' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 17   return <IconSignal {...props} signalClass={SignalsStyles.blocked} iconName="blocked12" />;
+@uifabric/experiments:                                                               ~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:24:34 - error TS2339: Property 'missingMetadata' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 24       signalClass={SignalsStyles.missingMetadata}
+@uifabric/experiments:                                     ~~~~~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:31:60 - error TS2339: Property 'warning' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 31   return <IconSignal {...props} signalClass={SignalsStyles.warning} iconName="warning12" />;
+@uifabric/experiments:                                                               ~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:35:60 - error TS2339: Property 'awaitingApproval' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 35   return <IconSignal {...props} signalClass={SignalsStyles.awaitingApproval} iconName="clock" />;
+@uifabric/experiments:                                                               ~~~~~~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:39:60 - error TS2339: Property 'trending' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 39   return <IconSignal {...props} signalClass={SignalsStyles.trending} iconName="market" />;
+@uifabric/experiments:                                                               ~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:43:60 - error TS2339: Property 'someoneCheckedOut' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 43   return <IconSignal {...props} signalClass={SignalsStyles.someoneCheckedOut} iconName="checkedoutbyother12" />;
+@uifabric/experiments:                                                               ~~~~~~~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:47:60 - error TS2339: Property 'record' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 47   return <IconSignal {...props} signalClass={SignalsStyles.record} iconName="lock" />;
+@uifabric/experiments:                                                               ~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:51:60 - error TS2339: Property 'needsRepublishing' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 51   return <IconSignal {...props} signalClass={SignalsStyles.needsRepublishing} iconName="readingmode" />;
+@uifabric/experiments:                                                               ~~~~~~~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:55:60 - error TS2339: Property 'itemScheduled' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 55   return <IconSignal {...props} signalClass={SignalsStyles.itemScheduled} iconName="datetime2" />;
+@uifabric/experiments:                                                               ~~~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:65:54 - error TS2339: Property 'signal' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 65     <span {...spanProps} className={css(SignalStyles.signal, SignalsStyles.newSignal)}>
+@uifabric/experiments:                                                         ~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:65:76 - error TS2339: Property 'newSignal' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 65     <span {...spanProps} className={css(SignalStyles.signal, SignalsStyles.newSignal)}>
+@uifabric/experiments:                                                                               ~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:66:70 - error TS2339: Property 'newIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 66       <Icon ariaLabel={props.ariaLabel} className={css(SignalsStyles.newIcon)} iconName="glimmer" />
+@uifabric/experiments:                                                                         ~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:77:58 - error TS2339: Property 'liveEdit' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 77   return <Signal className={css(className, SignalsStyles.liveEdit)} {...spanProps} />;
+@uifabric/experiments:                                                             ~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:81:60 - error TS2339: Property 'mention' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 81   return <IconSignal {...props} signalClass={SignalsStyles.mention} iconName="accounts" />;
+@uifabric/experiments:                                                               ~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:91:42 - error TS2339: Property 'comments' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 91     <Signal className={css(SignalsStyles.comments, className)} {...spanProps}>
+@uifabric/experiments:                                             ~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:92:70 - error TS2339: Property 'commentsIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 92       <Icon ariaLabel={props.ariaLabel} className={css(SignalsStyles.commentsIcon)} iconName="MessageFill" />
+@uifabric/experiments:                                                                         ~~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:93:54 - error TS2339: Property 'commentsCount' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 93       {children ? <span className={css(SignalsStyles.commentsCount)}>{children}</span> : null}
+@uifabric/experiments:                                                         ~~~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:102:60 - error TS2339: Property 'unseenReply' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 102   return <IconSignal {...props} signalClass={SignalsStyles.unseenReply} iconName="commentprevious" />;
+@uifabric/experiments:                                                                ~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:106:60 - error TS2339: Property 'unseenEdit' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 106   return <IconSignal {...props} signalClass={SignalsStyles.unseenEdit} iconName="edit" />;
+@uifabric/experiments:                                                                ~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:110:60 - error TS2339: Property 'readOnly' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 110   return <IconSignal {...props} signalClass={SignalsStyles.readOnly} iconName="uneditablesolid12" />;
+@uifabric/experiments:                                                                ~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:114:60 - error TS2339: Property 'emailed' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 114   return <IconSignal {...props} signalClass={SignalsStyles.emailed} iconName="mail" />;
+@uifabric/experiments:                                                                ~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:118:60 - error TS2339: Property 'shared' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 118   return <IconSignal {...props} signalClass={SignalsStyles.shared} iconName="people" />;
+@uifabric/experiments:                                                                ~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:122:60 - error TS2339: Property 'folder' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 122   return <IconSignal {...props} signalClass={SignalsStyles.folder} iconName="TVMonitor" />;
+@uifabric/experiments:                                                                ~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:126:60 - error TS2339: Property 'folder' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 126   return <IconSignal {...props} signalClass={SignalsStyles.folder} iconName="Page" />;
+@uifabric/experiments:                                                                ~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:130:60 - error TS2339: Property 'folder' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 130   return <IconSignal {...props} signalClass={SignalsStyles.folder} iconName="Photo2" />;
+@uifabric/experiments:                                                                ~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:134:60 - error TS2339: Property 'malwareDetected' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 134   return <IconSignal {...props} signalClass={SignalsStyles.malwareDetected} iconName="BlockedSiteSolid12" />;
+@uifabric/experiments:                                                                ~~~~~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:143:60 - error TS2339: Property 'external' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 143   return <IconSignal {...props} signalClass={SignalsStyles.external} iconName="Globe" />;
+@uifabric/experiments:                                                                ~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:147:60 - error TS2339: Property 'bookmarkOutline' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 147   return <IconSignal {...props} signalClass={SignalsStyles.bookmarkOutline} iconName="SingleBookmark" />;
+@uifabric/experiments:                                                                ~~~~~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:151:60 - error TS2339: Property 'bookmarkFilled' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 151   return <IconSignal {...props} signalClass={SignalsStyles.bookmarkFilled} iconName="SingleBookmarkSolid" />;
+@uifabric/experiments:                                                                ~~~~~~~~~~~~~~
+@uifabric/experiments: src/components/signals/Signals.tsx:169:82 - error TS2339: Property 'signal' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 169     <Icon {...spanProps} ariaLabel={props.ariaLabel} className={css(SignalStyles.signal, signalClass, className)} />
+@uifabric/experiments:                                                                                      ~~~~~~
+@uifabric/experiments: src/utilities/scrolling/ScrollContainer.tsx:76:68 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
+@uifabric/experiments: 76         className={css('ms-ScrollContainer', ScrollContainerStyles.root, className)}
+@uifabric/experiments:                                                                       ~~~~
+@uifabric/experiments: Found 53 errors.
+@uifabric/experiments: [XX:XX:XX XM] x ------------------------------------
+@uifabric/experiments: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@uifabric/experiments: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@uifabric/experiments: error Command failed with exit code 1.
+@uifabric/lists: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@uifabric/lists: [XX:XX:XX XM] x ------------------------------------
+@uifabric/lists: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/lists/tsconfig.json"
+@uifabric/lists:     at ChildProcess.exithandler (child_process.js:303:12)
+@uifabric/lists:     at ChildProcess.emit (events.js:315:20)
+@uifabric/lists:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@uifabric/lists:     at maybeClose (internal/child_process.js:1026:16)
+@uifabric/lists:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@uifabric/lists: [XX:XX:XX XM] x stdout:
+@uifabric/lists: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+@uifabric/lists: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+@uifabric/lists:                      ~~~~~~~~~~~~~~~~
+@uifabric/lists: ../tsx-editor/lib/interfaces/monaco.d.ts:1:25 - error TS2307: Cannot find module '@uifabric/monaco-editor/esm/vs/editor/editor.api' or its corresponding type declarations.
+@uifabric/lists: 1 import * as monaco from '@uifabric/monaco-editor/esm/vs/editor/editor.api';
+@uifabric/lists:                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/lists: Found 2 errors.
+@uifabric/lists: [XX:XX:XX XM] x ------------------------------------
+@uifabric/lists: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@uifabric/lists: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@uifabric/lists: error Command failed with exit code 1.
+@uifabric/react-cards: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@uifabric/react-cards: [XX:XX:XX XM] x ------------------------------------
+@uifabric/react-cards: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-cards/tsconfig.json"
+@uifabric/react-cards:     at ChildProcess.exithandler (child_process.js:303:12)
+@uifabric/react-cards:     at ChildProcess.emit (events.js:315:20)
+@uifabric/react-cards:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@uifabric/react-cards:     at maybeClose (internal/child_process.js:1026:16)
+@uifabric/react-cards:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@uifabric/react-cards: [XX:XX:XX XM] x stdout:
+@uifabric/react-cards: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+@uifabric/react-cards: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+@uifabric/react-cards:                      ~~~~~~~~~~~~~~~~
+@uifabric/react-cards: ../tsx-editor/lib/interfaces/monaco.d.ts:1:25 - error TS2307: Cannot find module '@uifabric/monaco-editor/esm/vs/editor/editor.api' or its corresponding type declarations.
+@uifabric/react-cards: 1 import * as monaco from '@uifabric/monaco-editor/esm/vs/editor/editor.api';
+@uifabric/react-cards:                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@uifabric/react-cards: Found 2 errors.
+@uifabric/react-cards: [XX:XX:XX XM] x ------------------------------------
+@uifabric/react-cards: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@uifabric/react-cards: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@uifabric/react-cards: error Command failed with exit code 1.
+@fluentui/react-avatar: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@fluentui/react-avatar: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react-avatar: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-avatar/tsconfig.json"
+@fluentui/react-avatar:     at ChildProcess.exithandler (child_process.js:303:12)
+@fluentui/react-avatar:     at ChildProcess.emit (events.js:315:20)
+@fluentui/react-avatar:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@fluentui/react-avatar:     at maybeClose (internal/child_process.js:1026:16)
+@fluentui/react-avatar:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@fluentui/react-avatar: [XX:XX:XX XM] x stdout:
+@fluentui/react-avatar: [XX:XX:XX XM] x src/components/Avatar/Avatar.tsx:10:38 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
+@fluentui/react-avatar: 10 const useAvatarClasses = makeClasses(classes);
+@fluentui/react-avatar:                                         ~~~~~~~
+@fluentui/react-avatar: src/components/Status/Status.tsx:8:45 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
+@fluentui/react-avatar:   Property 'styles' is incompatible with index signature.
+@fluentui/react-avatar:     Type '{ [className: string]: string; }' is not assignable to type 'string'.
+@fluentui/react-avatar: 8 export const useStatusClasses = makeClasses(classes);
+@fluentui/react-avatar:                                               ~~~~~~~
+@fluentui/react-avatar: src/components/utils/StoryExample.tsx:5:27 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-avatar: 5   <div className={classes.root}>
+@fluentui/react-avatar:                             ~~~~
+@fluentui/react-avatar: src/components/utils/StoryExample.tsx:7:29 - error TS2339: Property 'content' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-avatar: 7     <div className={classes.content}>{children}</div>
+@fluentui/react-avatar:                               ~~~~~~~
+@fluentui/react-avatar: Found 4 errors.
+@fluentui/react-avatar: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react-avatar: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@fluentui/react-avatar: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@fluentui/react-avatar: error Command failed with exit code 1.
+@fluentui/react-button: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
+@fluentui/react-button: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react-button: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-button/tsconfig.json"
+@fluentui/react-button:     at ChildProcess.exithandler (child_process.js:303:12)
+@fluentui/react-button:     at ChildProcess.emit (events.js:315:20)
+@fluentui/react-button:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@fluentui/react-button:     at maybeClose (internal/child_process.js:1026:16)
+@fluentui/react-button:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@fluentui/react-button: [XX:XX:XX XM] x stdout:
+@fluentui/react-button: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+@fluentui/react-button: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+@fluentui/react-button:                      ~~~~~~~~~~~~~~~~
+@fluentui/react-button: src/components/Button/Button.stories.tsx:12:57 - error TS2339: Property 'hStack' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-button: 12   return <div {...rest} className={horizontal ? classes.hStack : classes.vStack} />;
+@fluentui/react-button:                                                            ~~~~~~
+@fluentui/react-button: src/components/Button/Button.stories.tsx:12:74 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-button: 12   return <div {...rest} className={horizontal ? classes.hStack : classes.vStack} />;
+@fluentui/react-button:                                                                             ~~~~~~
+@fluentui/react-button: src/components/Button/Button.stories.tsx:19:88 - error TS2339: Property 'text' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-button: 19 const Text = (props: React.PropsWithChildren<{}>) => <h2 {...props} className={classes.text} />;
+@fluentui/react-button:                                                                                           ~~~~
+@fluentui/react-button: src/components/Button/Button.tsx:10:45 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
+@fluentui/react-button:   Property 'styles' is incompatible with index signature.
+@fluentui/react-button:     Type '{ [className: string]: string; }' is not assignable to type 'string'.
+@fluentui/react-button: 10 export const useButtonClasses = makeClasses(classes);
+@fluentui/react-button:                                                ~~~~~~~
+@fluentui/react-button: src/components/MenuButton/MenuButton.stories.tsx:21:27 - error TS2339: Property 'hStack' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-button: 21   <div className={classes.hStack}>
+@fluentui/react-button:                              ~~~~~~
+@fluentui/react-button: src/components/MenuButton/MenuButton.stories.tsx:46:29 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-button: 46     <div className={classes.vStack}>
+@fluentui/react-button:                                ~~~~~~
+@fluentui/react-button: src/components/MenuButton/MenuButton.stories.tsx:68:29 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-button: 68     <div className={classes.vStack}>
+@fluentui/react-button:                                ~~~~~~
+@fluentui/react-button: src/components/MenuButton/MenuButton.tsx:11:49 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
+@fluentui/react-button: 11 export const useMenuButtonClasses = makeClasses(classes);
+@fluentui/react-button:                                                    ~~~~~~~
+@fluentui/react-button: src/components/SplitButton/SplitButton.stories.tsx:21:27 - error TS2339: Property 'hStack' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-button: 21   <div className={classes.hStack}>
+@fluentui/react-button:                              ~~~~~~
+@fluentui/react-button: src/components/SplitButton/SplitButton.stories.tsx:46:29 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-button: 46     <div className={classes.vStack}>
+@fluentui/react-button:                                ~~~~~~
+@fluentui/react-button: src/components/SplitButton/SplitButton.stories.tsx:68:29 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-button: 68     <div className={classes.vStack}>
+@fluentui/react-button:                                ~~~~~~
+@fluentui/react-button: src/components/SplitButton/SplitButton.tsx:12:50 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
+@fluentui/react-button: 12 export const useSplitButtonClasses = makeClasses(classes);
+@fluentui/react-button:                                                     ~~~~~~~
+@fluentui/react-button: src/components/ToggleButton/ToggleButton.stories.tsx:8:27 - error TS2339: Property 'hStack' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-button: 8   <div className={classes.hStack}>
+@fluentui/react-button:                             ~~~~~~
+@fluentui/react-button: src/components/ToggleButton/ToggleButton.stories.tsx:33:29 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-button: 33     <div className={classes.vStack}>
+@fluentui/react-button:                                ~~~~~~
+@fluentui/react-button: src/components/ToggleButton/ToggleButton.stories.tsx:52:29 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-button: 52     <div className={classes.vStack}>
+@fluentui/react-button:                                ~~~~~~
+@fluentui/react-button: src/components/ToggleButton/ToggleButton.stories.tsx:61:29 - error TS2339: Property 'vStack' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-button: 61     <div className={classes.vStack}>
+@fluentui/react-button:                                ~~~~~~
+@fluentui/react-button: src/components/ToggleButton/ToggleButton.tsx:10:51 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
+@fluentui/react-button: 10 export const useToggleButtonClasses = makeClasses(toggleButtonClasses);
+@fluentui/react-button:                                                      ~~~~~~~~~~~~~~~~~~~
+@fluentui/react-button: Found 18 errors.
+@fluentui/react-button: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react-button: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@fluentui/react-button: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
+@fluentui/react-button: error Command failed with exit code 1.
+@fluentui/react-tabs: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@fluentui/react-tabs: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react-tabs: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-tabs/tsconfig.json"
+@fluentui/react-tabs:     at ChildProcess.exithandler (child_process.js:303:12)
+@fluentui/react-tabs:     at ChildProcess.emit (events.js:315:20)
+@fluentui/react-tabs:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@fluentui/react-tabs:     at maybeClose (internal/child_process.js:1026:16)
+@fluentui/react-tabs:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@fluentui/react-tabs: [XX:XX:XX XM] x stdout:
+@fluentui/react-tabs: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+@fluentui/react-tabs: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+@fluentui/react-tabs:                      ~~~~~~~~~~~~~~~~
+@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:27:39 - error TS2339: Property 'linkSize_large' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-tabs: 27       linkSize === 'large' && classes.linkSize_large,
+@fluentui/react-tabs:                                          ~~~~~~~~~~~~~~
+@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:28:40 - error TS2339: Property 'linkFormat_tabs' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-tabs: 28       linkFormat === 'tabs' && classes.linkFormat_tabs,
+@fluentui/react-tabs:                                           ~~~~~~~~~~~~~~~
+@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:34:17 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-tabs: 34         classes.root,
+@fluentui/react-tabs:                    ~~~~
+@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:40:25 - error TS2339: Property 'link' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-tabs: 40       link: css(classes.link, globalClassNames.link, ...modifierClasses),
+@fluentui/react-tabs:                            ~~~~
+@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:41:31 - error TS2339: Property 'linkInMenu' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-tabs: 41       linkInMenu: css(classes.linkInMenu, globalClassNames.linkInMenu, ...modifierClasses),
+@fluentui/react-tabs:                                  ~~~~~~~~~~
+@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:43:35 - error TS2339: Property 'linkIsSelected' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-tabs: 43       linkIsSelected: css(classes.linkIsSelected, globalClassNames.linkIsSelected),
+@fluentui/react-tabs:                                      ~~~~~~~~~~~~~~
+@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:44:32 - error TS2339: Property 'linkContent' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-tabs: 44       linkContent: css(classes.linkContent, globalClassNames.linkContent, ...modifierClasses),
+@fluentui/react-tabs:                                   ~~~~~~~~~~~
+@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:45:25 - error TS2339: Property 'text' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-tabs: 45       text: css(classes.text, globalClassNames.text, ...modifierClasses),
+@fluentui/react-tabs:                            ~~~~
+@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:46:26 - error TS2339: Property 'count' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-tabs: 46       count: css(classes.count, globalClassNames.count, ...modifierClasses),
+@fluentui/react-tabs:                             ~~~~~
+@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:48:34 - error TS2339: Property 'itemContainer' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-tabs: 48       itemContainer: css(classes.itemContainer, ...modifierClasses),
+@fluentui/react-tabs:                                     ~~~~~~~~~~~~~
+@fluentui/react-tabs: src/components/Pivot/Pivot.tsx:49:39 - error TS2339: Property 'overflowMenuButton' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-tabs: 49       overflowMenuButton: css(classes.overflowMenuButton, globalClassNames.overflowMenuButton, ...modifierClasses),
+@fluentui/react-tabs:                                          ~~~~~~~~~~~~~~~~~~
+@fluentui/react-tabs: Found 12 errors.
+@fluentui/react-tabs: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react-tabs: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@fluentui/react-tabs: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@fluentui/react-tabs: error Command failed with exit code 1.
+theming-designer: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+theming-designer: [XX:XX:XX XM] x ------------------------------------
+theming-designer: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/theming-designer/tsconfig.json"
+theming-designer:     at ChildProcess.exithandler (child_process.js:303:12)
+theming-designer:     at ChildProcess.emit (events.js:315:20)
+theming-designer:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+theming-designer:     at maybeClose (internal/child_process.js:1026:16)
+theming-designer:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+theming-designer: [XX:XX:XX XM] x stdout:
+theming-designer: [XX:XX:XX XM] x ../../packages/office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+theming-designer: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+theming-designer:                      ~~~~~~~~~~~~~~~~
+theming-designer: ../../packages/tsx-editor/lib/interfaces/monaco.d.ts:1:25 - error TS2307: Cannot find module '@uifabric/monaco-editor/esm/vs/editor/editor.api' or its corresponding type declarations.
+theming-designer: 1 import * as monaco from '@uifabric/monaco-editor/esm/vs/editor/editor.api';
+theming-designer:                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+theming-designer: Found 2 errors.
+theming-designer: [XX:XX:XX XM] x ------------------------------------
+theming-designer: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+theming-designer: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+theming-designer: error Command failed with exit code 1.
+@fluentui/react-flex: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@fluentui/react-flex: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react-flex: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/packages/react-flex/tsconfig.json"
+@fluentui/react-flex:     at ChildProcess.exithandler (child_process.js:303:12)
+@fluentui/react-flex:     at ChildProcess.emit (events.js:315:20)
+@fluentui/react-flex:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@fluentui/react-flex:     at maybeClose (internal/child_process.js:1026:16)
+@fluentui/react-flex:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@fluentui/react-flex: [XX:XX:XX XM] x stdout:
+@fluentui/react-flex: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+@fluentui/react-flex: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+@fluentui/react-flex:                      ~~~~~~~~~~~~~~~~
+@fluentui/react-flex: src/components/Flex/Flex.tsx:22:34 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
+@fluentui/react-flex:   Property 'styles' is incompatible with index signature.
+@fluentui/react-flex:     Type '{ [className: string]: string; }' is not assignable to type 'string'.
+@fluentui/react-flex: 22     classes: createClassResolver(classes),
+@fluentui/react-flex:                                     ~~~~~~~
+@fluentui/react-flex: src/components/FlexItem/FlexItem.tsx:20:34 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
+@fluentui/react-flex: 20     classes: createClassResolver(classes),
+@fluentui/react-flex:                                     ~~~~~~~
+@fluentui/react-flex: Found 3 errors.
+@fluentui/react-flex: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react-flex: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@fluentui/react-flex: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@fluentui/react-flex: error Command failed with exit code 1.
+@fluentui/react-next: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
+@fluentui/react-next: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react-next: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/react-next/tsconfig.json"
+@fluentui/react-next:     at ChildProcess.exithandler (child_process.js:303:12)
+@fluentui/react-next:     at ChildProcess.emit (events.js:315:20)
+@fluentui/react-next:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@fluentui/react-next:     at maybeClose (internal/child_process.js:1026:16)
+@fluentui/react-next:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@fluentui/react-next: [XX:XX:XX XM] x stdout:
+@fluentui/react-next: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+@fluentui/react-next: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+@fluentui/react-next:                      ~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx:147:19 - error TS2783: 'key' is specified more than once, so this usage will be overwritten.
+@fluentui/react-next: 147                   key={option.key}
+@fluentui/react-next:                       ~~~~~~~~~~~~~~~~
+@fluentui/react-next:   ../office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx:151:19
+@fluentui/react-next:     151                   {...innerOptionProps}
+@fluentui/react-next:                           ~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next:     This spread always overwrites this property.
+@fluentui/react-next: ../office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx:82:38 - error TS2554: Expected 1 arguments, but got 2.
+@fluentui/react-next: 82           {onRenderField(this.props, this._onRenderField)}
+@fluentui/react-next:                                         ~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx:415:13 - error TS2554: Expected 1 arguments, but got 2.
+@fluentui/react-next: 415             this._onRenderContainer,
+@fluentui/react-next:                 ~~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx:194:14 - error TS2790: The operand of a 'delete' operator must be optional.
+@fluentui/react-next: 194       delete this._dragDropSubscription;
+@fluentui/react-next:                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx:208:14 - error TS2790: The operand of a 'delete' operator must be optional.
+@fluentui/react-next: 208       delete this._dragDropSubscription;
+@fluentui/react-next:                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx:130:14 - error TS2790: The operand of a 'delete' operator must be optional.
+@fluentui/react-next: 130       delete this._subscriptionObject;
+@fluentui/react-next:                  ~~~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx:152:14 - error TS2790: The operand of a 'delete' operator must be optional.
+@fluentui/react-next: 152       delete this._subscriptionObject;
+@fluentui/react-next:                  ~~~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx:110:16 - error TS2790: The operand of a 'delete' operator must be optional.
+@fluentui/react-next: 110         delete this._dragDropSubscription;
+@fluentui/react-next:                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx:148:14 - error TS2790: The operand of a 'delete' operator must be optional.
+@fluentui/react-next: 148       delete this._dragDropSubscription;
+@fluentui/react-next:                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx:12:72 - error TS2339: Property 'peoplePickerPersonaContent' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 12     <div className={css('ms-PeoplePicker-personaContent', stylesImport.peoplePickerPersonaContent)}>
+@fluentui/react-next:                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx:16:64 - error TS2339: Property 'peoplePickerPersona' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 16         className={css('ms-PeoplePicker-Persona', stylesImport.peoplePickerPersona)}
+@fluentui/react-next:                                                                   ~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx:106:12 - error TS2790: The operand of a 'delete' operator must be optional.
+@fluentui/react-next: 106     delete this._previouslyFocusedElementOutsideTrapZone;
+@fluentui/react-next:                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx:174:16 - error TS2790: The operand of a 'delete' operator must be optional.
+@fluentui/react-next: 174         delete this._dragDropSubscription;
+@fluentui/react-next:                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/List/List.tsx:340:12 - error TS2790: The operand of a 'delete' operator must be optional.
+@fluentui/react-next: 340     delete this._scrollElement;
+@fluentui/react-next:                ~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx:88:12 - error TS2790: The operand of a 'delete' operator must be optional.
+@fluentui/react-next: 88     delete this._scrollableParent;
+@fluentui/react-next:               ~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx:89:12 - error TS2790: The operand of a 'delete' operator must be optional.
+@fluentui/react-next: 89     delete this._scrollableSurface;
+@fluentui/react-next:               ~~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/Popup/Popup.tsx:75:12 - error TS2790: The operand of a 'delete' operator must be optional.
+@fluentui/react-next: 75     delete this._originalFocusedElement;
+@fluentui/react-next:               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: ../office-ui-fabric-react/src/components/TextField/TextField.types.ts:327:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+@fluentui/react-next: 327 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+@fluentui/react-next:                      ~~~~~~~~~~~~~~~~
+@fluentui/react-next: src/components/Checkbox/useCheckboxClasses.tsx:15:50 - error TS2345: Argument of type 'typeof import("*.scss")' is not assignable to parameter of type 'Record<string, string>'.
+@fluentui/react-next:   Property 'styles' is incompatible with index signature.
+@fluentui/react-next:     Type '{ [className: string]: string; }' is not assignable to type 'string'.
+@fluentui/react-next: 15 const defaultClassResolver = createClassResolver(classes);
+@fluentui/react-next:                                                     ~~~~~~~
+@fluentui/react-next: src/components/ComboBox/ComboBox.tsx:417:13 - error TS2554: Expected 1 arguments, but got 2.
+@fluentui/react-next: 417             this._onRenderContainer,
+@fluentui/react-next:                 ~~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx:28:35 - error TS2339: Property 'iconContainer' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 28           <span className={styles.iconContainer}>
+@fluentui/react-next:                                      ~~~~~~~~~~~~~
+@fluentui/react-next: src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx:29:65 - error TS2339: Property 'logoFillIcon' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 29             <Icon iconName={'WordLogoFill16'} className={styles.logoFillIcon} />
+@fluentui/react-next:                                                                    ~~~~~~~~~~~~
+@fluentui/react-next: src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx:30:61 - error TS2339: Property 'logoIcon' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 30             <Icon iconName={'WordLogo16'} className={styles.logoIcon} />
+@fluentui/react-next:                                                                ~~~~~~~~
+@fluentui/react-next: src/components/FocusTrapZone/FocusTrapZone.tsx:90:12 - error TS2790: The operand of a 'delete' operator must be optional.
+@fluentui/react-next: 90     delete this._previouslyFocusedElementOutsideTrapZone;
+@fluentui/react-next:               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@fluentui/react-next: src/components/Link/Link.tsx:16:56 - error TS2339: Property 'button' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 16     const propControlledClasses = [isButton && classes.button, isDisabled && classes.disabled];
+@fluentui/react-next:                                                           ~~~~~~
+@fluentui/react-next: src/components/Link/Link.tsx:16:86 - error TS2339: Property 'disabled' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 16     const propControlledClasses = [isButton && classes.button, isDisabled && classes.disabled];
+@fluentui/react-next:                                                                                         ~~~~~~~~
+@fluentui/react-next: src/components/Link/Link.tsx:21:36 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 21       root: css(className, classes.root, globalClassNames.root, ...rootStaticClasses, ...propControlledClasses),
+@fluentui/react-next:                                       ~~~~
+@fluentui/react-next: src/components/Persona/Persona.test.tsx:188:13 - error TS2322: Type 'ReactWrapper<HTMLAttributes, any, Component<{}, {}, any>>' is not assignable to type 'ReactWrapper<ImgHTMLAttributes<unknown>, unknown, Component<{}, {}, any>>'.
+@fluentui/react-next:   Type 'HTMLAttributes' is not assignable to type 'ImgHTMLAttributes<unknown>'.
+@fluentui/react-next:     Types of property 'crossOrigin' are incompatible.
+@fluentui/react-next:       Type 'string | undefined' is not assignable to type '"" | "anonymous" | "use-credentials" | undefined'.
+@fluentui/react-next:         Type 'string' is not assignable to type '"" | "anonymous" | "use-credentials" | undefined'.
+@fluentui/react-next: 188       const image: ReactWrapper<React.ImgHTMLAttributes<unknown>, unknown> = wrapper.find('ImageBase');
+@fluentui/react-next:                 ~~~~~
+@fluentui/react-next: src/components/Persona/Persona.test.tsx:195:13 - error TS2322: Type 'ReactWrapper<HTMLAttributes, any, Component<{}, {}, any>>' is not assignable to type 'ReactWrapper<ImgHTMLAttributes<unknown>, unknown, Component<{}, {}, any>>'.
+@fluentui/react-next: 195       const image: ReactWrapper<React.ImgHTMLAttributes<unknown>, unknown> = wrapper.find('ImageBase');
+@fluentui/react-next:                 ~~~~~
+@fluentui/react-next: src/components/Slider/Slider.tsx:39:27 - error TS2339: Property 'disabled' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 39       disabled && classes.disabled,
+@fluentui/react-next:                              ~~~~~~~~
+@fluentui/react-next: src/components/Slider/Slider.tsx:40:27 - error TS2339: Property 'vertical' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 40       vertical && classes.vertical,
+@fluentui/react-next:                              ~~~~~~~~
+@fluentui/react-next: src/components/Slider/Slider.tsx:47:36 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 47       root: css(className, classes.root, globalClassNames.root, ...propClasses),
+@fluentui/react-next:                                       ~~~~
+@fluentui/react-next: src/components/Slider/Slider.tsx:48:30 - error TS2339: Property 'container' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 48       container: css(classes.container, globalClassNames.container, ...propClasses),
+@fluentui/react-next:                                 ~~~~~~~~~
+@fluentui/react-next: src/components/Slider/Slider.tsx:49:29 - error TS2339: Property 'slideBox' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 49       slideBox: css(classes.slideBox, globalClassNames.slideBox, ...propClasses),
+@fluentui/react-next:                                ~~~~~~~~
+@fluentui/react-next: src/components/Slider/Slider.tsx:50:25 - error TS2339: Property 'line' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 50       line: css(classes.line, globalClassNames.line, ...propClasses),
+@fluentui/react-next:                            ~~~~
+@fluentui/react-next: src/components/Slider/Slider.tsx:51:26 - error TS2339: Property 'thumb' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 51       thumb: css(classes.thumb, globalClassNames.thumb, ...propClasses),
+@fluentui/react-next:                             ~~~~~
+@fluentui/react-next: src/components/Slider/Slider.tsx:52:34 - error TS2339: Property 'activeSection' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 52       activeSection: css(classes.activeSection, globalClassNames.activeSection, ...propClasses),
+@fluentui/react-next:                                     ~~~~~~~~~~~~~
+@fluentui/react-next: src/components/Slider/Slider.tsx:53:36 - error TS2339: Property 'inactiveSection' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 53       inactiveSection: css(classes.inactiveSection, globalClassNames.inactiveSection, ...propClasses),
+@fluentui/react-next:                                       ~~~~~~~~~~~~~~~
+@fluentui/react-next: src/components/Slider/Slider.tsx:54:34 - error TS2339: Property 'lineContainer' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 54       lineContainer: css(classes.lineContainer, ...propClasses),
+@fluentui/react-next:                                     ~~~~~~~~~~~~~
+@fluentui/react-next: src/components/Slider/Slider.tsx:55:31 - error TS2339: Property 'valueLabel' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 55       valueLabel: css(classes.valueLabel, globalClassNames.valueLabel, ...propClasses),
+@fluentui/react-next:                                  ~~~~~~~~~~
+@fluentui/react-next: src/components/Slider/Slider.tsx:56:31 - error TS2339: Property 'titleLabel' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 56       titleLabel: css(classes.titleLabel, titleLabelClassName, ...propClasses),
+@fluentui/react-next:                                  ~~~~~~~~~~
+@fluentui/react-next: src/components/Slider/Slider.tsx:58:29 - error TS2339: Property 'zeroTick' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 58       zeroTick: css(classes.zeroTick, globalClassNames.zeroTick, ...propClasses),
+@fluentui/react-next:                                ~~~~~~~~
+@fluentui/react-next: src/components/TextField/TextField.types.ts:328:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+@fluentui/react-next: 328 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+@fluentui/react-next:                      ~~~~~~~~~~~~~~~~
+@fluentui/react-next: src/components/Toggle/Toggle.tsx:31:26 - error TS2339: Property 'checked' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 31       checked && classes.checked,
+@fluentui/react-next:                             ~~~~~~~
+@fluentui/react-next: src/components/Toggle/Toggle.tsx:32:27 - error TS2339: Property 'disabled' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 32       disabled && classes.disabled,
+@fluentui/react-next:                              ~~~~~~~~
+@fluentui/react-next: src/components/Toggle/Toggle.tsx:33:30 - error TS2339: Property 'inlineLabel' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 33       inlineLabel && classes.inlineLabel,
+@fluentui/react-next:                                 ~~~~~~~~~~~
+@fluentui/react-next: src/components/Toggle/Toggle.tsx:34:31 - error TS2339: Property 'onOffMissing' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 34       onOffMissing && classes.onOffMissing,
+@fluentui/react-next:                                  ~~~~~~~~~~~~
+@fluentui/react-next: src/components/Toggle/Toggle.tsx:40:36 - error TS2339: Property 'root' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 40       root: css(className, classes.root, globalClassNames.root, ...rootStaticClasses, ...propControlledClasses),
+@fluentui/react-next:                                       ~~~~
+@fluentui/react-next: src/components/Toggle/Toggle.tsx:41:26 - error TS2339: Property 'label' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 41       label: css(classes.label, globalClassNames.label, ...propControlledClasses),
+@fluentui/react-next:                             ~~~~~
+@fluentui/react-next: src/components/Toggle/Toggle.tsx:42:30 - error TS2339: Property 'container' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 42       container: css(classes.container, globalClassNames.container, ...propControlledClasses),
+@fluentui/react-next:                                 ~~~~~~~~~
+@fluentui/react-next: src/components/Toggle/Toggle.tsx:43:25 - error TS2339: Property 'pill' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 43       pill: css(classes.pill, globalClassNames.pill, ...propControlledClasses),
+@fluentui/react-next:                            ~~~~
+@fluentui/react-next: src/components/Toggle/Toggle.tsx:44:26 - error TS2339: Property 'thumb' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 44       thumb: css(classes.thumb, globalClassNames.thumb, ...propControlledClasses),
+@fluentui/react-next:                             ~~~~~
+@fluentui/react-next: src/components/Toggle/Toggle.tsx:45:25 - error TS2339: Property 'text' does not exist on type 'typeof import("*.scss")'.
+@fluentui/react-next: 45       text: css(classes.text, globalClassNames.text, ...propControlledClasses),
+@fluentui/react-next:                            ~~~~
+@fluentui/react-next: Found 54 errors.
+@fluentui/react-next: [XX:XX:XX XM] x ------------------------------------
+@fluentui/react-next: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@fluentui/react-next: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
+@fluentui/react-next: error Command failed with exit code 1.
+test-bundles: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
+test-bundles: [XX:XX:XX XM] x ------------------------------------
+test-bundles: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/test-bundles/tsconfig.json"
+test-bundles:     at ChildProcess.exithandler (child_process.js:303:12)
+test-bundles:     at ChildProcess.emit (events.js:315:20)
+test-bundles:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+test-bundles:     at maybeClose (internal/child_process.js:1026:16)
+test-bundles:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+test-bundles: [XX:XX:XX XM] x stdout:
+test-bundles: [XX:XX:XX XM] x ../../packages/office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+test-bundles: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+test-bundles:                      ~~~~~~~~~~~~~~~~
+test-bundles: Found 1 error.
+test-bundles: [XX:XX:XX XM] x ------------------------------------
+test-bundles: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+test-bundles: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
+test-bundles: error Command failed with exit code 1.
+vr-tests: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
+vr-tests: [XX:XX:XX XM] x ------------------------------------
+vr-tests: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/apps/vr-tests/tsconfig.json"
+vr-tests:     at ChildProcess.exithandler (child_process.js:303:12)
+vr-tests:     at ChildProcess.emit (events.js:315:20)
+vr-tests:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+vr-tests:     at maybeClose (internal/child_process.js:1026:16)
+vr-tests:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+vr-tests: [XX:XX:XX XM] x stdout:
+vr-tests: [XX:XX:XX XM] x ../../packages/office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+vr-tests: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+vr-tests:                      ~~~~~~~~~~~~~~~~
+vr-tests: ../../packages/react-next/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+vr-tests: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+vr-tests:                      ~~~~~~~~~~~~~~~~
+vr-tests: Found 2 errors.
+vr-tests: [XX:XX:XX XM] x ------------------------------------
+vr-tests: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+vr-tests: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
+vr-tests: error Command failed with exit code 1.
+a11y-tests: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+a11y-tests: [XX:XX:XX XM] x ------------------------------------
+a11y-tests: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/a11y-tests/tsconfig.json"
+a11y-tests:     at ChildProcess.exithandler (child_process.js:303:12)
+a11y-tests:     at ChildProcess.emit (events.js:315:20)
+a11y-tests:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+a11y-tests:     at maybeClose (internal/child_process.js:1026:16)
+a11y-tests:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+a11y-tests: [XX:XX:XX XM] x stdout:
+a11y-tests: [XX:XX:XX XM] x ../../packages/office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+a11y-tests: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+a11y-tests:                      ~~~~~~~~~~~~~~~~
+a11y-tests: Found 1 error.
+a11y-tests: [XX:XX:XX XM] x ------------------------------------
+a11y-tests: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+a11y-tests: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+a11y-tests: error Command failed with exit code 1.
+@uifabric/fabric-website: [XX:XX:XX XM] x Error detected while running 'ts:esm'
+@uifabric/fabric-website: [XX:XX:XX XM] x ------------------------------------
+@uifabric/fabric-website: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib --module esnext --project "/office-ui-fabric-react/apps/fabric-website/tsconfig.json"
+@uifabric/fabric-website:     at ChildProcess.exithandler (child_process.js:303:12)
+@uifabric/fabric-website:     at ChildProcess.emit (events.js:315:20)
+@uifabric/fabric-website:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@uifabric/fabric-website:     at maybeClose (internal/child_process.js:1026:16)
+@uifabric/fabric-website:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@uifabric/fabric-website: [XX:XX:XX XM] x stdout:
+@uifabric/fabric-website: [XX:XX:XX XM] x src/components/Nav/Nav.tsx:73:35 - error TS2339: Property 'navWrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 73     return <div className={styles.navWrapper}>{this._renderPageNav(pages)}</div>;
+@uifabric/fabric-website:                                      ~~~~~~~~~~
+@uifabric/fabric-website: src/components/Nav/Nav.tsx:90:34 - error TS2339: Property 'nav' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 90           <nav className={styles.nav} role="navigation">
+@uifabric/fabric-website:                                     ~~~
+@uifabric/fabric-website: src/components/Nav/Nav.tsx:115:33 - error TS2339: Property 'links' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 115       <ul className={css(styles.links, isSubMenu && styles.isSubMenu)} aria-label="Main website navigation">
+@uifabric/fabric-website:                                     ~~~~~
+@uifabric/fabric-website: src/components/Nav/Nav.tsx:115:60 - error TS2339: Property 'isSubMenu' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 115       <ul className={css(styles.links, isSubMenu && styles.isSubMenu)} aria-label="Main website navigation">
+@uifabric/fabric-website:                                                                ~~~~~~~~~
+@uifabric/fabric-website: src/components/Nav/Nav.tsx:137:56 - error TS2339: Property 'matchesFilter' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 137         const highlightMatch = <span className={styles.matchesFilter}>{match}</span>;
+@uifabric/fabric-website:                                                            ~~~~~~~~~~~~~
+@uifabric/fabric-website: src/components/Nav/Nav.tsx:151:18 - error TS2339: Property 'link' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 151           styles.link,
+@uifabric/fabric-website:                      ~~~~
+@uifabric/fabric-website: src/components/Nav/Nav.tsx:152:44 - error TS2339: Property 'isActive' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 152           isPageActive(page.url) && styles.isActive,
+@uifabric/fabric-website:                                                ~~~~~~~~
+@uifabric/fabric-website: src/components/Nav/Nav.tsx:153:42 - error TS2339: Property 'hasActiveChild' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 153           hasActiveChild(page) && styles.hasActiveChild,
+@uifabric/fabric-website:                                              ~~~~~~~~~~~~~~
+@uifabric/fabric-website: src/components/Nav/Nav.tsx:154:37 - error TS2339: Property 'isHomePage' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 154           page.isHomePage && styles.isHomePage,
+@uifabric/fabric-website:                                         ~~~~~~~~~~
+@uifabric/fabric-website: src/components/Nav/Nav.tsx:167:91 - error TS2339: Property 'externalIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 167             {page.isExternal && <Icon iconName="NavigateExternalInline" className={styles.externalIcon} />}
+@uifabric/fabric-website:                                                                                               ~~~~~~~~~~~~
+@uifabric/fabric-website: src/components/Nav/Nav.tsx:189:45 - error TS2339: Property 'section' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 189         <li key={key} className={css(styles.section, hasActiveChild(page) && styles.hasActiveChild)}>
+@uifabric/fabric-website:                                                 ~~~~~~~
+@uifabric/fabric-website: src/components/Nav/Nav.tsx:189:85 - error TS2339: Property 'hasActiveChild' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 189         <li key={key} className={css(styles.section, hasActiveChild(page) && styles.hasActiveChild)}>
+@uifabric/fabric-website:                                                                                         ~~~~~~~~~~~~~~
+@uifabric/fabric-website: src/components/Nav/Nav.tsx:257:30 - error TS2339: Property 'searchBoxWrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 257       <div className={styles.searchBoxWrapper}>
+@uifabric/fabric-website:                                  ~~~~~~~~~~~~~~~~
+@uifabric/fabric-website: src/components/Nav/Nav.tsx:259:29 - error TS2339: Property 'searchBox' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 259           className={styles.searchBox}
+@uifabric/fabric-website:                                 ~~~~~~~~~
+@uifabric/fabric-website: src/components/Nav/Nav.tsx:269:29 - error TS2339: Property 'filterButton' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 269           className={styles.filterButton}
+@uifabric/fabric-website:                                 ~~~~~~~~~~~~
+@uifabric/fabric-website: src/components/Site/Site.tsx:157:41 - error TS2339: Property 'siteRoot' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 157       <div key="site" className={styles.siteRoot}>
+@uifabric/fabric-website:                                             ~~~~~~~~
+@uifabric/fabric-website: src/components/Site/Site.tsx:160:36 - error TS2339: Property 'siteWrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 160         <div className={css(styles.siteWrapper, isContentFullBleed && styles.fullWidth)}>
+@uifabric/fabric-website:                                        ~~~~~~~~~~~
+@uifabric/fabric-website: src/components/Site/Site.tsx:160:78 - error TS2339: Property 'fullWidth' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 160         <div className={css(styles.siteWrapper, isContentFullBleed && styles.fullWidth)}>
+@uifabric/fabric-website:                                                                                  ~~~~~~~~~
+@uifabric/fabric-website: src/components/Site/Site.tsx:163:31 - error TS2339: Property 'siteContent' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 163             className={styles.siteContent}
+@uifabric/fabric-website:                                   ~~~~~~~~~~~
+@uifabric/fabric-website: src/components/Site/Site.tsx:280:32 - error TS2339: Property 'siteNavScrollWrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 280         <div className={styles.siteNavScrollWrapper}>
+@uifabric/fabric-website:                                    ~~~~~~~~~~~~~~~~~~~~
+@uifabric/fabric-website: src/components/Site/Site.tsx:282:36 - error TS2339: Property 'siteNavWrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 282             <div className={styles.siteNavWrapper}>
+@uifabric/fabric-website:                                        ~~~~~~~~~~~~~~
+@uifabric/fabric-website: src/components/Site/Site.tsx:283:38 - error TS2339: Property 'siteNavHeader' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 283               <div className={styles.siteNavHeader}>{this._renderPlatformPicker()}</div>
+@uifabric/fabric-website:                                          ~~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/ControlsPage/ControlsPage.tsx:37:41 - error TS2339: Property 'uListFlex' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 37               <ul className={PageStyles.uListFlex}>
+@uifabric/fabric-website:                                            ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/ControlsPage/ControlsPage.tsx:43:61 - error TS2339: Property 'uThird' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 43                     <li key={url} className={css(PageStyles.uThird)}>
+@uifabric/fabric-website:                                                                ~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:23:39 - error TS2339: Property 'cardWrapper' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 23       sectionWrapperClassName={styles.cardWrapper}
+@uifabric/fabric-website:                                          ~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:33:29 - error TS2339: Property 'card' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 33           className: styles.card,
+@uifabric/fabric-website:                                ~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:35:73 - error TS2339: Property 'cardLink' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 35             <Link href="#/styles/web/colors/products" className={styles.cardLink}>
+@uifabric/fabric-website:                                                                            ~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:36:38 - error TS2339: Property 'cardContent' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 36               <div className={styles.cardContent}>
+@uifabric/fabric-website:                                         ~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:37:71 - error TS2339: Property 'cardTitle' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 37                 <MarkdownHeader as="h2" id="colors" className={styles.cardTitle}>
+@uifabric/fabric-website:                                                                          ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:40:58 - error TS2339: Property 'cardIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 40                 <Icon iconName="Color" className={styles.cardIcon} />
+@uifabric/fabric-website:                                                             ~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:46:29 - error TS2339: Property 'card' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 46           className: styles.card,
+@uifabric/fabric-website:                                ~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:48:67 - error TS2339: Property 'cardLink' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 48             <Link href="#/styles/web/elevation" className={styles.cardLink}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:49:38 - error TS2339: Property 'cardContent' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 49               <div className={styles.cardContent}>
+@uifabric/fabric-website:                                         ~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:50:74 - error TS2339: Property 'cardTitle' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 50                 <MarkdownHeader as="h2" id="elevation" className={styles.cardTitle}>
+@uifabric/fabric-website:                                                                             ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:53:72 - error TS2339: Property 'cardIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 53                 <Icon iconName="ArrangeSendBackward" className={styles.cardIcon} />
+@uifabric/fabric-website:                                                                           ~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:59:29 - error TS2339: Property 'card' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 59           className: styles.card,
+@uifabric/fabric-website:                                ~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:61:63 - error TS2339: Property 'cardLink' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 61             <Link href="#/styles/web/icons" className={styles.cardLink}>
+@uifabric/fabric-website:                                                                  ~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:62:38 - error TS2339: Property 'cardContent' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 62               <div className={styles.cardContent}>
+@uifabric/fabric-website:                                         ~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:63:76 - error TS2339: Property 'cardTitle' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 63                 <MarkdownHeader as="h2" id="iconography" className={styles.cardTitle}>
+@uifabric/fabric-website:                                                                               ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:66:68 - error TS2339: Property 'cardIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 66                 <Icon iconName="EmojiTabSymbols" className={styles.cardIcon} />
+@uifabric/fabric-website:                                                                       ~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:72:29 - error TS2339: Property 'card' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 72           className: styles.card,
+@uifabric/fabric-website:                                ~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:74:64 - error TS2339: Property 'cardLink' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 74             <Link href="#/styles/web/layout" className={styles.cardLink}>
+@uifabric/fabric-website:                                                                   ~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:75:38 - error TS2339: Property 'cardContent' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 75               <div className={styles.cardContent}>
+@uifabric/fabric-website:                                         ~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:76:71 - error TS2339: Property 'cardTitle' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 76                 <MarkdownHeader as="h2" id="layout" className={styles.cardTitle}>
+@uifabric/fabric-website:                                                                          ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:79:58 - error TS2339: Property 'cardIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 79                 <Icon iconName="Tiles" className={styles.cardIcon} />
+@uifabric/fabric-website:                                                             ~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:85:29 - error TS2339: Property 'card' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 85           className: styles.card,
+@uifabric/fabric-website:                                ~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:87:64 - error TS2339: Property 'cardLink' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 87             <Link href="#/styles/web/motion" className={styles.cardLink}>
+@uifabric/fabric-website:                                                                   ~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:88:38 - error TS2339: Property 'cardContent' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 88               <div className={styles.cardContent}>
+@uifabric/fabric-website:                                         ~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:89:71 - error TS2339: Property 'cardTitle' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 89                 <MarkdownHeader as="h2" id="motion" className={styles.cardTitle}>
+@uifabric/fabric-website:                                                                          ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:92:63 - error TS2339: Property 'cardIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 92                 <Icon iconName="MiniExpand" className={styles.cardIcon} />
+@uifabric/fabric-website:                                                                  ~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:98:29 - error TS2339: Property 'card' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 98           className: styles.card,
+@uifabric/fabric-website:                                ~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:100:68 - error TS2339: Property 'cardLink' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 100             <Link href="#/styles/web/typography" className={styles.cardLink}>
+@uifabric/fabric-website:                                                                        ~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:101:38 - error TS2339: Property 'cardContent' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 101               <div className={styles.cardContent}>
+@uifabric/fabric-website:                                          ~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:102:75 - error TS2339: Property 'cardTitle' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 102                 <MarkdownHeader as="h2" id="typography" className={styles.cardTitle}>
+@uifabric/fabric-website:                                                                               ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:105:61 - error TS2339: Property 'cardIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 105                 <Icon iconName="FontSize" className={styles.cardIcon} />
+@uifabric/fabric-website:                                                                 ~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:111:29 - error TS2339: Property 'card' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 111           className: styles.card,
+@uifabric/fabric-website:                                 ~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:113:70 - error TS2339: Property 'cardLink' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 113             <Link href="#/styles/web/localization" className={styles.cardLink}>
+@uifabric/fabric-website:                                                                          ~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:114:38 - error TS2339: Property 'cardContent' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 114               <div className={styles.cardContent}>
+@uifabric/fabric-website:                                          ~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:115:77 - error TS2339: Property 'cardTitle' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 115                 <MarkdownHeader as="h2" id="localization" className={styles.cardTitle}>
+@uifabric/fabric-website:                                                                                 ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Overviews/StylesPage/StylesPage.tsx:118:58 - error TS2339: Property 'cardIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 118                 <Icon iconName="World" className={styles.cardIcon} />
+@uifabric/fabric-website:                                                              ~~~~~~~~
+@uifabric/fabric-website: src/pages/PageTemplates/TemplatePage/TemplatePage.tsx:101:33 - error TS2339: Property 'customSection' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 101           className: css(styles.customSection, 'customGlobalClassName', platform === 'web' && 'falseyGlobalClassName'),
+@uifabric/fabric-website:                                     ~~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/ElevationPage/ElevationPage.tsx:112:37 - error TS2339: Property 'usageList' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 112               <ul className={styles.usageList}>
+@uifabric/fabric-website:                                         ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/ElevationPage/ElevationPage.tsx:114:53 - error TS2339: Property 'usageListItem' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 114                   <li key={index} className={styles.usageListItem}>
+@uifabric/fabric-website:                                                         ~~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/ElevationPage/ElevationPage.tsx:122:42 - error TS2339: Property 'example' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 122               <div className={css(styles.example, styles.compact, `ms-depth-${row.level}`)}>
+@uifabric/fabric-website:                                              ~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/ElevationPage/ElevationPage.tsx:122:58 - error TS2339: Property 'compact' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 122               <div className={css(styles.example, styles.compact, `ms-depth-${row.level}`)}>
+@uifabric/fabric-website:                                                              ~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/ElevationPage/ElevationPage.tsx:123:41 - error TS2339: Property 'caption' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 123                 <span className={styles.caption}>Depth {row.level}</span>
+@uifabric/fabric-website:                                             ~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/FabricIconsPage/FabricIconsPage.tsx:48:73 - error TS2339: Property 'iconGrid' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 48               <PivotItem headerText="Fluent UI React" className={styles.iconGrid}>
+@uifabric/fabric-website:                                                                            ~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/FabricIconsPage/FabricIconsPage.tsx:51:69 - error TS2339: Property 'iconGrid' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 51               <PivotItem headerText="Fabric Core" className={styles.iconGrid}>
+@uifabric/fabric-website:                                                                        ~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:60:43 - error TS2339: Property 'exampleIcons' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 60                     <ul className={styles.exampleIcons}>
+@uifabric/fabric-website:                                              ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:64:45 - error TS2339: Property 'productIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 64                           className={styles.productIcon}
+@uifabric/fabric-website:                                                ~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:71:45 - error TS2339: Property 'productIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 71                           className={styles.productIcon}
+@uifabric/fabric-website:                                                ~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:78:45 - error TS2339: Property 'productIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 78                           className={styles.productIcon}
+@uifabric/fabric-website:                                                ~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:103:41 - error TS2339: Property 'exampleIcons' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 103                   <ul className={styles.exampleIcons}>
+@uifabric/fabric-website:                                             ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:142:37 - error TS2339: Property 'iconList' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 142               <ul className={styles.iconList}>
+@uifabric/fabric-website:                                         ~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:147:41 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 147                       className={styles.icon}
+@uifabric/fabric-website:                                             ~~~~
+@uifabric/fabric-website: src/pages/Styles/FileTypeIconsPage/FileTypeIconsPage.tsx:150:45 - error TS2339: Property 'iconName' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 150                     <span className={styles.iconName}>{icon.name}</span>
+@uifabric/fabric-website:                                                 ~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:64:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 64                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:65:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 65                     <div className={styles.demoBlock}>1</div>
+@uifabric/fabric-website:                                               ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:67:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 67                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:68:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 68                     <div className={styles.demoBlock}>1</div>
+@uifabric/fabric-website:                                               ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:70:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 70                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:71:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 71                     <div className={styles.demoBlock}>1</div>
+@uifabric/fabric-website:                                               ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:73:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 73                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:74:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 74                     <div className={styles.demoBlock}>1</div>
+@uifabric/fabric-website:                                               ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:76:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 76                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:77:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 77                     <div className={styles.demoBlock}>1</div>
+@uifabric/fabric-website:                                               ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:79:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 79                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:80:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 80                     <div className={styles.demoBlock}>1</div>
+@uifabric/fabric-website:                                               ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:82:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 82                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:83:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 83                     <div className={styles.demoBlock}>1</div>
+@uifabric/fabric-website:                                               ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:85:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 85                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:86:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 86                     <div className={styles.demoBlock}>1</div>
+@uifabric/fabric-website:                                               ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:88:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 88                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:89:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 89                     <div className={styles.demoBlock}>1</div>
+@uifabric/fabric-website:                                               ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:91:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 91                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:92:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 92                     <div className={styles.demoBlock}>1</div>
+@uifabric/fabric-website:                                               ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:94:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 94                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:95:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 95                     <div className={styles.demoBlock}>1</div>
+@uifabric/fabric-website:                                               ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:97:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 97                   <div className={'ms-Grid-col ms-sm1 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                     ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:98:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 98                     <div className={styles.demoBlock}>1</div>
+@uifabric/fabric-website:                                               ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:102:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 102                   <div className={'ms-Grid-col ms-sm2 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:103:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 103                     <div className={styles.demoBlock}>2</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:105:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 105                   <div className={'ms-Grid-col ms-sm2 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:106:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 106                     <div className={styles.demoBlock}>2</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:108:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 108                   <div className={'ms-Grid-col ms-sm2 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:109:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 109                     <div className={styles.demoBlock}>2</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:111:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 111                   <div className={'ms-Grid-col ms-sm2 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:112:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 112                     <div className={styles.demoBlock}>2</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:114:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 114                   <div className={'ms-Grid-col ms-sm2 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:115:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 115                     <div className={styles.demoBlock}>2</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:117:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 117                   <div className={'ms-Grid-col ms-sm2 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:118:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 118                     <div className={styles.demoBlock}>2</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:122:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 122                   <div className={'ms-Grid-col ms-sm3 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:123:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 123                     <div className={styles.demoBlock}>3</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:125:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 125                   <div className={'ms-Grid-col ms-sm3 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:126:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 126                     <div className={styles.demoBlock}>3</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:128:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 128                   <div className={'ms-Grid-col ms-sm3 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:129:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 129                     <div className={styles.demoBlock}>3</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:131:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 131                   <div className={'ms-Grid-col ms-sm3 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:132:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 132                     <div className={styles.demoBlock}>3</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:136:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 136                   <div className={'ms-Grid-col ms-sm4 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:137:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 137                     <div className={styles.demoBlock}>4</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:139:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 139                   <div className={'ms-Grid-col ms-sm4 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:140:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 140                     <div className={styles.demoBlock}>4</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:142:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 142                   <div className={'ms-Grid-col ms-sm4 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:143:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 143                     <div className={styles.demoBlock}>4</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:147:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 147                   <div className={'ms-Grid-col ms-sm6 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:148:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 148                     <div className={styles.demoBlock}>6</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:150:66 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 150                   <div className={'ms-Grid-col ms-sm6 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                      ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:151:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 151                     <div className={styles.demoBlock}>6</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:155:67 - error TS2339: Property 'demoBlockCol' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 155                   <div className={'ms-Grid-col ms-sm12 ' + styles.demoBlockCol}>
+@uifabric/fabric-website:                                                                       ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:156:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 156                     <div className={styles.demoBlock}>12</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:188:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 188                     <div className={styles.demoBlock}>Visible on smaller screens</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LayoutPage/LayoutPage.tsx:191:44 - error TS2339: Property 'demoBlock' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 191                     <div className={styles.demoBlock}>Visible on larger screens</div>
+@uifabric/fabric-website:                                                ~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LocalizationPage/LocalizationPage.tsx:48:37 - error TS2339: Property 'directionalIcons' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 48               <ul className={styles.directionalIcons}>
+@uifabric/fabric-website:                                        ~~~~~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LocalizationPage/LocalizationPage.tsx:50:41 - error TS2339: Property 'directionalIconPair' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 50                   <li className={styles.directionalIconPair} key={pairIndex}>
+@uifabric/fabric-website:                                            ~~~~~~~~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LocalizationPage/LocalizationPage.tsx:51:44 - error TS2339: Property 'directionalIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 51                     <div className={styles.directionalIcon}>
+@uifabric/fabric-website:                                               ~~~~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/LocalizationPage/LocalizationPage.tsx:55:44 - error TS2339: Property 'directionalIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 55                     <div className={styles.directionalIcon}>
+@uifabric/fabric-website:                                               ~~~~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:62:43 - error TS2339: Property 'exampleIcons' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 62                     <ul className={styles.exampleIcons}>
+@uifabric/fabric-website:                                              ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:66:45 - error TS2339: Property 'productIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 66                           className={styles.productIcon}
+@uifabric/fabric-website:                                                ~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:73:45 - error TS2339: Property 'productIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 73                           className={styles.productIcon}
+@uifabric/fabric-website:                                                ~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:80:45 - error TS2339: Property 'productIcon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 80                           className={styles.productIcon}
+@uifabric/fabric-website:                                                ~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:105:41 - error TS2339: Property 'exampleIcons' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 105                   <ul className={styles.exampleIcons}>
+@uifabric/fabric-website:                                             ~~~~~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:175:37 - error TS2339: Property 'iconList' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 175               <ul className={styles.iconList}>
+@uifabric/fabric-website:                                         ~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:183:41 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 183                       className={styles.icon}
+@uifabric/fabric-website:                                             ~~~~
+@uifabric/fabric-website: src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx:185:45 - error TS2339: Property 'iconName' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 185                     <span className={styles.iconName}>{icon.name}</span>
+@uifabric/fabric-website:                                                 ~~~~~~~~
+@uifabric/fabric-website: src/pages/Styles/TypographyPage/TypographyPage.tsx:137:42 - error TS2339: Property 'example' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 137               <div className={css(styles.example, `ms-fontSize-${row.size}`)}>
+@uifabric/fabric-website:                                              ~~~~~~~
+@uifabric/fabric-website: src/root.tsx:19:39 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 19       className: platformPickerStyles.icon,
+@uifabric/fabric-website:                                          ~~~~
+@uifabric/fabric-website: src/root.tsx:22:39 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 22       className: platformPickerStyles.icon,
+@uifabric/fabric-website:                                          ~~~~
+@uifabric/fabric-website: src/root.tsx:25:39 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 25       className: platformPickerStyles.icon,
+@uifabric/fabric-website:                                          ~~~~
+@uifabric/fabric-website: src/root.tsx:28:39 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 28       className: platformPickerStyles.icon,
+@uifabric/fabric-website:                                          ~~~~
+@uifabric/fabric-website: src/root.tsx:31:39 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 31       className: platformPickerStyles.icon,
+@uifabric/fabric-website:                                          ~~~~
+@uifabric/fabric-website: src/root.tsx:34:39 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 34       className: platformPickerStyles.icon,
+@uifabric/fabric-website:                                          ~~~~
+@uifabric/fabric-website: src/utilities/svgIcons.tsx:16:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 16   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
+@uifabric/fabric-website:                                 ~~~~
+@uifabric/fabric-website: src/utilities/svgIcons.tsx:49:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 49   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
+@uifabric/fabric-website:                                 ~~~~
+@uifabric/fabric-website: src/utilities/svgIcons.tsx:67:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 67   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
+@uifabric/fabric-website:                                 ~~~~
+@uifabric/fabric-website: src/utilities/svgIcons.tsx:91:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 91   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
+@uifabric/fabric-website:                                 ~~~~
+@uifabric/fabric-website: src/utilities/svgIcons.tsx:126:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 126   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
+@uifabric/fabric-website:                                  ~~~~
+@uifabric/fabric-website: src/utilities/svgIcons.tsx:158:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 158   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
+@uifabric/fabric-website:                                  ~~~~
+@uifabric/fabric-website: src/utilities/svgIconsColor.tsx:9:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 9   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
+@uifabric/fabric-website:                                ~~~~
+@uifabric/fabric-website: src/utilities/svgIconsColor.tsx:81:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 81   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
+@uifabric/fabric-website:                                 ~~~~
+@uifabric/fabric-website: src/utilities/svgIconsColor.tsx:126:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 126   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
+@uifabric/fabric-website:                                  ~~~~
+@uifabric/fabric-website: src/utilities/svgIconsColor.tsx:202:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 202   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
+@uifabric/fabric-website:                                  ~~~~
+@uifabric/fabric-website: src/utilities/svgIconsColor.tsx:285:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 285   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
+@uifabric/fabric-website:                                  ~~~~
+@uifabric/fabric-website: src/utilities/svgIconsColor.tsx:348:30 - error TS2339: Property 'icon' does not exist on type 'typeof import("*.scss")'.
+@uifabric/fabric-website: 348   const { className = styles.icon, iconColor, iconWidth, iconHeight, iconSize } = props;
+@uifabric/fabric-website:                                  ~~~~
+@uifabric/fabric-website: Found 165 errors.
+@uifabric/fabric-website: [XX:XX:XX XM] x ------------------------------------
+@uifabric/fabric-website: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@uifabric/fabric-website: [XX:XX:XX XM] x Other tasks that did not complete: [ts:commonjs]
+@uifabric/fabric-website: error Command failed with exit code 1.
+@fluentui/examples: [XX:XX:XX XM] x Error detected while running '_wrapFunction'
+@fluentui/examples: [XX:XX:XX XM] x ------------------------------------
+@fluentui/examples: [XX:XX:XX XM] x Error: Command failed: /usr/local/bin/node "/office-ui-fabric-react/node_modules/typescript/lib/tsc.js" --pretty --target es5 --outDir lib-commonjs --module commonjs --project "/office-ui-fabric-react/packages/examples/tsconfig.json"
+@fluentui/examples:     at ChildProcess.exithandler (child_process.js:303:12)
+@fluentui/examples:     at ChildProcess.emit (events.js:315:20)
+@fluentui/examples:     at ChildProcess.EventEmitter.emit (domain.js:547:15)
+@fluentui/examples:     at maybeClose (internal/child_process.js:1026:16)
+@fluentui/examples:     at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
+@fluentui/examples: [XX:XX:XX XM] x stdout:
+@fluentui/examples: [XX:XX:XX XM] x ../office-ui-fabric-react/lib/components/TextField/TextField.types.d.ts:267:18 - error TS2310: Type 'ITextFieldStyles' recursively references itself as a base type.
+@fluentui/examples: 267 export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+@fluentui/examples:                      ~~~~~~~~~~~~~~~~
+@fluentui/examples: Found 1 error.
+@fluentui/examples: [XX:XX:XX XM] x ------------------------------------
+@fluentui/examples: [XX:XX:XX XM] x Error previously detected. See above for error messages.
+@fluentui/examples: [XX:XX:XX XM] x Other tasks that did not complete: [ts:esm]
+@fluentui/examples: error Command failed with exit code 1.
+lerna ERR! Received non-zero exit code 1 during execution

--- a/tests/cases/docker/office-ui-fabric/Dockerfile
+++ b/tests/cases/docker/office-ui-fabric/Dockerfile
@@ -1,23 +1,20 @@
-FROM node:current
+# Lock to node 13 because the codebase throws hundreds of `Warning: Accessing non-existent property` warnings in node 14
+FROM node:13
 ENV CI=true
 ENV TF_BUILD=true
-RUN npm install -g yarn lerna --force
+# Download repo version, sets up better layer caching for the following clone
+ADD https://api.github.com/repos/OfficeDev/office-ui-fabric-react/git/ref/heads/master version.json
 RUN git clone https://github.com/OfficeDev/office-ui-fabric-react.git /office-ui-fabric-react
 WORKDIR /office-ui-fabric-react
 RUN git pull
+WORKDIR /
 COPY --from=typescript/typescript /typescript/typescript-*.tgz typescript.tgz
-# Sync up all TS versions used internally to the new one
-WORKDIR /office-ui-fabric-react/scripts
-RUN yarn add typescript@../typescript.tgz --exact --dev --ignore-scripts
-WORKDIR /office-ui-fabric-react/packages/tsx-editor
-RUN yarn add typescript@../../typescript.tgz --exact --ignore-scripts
-WORKDIR /office-ui-fabric-react/packages/migration
-RUN yarn add typescript@../../typescript.tgz --exact --ignore-scripts
-WORKDIR /office-ui-fabric-react/apps/vr-tests
-RUN yarn add typescript@../../typescript.tgz --exact --ignore-scripts
-WORKDIR /office-ui-fabric-react/apps/todo-app
-RUN yarn add typescript@../../typescript.tgz --exact --ignore-scripts
 WORKDIR /office-ui-fabric-react
-RUN yarn
-ENTRYPOINT [ "lerna" ]
-CMD [ "run", "build", "--stream", "--concurrency", "1", "--loglevel", "error", "--", "--production", "--lint", "--silent" ]
+# Sync up all TS versions used internally to the new one (we use `npm` because `yarn` chokes on tarballs installed
+# into multiple places in a workspace in a short timeframe (some kind of data race))
+RUN npx lerna exec --stream --concurrency 1 -- npm install /typescript.tgz --exact --ignore-scripts
+RUN npx yarn
+# Perform scss task to generate scss code if present
+RUN npx lerna exec --stream --concurrency 1 --bail=false -- yarn run just scss
+ENTRYPOINT [ "npx" ]
+CMD [ "lerna", "exec", "--stream", "--concurrency", "1", "--loglevel", "error", "--bail=false", "--", "yarn", "run", "just", "ts"]

--- a/tests/cases/docker/office-ui-fabric/Dockerfile
+++ b/tests/cases/docker/office-ui-fabric/Dockerfile
@@ -1,5 +1,5 @@
-# Lock to node 13 because the codebase throws hundreds of `Warning: Accessing non-existent property` warnings in node 14
-FROM node:13
+# Lock to node 12 because the codebase throws hundreds of `Warning: Accessing non-existent property` warnings in node 14
+FROM node:12
 ENV CI=true
 ENV TF_BUILD=true
 # Download repo version, sets up better layer caching for the following clone


### PR DESCRIPTION
and better handle recent changes to project structure (where explicit TS deps were added throughout the tree in more places than we'd previously recognized).

Mostly this: reverts to `node 13` to reduce the runtime warning noise (that's not our fault), uses only the `scss` and `ts` build steps (to remove noise from rollup and non-ts activities), and sets the build to `--bail=false`, so an error in an early project doesn't block later projects.