### PR TITLE
Fix `getContextualTypeForBindingElement` for arrays

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23023,12 +23023,16 @@ namespace ts {
             const name = declaration.propertyName || declaration.name;
             const parentType = getContextualTypeForVariableLikeDeclaration(parent) ||
                 parent.kind !== SyntaxKind.BindingElement && parent.initializer && checkDeclarationInitializer(parent);
-            if (parentType && !isBindingPattern(name) && !isComputedNonLiteralName(name)) {
-                const nameType = getLiteralTypeFromPropertyName(name);
-                if (isTypeUsableAsPropertyName(nameType)) {
-                    const text = getPropertyNameFromType(nameType);
-                    return getTypeOfPropertyOfType(parentType, text);
-                }
+            if (!parentType || isBindingPattern(name) || isComputedNonLiteralName(name)) return undefined;
+            if (parent.name.kind === SyntaxKind.ArrayBindingPattern) {
+                const index = indexOfNode(declaration.parent.elements, declaration);
+                if (index < 0) return undefined;
+                return getContextualTypeForElementExpression(parentType, index);
+            }
+            const nameType = getLiteralTypeFromPropertyName(name);
+            if (isTypeUsableAsPropertyName(nameType)) {
+                const text = getPropertyNameFromType(nameType);
+                return getTypeOfPropertyOfType(parentType, text);
             }
         }
 

--- a/tests/baselines/reference/contextualTypingArrayDestructuringWithDefaults.errors.txt
+++ b/tests/baselines/reference/contextualTypingArrayDestructuringWithDefaults.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/compiler/contextualTypingArrayDestructuringWithDefaults.ts(8,10): error TS2322: Type '{ a: number; }' is not assignable to type '1'.
+
+
+==== tests/cases/compiler/contextualTypingArrayDestructuringWithDefaults.ts (1 errors) ====
+    type I = { a: "a" };
+    let [ c0 = {a: "a"} ]: [I?] = [];
+    let [ x1, c1 = {a: "a"} ]: [number, I?] = [1];
+    let [ c_ = {a: "a"} ]: I[] = [];
+    
+    // not a great example, expect an error
+    function foo() {
+        let {length = {a: 1}}: [number] = [1];
+             ~~~~~~
+!!! error TS2322: Type '{ a: number; }' is not assignable to type '1'.
+        return length;
+    }
+    

--- a/tests/baselines/reference/contextualTypingArrayDestructuringWithDefaults.js
+++ b/tests/baselines/reference/contextualTypingArrayDestructuringWithDefaults.js
@@ -1,0 +1,22 @@
+//// [contextualTypingArrayDestructuringWithDefaults.ts]
+type I = { a: "a" };
+let [ c0 = {a: "a"} ]: [I?] = [];
+let [ x1, c1 = {a: "a"} ]: [number, I?] = [1];
+let [ c_ = {a: "a"} ]: I[] = [];
+
+// not a great example, expect an error
+function foo() {
+    let {length = {a: 1}}: [number] = [1];
+    return length;
+}
+
+
+//// [contextualTypingArrayDestructuringWithDefaults.js]
+var _a = [][0], c0 = _a === void 0 ? { a: "a" } : _a;
+var _b = [1], x1 = _b[0], _c = _b[1], c1 = _c === void 0 ? { a: "a" } : _c;
+var _d = [][0], c_ = _d === void 0 ? { a: "a" } : _d;
+// not a great example, expect an error
+function foo() {
+    var _a = [1].length, length = _a === void 0 ? { a: 1 } : _a;
+    return length;
+}

--- a/tests/baselines/reference/contextualTypingArrayDestructuringWithDefaults.symbols
+++ b/tests/baselines/reference/contextualTypingArrayDestructuringWithDefaults.symbols
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/contextualTypingArrayDestructuringWithDefaults.ts ===
+type I = { a: "a" };
+>I : Symbol(I, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 0, 0))
+>a : Symbol(a, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 0, 10))
+
+let [ c0 = {a: "a"} ]: [I?] = [];
+>c0 : Symbol(c0, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 1, 5))
+>a : Symbol(a, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 1, 12))
+>I : Symbol(I, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 0, 0))
+
+let [ x1, c1 = {a: "a"} ]: [number, I?] = [1];
+>x1 : Symbol(x1, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 2, 5))
+>c1 : Symbol(c1, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 2, 9))
+>a : Symbol(a, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 2, 16))
+>I : Symbol(I, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 0, 0))
+
+let [ c_ = {a: "a"} ]: I[] = [];
+>c_ : Symbol(c_, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 3, 5))
+>a : Symbol(a, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 3, 12))
+>I : Symbol(I, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 0, 0))
+
+// not a great example, expect an error
+function foo() {
+>foo : Symbol(foo, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 3, 32))
+
+    let {length = {a: 1}}: [number] = [1];
+>length : Symbol(length, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 7, 9))
+>a : Symbol(a, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 7, 19))
+
+    return length;
+>length : Symbol(length, Decl(contextualTypingArrayDestructuringWithDefaults.ts, 7, 9))
+}
+

--- a/tests/baselines/reference/contextualTypingArrayDestructuringWithDefaults.types
+++ b/tests/baselines/reference/contextualTypingArrayDestructuringWithDefaults.types
@@ -1,0 +1,44 @@
+=== tests/cases/compiler/contextualTypingArrayDestructuringWithDefaults.ts ===
+type I = { a: "a" };
+>I : I
+>a : "a"
+
+let [ c0 = {a: "a"} ]: [I?] = [];
+>c0 : I
+>{a: "a"} : { a: "a"; }
+>a : "a"
+>"a" : "a"
+>[] : []
+
+let [ x1, c1 = {a: "a"} ]: [number, I?] = [1];
+>x1 : number
+>c1 : I
+>{a: "a"} : { a: "a"; }
+>a : "a"
+>"a" : "a"
+>[1] : [number]
+>1 : 1
+
+let [ c_ = {a: "a"} ]: I[] = [];
+>c_ : I
+>{a: "a"} : { a: "a"; }
+>a : "a"
+>"a" : "a"
+>[] : undefined[]
+
+// not a great example, expect an error
+function foo() {
+>foo : () => 1
+
+    let {length = {a: 1}}: [number] = [1];
+>length : 1
+>{a: 1} : { a: number; }
+>a : number
+>1 : 1
+>[1] : [number]
+>1 : 1
+
+    return length;
+>length : 1
+}
+

--- a/tests/baselines/reference/staticFieldWithInterfaceContext.js
+++ b/tests/baselines/reference/staticFieldWithInterfaceContext.js
@@ -20,15 +20,14 @@ let { c: c5 = class { static x = { a: "a" } }}: { c?: I } = { c: class { static 
 let [ c6 ]: [I] = [class { static x = { a: "a" } }];
 let [ c7 ]: I[] = [class { static x = { a: "a" } }];
 
-// These are broken because of #40158
-// let [ c8 = class { static x = { a: "a" } } ]: [I?] = [];
-// let [ c9 = class { static x = { a: "a" } } ]: I[] = [];
-// let [ c10 = class { static x = { a: "a" } } ]: [I?] = [class { static x = { a: "a" } }];
-// let [ c11 = class { static x = { a: "a" } } ]: I[] = [class { static x = { a: "a" } }];
+let [ c8 = class { static x = { a: "a" } } ]: [I?] = [];
+let [ c9 = class { static x = { a: "a" } } ]: I[] = [];
+let [ c10 = class { static x = { a: "a" } } ]: [I?] = [class { static x = { a: "a" } }];
+let [ c11 = class { static x = { a: "a" } } ]: I[] = [class { static x = { a: "a" } }];
 
 
 //// [staticFieldWithInterfaceContext.js]
-var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q;
 var c = (_a = /** @class */ (function () {
         function class_1() {
         }
@@ -65,26 +64,26 @@ var c3 = { c: (_d = /** @class */ (function () {
         }()),
         _d.x = { a: "a" },
         _d) }.c;
-var _k = {}.c, c4 = _k === void 0 ? (_e = /** @class */ (function () {
+var _r = {}.c, c4 = _r === void 0 ? (_e = /** @class */ (function () {
         function class_5() {
         }
         return class_5;
     }()),
     _e.x = { a: "a" },
-    _e) : _k;
-var _l = { c: (_g = /** @class */ (function () {
+    _e) : _r;
+var _s = { c: (_g = /** @class */ (function () {
             function class_6() {
             }
             return class_6;
         }()),
         _g.x = { a: "a" },
-        _g) }.c, c5 = _l === void 0 ? (_f = /** @class */ (function () {
+        _g) }.c, c5 = _s === void 0 ? (_f = /** @class */ (function () {
         function class_7() {
         }
         return class_7;
     }()),
     _f.x = { a: "a" },
-    _f) : _l;
+    _f) : _s;
 var c6 = [(_h = /** @class */ (function () {
             function class_8() {
             }
@@ -99,8 +98,43 @@ var c7 = [(_j = /** @class */ (function () {
         }()),
         _j.x = { a: "a" },
         _j)][0];
-// These are broken because of #40158
-// let [ c8 = class { static x = { a: "a" } } ]: [I?] = [];
-// let [ c9 = class { static x = { a: "a" } } ]: I[] = [];
-// let [ c10 = class { static x = { a: "a" } } ]: [I?] = [class { static x = { a: "a" } }];
-// let [ c11 = class { static x = { a: "a" } } ]: I[] = [class { static x = { a: "a" } }];
+var _t = [][0], c8 = _t === void 0 ? (_k = /** @class */ (function () {
+        function class_10() {
+        }
+        return class_10;
+    }()),
+    _k.x = { a: "a" },
+    _k) : _t;
+var _u = [][0], c9 = _u === void 0 ? (_l = /** @class */ (function () {
+        function class_11() {
+        }
+        return class_11;
+    }()),
+    _l.x = { a: "a" },
+    _l) : _u;
+var _v = [(_o = /** @class */ (function () {
+            function class_12() {
+            }
+            return class_12;
+        }()),
+        _o.x = { a: "a" },
+        _o)][0], c10 = _v === void 0 ? (_m = /** @class */ (function () {
+        function class_13() {
+        }
+        return class_13;
+    }()),
+    _m.x = { a: "a" },
+    _m) : _v;
+var _w = [(_q = /** @class */ (function () {
+            function class_14() {
+            }
+            return class_14;
+        }()),
+        _q.x = { a: "a" },
+        _q)][0], c11 = _w === void 0 ? (_p = /** @class */ (function () {
+        function class_15() {
+        }
+        return class_15;
+    }()),
+    _p.x = { a: "a" },
+    _p) : _w;

--- a/tests/baselines/reference/staticFieldWithInterfaceContext.symbols
+++ b/tests/baselines/reference/staticFieldWithInterfaceContext.symbols
@@ -84,9 +84,31 @@ let [ c7 ]: I[] = [class { static x = { a: "a" } }];
 >x : Symbol((Anonymous class).x, Decl(staticFieldWithInterfaceContext.ts, 19, 26))
 >a : Symbol(a, Decl(staticFieldWithInterfaceContext.ts, 19, 39))
 
-// These are broken because of #40158
-// let [ c8 = class { static x = { a: "a" } } ]: [I?] = [];
-// let [ c9 = class { static x = { a: "a" } } ]: I[] = [];
-// let [ c10 = class { static x = { a: "a" } } ]: [I?] = [class { static x = { a: "a" } }];
-// let [ c11 = class { static x = { a: "a" } } ]: I[] = [class { static x = { a: "a" } }];
+let [ c8 = class { static x = { a: "a" } } ]: [I?] = [];
+>c8 : Symbol(c8, Decl(staticFieldWithInterfaceContext.ts, 21, 5))
+>x : Symbol(c8.x, Decl(staticFieldWithInterfaceContext.ts, 21, 18))
+>a : Symbol(a, Decl(staticFieldWithInterfaceContext.ts, 21, 31))
+>I : Symbol(I, Decl(staticFieldWithInterfaceContext.ts, 0, 0))
+
+let [ c9 = class { static x = { a: "a" } } ]: I[] = [];
+>c9 : Symbol(c9, Decl(staticFieldWithInterfaceContext.ts, 22, 5))
+>x : Symbol(c9.x, Decl(staticFieldWithInterfaceContext.ts, 22, 18))
+>a : Symbol(a, Decl(staticFieldWithInterfaceContext.ts, 22, 31))
+>I : Symbol(I, Decl(staticFieldWithInterfaceContext.ts, 0, 0))
+
+let [ c10 = class { static x = { a: "a" } } ]: [I?] = [class { static x = { a: "a" } }];
+>c10 : Symbol(c10, Decl(staticFieldWithInterfaceContext.ts, 23, 5))
+>x : Symbol(c10.x, Decl(staticFieldWithInterfaceContext.ts, 23, 19))
+>a : Symbol(a, Decl(staticFieldWithInterfaceContext.ts, 23, 32))
+>I : Symbol(I, Decl(staticFieldWithInterfaceContext.ts, 0, 0))
+>x : Symbol((Anonymous class).x, Decl(staticFieldWithInterfaceContext.ts, 23, 62))
+>a : Symbol(a, Decl(staticFieldWithInterfaceContext.ts, 23, 75))
+
+let [ c11 = class { static x = { a: "a" } } ]: I[] = [class { static x = { a: "a" } }];
+>c11 : Symbol(c11, Decl(staticFieldWithInterfaceContext.ts, 24, 5))
+>x : Symbol(c11.x, Decl(staticFieldWithInterfaceContext.ts, 24, 19))
+>a : Symbol(a, Decl(staticFieldWithInterfaceContext.ts, 24, 32))
+>I : Symbol(I, Decl(staticFieldWithInterfaceContext.ts, 0, 0))
+>x : Symbol((Anonymous class).x, Decl(staticFieldWithInterfaceContext.ts, 24, 61))
+>a : Symbol(a, Decl(staticFieldWithInterfaceContext.ts, 24, 74))
 

--- a/tests/baselines/reference/staticFieldWithInterfaceContext.types
+++ b/tests/baselines/reference/staticFieldWithInterfaceContext.types
@@ -114,9 +114,49 @@ let [ c7 ]: I[] = [class { static x = { a: "a" } }];
 >a : "a"
 >"a" : "a"
 
-// These are broken because of #40158
-// let [ c8 = class { static x = { a: "a" } } ]: [I?] = [];
-// let [ c9 = class { static x = { a: "a" } } ]: I[] = [];
-// let [ c10 = class { static x = { a: "a" } } ]: [I?] = [class { static x = { a: "a" } }];
-// let [ c11 = class { static x = { a: "a" } } ]: I[] = [class { static x = { a: "a" } }];
+let [ c8 = class { static x = { a: "a" } } ]: [I?] = [];
+>c8 : I
+>class { static x = { a: "a" } } : typeof c8
+>x : { a: "a"; }
+>{ a: "a" } : { a: "a"; }
+>a : "a"
+>"a" : "a"
+>[] : []
+
+let [ c9 = class { static x = { a: "a" } } ]: I[] = [];
+>c9 : I
+>class { static x = { a: "a" } } : typeof c9
+>x : { a: "a"; }
+>{ a: "a" } : { a: "a"; }
+>a : "a"
+>"a" : "a"
+>[] : undefined[]
+
+let [ c10 = class { static x = { a: "a" } } ]: [I?] = [class { static x = { a: "a" } }];
+>c10 : I
+>class { static x = { a: "a" } } : typeof c10
+>x : { a: "a"; }
+>{ a: "a" } : { a: "a"; }
+>a : "a"
+>"a" : "a"
+>[class { static x = { a: "a" } }] : [typeof (Anonymous class)]
+>class { static x = { a: "a" } } : typeof (Anonymous class)
+>x : { a: "a"; }
+>{ a: "a" } : { a: "a"; }
+>a : "a"
+>"a" : "a"
+
+let [ c11 = class { static x = { a: "a" } } ]: I[] = [class { static x = { a: "a" } }];
+>c11 : I
+>class { static x = { a: "a" } } : typeof c11
+>x : { a: "a"; }
+>{ a: "a" } : { a: "a"; }
+>a : "a"
+>"a" : "a"
+>[class { static x = { a: "a" } }] : (typeof (Anonymous class))[]
+>class { static x = { a: "a" } } : typeof (Anonymous class)
+>x : { a: "a"; }
+>{ a: "a" } : { a: "a"; }
+>a : "a"
+>"a" : "a"
 

--- a/tests/cases/compiler/contextualTypingArrayDestructuringWithDefaults.ts
+++ b/tests/cases/compiler/contextualTypingArrayDestructuringWithDefaults.ts
@@ -1,0 +1,10 @@
+type I = { a: "a" };
+let [ c0 = {a: "a"} ]: [I?] = [];
+let [ x1, c1 = {a: "a"} ]: [number, I?] = [1];
+let [ c_ = {a: "a"} ]: I[] = [];
+
+// not a great example, expect an error
+function foo() {
+    let {length = {a: 1}}: [number] = [1];
+    return length;
+}

--- a/tests/cases/compiler/staticFieldWithInterfaceContext.ts
+++ b/tests/cases/compiler/staticFieldWithInterfaceContext.ts
@@ -19,8 +19,7 @@ let { c: c5 = class { static x = { a: "a" } }}: { c?: I } = { c: class { static 
 let [ c6 ]: [I] = [class { static x = { a: "a" } }];
 let [ c7 ]: I[] = [class { static x = { a: "a" } }];
 
-// These are broken because of #40158
-// let [ c8 = class { static x = { a: "a" } } ]: [I?] = [];
-// let [ c9 = class { static x = { a: "a" } } ]: I[] = [];
-// let [ c10 = class { static x = { a: "a" } } ]: [I?] = [class { static x = { a: "a" } }];
-// let [ c11 = class { static x = { a: "a" } } ]: I[] = [class { static x = { a: "a" } }];
+let [ c8 = class { static x = { a: "a" } } ]: [I?] = [];
+let [ c9 = class { static x = { a: "a" } } ]: I[] = [];
+let [ c10 = class { static x = { a: "a" } } ]: [I?] = [class { static x = { a: "a" } }];
+let [ c11 = class { static x = { a: "a" } } ]: I[] = [class { static x = { a: "a" } }];


### PR DESCRIPTION
When handling an array type, the lookup should use the position index
instead of the identifier name.

Also uncomment the tests in the `staticFieldWithInterfaceContext.ts`
test which failed because of this bug.

Fixes #40158.
