### PR TITLE
Treat trailing 'void' as optional for assignability

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -248,6 +248,12 @@ namespace ts {
         ExportNamespace = 1 << 2,
     }
 
+    const enum MinArgumentCountFlags {
+        None = 0,
+        StrongArityForUntypedJS = 1 << 0,
+        VoidIsNonOptional = 1 << 1,
+    }
+
     function SymbolLinks(this: SymbolLinks) {
     }
 
@@ -9859,6 +9865,7 @@ namespace ts {
             sig.resolvedReturnType = resolvedReturnType;
             sig.resolvedTypePredicate = resolvedTypePredicate;
             sig.minArgumentCount = minArgumentCount;
+            sig.resolvedMinArgumentCount = undefined;
             sig.target = undefined;
             sig.mapper = undefined;
             sig.unionSignatures = undefined;
@@ -11318,7 +11325,10 @@ namespace ts {
                 const signature = getSignatureFromDeclaration(node.parent);
                 const parameterIndex = node.parent.parameters.indexOf(node);
                 Debug.assert(parameterIndex >= 0);
-                return parameterIndex >= getMinArgumentCount(signature, /*strongArityForUntypedJS*/ true);
+                // Only consider syntactic or instantiated parameters as optional, not `void` parameters as this function is used
+                // in grammar checks and checking for `void` too early results in parameter types widening too early
+                // and causes some noImplicitAny errors to be lost.
+                return parameterIndex >= getMinArgumentCount(signature, MinArgumentCountFlags.StrongArityForUntypedJS | MinArgumentCountFlags.VoidIsNonOptional);
             }
             const iife = getImmediatelyInvokedFunctionExpression(node.parent);
             if (iife) {
@@ -28024,21 +28034,40 @@ namespace ts {
             return length;
         }
 
-        function getMinArgumentCount(signature: Signature, strongArityForUntypedJS?: boolean) {
-            if (signatureHasRestParameter(signature)) {
-                const restType = getTypeOfSymbol(signature.parameters[signature.parameters.length - 1]);
-                if (isTupleType(restType)) {
-                    const firstOptionalIndex = findIndex(restType.target.elementFlags, f => !(f & ElementFlags.Required));
-                    const requiredCount = firstOptionalIndex < 0 ? restType.target.fixedLength : firstOptionalIndex;
-                    if (requiredCount > 0) {
-                        return signature.parameters.length - 1 + requiredCount;
+        function getMinArgumentCount(signature: Signature, flags?: MinArgumentCountFlags) {
+            const strongArityForUntypedJS = flags! & MinArgumentCountFlags.StrongArityForUntypedJS;
+            const voidIsNonOptional = flags! & MinArgumentCountFlags.VoidIsNonOptional;
+            if (voidIsNonOptional || signature.resolvedMinArgumentCount === undefined) {
+                let minArgumentCount: number | undefined;
+                if (signatureHasRestParameter(signature)) {
+                    const restType = getTypeOfSymbol(signature.parameters[signature.parameters.length - 1]);
+                    if (isTupleType(restType)) {
+                        const firstOptionalIndex = findIndex(restType.target.elementFlags, f => !(f & ElementFlags.Required));
+                        const requiredCount = firstOptionalIndex < 0 ? restType.target.fixedLength : firstOptionalIndex;
+                        if (requiredCount > 0) {
+                            minArgumentCount = signature.parameters.length - 1 + requiredCount;
+                        }
                     }
                 }
+                if (minArgumentCount === undefined) {
+                    if (!strongArityForUntypedJS && signature.flags & SignatureFlags.IsUntypedSignatureInJSFile) {
+                        return 0;
+                    }
+                    minArgumentCount = signature.minArgumentCount;
+                }
+                if (voidIsNonOptional) {
+                    return minArgumentCount;
+                }
+                for (let i = minArgumentCount - 1; i >= 0; i--) {
+                    const type = getTypeAtPosition(signature, i);
+                    if (filterType(type, acceptsVoid).flags & TypeFlags.Never) {
+                        break;
+                    }
+                    minArgumentCount = i;
+                }
+                signature.resolvedMinArgumentCount = minArgumentCount;
             }
-            if (!strongArityForUntypedJS && signature.flags & SignatureFlags.IsUntypedSignatureInJSFile) {
-                return 0;
-            }
-            return signature.minArgumentCount;
+            return signature.resolvedMinArgumentCount;
         }
 
         function hasEffectiveRestParameter(signature: Signature) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5375,6 +5375,8 @@ namespace ts {
         /* @internal */
         minArgumentCount: number;           // Number of non-optional parameters
         /* @internal */
+        resolvedMinArgumentCount?: number;  // Number of non-optional parameters (excluding trailing `void`)
+        /* @internal */
         target?: Signature;                 // Instantiation target
         /* @internal */
         mapper?: TypeMapper;                // Instantiation mapper

--- a/src/lib/es2015.promise.d.ts
+++ b/src/lib/es2015.promise.d.ts
@@ -114,17 +114,17 @@ interface PromiseConstructor {
     reject<T = never>(reason?: any): Promise<T>;
 
     /**
+     * Creates a new resolved promise.
+     * @returns A resolved promise.
+     */
+    resolve(): Promise<void>;
+
+    /**
      * Creates a new resolved promise for the provided value.
      * @param value A promise.
      * @returns A promise whose internal state matches the provided promise.
      */
     resolve<T>(value: T | PromiseLike<T>): Promise<T>;
-
-    /**
-     * Creates a new resolved promise .
-     * @returns A resolved promise.
-     */
-    resolve(): Promise<void>;
 }
 
 declare var Promise: PromiseConstructor;

--- a/tests/baselines/reference/arrayFrom.types
+++ b/tests/baselines/reference/arrayFrom.types
@@ -29,7 +29,7 @@ const inputALike: ArrayLike<A> = { length: 0 };
 const inputARand = getEither(inputA, inputALike);
 >inputARand : ArrayLike<A> | Iterable<A>
 >getEither(inputA, inputALike) : ArrayLike<A> | Iterable<A>
->getEither : <T>(in1: Iterable<T>, in2: ArrayLike<T>) => Iterable<T> | ArrayLike<T>
+>getEither : <T>(in1: Iterable<T>, in2: ArrayLike<T>) => ArrayLike<T> | Iterable<T>
 >inputA : A[]
 >inputALike : ArrayLike<A>
 
@@ -161,12 +161,12 @@ const result11: B[] = Array.from(inputASet, ({ a }): B => ({ b: a }));
 // the ?: as always taking the false branch, narrowing to ArrayLike<T>,
 // even when the type is written as : Iterable<T>|ArrayLike<T>
 function getEither<T> (in1: Iterable<T>, in2: ArrayLike<T>) {
->getEither : <T>(in1: Iterable<T>, in2: ArrayLike<T>) => Iterable<T> | ArrayLike<T>
+>getEither : <T>(in1: Iterable<T>, in2: ArrayLike<T>) => ArrayLike<T> | Iterable<T>
 >in1 : Iterable<T>
 >in2 : ArrayLike<T>
 
   return Math.random() > 0.5 ? in1 : in2;
->Math.random() > 0.5 ? in1 : in2 : Iterable<T> | ArrayLike<T>
+>Math.random() > 0.5 ? in1 : in2 : ArrayLike<T> | Iterable<T>
 >Math.random() > 0.5 : boolean
 >Math.random() : number
 >Math.random : () => number

--- a/tests/baselines/reference/asyncArrowFunction11_es5.types
+++ b/tests/baselines/reference/asyncArrowFunction11_es5.types
@@ -11,9 +11,9 @@ class A {
         await Promise.resolve();
 >await Promise.resolve() : void
 >Promise.resolve() : Promise<void>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 
         const obj = { ["a"]: () => this }; // computed property name after `await` triggers case
 >obj : { a: () => this; }

--- a/tests/baselines/reference/asyncFunctionReturnType.types
+++ b/tests/baselines/reference/asyncFunctionReturnType.types
@@ -44,9 +44,9 @@ async function fIndexedTypeForPromiseOfStringProp(obj: Obj): Promise<Obj["string
 
     return Promise.resolve(obj.stringProp);
 >Promise.resolve(obj.stringProp) : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >obj.stringProp : string
 >obj : Obj
 >stringProp : string
@@ -58,9 +58,9 @@ async function fIndexedTypeForExplicitPromiseOfStringProp(obj: Obj): Promise<Obj
 
     return Promise.resolve<Obj["stringProp"]>(obj.stringProp);
 >Promise.resolve<Obj["stringProp"]>(obj.stringProp) : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >obj.stringProp : string
 >obj : Obj
 >stringProp : string
@@ -82,9 +82,9 @@ async function fIndexedTypeForPromiseOfAnyProp(obj: Obj): Promise<Obj["anyProp"]
 
     return Promise.resolve(obj.anyProp);
 >Promise.resolve(obj.anyProp) : Promise<any>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >obj.anyProp : any
 >obj : Obj
 >anyProp : any
@@ -96,9 +96,9 @@ async function fIndexedTypeForExplicitPromiseOfAnyProp(obj: Obj): Promise<Obj["a
 
     return Promise.resolve<Obj["anyProp"]>(obj.anyProp);
 >Promise.resolve<Obj["anyProp"]>(obj.anyProp) : Promise<any>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >obj.anyProp : any
 >obj : Obj
 >anyProp : any
@@ -120,9 +120,9 @@ async function fGenericIndexedTypeForPromiseOfStringProp<TObj extends Obj>(obj: 
 
     return Promise.resolve(obj.stringProp);
 >Promise.resolve(obj.stringProp) : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >obj.stringProp : string
 >obj : TObj
 >stringProp : string
@@ -134,9 +134,9 @@ async function fGenericIndexedTypeForExplicitPromiseOfStringProp<TObj extends Ob
 
     return Promise.resolve<TObj["stringProp"]>(obj.stringProp);
 >Promise.resolve<TObj["stringProp"]>(obj.stringProp) : Promise<TObj["stringProp"]>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >obj.stringProp : string
 >obj : TObj
 >stringProp : string
@@ -158,9 +158,9 @@ async function fGenericIndexedTypeForPromiseOfAnyProp<TObj extends Obj>(obj: TOb
 
     return Promise.resolve(obj.anyProp);
 >Promise.resolve(obj.anyProp) : Promise<any>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >obj.anyProp : any
 >obj : TObj
 >anyProp : any
@@ -172,9 +172,9 @@ async function fGenericIndexedTypeForExplicitPromiseOfAnyProp<TObj extends Obj>(
 
     return Promise.resolve<TObj["anyProp"]>(obj.anyProp);
 >Promise.resolve<TObj["anyProp"]>(obj.anyProp) : Promise<TObj["anyProp"]>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >obj.anyProp : any
 >obj : TObj
 >anyProp : any
@@ -198,9 +198,9 @@ async function fGenericIndexedTypeForPromiseOfKProp<TObj extends Obj, K extends 
 
     return Promise.resolve(obj[key]);
 >Promise.resolve(obj[key]) : Promise<TObj[K]>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >obj[key] : TObj[K]
 >obj : TObj
 >key : K
@@ -213,9 +213,9 @@ async function fGenericIndexedTypeForExplicitPromiseOfKProp<TObj extends Obj, K 
 
     return Promise.resolve<TObj[K]>(obj[key]);
 >Promise.resolve<TObj[K]>(obj[key]) : Promise<TObj[K]>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >obj[key] : TObj[K]
 >obj : TObj
 >key : K

--- a/tests/baselines/reference/callWithMissingVoid.errors.txt
+++ b/tests/baselines/reference/callWithMissingVoid.errors.txt
@@ -4,7 +4,7 @@ tests/cases/conformance/expressions/functionCalls/callWithMissingVoid.ts(22,8): 
 tests/cases/conformance/expressions/functionCalls/callWithMissingVoid.ts(35,31): error TS2554: Expected 1 arguments, but got 0.
 tests/cases/conformance/expressions/functionCalls/callWithMissingVoid.ts(36,35): error TS2554: Expected 1 arguments, but got 0.
 tests/cases/conformance/expressions/functionCalls/callWithMissingVoid.ts(37,33): error TS2554: Expected 1 arguments, but got 0.
-tests/cases/conformance/expressions/functionCalls/callWithMissingVoid.ts(48,1): error TS2554: Expected 3 arguments, but got 1.
+tests/cases/conformance/expressions/functionCalls/callWithMissingVoid.ts(48,1): error TS2554: Expected 2-3 arguments, but got 1.
 tests/cases/conformance/expressions/functionCalls/callWithMissingVoid.ts(55,1): error TS2554: Expected 4 arguments, but got 2.
 tests/cases/conformance/expressions/functionCalls/callWithMissingVoid.ts(56,1): error TS2554: Expected 4 arguments, but got 3.
 tests/cases/conformance/expressions/functionCalls/callWithMissingVoid.ts(57,1): error TS2554: Expected 4 arguments, but got 1.
@@ -79,7 +79,7 @@ tests/cases/conformance/expressions/functionCalls/callWithMissingVoid.ts(75,1): 
     a(4, "hello", void 0); // ok
     a(4); // not ok
     ~~~~
-!!! error TS2554: Expected 3 arguments, but got 1.
+!!! error TS2554: Expected 2-3 arguments, but got 1.
 !!! related TS6210 tests/cases/conformance/expressions/functionCalls/callWithMissingVoid.ts:42:23: An argument for 'y' was not provided.
     
     function b(x: number, y: string, z: void, what: number): void  {

--- a/tests/baselines/reference/exportDefaultAsyncFunction2.types
+++ b/tests/baselines/reference/exportDefaultAsyncFunction2.types
@@ -19,9 +19,9 @@ export default async(() => await(Promise.resolve(1)));
 >await(Promise.resolve(1)) : any
 >await : (...args: any[]) => any
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 === tests/cases/compiler/b.ts ===

--- a/tests/baselines/reference/generatorReturnContextualType.types
+++ b/tests/baselines/reference/generatorReturnContextualType.types
@@ -27,9 +27,9 @@ async function* f3(): AsyncGenerator<any, { x: 'x' }, any> {
 
   return Promise.resolve({ x: 'x' });
 >Promise.resolve({ x: 'x' }) : Promise<{ x: "x"; }>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >{ x: 'x' } : { x: "x"; }
 >x : "x"
 >'x' : "x"
@@ -47,9 +47,9 @@ async function* f4(): AsyncGenerator<any, { x: 'x' }, any> {
 
   return Promise.resolve(ret); // Error
 >Promise.resolve(ret) : Promise<{ x: string; }>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >ret : { x: string; }
 }
 

--- a/tests/baselines/reference/genericFunctionInference1.types
+++ b/tests/baselines/reference/genericFunctionInference1.types
@@ -835,9 +835,9 @@ const fn30: Fn = pipe(
 const promise = Promise.resolve(1);
 >promise : Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 promise.then(

--- a/tests/baselines/reference/inferFromGenericFunctionReturnTypes3.types
+++ b/tests/baselines/reference/inferFromGenericFunctionReturnTypes3.types
@@ -7,9 +7,9 @@ function truePromise(): Promise<true> {
 
     return Promise.resolve(true);
 >Promise.resolve(true) : Promise<true>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >true : true
 }
 

--- a/tests/baselines/reference/instantiateContextualTypes.types
+++ b/tests/baselines/reference/instantiateContextualTypes.types
@@ -342,9 +342,9 @@ class Interesting {
 >Promise.resolve().then(() => {			if (1 < 2) {				return 'SOMETHING';			}			return 'ELSE';		}) : Promise<DooDad>
 >Promise.resolve().then : <TResult1 = void, TResult2 = never>(onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >Promise.resolve() : Promise<void>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >then : <TResult1 = void, TResult2 = never>(onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >() => {			if (1 < 2) {				return 'SOMETHING';			}			return 'ELSE';		} : () => "SOMETHING" | "ELSE"
 
@@ -369,9 +369,9 @@ class Interesting {
 >Promise.resolve().then(() => {			return 'ELSE';		}) : Promise<DooDad>
 >Promise.resolve().then : <TResult1 = void, TResult2 = never>(onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >Promise.resolve() : Promise<void>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >then : <TResult1 = void, TResult2 = never>(onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >() => {			return 'ELSE';		} : () => "ELSE"
 
@@ -388,9 +388,9 @@ class Interesting {
 >Promise.resolve().then(() => {			if (1 < 2) {				return 'SOMETHING';			}			return 'SOMETHING';		}) : Promise<DooDad>
 >Promise.resolve().then : <TResult1 = void, TResult2 = never>(onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >Promise.resolve() : Promise<void>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >then : <TResult1 = void, TResult2 = never>(onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >() => {			if (1 < 2) {				return 'SOMETHING';			}			return 'SOMETHING';		} : () => "SOMETHING"
 

--- a/tests/baselines/reference/intersectionWithConflictingPrivates.types
+++ b/tests/baselines/reference/intersectionWithConflictingPrivates.types
@@ -144,9 +144,9 @@ class Foo {
 
     return Promise.resolve(undefined);
 >Promise.resolve(undefined) : Promise<undefined>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >undefined : undefined
   }
 }

--- a/tests/baselines/reference/jsDeclarationsJSDocRedirectedLookups.types
+++ b/tests/baselines/reference/jsDeclarationsJSDocRedirectedLookups.types
@@ -43,9 +43,9 @@
 /** @type {promise} */const j = Promise.resolve(0);
 >j : Promise<any>
 >Promise.resolve(0) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >0 : 0
 
 /** @type {Object<string, string>} */const k = {x: "x"};

--- a/tests/baselines/reference/jsFileCompilationAwaitModifier.types
+++ b/tests/baselines/reference/jsFileCompilationAwaitModifier.types
@@ -8,9 +8,9 @@ class Foo {
         await Promise.resolve(1);
 >await Promise.resolve(1) : number
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
     }
 
@@ -21,9 +21,9 @@ class Foo {
         await Promise.resolve(1);
 >await Promise.resolve(1) : number
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
     }
 }

--- a/tests/baselines/reference/jsdocArrayObjectPromiseImplicitAny.types
+++ b/tests/baselines/reference/jsdocArrayObjectPromiseImplicitAny.types
@@ -27,18 +27,18 @@ function returnAnyArray(arr) {
 var anyPromise = Promise.resolve(5);
 >anyPromise : Promise<any>
 >Promise.resolve(5) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >5 : 5
 
 /** @type {Promise<number>} */
 var numberPromise = Promise.resolve(5);
 >numberPromise : Promise<number>
 >Promise.resolve(5) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >5 : 5
 
 /**

--- a/tests/baselines/reference/jsdocArrayObjectPromiseNoImplicitAny.types
+++ b/tests/baselines/reference/jsdocArrayObjectPromiseNoImplicitAny.types
@@ -27,18 +27,18 @@ function returnNotAnyArray(arr) {
 var notAnyPromise = Promise.resolve(5);
 >notAnyPromise : Promise<any>
 >Promise.resolve(5) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >5 : 5
 
 /** @type {Promise<number>} */
 var numberPromise = Promise.resolve(5);
 >numberPromise : Promise<number>
 >Promise.resolve(5) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >5 : 5
 
 /**

--- a/tests/baselines/reference/noImplicitReturnsInAsync1.types
+++ b/tests/baselines/reference/noImplicitReturnsInAsync1.types
@@ -15,8 +15,8 @@ async function test(isError: boolean = false) {
 >x : string
 >await Promise.resolve("The test is passed without an error.") : string
 >Promise.resolve("The test is passed without an error.") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"The test is passed without an error." : "The test is passed without an error."
 }

--- a/tests/baselines/reference/promiseType.types
+++ b/tests/baselines/reference/promiseType.types
@@ -283,9 +283,9 @@ const p19 = p.catch(() => Promise.resolve(1));
 >catch : <TResult = never>(onrejected?: (reason: any) => TResult | PromiseLike<TResult>) => Promise<boolean | TResult>
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p20 = p.then(undefined);
@@ -365,9 +365,9 @@ const p28 = p.then(() => Promise.resolve(1));
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: (value: boolean) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p29 = p.then(() => Promise.reject(1));
@@ -469,9 +469,9 @@ const p38 = p.then(undefined, () => Promise.resolve(1));
 >undefined : undefined
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p39 = p.then(undefined, () => Promise.reject(1));
@@ -574,9 +574,9 @@ const p48 = p.then(null, () => Promise.resolve(1));
 >null : null
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p49 = p.then(null, () => Promise.reject(1));
@@ -688,9 +688,9 @@ const p58 = p.then(() => "1", () => Promise.resolve(1));
 >"1" : "1"
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p59 = p.then(() => "1", () => Promise.reject(1));
@@ -803,9 +803,9 @@ const p68 = p.then(() => x, () => Promise.resolve(1));
 >x : any
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p69 = p.then(() => x, () => Promise.reject(1));
@@ -918,9 +918,9 @@ const p78 = p.then(() => undefined, () => Promise.resolve(1));
 >undefined : undefined
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p79 = p.then(() => undefined, () => Promise.reject(1));
@@ -1033,9 +1033,9 @@ const p88 = p.then(() => null, () => Promise.resolve(1));
 >null : null
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p89 = p.then(() => null, () => Promise.reject(1));
@@ -1139,9 +1139,9 @@ const p98 = p.then(() => {}, () => Promise.resolve(1));
 >() => {} : () => void
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p99 = p.then(() => {}, () => Promise.reject(1));
@@ -1253,9 +1253,9 @@ const pa8 = p.then(() => {throw 1}, () => Promise.resolve(1));
 >1 : 1
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const pa9 = p.then(() => {throw 1}, () => Promise.reject(1));
@@ -1281,9 +1281,9 @@ const pb0 = p.then(() => Promise.resolve("1"), undefined);
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: (value: boolean) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >undefined : undefined
 
@@ -1295,9 +1295,9 @@ const pb1 = p.then(() => Promise.resolve("1"), null);
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: (value: boolean) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >null : null
 
@@ -1309,9 +1309,9 @@ const pb2 = p.then(() => Promise.resolve("1"), () => 1);
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: (value: boolean) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => 1 : () => number
 >1 : 1
@@ -1324,9 +1324,9 @@ const pb3 = p.then(() => Promise.resolve("1"), () => x);
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: (value: boolean) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => x : () => any
 >x : any
@@ -1339,9 +1339,9 @@ const pb4 = p.then(() => Promise.resolve("1"), () => undefined);
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: (value: boolean) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => undefined : () => any
 >undefined : undefined
@@ -1354,9 +1354,9 @@ const pb5 = p.then(() => Promise.resolve("1"), () => null);
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: (value: boolean) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => null : () => any
 >null : null
@@ -1369,9 +1369,9 @@ const pb6 = p.then(() => Promise.resolve("1"), () => {});
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: (value: boolean) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => {} : () => void
 
@@ -1383,9 +1383,9 @@ const pb7 = p.then(() => Promise.resolve("1"), () => {throw 1});
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: (value: boolean) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => {throw 1} : () => never
 >1 : 1
@@ -1398,15 +1398,15 @@ const pb8 = p.then(() => Promise.resolve("1"), () => Promise.resolve(1));
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: (value: boolean) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const pb9 = p.then(() => Promise.resolve("1"), () => Promise.reject(1));
@@ -1417,9 +1417,9 @@ const pb9 = p.then(() => Promise.resolve("1"), () => Promise.reject(1));
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: (value: boolean) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => Promise.reject(1) : () => Promise<never>
 >Promise.reject(1) : Promise<never>
@@ -1559,9 +1559,9 @@ const pc8 = p.then(() => Promise.reject("1"), () => Promise.resolve(1));
 >"1" : "1"
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const pc9 = p.then(() => Promise.reject("1"), () => Promise.reject(1));

--- a/tests/baselines/reference/promiseTypeStrictNull.types
+++ b/tests/baselines/reference/promiseTypeStrictNull.types
@@ -283,9 +283,9 @@ const p19 = p.catch(() => Promise.resolve(1));
 >catch : <TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null | undefined) => Promise<boolean | TResult>
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p20 = p.then(undefined);
@@ -365,9 +365,9 @@ const p28 = p.then(() => Promise.resolve(1));
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: ((value: boolean) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p29 = p.then(() => Promise.reject(1));
@@ -469,9 +469,9 @@ const p38 = p.then(undefined, () => Promise.resolve(1));
 >undefined : undefined
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p39 = p.then(undefined, () => Promise.reject(1));
@@ -574,9 +574,9 @@ const p48 = p.then(null, () => Promise.resolve(1));
 >null : null
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p49 = p.then(null, () => Promise.reject(1));
@@ -688,9 +688,9 @@ const p58 = p.then(() => "1", () => Promise.resolve(1));
 >"1" : "1"
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p59 = p.then(() => "1", () => Promise.reject(1));
@@ -803,9 +803,9 @@ const p68 = p.then(() => x, () => Promise.resolve(1));
 >x : any
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p69 = p.then(() => x, () => Promise.reject(1));
@@ -918,9 +918,9 @@ const p78 = p.then(() => undefined, () => Promise.resolve(1));
 >undefined : undefined
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p79 = p.then(() => undefined, () => Promise.reject(1));
@@ -1033,9 +1033,9 @@ const p88 = p.then(() => null, () => Promise.resolve(1));
 >null : null
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p89 = p.then(() => null, () => Promise.reject(1));
@@ -1139,9 +1139,9 @@ const p98 = p.then(() => {}, () => Promise.resolve(1));
 >() => {} : () => void
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const p99 = p.then(() => {}, () => Promise.reject(1));
@@ -1253,9 +1253,9 @@ const pa8 = p.then(() => {throw 1}, () => Promise.resolve(1));
 >1 : 1
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const pa9 = p.then(() => {throw 1}, () => Promise.reject(1));
@@ -1281,9 +1281,9 @@ const pb0 = p.then(() => Promise.resolve("1"), undefined);
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: ((value: boolean) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >undefined : undefined
 
@@ -1295,9 +1295,9 @@ const pb1 = p.then(() => Promise.resolve("1"), null);
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: ((value: boolean) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >null : null
 
@@ -1309,9 +1309,9 @@ const pb2 = p.then(() => Promise.resolve("1"), () => 1);
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: ((value: boolean) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => 1 : () => number
 >1 : 1
@@ -1324,9 +1324,9 @@ const pb3 = p.then(() => Promise.resolve("1"), () => x);
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: ((value: boolean) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => x : () => any
 >x : any
@@ -1339,9 +1339,9 @@ const pb4 = p.then(() => Promise.resolve("1"), () => undefined);
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: ((value: boolean) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => undefined : () => undefined
 >undefined : undefined
@@ -1354,9 +1354,9 @@ const pb5 = p.then(() => Promise.resolve("1"), () => null);
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: ((value: boolean) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => null : () => null
 >null : null
@@ -1369,9 +1369,9 @@ const pb6 = p.then(() => Promise.resolve("1"), () => {});
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: ((value: boolean) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => {} : () => void
 
@@ -1383,9 +1383,9 @@ const pb7 = p.then(() => Promise.resolve("1"), () => {throw 1});
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: ((value: boolean) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => {throw 1} : () => never
 >1 : 1
@@ -1398,15 +1398,15 @@ const pb8 = p.then(() => Promise.resolve("1"), () => Promise.resolve(1));
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: ((value: boolean) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const pb9 = p.then(() => Promise.resolve("1"), () => Promise.reject(1));
@@ -1417,9 +1417,9 @@ const pb9 = p.then(() => Promise.resolve("1"), () => Promise.reject(1));
 >then : <TResult1 = boolean, TResult2 = never>(onfulfilled?: ((value: boolean) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => Promise<TResult1 | TResult2>
 >() => Promise.resolve("1") : () => Promise<string>
 >Promise.resolve("1") : Promise<string>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >"1" : "1"
 >() => Promise.reject(1) : () => Promise<never>
 >Promise.reject(1) : Promise<never>
@@ -1559,9 +1559,9 @@ const pc8 = p.then(() => Promise.reject("1"), () => Promise.resolve(1));
 >"1" : "1"
 >() => Promise.resolve(1) : () => Promise<number>
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 const pc9 = p.then(() => Promise.reject("1"), () => Promise.reject(1));

--- a/tests/baselines/reference/promiseVoidErrorCallback.types
+++ b/tests/baselines/reference/promiseVoidErrorCallback.types
@@ -19,9 +19,9 @@ function f1(): Promise<T1> {
 
     return Promise.resolve({ __t1: "foo_t1" });
 >Promise.resolve({ __t1: "foo_t1" }) : Promise<{ __t1: string; }>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >{ __t1: "foo_t1" } : { __t1: string; }
 >__t1 : string
 >"foo_t1" : "foo_t1"

--- a/tests/baselines/reference/transformNestedGeneratorsWithTry.types
+++ b/tests/baselines/reference/transformNestedGeneratorsWithTry.types
@@ -16,9 +16,9 @@ async function a(): Bluebird<void> {
         await Bluebird.resolve(); // -- remove this and it compiles
 >await Bluebird.resolve() : void
 >Bluebird.resolve() : Promise<void>
->Bluebird.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Bluebird.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Bluebird : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 
       } catch (error) { }
 >error : any

--- a/tests/baselines/reference/types.asyncGenerators.es2018.1.types
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.1.types
@@ -21,9 +21,9 @@ async function * inferReturnType4() {
     yield Promise.resolve(1);
 >yield Promise.resolve(1) : any
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 }
 async function * inferReturnType5() {
@@ -36,9 +36,9 @@ async function * inferReturnType5() {
     yield Promise.resolve(2);
 >yield Promise.resolve(2) : any
 >Promise.resolve(2) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >2 : 2
 }
 async function * inferReturnType6() {
@@ -57,9 +57,9 @@ async function * inferReturnType7() {
 >yield* [Promise.resolve(1)] : any
 >[Promise.resolve(1)] : Promise<number>[]
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 }
 async function * inferReturnType8() {
@@ -89,9 +89,9 @@ const assignability2: () => AsyncIterableIterator<number> = async function * () 
     yield Promise.resolve(1);
 >yield Promise.resolve(1) : undefined
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 };
@@ -114,9 +114,9 @@ const assignability4: () => AsyncIterableIterator<number> = async function * () 
 >yield* [Promise.resolve(1)] : any
 >[Promise.resolve(1)] : Promise<number>[]
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 };
@@ -149,9 +149,9 @@ const assignability7: () => AsyncIterable<number> = async function * () {
     yield Promise.resolve(1);
 >yield Promise.resolve(1) : undefined
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 };
@@ -174,9 +174,9 @@ const assignability9: () => AsyncIterable<number> = async function * () {
 >yield* [Promise.resolve(1)] : any
 >[Promise.resolve(1)] : Promise<number>[]
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 };
@@ -209,9 +209,9 @@ const assignability12: () => AsyncIterator<number> = async function * () {
     yield Promise.resolve(1);
 >yield Promise.resolve(1) : undefined
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 };
@@ -234,9 +234,9 @@ const assignability14: () => AsyncIterator<number> = async function * () {
 >yield* [Promise.resolve(1)] : any
 >[Promise.resolve(1)] : Promise<number>[]
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 
 };
@@ -266,9 +266,9 @@ async function * explicitReturnType2(): AsyncIterableIterator<number> {
     yield Promise.resolve(1);
 >yield Promise.resolve(1) : undefined
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 }
 async function * explicitReturnType3(): AsyncIterableIterator<number> {
@@ -287,9 +287,9 @@ async function * explicitReturnType4(): AsyncIterableIterator<number> {
 >yield* [Promise.resolve(1)] : any
 >[Promise.resolve(1)] : Promise<number>[]
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 }
 async function * explicitReturnType5(): AsyncIterableIterator<number> {
@@ -316,9 +316,9 @@ async function * explicitReturnType7(): AsyncIterable<number> {
     yield Promise.resolve(1);
 >yield Promise.resolve(1) : undefined
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 }
 async function * explicitReturnType8(): AsyncIterable<number> {
@@ -337,9 +337,9 @@ async function * explicitReturnType9(): AsyncIterable<number> {
 >yield* [Promise.resolve(1)] : any
 >[Promise.resolve(1)] : Promise<number>[]
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 }
 async function * explicitReturnType10(): AsyncIterable<number> {
@@ -366,9 +366,9 @@ async function * explicitReturnType12(): AsyncIterator<number> {
     yield Promise.resolve(1);
 >yield Promise.resolve(1) : undefined
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 }
 async function * explicitReturnType13(): AsyncIterator<number> {
@@ -387,9 +387,9 @@ async function * explicitReturnType14(): AsyncIterator<number> {
 >yield* [Promise.resolve(1)] : any
 >[Promise.resolve(1)] : Promise<number>[]
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 }
 async function * explicitReturnType15(): AsyncIterator<number> {
@@ -425,9 +425,9 @@ async function * awaitedType2() {
 >x : number
 >await Promise.resolve(1) : number
 >Promise.resolve(1) : Promise<number>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >1 : 1
 }
 async function * nextType1(): { next(...args: [] | [number | PromiseLike<number>]): any } {

--- a/tests/baselines/reference/types.asyncGenerators.es2018.2.types
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.2.types
@@ -20,9 +20,9 @@ async function * inferReturnType3() {
     yield* Promise.resolve([1, 2]);
 >yield* Promise.resolve([1, 2]) : any
 >Promise.resolve([1, 2]) : Promise<number[]>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >[1, 2] : number[]
 >1 : 1
 >2 : 2

--- a/tests/baselines/reference/unionAndIntersectionInference1.types
+++ b/tests/baselines/reference/unionAndIntersectionInference1.types
@@ -192,9 +192,9 @@ const createTestAsync = (): Promise<ITest> => Promise.resolve().then(() => ({ na
 >Promise.resolve().then(() => ({ name: 'test' })) : Promise<ITest | { name: "test"; }>
 >Promise.resolve().then : <TResult1 = void, TResult2 = never>(onfulfilled?: (value: void) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >Promise.resolve() : Promise<void>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >then : <TResult1 = void, TResult2 = never>(onfulfilled?: (value: void) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >() => ({ name: 'test' }) : () => { name: "test"; }
 >({ name: 'test' }) : { name: "test"; }

--- a/tests/baselines/reference/uniqueSymbols.types
+++ b/tests/baselines/reference/uniqueSymbols.types
@@ -400,9 +400,9 @@ const constInitToLReadonlyNestedTypeWithIndexedAccess: L["nested"]["readonlyNest
 const promiseForConstCall = Promise.resolve(constCall);
 >promiseForConstCall : Promise<unique symbol>
 >Promise.resolve(constCall) : Promise<unique symbol>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >constCall : unique symbol
 
 const arrayOfConstCall = [constCall];

--- a/tests/baselines/reference/uniqueSymbolsDeclarations.types
+++ b/tests/baselines/reference/uniqueSymbolsDeclarations.types
@@ -393,9 +393,9 @@ const constInitToLReadonlyNestedTypeWithIndexedAccess: L["nested"]["readonlyNest
 const promiseForConstCall = Promise.resolve(constCall);
 >promiseForConstCall : Promise<unique symbol>
 >Promise.resolve(constCall) : Promise<unique symbol>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
 >constCall : unique symbol
 
 const arrayOfConstCall = [constCall];

--- a/tests/baselines/reference/voidParamAssignmentCompatibility.js
+++ b/tests/baselines/reference/voidParamAssignmentCompatibility.js
@@ -1,0 +1,16 @@
+//// [voidParamAssignmentCompatibility.ts]
+declare function g(a: void): void;
+let gg: () => void = g;
+
+interface Obj<T> {
+    method(value: T): void;
+}
+
+declare const o: Obj<void>;
+gg = o.method;
+
+
+//// [voidParamAssignmentCompatibility.js]
+"use strict";
+var gg = g;
+gg = o.method;

--- a/tests/baselines/reference/voidParamAssignmentCompatibility.symbols
+++ b/tests/baselines/reference/voidParamAssignmentCompatibility.symbols
@@ -1,0 +1,29 @@
+=== tests/cases/conformance/expressions/functions/voidParamAssignmentCompatibility.ts ===
+declare function g(a: void): void;
+>g : Symbol(g, Decl(voidParamAssignmentCompatibility.ts, 0, 0))
+>a : Symbol(a, Decl(voidParamAssignmentCompatibility.ts, 0, 19))
+
+let gg: () => void = g;
+>gg : Symbol(gg, Decl(voidParamAssignmentCompatibility.ts, 1, 3))
+>g : Symbol(g, Decl(voidParamAssignmentCompatibility.ts, 0, 0))
+
+interface Obj<T> {
+>Obj : Symbol(Obj, Decl(voidParamAssignmentCompatibility.ts, 1, 23))
+>T : Symbol(T, Decl(voidParamAssignmentCompatibility.ts, 3, 14))
+
+    method(value: T): void;
+>method : Symbol(Obj.method, Decl(voidParamAssignmentCompatibility.ts, 3, 18))
+>value : Symbol(value, Decl(voidParamAssignmentCompatibility.ts, 4, 11))
+>T : Symbol(T, Decl(voidParamAssignmentCompatibility.ts, 3, 14))
+}
+
+declare const o: Obj<void>;
+>o : Symbol(o, Decl(voidParamAssignmentCompatibility.ts, 7, 13))
+>Obj : Symbol(Obj, Decl(voidParamAssignmentCompatibility.ts, 1, 23))
+
+gg = o.method;
+>gg : Symbol(gg, Decl(voidParamAssignmentCompatibility.ts, 1, 3))
+>o.method : Symbol(Obj.method, Decl(voidParamAssignmentCompatibility.ts, 3, 18))
+>o : Symbol(o, Decl(voidParamAssignmentCompatibility.ts, 7, 13))
+>method : Symbol(Obj.method, Decl(voidParamAssignmentCompatibility.ts, 3, 18))
+

--- a/tests/baselines/reference/voidParamAssignmentCompatibility.types
+++ b/tests/baselines/reference/voidParamAssignmentCompatibility.types
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/expressions/functions/voidParamAssignmentCompatibility.ts ===
+declare function g(a: void): void;
+>g : (a: void) => void
+>a : void
+
+let gg: () => void = g;
+>gg : () => void
+>g : (a: void) => void
+
+interface Obj<T> {
+    method(value: T): void;
+>method : (value: T) => void
+>value : T
+}
+
+declare const o: Obj<void>;
+>o : Obj<void>
+
+gg = o.method;
+>gg = o.method : (value: void) => void
+>gg : () => void
+>o.method : (value: void) => void
+>o : Obj<void>
+>method : (value: void) => void
+

--- a/tests/cases/conformance/expressions/functions/voidParamAssignmentCompatibility.ts
+++ b/tests/cases/conformance/expressions/functions/voidParamAssignmentCompatibility.ts
@@ -1,0 +1,10 @@
+// @strict: true
+declare function g(a: void): void;
+let gg: () => void = g;
+
+interface Obj<T> {
+    method(value: T): void;
+}
+
+declare const o: Obj<void>;
+gg = o.method;


### PR DESCRIPTION
This adds checking for `void` types in `getMinArgumentCount` so that we not only treat `void` params as optional for function calls, but also for assignability.

This does not yet support the recent addition of treating `unknown`, `any`, or `undefined` as optional in JS files as there is no `Node` available that can be used as the context for the assignment to know whether we are currently in a JS file.

Related #36749
Fixes #40227

This does *not* address #29131, as that issue will require a separate change in overload resolution.