### PR TITLE
Fix crash intersecting dynamic import w/esModuleInterop

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9703,14 +9703,12 @@ namespace ts {
 
                 // fill in any as-yet-unresolved late-bound members.
                 const lateSymbols = createSymbolTable() as UnderscoreEscapedMap<TransientSymbol>;
-                if (symbol.declarations) {
-                    for (const decl of symbol.declarations) {
-                        const members = getMembersOfDeclaration(decl);
-                        if (members) {
-                            for (const member of members) {
-                                if (isStatic === hasStaticModifier(member) && hasLateBindableName(member)) {
-                                    lateBindMember(symbol, earlySymbols, lateSymbols, member);
-                                }
+                for (const decl of symbol.declarations || emptyArray) {
+                    const members = getMembersOfDeclaration(decl);
+                    if (members) {
+                        for (const member of members) {
+                            if (isStatic === hasStaticModifier(member) && hasLateBindableName(member)) {
+                                lateBindMember(symbol, earlySymbols, lateSymbols, member);
                             }
                         }
                     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27753,6 +27753,7 @@ namespace ts {
                         newSymbol.target = resolveSymbol(symbol);
                         memberTable.set(InternalSymbolName.Default, newSymbol);
                         const anonymousSymbol = createSymbol(SymbolFlags.TypeLiteral, InternalSymbolName.Type);
+                        anonymousSymbol.declarations = [];
                         const defaultContainingObject = createAnonymousType(anonymousSymbol, memberTable, emptyArray, emptyArray, /*stringIndexInfo*/ undefined, /*numberIndexInfo*/ undefined);
                         anonymousSymbol.type = defaultContainingObject;
                         synthType.syntheticType = isValidSpreadType(type) ? getSpreadType(type, defaultContainingObject, anonymousSymbol, /*objectFlags*/ 0, /*readonly*/ false) : defaultContainingObject;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27753,7 +27753,7 @@ namespace ts {
                         newSymbol.target = resolveSymbol(symbol);
                         memberTable.set(InternalSymbolName.Default, newSymbol);
                         const anonymousSymbol = createSymbol(SymbolFlags.TypeLiteral, InternalSymbolName.Type);
-                        anonymousSymbol.declarations = [];
+                        anonymousSymbol.declarations = symbol.declarations ? symbol.declarations.slice() : [];
                         const defaultContainingObject = createAnonymousType(anonymousSymbol, memberTable, emptyArray, emptyArray, /*stringIndexInfo*/ undefined, /*numberIndexInfo*/ undefined);
                         anonymousSymbol.type = defaultContainingObject;
                         synthType.syntheticType = isValidSpreadType(type) ? getSpreadType(type, defaultContainingObject, anonymousSymbol, /*objectFlags*/ 0, /*readonly*/ false) : defaultContainingObject;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9703,12 +9703,14 @@ namespace ts {
 
                 // fill in any as-yet-unresolved late-bound members.
                 const lateSymbols = createSymbolTable() as UnderscoreEscapedMap<TransientSymbol>;
-                for (const decl of symbol.declarations) {
-                    const members = getMembersOfDeclaration(decl);
-                    if (members) {
-                        for (const member of members) {
-                            if (isStatic === hasStaticModifier(member) && hasLateBindableName(member)) {
-                                lateBindMember(symbol, earlySymbols, lateSymbols, member);
+                if (symbol.declarations) {
+                    for (const decl of symbol.declarations) {
+                        const members = getMembersOfDeclaration(decl);
+                        if (members) {
+                            for (const member of members) {
+                                if (isStatic === hasStaticModifier(member) && hasLateBindableName(member)) {
+                                    lateBindMember(symbol, earlySymbols, lateSymbols, member);
+                                }
                             }
                         }
                     }
@@ -27753,7 +27755,6 @@ namespace ts {
                         newSymbol.target = resolveSymbol(symbol);
                         memberTable.set(InternalSymbolName.Default, newSymbol);
                         const anonymousSymbol = createSymbol(SymbolFlags.TypeLiteral, InternalSymbolName.Type);
-                        anonymousSymbol.declarations = symbol.declarations ? symbol.declarations.slice() : [];
                         const defaultContainingObject = createAnonymousType(anonymousSymbol, memberTable, emptyArray, emptyArray, /*stringIndexInfo*/ undefined, /*numberIndexInfo*/ undefined);
                         anonymousSymbol.type = defaultContainingObject;
                         synthType.syntheticType = isValidSpreadType(type) ? getSpreadType(type, defaultContainingObject, anonymousSymbol, /*objectFlags*/ 0, /*readonly*/ false) : defaultContainingObject;

--- a/tests/baselines/reference/intersectionsAndEmptyObjects.js
+++ b/tests/baselines/reference/intersectionsAndEmptyObjects.js
@@ -1,3 +1,5 @@
+//// [tests/cases/conformance/types/intersection/intersectionsAndEmptyObjects.ts] ////
+
 //// [intersectionsAndEmptyObjects.ts]
 // Empty object type literals are removed from intersections types
 // that contain other object types
@@ -81,10 +83,37 @@ var unknownChoicesAndEmpty: choices<IUnknownChoiceList & {}>;
 type Foo1 = { x: string } & { [x: number]: Foo1 };
 type Foo2 = { x: string } & { [K in number]: Foo2 };
 
+// Repro from #40239
+
+declare function mock<M>(_: Promise<M>): {} & M;
+mock(import('./ex'))
+
+//// [ex.d.ts]
+export {}
+
 
 //// [intersectionsAndEmptyObjects.js]
 // Empty object type literals are removed from intersections types
 // that contain other object types
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 let x01;
 let x02;
 let x03;
@@ -121,3 +150,4 @@ var myChoices;
 var myChoicesAndEmpty;
 var unknownChoices;
 var unknownChoicesAndEmpty;
+mock(Promise.resolve().then(() => __importStar(require('./ex'))));

--- a/tests/baselines/reference/intersectionsAndEmptyObjects.symbols
+++ b/tests/baselines/reference/intersectionsAndEmptyObjects.symbols
@@ -260,3 +260,21 @@ type Foo2 = { x: string } & { [K in number]: Foo2 };
 >K : Symbol(K, Decl(intersectionsAndEmptyObjects.ts, 80, 31))
 >Foo2 : Symbol(Foo2, Decl(intersectionsAndEmptyObjects.ts, 79, 50))
 
+// Repro from #40239
+
+declare function mock<M>(_: Promise<M>): {} & M;
+>mock : Symbol(mock, Decl(intersectionsAndEmptyObjects.ts, 80, 52))
+>M : Symbol(M, Decl(intersectionsAndEmptyObjects.ts, 84, 22))
+>_ : Symbol(_, Decl(intersectionsAndEmptyObjects.ts, 84, 25))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>M : Symbol(M, Decl(intersectionsAndEmptyObjects.ts, 84, 22))
+>M : Symbol(M, Decl(intersectionsAndEmptyObjects.ts, 84, 22))
+
+mock(import('./ex'))
+>mock : Symbol(mock, Decl(intersectionsAndEmptyObjects.ts, 80, 52))
+>'./ex' : Symbol("tests/cases/conformance/types/intersection/ex", Decl(ex.d.ts, 0, 0))
+
+=== tests/cases/conformance/types/intersection/ex.d.ts ===
+export {}
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/intersectionsAndEmptyObjects.types
+++ b/tests/baselines/reference/intersectionsAndEmptyObjects.types
@@ -217,3 +217,19 @@ type Foo2 = { x: string } & { [K in number]: Foo2 };
 >Foo2 : Foo2
 >x : string
 
+// Repro from #40239
+
+declare function mock<M>(_: Promise<M>): {} & M;
+>mock : <M>(_: Promise<M>) => {} & M
+>_ : Promise<M>
+
+mock(import('./ex'))
+>mock(import('./ex')) : {}
+>mock : <M>(_: Promise<M>) => {} & M
+>import('./ex') : Promise<{ default: typeof import("tests/cases/conformance/types/intersection/ex"); }>
+>'./ex' : "./ex"
+
+=== tests/cases/conformance/types/intersection/ex.d.ts ===
+export {}
+No type information for this code.
+No type information for this code.

--- a/tests/cases/conformance/types/intersection/intersectionsAndEmptyObjects.ts
+++ b/tests/cases/conformance/types/intersection/intersectionsAndEmptyObjects.ts
@@ -1,4 +1,7 @@
 // @target: es2015
+// @module: commonjs
+// @esModuleInterop: true
+// @filename: intersectionsAndEmptyObjects.ts
 
 // Empty object type literals are removed from intersections types
 // that contain other object types
@@ -81,3 +84,11 @@ var unknownChoicesAndEmpty: choices<IUnknownChoiceList & {}>;
 
 type Foo1 = { x: string } & { [x: number]: Foo1 };
 type Foo2 = { x: string } & { [K in number]: Foo2 };
+
+// Repro from #40239
+
+declare function mock<M>(_: Promise<M>): {} & M;
+mock(import('./ex'))
+
+// @filename: ex.d.ts
+export {}


### PR DESCRIPTION
The dynamic import shim creates a symbol without some properties that the intersection-creating code assumes are present as of #38673.

This PR adds the smallest possible set of properties to avoid the crash.

Fixes #40239