### PR TITLE
Partially disable inference recursion tracking changes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19603,7 +19603,7 @@ namespace ts {
                 const sourceIdentity = getRecursionIdentity(source);
                 const targetIdentity = getRecursionIdentity(target);
                 if (sourceIdentity && contains(sourceStack, sourceIdentity)) expandingFlags |= ExpandingFlags.Source;
-                if (targetIdentity && contains(targetStack, targetIdentity)) expandingFlags |= ExpandingFlags.Target;
+                if (targetIdentity && contains(targetStack, targetIdentity)) expandingFlags |= ExpandingFlags.Both;
                 if (expandingFlags !== ExpandingFlags.Both) {
                     if (sourceIdentity) (sourceStack || (sourceStack = [])).push(sourceIdentity);
                     if (targetIdentity) (targetStack || (targetStack = [])).push(targetIdentity);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18287,12 +18287,12 @@ namespace ts {
         // identity is some object that is common to instantiations of the type with the same origin.
         function getRecursionIdentity(type: Type): object | undefined {
             if (type.flags & TypeFlags.Object && !isObjectOrArrayLiteralType(type)) {
-                if (getObjectFlags(type) && ObjectFlags.Reference && (type as TypeReference).node) {
-                    // Deferred type references are tracked through their associated AST node. This gives us finer
-                    // granularity than using their associated target because each manifest type reference has a
-                    // unique AST node.
-                    return (type as TypeReference).node;
-                }
+                // if (getObjectFlags(type) && ObjectFlags.Reference && (type as TypeReference).node) {
+                //     // Deferred type references are tracked through their associated AST node. This gives us finer
+                //     // granularity than using their associated target because each manifest type reference has a
+                //     // unique AST node.
+                //     return (type as TypeReference).node;
+                // }
                 if (type.symbol && !(getObjectFlags(type) & ObjectFlags.Anonymous && type.symbol.flags & SymbolFlags.Class)) {
                     // We track all object types that have an associated symbol (representing the origin of the type), but
                     // exclude the static side of classes from this check since it shares its symbol with the instance side.

--- a/tests/baselines/reference/promiseTypeInference.types
+++ b/tests/baselines/reference/promiseTypeInference.types
@@ -22,8 +22,8 @@ declare function convert(s: string): IPromise<number>;
 >s : string
 
 var $$x = load("something").then(s => convert(s));
->$$x : CPromise<number>
->load("something").then(s => convert(s)) : CPromise<number>
+>$$x : CPromise<unknown>
+>load("something").then(s => convert(s)) : CPromise<unknown>
 >load("something").then : <U>(success?: (value: string) => CPromise<U>) => CPromise<U>
 >load("something") : CPromise<string>
 >load : (name: string) => CPromise<string>

--- a/tests/baselines/reference/recursiveConditionalTypes.types
+++ b/tests/baselines/reference/recursiveConditionalTypes.types
@@ -190,7 +190,7 @@ unbox(b1);  // string
 >b1 : Box<Box<Box<Box<Box<Box<string>>>>>>
 
 unbox(b2);  // string
->unbox(b2) : string
+>unbox(b2) : T6
 >unbox : <T>(box: RecBox<T>) => T
 >b2 : T6
 
@@ -200,7 +200,7 @@ unbox(b3);  // InfBox<string>
 >b3 : InfBox<string>
 
 unbox({ value: { value: { value: { value: { value: { value: 5 }}}}}});  // number
->unbox({ value: { value: { value: { value: { value: { value: 5 }}}}}}) : number
+>unbox({ value: { value: { value: { value: { value: { value: 5 }}}}}}) : { value: { value: { value: { value: { value: number; }; }; }; }; } | { value: { value: { value: { value: { value: { value: number; }; }; }; }; }; }
 >unbox : <T>(box: RecBox<T>) => T
 >{ value: { value: { value: { value: { value: { value: 5 }}}}}} : { value: { value: { value: { value: { value: { value: number; }; }; }; }; }; }
 >value : { value: { value: { value: { value: { value: number; }; }; }; }; }
@@ -222,7 +222,7 @@ unbox(b4);  // { value: { value: typeof b4 }}
 >b4 : { value: { value: { value: any; }; }; }
 
 unbox({ value: { value: { get value() { return this; } }}});  // { readonly value: ... }
->unbox({ value: { value: { get value() { return this; } }}}) : { readonly value: { readonly value: any; }; }
+>unbox({ value: { value: { get value() { return this; } }}}) : { value: { readonly value: { readonly value: any; }; }; }
 >unbox : <T>(box: RecBox<T>) => T
 >{ value: { value: { get value() { return this; } }}} : { value: { value: { readonly value: { readonly value: any; }; }; }; }
 >value : { value: { readonly value: { readonly value: any; }; }; }
@@ -230,7 +230,7 @@ unbox({ value: { value: { get value() { return this; } }}});  // { readonly valu
 >value : { readonly value: { readonly value: any; }; }
 >{ get value() { return this; } } : { readonly value: { readonly value: any; }; }
 >value : { readonly value: any; }
->this : { readonly value: any; } | { readonly value: { readonly value: any; }; } | Box<RecBox<{ readonly value: { readonly value: any; }; }>>
+>this : { readonly value: any; } | { readonly value: { readonly value: any; }; } | { value: { readonly value: { readonly value: any; }; }; } | Box<RecBox<{ value: { readonly value: { readonly value: any; }; }; }>>
 
 // Inference from nested instantiations of same generic types
 

--- a/tests/baselines/reference/selfReferencingTypeReferenceInference.types
+++ b/tests/baselines/reference/selfReferencingTypeReferenceInference.types
@@ -18,7 +18,7 @@ type t1 = Box<string | Box<number | boolean>>
 >t1 : t1
 
 type t2 = InferRecursive<t1>
->t2 : string | number | boolean
+>t2 : "never!"
 
 type t3 = InferRecursive<Box<string | Box<number | boolean>>> // write t1 explicitly
 >t3 : string | number | boolean


### PR DESCRIPTION
Experiment to see if partially disabling inference recursion tracking changes from recursive conditional types PR resolves the OOM we're seeing in the RWC test suites.