### PR TITLE
Use a correct Object.entries polyfill

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1304,7 +1304,7 @@ namespace ts {
         return values;
     }
 
-    const _entries = Object.entries ? Object.entries : <T>(obj: MapLike<T>) => {
+    const _entries = Object.entries || <T>(obj: MapLike<T>) => {
         const keys = getOwnKeys(obj);
         const result: [string, T][] = Array(keys.length);
         for (let i = 0; i < keys.length; i++) {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1304,14 +1304,14 @@ namespace ts {
         return values;
     }
 
-    const _entries = Object.entries || <T>(obj: MapLike<T>) => {
+    const _entries = Object.entries || (<T>(obj: MapLike<T>) => {
         const keys = getOwnKeys(obj);
         const result: [string, T][] = Array(keys.length);
         for (let i = 0; i < keys.length; i++) {
             result[i] = [keys[i], obj[keys[i]]];
         }
         return result;
-    };
+    });
 
     export function getEntries<T>(obj: MapLike<T>): [string, T][] {
         return obj ? _entries(obj) : [];

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1307,8 +1307,8 @@ namespace ts {
     const _entries = Object.entries ? Object.entries : <T>(obj: MapLike<T>) => {
         const keys = getOwnKeys(obj);
         const result: [string, T][] = Array(keys.length);
-        for (const key of keys) {
-            result.push([key, obj[key]]);
+        for (let i = 0; i < keys.length; i++) {
+            result[i] = [keys[i], obj[keys[i]]];
         }
         return result;
     };


### PR DESCRIPTION
Fixes #40243

The prior polyfill initialized the array slots with `keys.length`, then used `push`, creating a sparse array:

```
> console.log(_entries({ a: 1, b: "", c: false, 4: "d" }));

[ <4 empty items>,
  [ '4', 'd' ],
  [ 'a', 1 ],
  [ 'b', '' ],
  [ 'c', false ] ]
```
