### PR TITLE
Fix extract symbol crash on unterminated literals; don’t offer to extract `export = ...`

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4546,7 +4546,11 @@ namespace ts {
                 }
             }
 
-            return getLiteralText(node, currentSourceFile!, neverAsciiEscape, jsxAttributeEscape);
+            const flags = (neverAsciiEscape ? GetLiteralTextFlags.NeverAsciiEscape : 0)
+                | (jsxAttributeEscape ? GetLiteralTextFlags.JsxAttributeEscape : 0)
+                | (printerOptions.terminateUnterminatedLiterals ? GetLiteralTextFlags.TerminateUnterminatedLiterals : 0);
+
+            return getLiteralText(node, currentSourceFile!, flags);
         }
 
         /**

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -7650,6 +7650,7 @@ namespace ts {
         /*@internal*/ recordInternalSection?: boolean;
         /*@internal*/ stripInternal?: boolean;
         /*@internal*/ preserveSourceNewlines?: boolean;
+        /*@internal*/ terminateUnterminatedLiterals?: boolean;
         /*@internal*/ relativeToBuildInfo?: (path: string) => string;
     }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -563,12 +563,13 @@ namespace ts {
     }
 
     export const enum GetLiteralTextFlags {
+        None = 0,
         NeverAsciiEscape = 1 << 0,
         JsxAttributeEscape = 1 << 1,
         TerminateUnterminatedLiterals = 1 << 2,
     }
 
-    export function getLiteralText(node: LiteralLikeNode, sourceFile: SourceFile, flags: GetLiteralTextFlags = 0) {
+    export function getLiteralText(node: LiteralLikeNode, sourceFile: SourceFile, flags: GetLiteralTextFlags) {
         // If we don't need to downlevel and we can reach the original source text using
         // the node's parent reference, then simply get the text as it was originally written.
         if (!nodeIsSynthesized(node) && node.parent && !(flags & GetLiteralTextFlags.TerminateUnterminatedLiterals && node.isUnterminated) && !(

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -439,7 +439,7 @@ namespace ts.refactor.extractSymbol {
                         // TODO: GH#18217 Silly to use `errors ||` since it's definitely not defined (see top of `visit`)
                         // Also, if we're only pushing one error, just use `let error: Diagnostic | undefined`!
                         // Also TODO: GH#19956
-                        (errors || (errors = [] as Diagnostic[])).push(createDiagnosticForNode(node, Messages.cannotExtractExportedEntity));
+                        (errors ||= []).push(createDiagnosticForNode(node, Messages.cannotExtractExportedEntity));
                         return true;
                     }
                     declarations.push(node.symbol);
@@ -448,7 +448,10 @@ namespace ts.refactor.extractSymbol {
                 // Some things can't be extracted in certain situations
                 switch (node.kind) {
                     case SyntaxKind.ImportDeclaration:
-                        (errors || (errors = [] as Diagnostic[])).push(createDiagnosticForNode(node, Messages.cannotExtractImport));
+                        (errors ||= []).push(createDiagnosticForNode(node, Messages.cannotExtractImport));
+                        return true;
+                    case SyntaxKind.ExportAssignment:
+                        (errors ||= []).push(createDiagnosticForNode(node, Messages.cannotExtractExportedEntity));
                         return true;
                     case SyntaxKind.SuperKeyword:
                         // For a super *constructor call*, we have to be extracting the entire class,
@@ -457,7 +460,7 @@ namespace ts.refactor.extractSymbol {
                             // Super constructor call
                             const containingClass = getContainingClass(node)!; // TODO:GH#18217
                             if (containingClass.pos < span.start || containingClass.end >= (span.start + span.length)) {
-                                (errors || (errors = [] as Diagnostic[])).push(createDiagnosticForNode(node, Messages.cannotExtractSuper));
+                                (errors ||= []).push(createDiagnosticForNode(node, Messages.cannotExtractSuper));
                                 return true;
                             }
                         }
@@ -483,7 +486,7 @@ namespace ts.refactor.extractSymbol {
                     case SyntaxKind.FunctionDeclaration:
                         if (isSourceFile(node.parent) && node.parent.externalModuleIndicator === undefined) {
                             // You cannot extract global declarations
-                            (errors || (errors = [] as Diagnostic[])).push(createDiagnosticForNode(node, Messages.functionWillNotBeVisibleInTheNewScope));
+                            (errors ||= []).push(createDiagnosticForNode(node, Messages.functionWillNotBeVisibleInTheNewScope));
                         }
                         // falls through
                     case SyntaxKind.ClassExpression:
@@ -542,13 +545,13 @@ namespace ts.refactor.extractSymbol {
                         if (label) {
                             if (!contains(seenLabels, label.escapedText)) {
                                 // attempts to jump to label that is not in range to be extracted
-                                (errors || (errors = [] as Diagnostic[])).push(createDiagnosticForNode(node, Messages.cannotExtractRangeContainingLabeledBreakOrContinueStatementWithTargetOutsideOfTheRange));
+                                (errors ||= []).push(createDiagnosticForNode(node, Messages.cannotExtractRangeContainingLabeledBreakOrContinueStatementWithTargetOutsideOfTheRange));
                             }
                         }
                         else {
                             if (!(permittedJumps & (node.kind === SyntaxKind.BreakStatement ? PermittedJumps.Break : PermittedJumps.Continue))) {
                                 // attempt to break or continue in a forbidden context
-                                (errors || (errors = [] as Diagnostic[])).push(createDiagnosticForNode(node, Messages.cannotExtractRangeContainingConditionalBreakOrContinueStatements));
+                                (errors ||= []).push(createDiagnosticForNode(node, Messages.cannotExtractRangeContainingConditionalBreakOrContinueStatements));
                             }
                         }
                         break;
@@ -564,7 +567,7 @@ namespace ts.refactor.extractSymbol {
                             rangeFacts |= RangeFacts.HasReturn;
                         }
                         else {
-                            (errors || (errors = [] as Diagnostic[])).push(createDiagnosticForNode(node, Messages.cannotExtractRangeContainingConditionalReturnStatement));
+                            (errors ||= []).push(createDiagnosticForNode(node, Messages.cannotExtractRangeContainingConditionalReturnStatement));
                         }
                         break;
                     default:

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -986,7 +986,12 @@ namespace ts.textChanges {
         export function getNonformattedText(node: Node, sourceFile: SourceFile | undefined, newLineCharacter: string): { text: string, node: Node } {
             const writer = createWriter(newLineCharacter);
             const newLine = newLineCharacter === "\n" ? NewLineKind.LineFeed : NewLineKind.CarriageReturnLineFeed;
-            createPrinter({ newLine, neverAsciiEscape: true, preserveSourceNewlines: true }, writer).writeNode(EmitHint.Unspecified, node, sourceFile, writer);
+            createPrinter({
+                newLine,
+                neverAsciiEscape: true,
+                preserveSourceNewlines: true,
+                terminateUnterminatedLiterals: true
+            }, writer).writeNode(EmitHint.Unspecified, node, sourceFile, writer);
             return { text: writer.getText(), node: assignPositionsToNode(node) };
         }
     }

--- a/tests/cases/fourslash/extract-export-assignment.ts
+++ b/tests/cases/fourslash/extract-export-assignment.ts
@@ -1,0 +1,6 @@
+/// <reference path="fourslash.ts" />
+
+//// /*1*/export = 0;/*2*/
+
+goTo.select("1", "2");
+verify.not.refactorAvailable("Extract Symbol");

--- a/tests/cases/fourslash/extract-unterminated1.ts
+++ b/tests/cases/fourslash/extract-unterminated1.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// Unterminated RegExp literal:
+//// /*1*/const foo = /asdfasf/*2*/
+
+goTo.select("1", "2");
+edit.applyRefactor({
+  refactorName: "Extract Symbol",
+  actionName: "function_scope_0",
+  actionDescription: "Extract to function in global scope",
+  newContent: `const foo = /*RENAME*/newFunction()
+
+function newFunction() {
+    return /asdfasf/;
+}
+`
+});

--- a/tests/cases/fourslash/extract-unterminated2.ts
+++ b/tests/cases/fourslash/extract-unterminated2.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// Unterminated string literal:
+//// /*1*/const foo = "foo/*2*/
+
+goTo.select("1", "2");
+edit.applyRefactor({
+  refactorName: "Extract Symbol",
+  actionName: "function_scope_0",
+  actionDescription: "Extract to function in global scope",
+  newContent: `const foo = /*RENAME*/newFunction()
+
+function newFunction() {
+    return "foo";
+}
+`
+});

--- a/tests/cases/fourslash/extract-unterminated3.ts
+++ b/tests/cases/fourslash/extract-unterminated3.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// Unterminated template literal:
+//// /*1*/const foo = `head${middle}tail/*2*/
+
+goTo.select("1", "2");
+edit.applyRefactor({
+  refactorName: "Extract Symbol",
+  actionName: "function_scope_0",
+  actionDescription: "Extract to function in global scope",
+  newContent: `const foo = /*RENAME*/newFunction()
+
+function newFunction() {
+    return \`head\${middle}tail\`;
+}
+`
+});

--- a/tests/cases/fourslash/extract-unterminated4.ts
+++ b/tests/cases/fourslash/extract-unterminated4.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// Unterminated template literal:
+//// /*1*/const foo = /endsinbackslash\/*2*/
+
+goTo.select("1", "2");
+edit.applyRefactor({
+  refactorName: "Extract Symbol",
+  actionName: "function_scope_0",
+  actionDescription: "Extract to function in global scope",
+  newContent: `const foo = /*RENAME*/newFunction()
+
+function newFunction() {
+    return /endsinbackslash\\ /;
+}
+`
+});

--- a/tests/cases/fourslash/extract-unterminated5.ts
+++ b/tests/cases/fourslash/extract-unterminated5.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// Unterminated template literal:
+//// /*1*/const foo = "endsinbackslash\/*2*/
+
+goTo.select("1", "2");
+edit.applyRefactor({
+  refactorName: "Extract Symbol",
+  actionName: "function_scope_0",
+  actionDescription: "Extract to function in global scope",
+  newContent: `const foo = /*RENAME*/newFunction()
+
+function newFunction() {
+    return "endsinbackslash";
+}
+`
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #32862, or at least, fixes one manifestation of it

As a bonus, also disables the refactor on export assignments, since that’s invalid.
