### PR TITLE
Fix misplaced comma in auto imported specifier

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -700,7 +700,7 @@ namespace ts.codefix {
             }
             else if (existingSpecifiers?.length) {
                 for (const spec of newSpecifiers) {
-                    changes.insertNodeAtEndOfList(sourceFile, existingSpecifiers, spec);
+                    changes.insertNodeInListAfter(sourceFile, last(existingSpecifiers), spec, existingSpecifiers);
                 }
             }
             else {

--- a/tests/cases/fourslash/importNameCodeFix_trailingComma.ts
+++ b/tests/cases/fourslash/importNameCodeFix_trailingComma.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts" />
+
+// Bug #40219 only happens when existing import specifiers are unsorted.
+
+// @Filename: index.ts
+//// import {
+////   T2,
+////   T1,
+//// } from "./types";
+////
+//// const x: T3/**/
+
+// @Filename: types.ts
+//// export type T1 = 0;
+//// export type T2 = 0;
+//// export type T3 = 0;
+
+verify.importFixAtPosition([`import {
+  T2,
+  T1,
+  T3,
+} from "./types";
+
+const x: T3`]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #40219

Note: `insertNodeAfter` and `insertNodeAtEndOfList` are pretty dumb, and should probably be deleted, because `insertNodeInLastAfter` is very smart.
