### PR TITLE
Remove incorrect assert that triggers crash on completions of globalThis

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -71,8 +71,6 @@ namespace ts.SymbolDisplay {
                     if (rootSymbolFlags & (SymbolFlags.PropertyOrAccessor | SymbolFlags.Variable)) {
                         return ScriptElementKind.memberVariableElement;
                     }
-                    // May be a Function if this was from `typeof N` with `namespace N { function f();. }`.
-                    Debug.assert(!!(rootSymbolFlags & (SymbolFlags.Method | SymbolFlags.Function)));
                 });
                 if (!unionPropertyKind) {
                     // If this was union of all methods,

--- a/tests/cases/fourslash/globalThisCompletion.ts
+++ b/tests/cases/fourslash/globalThisCompletion.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @target: esnext
+
+// @Filename: test.js
+//// (typeof foo !== "undefined"
+////   ? foo
+////   : {}
+//// )./**/;
+
+// @Filename: someLib.d.ts
+//// declare var foo: typeof globalThis;
+
+goTo.marker();
+verify.completions({
+    marker: ""
+});


### PR DESCRIPTION
Fixes #39338

The assertion appears to simply be incorrect based on my reading, but I could be wrong here. The symbol that induces the crash is the `globalThis` symbol - the asserted invariant isn't true for it, and AFAICT shouldn't be.