### PR TITLE
Emit error when trying to iterate a value with union type with non-iterable constituent when --downlevelIterator

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33581,6 +33581,8 @@ namespace ts {
                         reportTypeNotIterableError(errorNode, type, !!(use & IterationUse.AllowsAsyncIterablesFlag));
                         errorNode = undefined;
                     }
+                    allIterationTypes = undefined;
+                    break;
                 }
                 else {
                     allIterationTypes = append(allIterationTypes, iterationTypes);

--- a/tests/baselines/reference/arraySpreadDownlevelIteratorUndefined.errors.txt
+++ b/tests/baselines/reference/arraySpreadDownlevelIteratorUndefined.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/compiler/arraySpreadDownlevelIteratorUndefined.ts(2,5): error TS2548: Type 'number[] | undefined' is not an array type or does not have a '[Symbol.iterator]()' method that returns an iterator.
+
+
+==== tests/cases/compiler/arraySpreadDownlevelIteratorUndefined.ts (1 errors) ====
+    declare const arr: number[] | undefined;
+    [...arr];
+        ~~~
+!!! error TS2548: Type 'number[] | undefined' is not an array type or does not have a '[Symbol.iterator]()' method that returns an iterator.
+    

--- a/tests/baselines/reference/arraySpreadDownlevelIteratorUndefined.js
+++ b/tests/baselines/reference/arraySpreadDownlevelIteratorUndefined.js
@@ -1,0 +1,28 @@
+//// [arraySpreadDownlevelIteratorUndefined.ts]
+declare const arr: number[] | undefined;
+[...arr];
+
+
+//// [arraySpreadDownlevelIteratorUndefined.js]
+"use strict";
+var __read = (this && this.__read) || function (o, n) {
+    var m = typeof Symbol === "function" && o[Symbol.iterator];
+    if (!m) return o;
+    var i = m.call(o), r, ar = [], e;
+    try {
+        while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
+    }
+    catch (error) { e = { error: error }; }
+    finally {
+        try {
+            if (r && !r.done && (m = i["return"])) m.call(i);
+        }
+        finally { if (e) throw e.error; }
+    }
+    return ar;
+};
+var __spread = (this && this.__spread) || function () {
+    for (var ar = [], i = 0; i < arguments.length; i++) ar = ar.concat(__read(arguments[i]));
+    return ar;
+};
+__spread(arr);

--- a/tests/baselines/reference/arraySpreadDownlevelIteratorUndefined.symbols
+++ b/tests/baselines/reference/arraySpreadDownlevelIteratorUndefined.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/arraySpreadDownlevelIteratorUndefined.ts ===
+declare const arr: number[] | undefined;
+>arr : Symbol(arr, Decl(arraySpreadDownlevelIteratorUndefined.ts, 0, 13))
+
+[...arr];
+>arr : Symbol(arr, Decl(arraySpreadDownlevelIteratorUndefined.ts, 0, 13))
+

--- a/tests/baselines/reference/arraySpreadDownlevelIteratorUndefined.types
+++ b/tests/baselines/reference/arraySpreadDownlevelIteratorUndefined.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/arraySpreadDownlevelIteratorUndefined.ts ===
+declare const arr: number[] | undefined;
+>arr : number[] | undefined
+
+[...arr];
+>[...arr] : any[]
+>...arr : any
+>arr : number[] | undefined
+

--- a/tests/cases/compiler/arraySpreadDownlevelIteratorUndefined.ts
+++ b/tests/cases/compiler/arraySpreadDownlevelIteratorUndefined.ts
@@ -1,0 +1,7 @@
+// @target: es5
+// @lib: es2015
+// @downlevelIteration: true
+// @strict: true
+
+declare const arr: number[] | undefined;
+[...arr];


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #39161 .

## Example

**code**

```ts
function getArrayOrUndefined() {
  return Math.random() > 0.5 ? [] : undefined;
}

const result = [...getArrayOrUndefined()];
```

```json
{
  "compilerOptions": {
    "target": "es5",
    "lib": ["es2015"],
    "strict": true,
    "downlevelIteration": true
  }
}
```

**Current Behavior**

(no compile error)

**New Behavior**

```
src/index.ts:5:20 - error TS2548: Type 'never[] | undefined' is not an array type or does not have a '[Symbol.iterator]()' method that returns an iterator.

5 const result = [...getArrayOrUndefined()];
                     ~~~~~~~~~~~~~~~~~~~~~


Found 1 error.
```

## Details of Code Change

This PR adds a `shouldIgnoreNonIterableUnionConstituent` parameter to `getIterationTypesOfIterable` which, if `false` is specified, returns `noIterationTypes` whenever given union type includes a non-iterable constituent. Otherwise, non-iterable constituents are just ignored; for example, the yielded type of `number[] | undefined` is considered `number`.

I first considered making this the default behavior, but then one test failed (namely `generatorYieldContextualType.ts`). As the old behavior seemed kind of reasonable in some situations, I kept the change smaller by adding that parameter.