### PR TITLE
Unify the codepaths for determining if something is generic and showing type help

### DIFF
--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -86,11 +86,14 @@ namespace ts.SignatureHelp {
                 if (onlyUseSyntacticOwners && !containsPrecedingToken(startingToken, sourceFile, isIdentifier(called) ? called.parent : called)) {
                     return undefined;
                 }
-                const candidates = getPossibleGenericSignatures(called, argumentCount, checker);
+                const symbol = checker.getSymbolAtLocation(called);
+                if (!symbol) {
+                    return undefined;
+                }
+                const candidates = getPossibleGenericSignaturesOfType(checker.getTypeOfSymbolAtLocation(symbol, called), called, argumentCount);
                 if (candidates.length !== 0) return { kind: CandidateOrTypeKind.Candidate, candidates, resolvedSignature: first(candidates) };
 
-                const symbol = checker.getSymbolAtLocation(called);
-                return symbol && { kind: CandidateOrTypeKind.Type, symbol };
+                return { kind: CandidateOrTypeKind.Type, symbol };
             }
             case InvocationKind.Contextual:
                 return { kind: CandidateOrTypeKind.Candidate, candidates: [invocation.signature], resolvedSignature: invocation.signature };

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1390,11 +1390,11 @@ namespace ts {
     }
 
     export function getPossibleGenericSignatures(called: Expression, typeArgumentCount: number, checker: TypeChecker): readonly Signature[] {
-        let type = checker.getTypeAtLocation(called);
-        if (isOptionalChain(called.parent)) {
-            type = removeOptionality(type, isOptionalChainRoot(called.parent), /*isOptionalChain*/ true);
-        }
+        const type = checker.getTypeAtLocation(called);
+        return getPossibleGenericSignaturesOfType(type, called, typeArgumentCount);
+    }
 
+    export function getPossibleGenericSignaturesOfType(type: Type, called: Expression, typeArgumentCount: number): readonly Signature[] {
         const signatures = isNewExpression(called.parent) ? type.getConstructSignatures() : type.getCallSignatures();
         return signatures.filter(candidate => !!candidate.typeParameters && candidate.typeParameters.length >= typeArgumentCount);
     }


### PR DESCRIPTION
Previously, this code went down two paths:
 * Call `getTypeAtLocation` and see if the type returned from this call had generic signatures
 * Call `getSymbolAtLocation` and use this for computing signature help items

This is not guaranteed to do the right thing, because `getTypeAtLocation` is effectively heuristic, and so might not necessarily return the a type based on the symbol that `getSymbolAtLocation` returns. This led to a crash when we assumed we had a symbol with `declarations` because it had a generic signature. I have not found a way to repro this outside of the fuzzer (which runs into it constantly).

This PR merges the codepaths so that both the type and symbol computation are done off the same information (namely `getSymbolAtLocation` and `getTypeOfSymbolAtLocation`), which will return consistent results about whether something's generic

Fixes #38709, probably