### PR TITLE
Don't crash when observing invalid 'export' in object literal

### DIFF
--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -204,7 +204,7 @@ namespace ts {
 
         function getNodesToSearchForModifier(declaration: Node, modifierFlag: ModifierFlags): readonly Node[] | undefined {
             // Types of node whose children might have modifiers.
-            const container = declaration.parent as ModuleBlock | SourceFile | Block | CaseClause | DefaultClause | ConstructorDeclaration | MethodDeclaration | FunctionDeclaration | ObjectTypeDeclaration;
+            const container = declaration.parent as ModuleBlock | SourceFile | Block | CaseClause | DefaultClause | ConstructorDeclaration | MethodDeclaration | FunctionDeclaration | ObjectTypeDeclaration | ObjectLiteralExpression;
             switch (container.kind) {
                 case SyntaxKind.ModuleBlock:
                 case SyntaxKind.SourceFile:
@@ -240,6 +240,11 @@ namespace ts {
                         return [...nodes, container];
                     }
                     return nodes;
+
+                // Syntactically invalid positions that the parser might produce anyway
+                case SyntaxKind.ObjectLiteralExpression:
+                    return undefined;
+
                 default:
                     Debug.assertNever(container, "Invalid container kind.");
             }

--- a/tests/cases/fourslash/exportInObjectLiteral.ts
+++ b/tests/cases/fourslash/exportInObjectLiteral.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: a.ts
+//// const k = {
+////     [|export|] f() { }
+//// }
+
+verify.documentHighlightsOf(test.ranges()[0], [], { filesToSearch: [test.ranges()[0].fileName] });
+


### PR DESCRIPTION
Fixes #32870