### PR TITLE
Don't crash when renaming a JS property declared via module.exports

### DIFF
--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -628,7 +628,8 @@ namespace ts.FindAllReferences {
                     return checker.getExportSpecifierLocalTargetSymbol(declaration)!;
                 }
                 else if (isPropertyAccessExpression(declaration) && isModuleExportsAccessExpression(declaration.expression) && !isPrivateIdentifier(declaration.name)) {
-                    return checker.getExportSpecifierLocalTargetSymbol(declaration.name)!;
+                    // Export of form 'module.exports.propName = expr';
+                    return checker.getSymbolAtLocation(declaration)!;
                 }
                 else if (isShorthandPropertyAssignment(declaration)
                     && isBinaryExpression(declaration.parent.parent)

--- a/tests/baselines/reference/findAllRefsCommonJsRequire2.baseline.jsonc
+++ b/tests/baselines/reference/findAllRefsCommonJsRequire2.baseline.jsonc
@@ -3,8 +3,8 @@
 // [|f|]
 
 // === /a.js ===
-// function [|f|]() { }
-// module.exports.f = [|f|]
+// function f() { }
+// module.exports.[|f|] = f
 
 [
   {
@@ -139,16 +139,24 @@
       "containerKind": "",
       "containerName": "",
       "fileName": "/a.js",
-      "kind": "function",
-      "name": "function f(): void",
+      "kind": "property",
+      "name": "(property) f: () => void",
       "textSpan": {
-        "start": 9,
+        "start": 32,
         "length": 1
       },
       "displayParts": [
         {
-          "text": "function",
-          "kind": "keyword"
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
         },
         {
           "text": " ",
@@ -156,7 +164,15 @@
         },
         {
           "text": "f",
-          "kind": "functionName"
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
         },
         {
           "text": "(",
@@ -167,7 +183,11 @@
           "kind": "punctuation"
         },
         {
-          "text": ":",
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
           "kind": "punctuation"
         },
         {
@@ -180,27 +200,14 @@
         }
       ],
       "contextSpan": {
-        "start": 0,
+        "start": 17,
         "length": 16
       }
     },
     "references": [
       {
         "textSpan": {
-          "start": 9,
-          "length": 1
-        },
-        "fileName": "/a.js",
-        "contextSpan": {
-          "start": 0,
-          "length": 16
-        },
-        "isWriteAccess": true,
-        "isDefinition": true
-      },
-      {
-        "textSpan": {
-          "start": 36,
+          "start": 32,
           "length": 1
         },
         "fileName": "/a.js",
@@ -208,8 +215,8 @@
           "start": 17,
           "length": 20
         },
-        "isWriteAccess": false,
-        "isDefinition": false
+        "isWriteAccess": true,
+        "isDefinition": true
       }
     ]
   }

--- a/tests/baselines/reference/indirectJsRequireRename.baseline.jsonc
+++ b/tests/baselines/reference/indirectJsRequireRename.baseline.jsonc
@@ -1,0 +1,135 @@
+// === /lib/plugins/aws/package/compile/events/httpApi/index.js ===
+// const { [|logWarning|] } = require('../../../../../../classes/Error');
+
+// === /lib/classes/Error.js ===
+// module.exports.[|logWarning|] = message => { };
+
+// === /bin/serverless.js ===
+// /*FIND ALL REFS*/require('../lib/classes/Error').[|logWarning|](`CLI triage crashed with: ${error.stack}`);
+
+[
+  {
+    "definition": {
+      "containerKind": "",
+      "containerName": "",
+      "fileName": "/lib/classes/Error.js",
+      "kind": "property",
+      "name": "(property) logWarning: (message: any) => void",
+      "textSpan": {
+        "start": 15,
+        "length": 10
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "logWarning",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "message",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "any",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "contextSpan": {
+        "start": 0,
+        "length": 25
+      }
+    },
+    "references": [
+      {
+        "textSpan": {
+          "start": 15,
+          "length": 10
+        },
+        "fileName": "/lib/classes/Error.js",
+        "contextSpan": {
+          "start": 0,
+          "length": 43
+        },
+        "isWriteAccess": true,
+        "isDefinition": true
+      },
+      {
+        "textSpan": {
+          "start": 32,
+          "length": 10
+        },
+        "fileName": "/bin/serverless.js",
+        "isWriteAccess": false,
+        "isDefinition": false
+      },
+      {
+        "textSpan": {
+          "start": 8,
+          "length": 10
+        },
+        "fileName": "/lib/plugins/aws/package/compile/events/httpApi/index.js",
+        "contextSpan": {
+          "start": 0,
+          "length": 66
+        },
+        "isWriteAccess": true,
+        "isDefinition": true
+      }
+    ]
+  }
+]

--- a/tests/cases/fourslash/indirectJsRequireRename.ts
+++ b/tests/cases/fourslash/indirectJsRequireRename.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+
+// @Filename: /bin/serverless.js
+//// require('../lib/classes/Error').log/**/Warning(`CLI triage crashed with: ${error.stack}`);
+
+// @Filename: /lib/plugins/aws/package/compile/events/httpApi/index.js
+//// const { logWarning } = require('../../../../../../classes/Error');
+
+// @Filename: /lib/classes/Error.js
+//// module.exports.logWarning = message => { };
+
+goTo.marker();
+verify.baselineFindAllReferences("");


### PR DESCRIPTION
Fixes #38070

When the originating definition was of the form
```js
module.exports.foo = expr
```
we were incorrectly trying to call `resolveName` on just the `foo` portion to get the "local" symbol, which simply failed to resolve (or would have resolved to the wrong thing), but for this form, the local symbol we want to resolve to is just the containing property access expression