### PR TITLE
Add support for customDescriptionGenerators (for compiler debugging)

### DIFF
--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -47,14 +47,24 @@
       "console": "integratedTerminal",
       "outFiles": [
         "${workspaceRoot}/built/local/run.js"
-      ]
+      ],
+
+      // NOTE: To use this, you must switch the "type" above to "pwa-node". You may also need to follow the instructions
+      // here: https://github.com/microsoft/vscode-js-debug#nightly-extension to use the js-debug nightly until
+      // this feature is shipping in insiders or to a release:
+      // "customDescriptionGenerator": "'__tsDebuggerDisplay' in this ? this.__tsDebuggerDisplay(defaultValue) : defaultValue"
     },
     {
       // See: https://github.com/microsoft/TypeScript/wiki/Debugging-Language-Service-in-VS-Code
       "type": "node",
       "request": "attach",
       "name": "Attach to VS Code TS Server via Port",
-      "processId": "${command:PickProcess}"
+      "processId": "${command:PickProcess}",
+
+      // NOTE: To use this, you must switch the "type" above to "pwa-node". You may also need to follow the instructions
+      // here: https://github.com/microsoft/vscode-js-debug#nightly-extension to use the js-debug nightly until
+      // this feature is shipping in insiders or to a release:
+      // "customDescriptionGenerator": "'__tsDebuggerDisplay' in this ? this.__tsDebuggerDisplay(defaultValue) : defaultValue"
     }
   ]
 }

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -509,6 +509,7 @@ namespace ts {
                 if (elements.transformFlags === undefined) {
                     aggregateChildrenFlags(elements as MutableNodeArray<T>);
                 }
+                Debug.attachNodeArrayDebugInfo(elements);
                 return elements;
             }
 
@@ -520,6 +521,7 @@ namespace ts {
             setTextRangePosEnd(array, -1, -1);
             array.hasTrailingComma = !!hasTrailingComma;
             aggregateChildrenFlags(array);
+            Debug.attachNodeArrayDebugInfo(array);
             return array;
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5021,7 +5021,11 @@ namespace ts {
         /* @internal */
         RequiresWidening = ContainsWideningType | ContainsObjectOrArrayLiteral,
         /* @internal */
-        PropagatingFlags = ContainsWideningType | ContainsObjectOrArrayLiteral | NonInferrableType
+        PropagatingFlags = ContainsWideningType | ContainsObjectOrArrayLiteral | NonInferrableType,
+
+        // Object flags that uniquely identify the kind of ObjectType
+        /* @internal */
+        ObjectTypeKindMask = ClassOrInterface | Reference | Tuple | Anonymous | Mapped | ReverseMapped | EvolvingArray,
     }
 
     /* @internal */


### PR DESCRIPTION
This adds a custom watch/locals description generator for use when debugging the compiler using the new [`"customDescriptionGenerators"` feature](https://github.com/microsoft/vscode-js-debug/blob/master/OPTIONS.md#customdescriptiongenerator) recently added to the new preview js debugger for VS Code.

This adds custom Watch window descriptions for the following kinds of objects in the compiler:

- `Symbol`
- `Type`
- `Node`
- `NodeArray`
- `FlowNode`

Examples:

![image](https://user-images.githubusercontent.com/3902892/91613019-8ad46280-e933-11ea-8664-e7830c7e5cc1.png)

![image](https://user-images.githubusercontent.com/3902892/91613083-b0616c00-e933-11ea-8f4a-205f0744768f.png)


Instructions for enabling this when debugging can be found in `.vscode/launch.template.json`.