### PR TITLE
Mark comparisons of union constituents involving markers as being unreliable sources of variance

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16760,6 +16760,12 @@ namespace ts {
                     }
                     result &= related;
                 }
+                if (result && source.flags & TypeFlags.Union && some(sourceTypes, t => t === markerSubType) && (target === markerSuperType || (target.flags & TypeFlags.Union && some((target as UnionType).types, t => t === markerSuperType)))) {
+                    // If we're checking if `(U extends T) | A | B` is assignable to `T | A | B`, we return true, but we want
+                    // to mark the result as `Unreliable`, since `T | A`, `T | B` and `T | A | B` and the like are all
+                    // assignable to the target, even if they're not assignable to `T`
+                    outofbandVarianceMarkerHandler?.(/*onlyUnreliable*/ true);
+                }
                 return result;
             }
 

--- a/tests/baselines/reference/inlinedAliasOfSignatureSameAsSignature.js
+++ b/tests/baselines/reference/inlinedAliasOfSignatureSameAsSignature.js
@@ -1,0 +1,51 @@
+//// [inlinedAliasOfSignatureSameAsSignature.ts]
+export type Example<TData>
+    = (data: TData | null | undefined) => string | null;
+
+function foo<T>() {
+    let x: Example<T> = undefined!;
+    let y: Example<T | null | undefined> = undefined!;
+
+    y = x;
+
+    let x1: (data: T | null | undefined) => string | null = undefined!;
+    let y1: (data: (T | null | undefined) | null | undefined) => string | null = undefined!;
+
+    y1 = x1
+}
+
+export interface Example2<TData> {
+    item: (data: TData | null | undefined) => string | null;
+}
+
+function bar<T>() {
+    let x: Example2<T> = undefined!;
+    let y: Example2<T | null | undefined> = undefined!;
+
+    y = x;
+
+    let x1: { item: (data: T | null | undefined) => string | null } = undefined!;
+    let y1: { item: (data: (T | null | undefined) | null | undefined) => string | null } = undefined!;
+
+    y1 = x1
+}
+
+//// [inlinedAliasOfSignatureSameAsSignature.js]
+"use strict";
+exports.__esModule = true;
+function foo() {
+    var x = undefined;
+    var y = undefined;
+    y = x;
+    var x1 = undefined;
+    var y1 = undefined;
+    y1 = x1;
+}
+function bar() {
+    var x = undefined;
+    var y = undefined;
+    y = x;
+    var x1 = undefined;
+    var y1 = undefined;
+    y1 = x1;
+}

--- a/tests/baselines/reference/inlinedAliasOfSignatureSameAsSignature.symbols
+++ b/tests/baselines/reference/inlinedAliasOfSignatureSameAsSignature.symbols
@@ -1,0 +1,94 @@
+=== tests/cases/compiler/inlinedAliasOfSignatureSameAsSignature.ts ===
+export type Example<TData>
+>Example : Symbol(Example, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 0, 0))
+>TData : Symbol(TData, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 0, 20))
+
+    = (data: TData | null | undefined) => string | null;
+>data : Symbol(data, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 1, 7))
+>TData : Symbol(TData, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 0, 20))
+
+function foo<T>() {
+>foo : Symbol(foo, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 1, 56))
+>T : Symbol(T, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 3, 13))
+
+    let x: Example<T> = undefined!;
+>x : Symbol(x, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 4, 7))
+>Example : Symbol(Example, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 0, 0))
+>T : Symbol(T, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 3, 13))
+>undefined : Symbol(undefined)
+
+    let y: Example<T | null | undefined> = undefined!;
+>y : Symbol(y, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 5, 7))
+>Example : Symbol(Example, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 0, 0))
+>T : Symbol(T, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 3, 13))
+>undefined : Symbol(undefined)
+
+    y = x;
+>y : Symbol(y, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 5, 7))
+>x : Symbol(x, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 4, 7))
+
+    let x1: (data: T | null | undefined) => string | null = undefined!;
+>x1 : Symbol(x1, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 9, 7))
+>data : Symbol(data, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 9, 13))
+>T : Symbol(T, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 3, 13))
+>undefined : Symbol(undefined)
+
+    let y1: (data: (T | null | undefined) | null | undefined) => string | null = undefined!;
+>y1 : Symbol(y1, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 10, 7))
+>data : Symbol(data, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 10, 13))
+>T : Symbol(T, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 3, 13))
+>undefined : Symbol(undefined)
+
+    y1 = x1
+>y1 : Symbol(y1, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 10, 7))
+>x1 : Symbol(x1, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 9, 7))
+}
+
+export interface Example2<TData> {
+>Example2 : Symbol(Example2, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 13, 1))
+>TData : Symbol(TData, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 15, 26))
+
+    item: (data: TData | null | undefined) => string | null;
+>item : Symbol(Example2.item, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 15, 34))
+>data : Symbol(data, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 16, 11))
+>TData : Symbol(TData, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 15, 26))
+}
+
+function bar<T>() {
+>bar : Symbol(bar, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 17, 1))
+>T : Symbol(T, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 19, 13))
+
+    let x: Example2<T> = undefined!;
+>x : Symbol(x, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 20, 7))
+>Example2 : Symbol(Example2, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 13, 1))
+>T : Symbol(T, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 19, 13))
+>undefined : Symbol(undefined)
+
+    let y: Example2<T | null | undefined> = undefined!;
+>y : Symbol(y, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 21, 7))
+>Example2 : Symbol(Example2, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 13, 1))
+>T : Symbol(T, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 19, 13))
+>undefined : Symbol(undefined)
+
+    y = x;
+>y : Symbol(y, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 21, 7))
+>x : Symbol(x, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 20, 7))
+
+    let x1: { item: (data: T | null | undefined) => string | null } = undefined!;
+>x1 : Symbol(x1, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 25, 7))
+>item : Symbol(item, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 25, 13))
+>data : Symbol(data, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 25, 21))
+>T : Symbol(T, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 19, 13))
+>undefined : Symbol(undefined)
+
+    let y1: { item: (data: (T | null | undefined) | null | undefined) => string | null } = undefined!;
+>y1 : Symbol(y1, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 26, 7))
+>item : Symbol(item, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 26, 13))
+>data : Symbol(data, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 26, 21))
+>T : Symbol(T, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 19, 13))
+>undefined : Symbol(undefined)
+
+    y1 = x1
+>y1 : Symbol(y1, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 26, 7))
+>x1 : Symbol(x1, Decl(inlinedAliasOfSignatureSameAsSignature.ts, 25, 7))
+}

--- a/tests/baselines/reference/inlinedAliasOfSignatureSameAsSignature.types
+++ b/tests/baselines/reference/inlinedAliasOfSignatureSameAsSignature.types
@@ -1,0 +1,102 @@
+=== tests/cases/compiler/inlinedAliasOfSignatureSameAsSignature.ts ===
+export type Example<TData>
+>Example : Example<TData>
+
+    = (data: TData | null | undefined) => string | null;
+>data : TData | null | undefined
+>null : null
+>null : null
+
+function foo<T>() {
+>foo : <T>() => void
+
+    let x: Example<T> = undefined!;
+>x : Example<T>
+>undefined! : never
+>undefined : undefined
+
+    let y: Example<T | null | undefined> = undefined!;
+>y : Example<T | null | undefined>
+>null : null
+>undefined! : never
+>undefined : undefined
+
+    y = x;
+>y = x : Example<T>
+>y : Example<T | null | undefined>
+>x : Example<T>
+
+    let x1: (data: T | null | undefined) => string | null = undefined!;
+>x1 : (data: T | null | undefined) => string | null
+>data : T | null | undefined
+>null : null
+>null : null
+>undefined! : never
+>undefined : undefined
+
+    let y1: (data: (T | null | undefined) | null | undefined) => string | null = undefined!;
+>y1 : (data: (T | null | undefined) | null | undefined) => string | null
+>data : T | null | undefined
+>null : null
+>null : null
+>null : null
+>undefined! : never
+>undefined : undefined
+
+    y1 = x1
+>y1 = x1 : (data: T | null | undefined) => string | null
+>y1 : (data: T | null | undefined) => string | null
+>x1 : (data: T | null | undefined) => string | null
+}
+
+export interface Example2<TData> {
+    item: (data: TData | null | undefined) => string | null;
+>item : (data: TData | null | undefined) => string | null
+>data : TData | null | undefined
+>null : null
+>null : null
+}
+
+function bar<T>() {
+>bar : <T>() => void
+
+    let x: Example2<T> = undefined!;
+>x : Example2<T>
+>undefined! : never
+>undefined : undefined
+
+    let y: Example2<T | null | undefined> = undefined!;
+>y : Example2<T | null | undefined>
+>null : null
+>undefined! : never
+>undefined : undefined
+
+    y = x;
+>y = x : Example2<T>
+>y : Example2<T | null | undefined>
+>x : Example2<T>
+
+    let x1: { item: (data: T | null | undefined) => string | null } = undefined!;
+>x1 : { item: (data: T | null | undefined) => string | null; }
+>item : (data: T | null | undefined) => string | null
+>data : T | null | undefined
+>null : null
+>null : null
+>undefined! : never
+>undefined : undefined
+
+    let y1: { item: (data: (T | null | undefined) | null | undefined) => string | null } = undefined!;
+>y1 : { item: (data: (T | null | undefined) | null | undefined) => string | null; }
+>item : (data: (T | null | undefined) | null | undefined) => string | null
+>data : T | null | undefined
+>null : null
+>null : null
+>null : null
+>undefined! : never
+>undefined : undefined
+
+    y1 = x1
+>y1 = x1 : { item: (data: T | null | undefined) => string | null; }
+>y1 : { item: (data: T | null | undefined) => string | null; }
+>x1 : { item: (data: T | null | undefined) => string | null; }
+}

--- a/tests/cases/compiler/inlinedAliasOfSignatureSameAsSignature.ts
+++ b/tests/cases/compiler/inlinedAliasOfSignatureSameAsSignature.ts
@@ -1,0 +1,31 @@
+// @strict: true
+export type Example<TData>
+    = (data: TData | null | undefined) => string | null;
+
+function foo<T>() {
+    let x: Example<T> = undefined!;
+    let y: Example<T | null | undefined> = undefined!;
+
+    y = x;
+
+    let x1: (data: T | null | undefined) => string | null = undefined!;
+    let y1: (data: (T | null | undefined) | null | undefined) => string | null = undefined!;
+
+    y1 = x1
+}
+
+export interface Example2<TData> {
+    item: (data: TData | null | undefined) => string | null;
+}
+
+function bar<T>() {
+    let x: Example2<T> = undefined!;
+    let y: Example2<T | null | undefined> = undefined!;
+
+    y = x;
+
+    let x1: { item: (data: T | null | undefined) => string | null } = undefined!;
+    let y1: { item: (data: (T | null | undefined) | null | undefined) => string | null } = undefined!;
+
+    y1 = x1
+}


### PR DESCRIPTION
Fixes #40312

The root cause is that when measuring the variance of something like `T | A | B`, we'd check if `T' | A | B` is assignable to `T | A | B` and return a strong variance result, since, yes, it does hold that for all subtypes of `T`, the relationship holds. _However_, the relationship between `T'` and `T` is not the same as the relationship between `T` and `T | A | B` - while every subtype of `T` will be assignable to the union, there as some things which are _not_ subtypes of `T` (eg, `T | A`) which will _also_ be assignable to the union - when we detect we are making such a measurement, we need to mark the variance result as `Unreliable`, so we can, in the negative case, fall back to a structural comparison of the union members.

Included is an interface-based test case for the same issue - this has been an issue in our variance calculations since their inception, so you can see the interface case replicate the undesirable assignability behavior far into our past (at least as old as 2.7) ❤️ 