### PR TITLE
fix(40218): Adds codefix to remove an unused declaration but keep the body

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -5327,6 +5327,10 @@
         "category": "Message",
         "code": 90053
     },
+    "Remove unused declaration but keep body for: '{0}'": {
+        "category": "Message",
+        "code": 90054
+    },
     "Convert function to an ES2015 class": {
         "category": "Message",
         "code": 95001


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #40218

Instead of trying to determine if an unused declaration contains side-effects this code fix leaves that determination up to the user.


![removed-unused-decl](https://user-images.githubusercontent.com/1046198/92181230-a214c380-edfd-11ea-8078-70d1b65cb9d1.gif)
![removed-unused-decl-keep-body](https://user-images.githubusercontent.com/1046198/92181234-a6d97780-edfd-11ea-91b2-7274f23aab1b.gif)
Since creating that GIF, I changed the wording.

One thing I’m struggling with a bit right now is the best way to fix the tests. For instance, in [`unusedVariableInBlocks.ts`](https://github.com/microsoft/TypeScript/blob/8ffb7f083daa1af68b8950896db42271c47bbd2c/tests/cases/fourslash/unusedVariableInBlocks.ts) the call to `verify.codeFix` errors out since it finds two code fixes available instead of one. Is there a way to make that work for two different fixes? I want to do something like this:

```typescript
verify.codeFix([
    {
        description: "Remove unused declaration for: 'x'",
        newRangeContent: `let x = 10;
    {
    }
    x;`,
    },
    {
        description: "Remove unused declaration but keep body for: 'x'",
        newRangeContent: `let x = 10;
    {
        11;
    }
    x;`,
    }
]);
```

This is my first opportunity to dive into TypeScript’s codebase so I sincerely appreciate any guidance.