### PR TITLE
Throw types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4493,6 +4493,9 @@ namespace ts {
                 if (type.flags & TypeFlags.Substitution) {
                     return typeToTypeNodeHelper((<SubstitutionType>type).baseType, context);
                 }
+                if (type.flags & TypeFlags.ThrowType) {
+                    return typeToTypeNodeHelper(errorType, context);
+                }
 
                 return Debug.fail("Should be unreachable.");
 
@@ -13391,6 +13394,9 @@ namespace ts {
                     case SyntaxKind.ReadonlyKeyword:
                         links.resolvedType = getTypeFromTypeNode(node.type);
                         break;
+                    case SyntaxKind.ThrowKeyword:
+                        links.resolvedType = createThrowType(getTypeFromTypeNode(node.type));
+                        break;
                     default:
                         throw Debug.assertNever(node.operator);
                 }
@@ -14461,6 +14467,12 @@ namespace ts {
             return type;
         }
 
+        function createThrowType(containingType: Type) {
+            const type = <ThrowType>createType(TypeFlags.ThrowType);
+            type.value = containingType;
+            return type;
+        }
+
         function getESSymbolLikeTypeForNode(node: Node) {
             if (isValidESSymbolDeclaration(node)) {
                 const symbol = getSymbolOfNode(node);
@@ -15112,6 +15124,15 @@ namespace ts {
                     }
                     return sub;
                 }
+            }
+            if (flags & TypeFlags.ThrowType) {
+                const innerType = instantiateType((<ThrowType>type).value, mapper);
+                let errorMessage = "Unknown";
+                if (innerType.flags & TypeFlags.StringLiteral) {
+                    errorMessage = (<StringLiteralType>innerType).value;
+                }
+                error(currentNode, Diagnostics.Type_instantiated_results_in_a_throw_type_saying_Colon_0, errorMessage);
+                return errorType;
             }
             return type;
         }
@@ -19312,6 +19333,9 @@ namespace ts {
         // results for union and intersection types for performance reasons.
         function couldContainTypeVariables(type: Type): boolean {
             const objectFlags = getObjectFlags(type);
+            if (type.flags & TypeFlags.ThrowType) {
+                return couldContainTypeVariables((<ThrowType>type).value);
+            }
             if (objectFlags & ObjectFlags.CouldContainTypeVariablesComputed) {
                 return !!(objectFlags & ObjectFlags.CouldContainTypeVariables);
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13439,12 +13439,15 @@ namespace ts {
             let text = texts[0];
             for (let i = 0; i < types.length; i++) {
                 const t = types[i];
-                if (t.flags & TypeFlags.Literal) {
-                    const s = applyTemplateCasing(getTemplateStringForType(t) || "", casings[i]);
+                const casingType = casings[i];
+                const isGeneric = isGenericIndexType(t);
+                const resolvable = (t.flags & TypeFlags.Literal) || (!isGeneric && casingType === TemplateCasing.TypeOf);
+                if (resolvable) {
+                    const s = applyTemplateCasing(getTemplateStringForType(t, casingType) || "", casingType);
                     text += s;
                     text += texts[i + 1];
                 }
-                else if (isGenericIndexType(t)) {
+                else if (isGeneric) {
                     newTypes.push(t);
                     newCasings.push(casings[i]);
                     newTexts.push(text);
@@ -13466,7 +13469,10 @@ namespace ts {
             return type;
         }
 
-        function getTemplateStringForType(type: Type) {
+        function getTemplateStringForType(type: Type, casing: TemplateCasing) {
+            if (casing === TemplateCasing.TypeOf) {
+                return getTypeNameForErrorDisplay(type);
+            }
             return type.flags & TypeFlags.StringLiteral ? (<StringLiteralType>type).value :
                 type.flags & TypeFlags.NumberLiteral ? "" + (<NumberLiteralType>type).value :
                 type.flags & TypeFlags.BigIntLiteral ? pseudoBigIntToString((<BigIntLiteralType>type).value) :
@@ -31424,7 +31430,9 @@ namespace ts {
             getTypeFromTypeNode(node);
             for (const span of node.templateSpans) {
                 const type = getTypeFromTypeNode(span.type);
-                checkTypeAssignableTo(type, templateConstraintType, span.type);
+                if (span.casing !== TemplateCasing.TypeOf) {
+                    checkTypeAssignableTo(type, templateConstraintType, span.type);
+                }
                 if (!everyType(type, t => !!(t.flags & TypeFlags.Literal) || isGenericIndexType(t))) {
                     error(span.type, Diagnostics.Template_type_argument_0_is_not_literal_type_or_a_generic_type, typeToString(type));
                 }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3020,7 +3020,10 @@
         "category": "Error",
         "code": 2793
     },
-
+    "Type instantiated results in a throw type saying: {0}": {
+        "category": "Error",
+        "code": 2794
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2013,6 +2013,7 @@ namespace ts {
                 node.casing === TemplateCasing.Lowercase ? "lowercase" :
                 node.casing === TemplateCasing.Capitalize ? "capitalize" :
                 node.casing === TemplateCasing.Uncapitalize ? "uncapitalize" :
+                node.casing === TemplateCasing.TypeOf ? "typeof" :
                 undefined;
             if (keyword) {
                 writeKeyword(keyword);

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -1969,7 +1969,7 @@ namespace ts {
         }
 
         // @api
-        function createTypeOperatorNode(operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword, type: TypeNode): TypeOperatorNode {
+        function createTypeOperatorNode(operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword | SyntaxKind.ThrowKeyword, type: TypeNode): TypeOperatorNode {
             const node = createBaseNode<TypeOperatorNode>(SyntaxKind.TypeOperator);
             node.operator = operator;
             node.type = parenthesizerRules().parenthesizeMemberOfElementType(type);

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2621,6 +2621,7 @@ namespace ts {
                 parseOptional(SyntaxKind.LowercaseKeyword) ? TemplateCasing.Lowercase :
                 parseOptional(SyntaxKind.CapitalizeKeyword) ? TemplateCasing.Capitalize :
                 parseOptional(SyntaxKind.UncapitalizeKeyword) ? TemplateCasing.Uncapitalize :
+                parseOptional(SyntaxKind.TypeOfKeyword) ? TemplateCasing.TypeOf :
                 TemplateCasing.None;
         }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3585,7 +3585,7 @@ namespace ts {
             return type;
         }
 
-        function parseTypeOperator(operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword) {
+        function parseTypeOperator(operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword | SyntaxKind.ThrowKeyword) {
             const pos = getNodePos();
             parseExpected(operator);
             return finishNode(factory.createTypeOperatorNode(operator, parseTypeOperatorOrHigher()), pos);
@@ -3615,6 +3615,7 @@ namespace ts {
                 case SyntaxKind.KeyOfKeyword:
                 case SyntaxKind.UniqueKeyword:
                 case SyntaxKind.ReadonlyKeyword:
+                case SyntaxKind.ThrowKeyword:
                     return parseTypeOperator(operator);
                 case SyntaxKind.InferKeyword:
                     return parseInferType();

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1672,6 +1672,7 @@ namespace ts {
         Lowercase,
         Capitalize,
         Uncapitalize,
+        TypeOf,
     }
 
     // Note: 'brands' in our syntax nodes serve to give us a small amount of nominal typing.

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1613,7 +1613,7 @@ namespace ts {
 
     export interface TypeOperatorNode extends TypeNode {
         readonly kind: SyntaxKind.TypeOperator;
-        readonly operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword;
+        readonly operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword | SyntaxKind.ThrowKeyword;
         readonly type: TypeNode;
     }
 
@@ -4873,6 +4873,7 @@ namespace ts {
         Substitution    = 1 << 25,  // Type parameter substitution
         NonPrimitive    = 1 << 26,  // intrinsic object type
         TemplateLiteral = 1 << 27,  // Template literal type
+        ThrowType       = 1 << 28,  // throw T
 
         /* @internal */
         AnyOrUnknown = Any | Unknown,
@@ -5006,6 +5007,10 @@ namespace ts {
 
     // Enum types (TypeFlags.Enum)
     export interface EnumType extends Type {
+    }
+
+    export interface ThrowType extends Type {
+        value: Type;
     }
 
     export const enum ObjectFlags {
@@ -6781,7 +6786,7 @@ namespace ts {
         createParenthesizedType(type: TypeNode): ParenthesizedTypeNode;
         updateParenthesizedType(node: ParenthesizedTypeNode, type: TypeNode): ParenthesizedTypeNode;
         createThisTypeNode(): ThisTypeNode;
-        createTypeOperatorNode(operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword, type: TypeNode): TypeOperatorNode;
+        createTypeOperatorNode(operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword | SyntaxKind.ThrowKeyword, type: TypeNode): TypeOperatorNode;
         updateTypeOperatorNode(node: TypeOperatorNode, type: TypeNode): TypeOperatorNode;
         createIndexedAccessTypeNode(objectType: TypeNode, indexType: TypeNode): IndexedAccessTypeNode;
         updateIndexedAccessTypeNode(node: IndexedAccessTypeNode, objectType: TypeNode, indexType: TypeNode): IndexedAccessTypeNode;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -936,7 +936,7 @@ declare namespace ts {
     }
     export interface TypeOperatorNode extends TypeNode {
         readonly kind: SyntaxKind.TypeOperator;
-        readonly operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword;
+        readonly operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword | SyntaxKind.ThrowKeyword;
         readonly type: TypeNode;
     }
     export interface IndexedAccessTypeNode extends TypeNode {
@@ -978,7 +978,8 @@ declare namespace ts {
         Uppercase = 1,
         Lowercase = 2,
         Capitalize = 3,
-        Uncapitalize = 4
+        Uncapitalize = 4,
+        TypeOf = 5
     }
     export interface Expression extends Node {
         _expressionBrand: any;
@@ -2477,6 +2478,7 @@ declare namespace ts {
         Substitution = 33554432,
         NonPrimitive = 67108864,
         TemplateLiteral = 134217728,
+        ThrowType = 268435456,
         Literal = 2944,
         Unit = 109440,
         StringOrNumberLiteral = 384,
@@ -2524,6 +2526,9 @@ declare namespace ts {
         value: PseudoBigInt;
     }
     export interface EnumType extends Type {
+    }
+    export interface ThrowType extends Type {
+        value: Type;
     }
     export enum ObjectFlags {
         Class = 1,
@@ -3246,7 +3251,7 @@ declare namespace ts {
         createParenthesizedType(type: TypeNode): ParenthesizedTypeNode;
         updateParenthesizedType(node: ParenthesizedTypeNode, type: TypeNode): ParenthesizedTypeNode;
         createThisTypeNode(): ThisTypeNode;
-        createTypeOperatorNode(operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword, type: TypeNode): TypeOperatorNode;
+        createTypeOperatorNode(operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword | SyntaxKind.ThrowKeyword, type: TypeNode): TypeOperatorNode;
         updateTypeOperatorNode(node: TypeOperatorNode, type: TypeNode): TypeOperatorNode;
         createIndexedAccessTypeNode(objectType: TypeNode, indexType: TypeNode): IndexedAccessTypeNode;
         updateIndexedAccessTypeNode(node: IndexedAccessTypeNode, objectType: TypeNode, indexType: TypeNode): IndexedAccessTypeNode;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -936,7 +936,7 @@ declare namespace ts {
     }
     export interface TypeOperatorNode extends TypeNode {
         readonly kind: SyntaxKind.TypeOperator;
-        readonly operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword;
+        readonly operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword | SyntaxKind.ThrowKeyword;
         readonly type: TypeNode;
     }
     export interface IndexedAccessTypeNode extends TypeNode {
@@ -978,7 +978,8 @@ declare namespace ts {
         Uppercase = 1,
         Lowercase = 2,
         Capitalize = 3,
-        Uncapitalize = 4
+        Uncapitalize = 4,
+        TypeOf = 5
     }
     export interface Expression extends Node {
         _expressionBrand: any;
@@ -2477,6 +2478,7 @@ declare namespace ts {
         Substitution = 33554432,
         NonPrimitive = 67108864,
         TemplateLiteral = 134217728,
+        ThrowType = 268435456,
         Literal = 2944,
         Unit = 109440,
         StringOrNumberLiteral = 384,
@@ -2524,6 +2526,9 @@ declare namespace ts {
         value: PseudoBigInt;
     }
     export interface EnumType extends Type {
+    }
+    export interface ThrowType extends Type {
+        value: Type;
     }
     export enum ObjectFlags {
         Class = 1,
@@ -3246,7 +3251,7 @@ declare namespace ts {
         createParenthesizedType(type: TypeNode): ParenthesizedTypeNode;
         updateParenthesizedType(node: ParenthesizedTypeNode, type: TypeNode): ParenthesizedTypeNode;
         createThisTypeNode(): ThisTypeNode;
-        createTypeOperatorNode(operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword, type: TypeNode): TypeOperatorNode;
+        createTypeOperatorNode(operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword | SyntaxKind.ThrowKeyword, type: TypeNode): TypeOperatorNode;
         updateTypeOperatorNode(node: TypeOperatorNode, type: TypeNode): TypeOperatorNode;
         createIndexedAccessTypeNode(objectType: TypeNode, indexType: TypeNode): IndexedAccessTypeNode;
         updateIndexedAccessTypeNode(node: IndexedAccessTypeNode, objectType: TypeNode, indexType: TypeNode): IndexedAccessTypeNode;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #23689

**This PR is based on #40336 (Template string types and mapped type 'as' clauses)** so it doesn't use `master` as the base branch.

This PR introduces:
1. A new type-level expression: `throw type_expr`. Currently `throw` type only throws in a conditional type.
2. A new modifier to use in the template string `typeof T` to make it easier to debug.

## Considered use cases:

Welcome to suggest more use cases!

### TypeAlias instantation

```ts
type MustNumber<T> = T extends number ? T : throw `Expected, but found "${typeof T}"`
type A = MustNumber<1>
type B = MustNumber<typeof window>
```

![image](https://user-images.githubusercontent.com/5390719/92322225-9544d980-f062-11ea-9f93-807a277df55b.png)

### Prevent CallExpression


```ts
class X<T> {
    constructor(public item: T) { }
    add(a: T): T extends number | string | bigint ? T : throw `Cannot apply + operator on this type` {
        // @ts-ignore
        return a + this.item
    }
}
new X(1).add(2).toExponential()
new X("").add("")
new X({}).add({})
```

![image](https://user-images.githubusercontent.com/5390719/92321315-8f97c580-f05b-11ea-9c86-27b211adb21a.png)


## TODO:

1. [x] Figure out how to "print" types in the error message. Maybe a new modifier `\`${typeof T}\``
2. [ ] Write tests and fix broken parts
3. [ ] Wait for #40336 to be merged