### PR TITLE
Remove Language specification link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ with any additional questions or comments.
 
 *  [TypeScript in 5 minutes](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html)
 *  [Programming handbook](https://www.typescriptlang.org/docs/handbook/basic-types.html)
-*  [Language specification](https://github.com/microsoft/TypeScript/blob/master/doc/spec.md)
 *  [Homepage](https://www.typescriptlang.org/)
 
 ## Building


### PR DESCRIPTION
Link is broken but my understanding is that spec is no longer maintained anyways