### PR TITLE
fix(39899): Export default child items of function parameter not included in 'navtree' 

### DIFF
--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -310,7 +310,7 @@ namespace ts.NavigationBar {
 
             case SyntaxKind.ExportAssignment: {
                 const expression = (<ExportAssignment>node).expression;
-                const child = isObjectLiteralExpression(expression) ? expression :
+                const child = isObjectLiteralExpression(expression) || isCallExpression(expression) ? expression :
                     isArrowFunction(expression) || isFunctionExpression(expression) ? expression.body : undefined;
                 if (child) {
                     startNode(node);
@@ -843,16 +843,11 @@ namespace ts.NavigationBar {
         }
 
         // Otherwise, we need to aggregate each identifier to build up the qualified name.
-        const result: string[] = [];
-
-        result.push(getTextOfIdentifierOrLiteral(moduleDeclaration.name));
-
+        const result = [getTextOfIdentifierOrLiteral(moduleDeclaration.name)];
         while (moduleDeclaration.body && moduleDeclaration.body.kind === SyntaxKind.ModuleDeclaration) {
             moduleDeclaration = <ModuleDeclaration>moduleDeclaration.body;
-
             result.push(getTextOfIdentifierOrLiteral(moduleDeclaration.name));
         }
-
         return result.join(".");
     }
 

--- a/tests/cases/fourslash/navigationItemsExportDefaultExpression.ts
+++ b/tests/cases/fourslash/navigationItemsExportDefaultExpression.ts
@@ -28,6 +28,9 @@
 ////         d: 1
 ////     }
 //// }
+////
+//// function foo(props: { x: number; y: number }) {}
+//// export default foo({ x: 1, y: 1 });
 
 verify.navigationTree({
   "text": '"navigationItemsExportDefaultExpression"',
@@ -91,6 +94,21 @@ verify.navigationTree({
       ]
     },
     {
+      "text": "default",
+      "kind": "const",
+      "kindModifiers": "export",
+      "childItems": [
+        {
+          "text": "x",
+          "kind": "property"
+        },
+        {
+          "text": "y",
+          "kind": "property"
+        }
+      ]
+    },
+    {
       "text": "AB",
       "kind": "class",
       "kindModifiers": "export"
@@ -119,6 +137,10 @@ verify.navigationTree({
           "kind": "class"
         }
       ]
+    },
+    {
+      "text": "foo",
+      "kind": "function"
     }
   ]
 });


### PR DESCRIPTION
Fixes #39899