### PR TITLE
Add inference for 'Promise' based on call to 'resolve'

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26039,7 +26039,7 @@ namespace ts {
             // If the above conditions are met then:
             // - Determine the name in function `callbackFunc` given to the parameter `innerCallbackParam`
             // - Find all references to that name in the body of the function `callbackFunc`
-            // - If `innerCallbackParam` is called directly, collect inferences for the type of the argument passed to the parameter (`innerCallbackValueType`) each call to `innerCallbackParam`
+            // - If `innerCallbackParam` is called directly, collect inferences for the type of the argument passed to the parameter (`innerCallbackValueType`)
             // - If `innerCallbackParam` is passed as the argument to another function, we can attempt to use the contextual type of that parameter for inference.
             if (isNewExpression(node) && argCount === 1) {
                 const callbackType = getTypeAtPosition(signature, 0); // executor: ...

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5437,10 +5437,11 @@ namespace ts {
         ReturnType                   = 1 << 6,  // Inference made from return type of generic function
         LiteralKeyof                 = 1 << 7,  // Inference made from a string literal to a keyof T
         NoConstraints                = 1 << 8,  // Don't infer from constraints of instantiable types
-        AlwaysStrict                 = 1 << 9,  // Always use strict rules for contravariant inferences
-        MaxValue                     = 1 << 10, // Seed for inference priority tracking
+        RevealingConstructor         = 1 << 9,  // Inference made to a callback in a "revealing constructor" (i.e., `new Promise(resolve => resolve(1))`)
+        AlwaysStrict                 = 1 << 10, // Always use strict rules for contravariant inferences
+        MaxValue                     = 1 << 11, // Seed for inference priority tracking
 
-        PriorityImpliesCombination = ReturnType | MappedTypeConstraint | LiteralKeyof,  // These priorities imply that the resulting type should be a combination of all candidates
+        PriorityImpliesCombination = ReturnType | MappedTypeConstraint | LiteralKeyof | RevealingConstructor,  // These priorities imply that the resulting type should be a combination of all candidates
         Circularity = -1,  // Inference circularity (value less than all other priorities)
     }
 

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1261,41 +1261,6 @@ namespace ts.FindAllReferences {
             return getPossibleSymbolReferencePositions(sourceFile, symbolName, container).map(pos => getTouchingPropertyName(sourceFile, pos));
         }
 
-        function getPossibleSymbolReferencePositions(sourceFile: SourceFile, symbolName: string, container: Node = sourceFile): readonly number[] {
-            const positions: number[] = [];
-
-            /// TODO: Cache symbol existence for files to save text search
-            // Also, need to make this work for unicode escapes.
-
-            // Be resilient in the face of a symbol with no name or zero length name
-            if (!symbolName || !symbolName.length) {
-                return positions;
-            }
-
-            const text = sourceFile.text;
-            const sourceLength = text.length;
-            const symbolNameLength = symbolName.length;
-
-            let position = text.indexOf(symbolName, container.pos);
-            while (position >= 0) {
-                // If we are past the end, stop looking
-                if (position > container.end) break;
-
-                // We found a match.  Make sure it's not part of a larger word (i.e. the char
-                // before and after it have to be a non-identifier char).
-                const endPosition = position + symbolNameLength;
-
-                if ((position === 0 || !isIdentifierPart(text.charCodeAt(position - 1), ScriptTarget.Latest)) &&
-                    (endPosition === sourceLength || !isIdentifierPart(text.charCodeAt(endPosition), ScriptTarget.Latest))) {
-                    // Found a real match.  Keep searching.
-                    positions.push(position);
-                }
-                position = text.indexOf(symbolName, position + symbolNameLength + 1);
-            }
-
-            return positions;
-        }
-
         function getLabelReferencesInNode(container: Node, targetLabel: Identifier): SymbolAndEntries[] {
             const sourceFile = container.getSourceFile();
             const labelName = targetLabel.text;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2651,9 +2651,10 @@ declare namespace ts {
         ReturnType = 64,
         LiteralKeyof = 128,
         NoConstraints = 256,
-        AlwaysStrict = 512,
-        MaxValue = 1024,
-        PriorityImpliesCombination = 208,
+        RevealingConstructor = 512,
+        AlwaysStrict = 1024,
+        MaxValue = 2048,
+        PriorityImpliesCombination = 720,
         Circularity = -1
     }
     /** @deprecated Use FileExtensionInfo instead. */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2651,9 +2651,10 @@ declare namespace ts {
         ReturnType = 64,
         LiteralKeyof = 128,
         NoConstraints = 256,
-        AlwaysStrict = 512,
-        MaxValue = 1024,
-        PriorityImpliesCombination = 208,
+        RevealingConstructor = 512,
+        AlwaysStrict = 1024,
+        MaxValue = 2048,
+        PriorityImpliesCombination = 720,
         Circularity = -1
     }
     /** @deprecated Use FileExtensionInfo instead. */

--- a/tests/baselines/reference/defaultExportInAwaitExpression01.types
+++ b/tests/baselines/reference/defaultExportInAwaitExpression01.types
@@ -1,21 +1,21 @@
 === tests/cases/conformance/es6/modules/a.ts ===
 const x = new Promise( ( resolve, reject ) => { resolve( {} ); } );
->x : Promise<unknown>
->new Promise( ( resolve, reject ) => { resolve( {} ); } ) : Promise<unknown>
+>x : Promise<{}>
+>new Promise( ( resolve, reject ) => { resolve( {} ); } ) : Promise<{}>
 >Promise : PromiseConstructor
->( resolve, reject ) => { resolve( {} ); } : (resolve: (value: unknown) => void, reject: (reason?: any) => void) => void
->resolve : (value: unknown) => void
+>( resolve, reject ) => { resolve( {} ); } : (resolve: (value: {} | PromiseLike<{}>) => void, reject: (reason?: any) => void) => void
+>resolve : (value: {} | PromiseLike<{}>) => void
 >reject : (reason?: any) => void
 >resolve( {} ) : void
->resolve : (value: unknown) => void
+>resolve : (value: {} | PromiseLike<{}>) => void
 >{} : {}
 
 export default x;
->x : Promise<unknown>
+>x : Promise<{}>
 
 === tests/cases/conformance/es6/modules/b.ts ===
 import x from './a';
->x : Promise<unknown>
+>x : Promise<{}>
 
 ( async function() {
 >( async function() {    const value = await x;}() ) : Promise<void>
@@ -23,9 +23,9 @@ import x from './a';
 >async function() {    const value = await x;} : () => Promise<void>
 
     const value = await x;
->value : unknown
->await x : unknown
->x : Promise<unknown>
+>value : {}
+>await x : {}
+>x : Promise<{}>
 
 }() );
 

--- a/tests/baselines/reference/defaultExportInAwaitExpression02.types
+++ b/tests/baselines/reference/defaultExportInAwaitExpression02.types
@@ -1,21 +1,21 @@
 === tests/cases/conformance/es6/modules/a.ts ===
 const x = new Promise( ( resolve, reject ) => { resolve( {} ); } );
->x : Promise<unknown>
->new Promise( ( resolve, reject ) => { resolve( {} ); } ) : Promise<unknown>
+>x : Promise<{}>
+>new Promise( ( resolve, reject ) => { resolve( {} ); } ) : Promise<{}>
 >Promise : PromiseConstructor
->( resolve, reject ) => { resolve( {} ); } : (resolve: (value: unknown) => void, reject: (reason?: any) => void) => void
->resolve : (value: unknown) => void
+>( resolve, reject ) => { resolve( {} ); } : (resolve: (value: {} | PromiseLike<{}>) => void, reject: (reason?: any) => void) => void
+>resolve : (value: {} | PromiseLike<{}>) => void
 >reject : (reason?: any) => void
 >resolve( {} ) : void
->resolve : (value: unknown) => void
+>resolve : (value: {} | PromiseLike<{}>) => void
 >{} : {}
 
 export default x;
->x : Promise<unknown>
+>x : Promise<{}>
 
 === tests/cases/conformance/es6/modules/b.ts ===
 import x from './a';
->x : Promise<unknown>
+>x : Promise<{}>
 
 ( async function() {
 >( async function() {    const value = await x;}() ) : Promise<void>
@@ -23,9 +23,9 @@ import x from './a';
 >async function() {    const value = await x;} : () => Promise<void>
 
     const value = await x;
->value : unknown
->await x : unknown
->x : Promise<unknown>
+>value : {}
+>await x : {}
+>x : Promise<{}>
 
 }() );
 

--- a/tests/baselines/reference/inferenceLimit.types
+++ b/tests/baselines/reference/inferenceLimit.types
@@ -29,15 +29,15 @@ export class BrokenClass {
 >[] : undefined[]
 
     let populateItems = (order) => {
->populateItems : (order: any) => Promise<unknown>
->(order) => {      return new Promise((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      });    } : (order: any) => Promise<unknown>
+>populateItems : (order: any) => Promise<any>
+>(order) => {      return new Promise((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      });    } : (order: any) => Promise<any>
 >order : any
 
       return new Promise((resolve, reject) => {
->new Promise((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      }) : Promise<unknown>
+>new Promise((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      }) : Promise<any>
 >Promise : PromiseConstructor
->(resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      } : (resolve: (value: unknown) => void, reject: (reason?: any) => void) => void
->resolve : (value: unknown) => void
+>(resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      } : (resolve: (value: any) => void, reject: (reason?: any) => void) => void
+>resolve : (value: any) => void
 >reject : (reason?: any) => void
 
         this.doStuff(order.id)
@@ -65,7 +65,7 @@ export class BrokenClass {
 
             resolve(order);
 >resolve(order) : void
->resolve : (value: unknown) => void
+>resolve : (value: any) => void
 >order : any
 
           });
@@ -74,19 +74,19 @@ export class BrokenClass {
 
     return Promise.all(result.map(populateItems))
 >Promise.all(result.map(populateItems))      .then((orders: Array<MyModule.MyModel>) => {        resolve(orders);      }) : Promise<void>
->Promise.all(result.map(populateItems))      .then : <TResult1 = unknown[], TResult2 = never>(onfulfilled?: (value: unknown[]) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
->Promise.all(result.map(populateItems)) : Promise<unknown[]>
+>Promise.all(result.map(populateItems))      .then : <TResult1 = any[], TResult2 = never>(onfulfilled?: (value: any[]) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>Promise.all(result.map(populateItems)) : Promise<any[]>
 >Promise.all : { <T>(values: Iterable<T | PromiseLike<T>>): Promise<T[]>; <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>, T10 | PromiseLike<T10>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>; <T1, T2, T3, T4, T5, T6, T7, T8, T9>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>; <T1, T2, T3, T4, T5, T6, T7, T8>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8]>; <T1, T2, T3, T4, T5, T6, T7>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>]): Promise<[T1, T2, T3, T4, T5, T6, T7]>; <T1, T2, T3, T4, T5, T6>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>]): Promise<[T1, T2, T3, T4, T5, T6]>; <T1, T2, T3, T4, T5>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>]): Promise<[T1, T2, T3, T4, T5]>; <T1, T2, T3, T4>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>]): Promise<[T1, T2, T3, T4]>; <T1, T2, T3>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>]): Promise<[T1, T2, T3]>; <T1, T2>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>]): Promise<[T1, T2]>; <T>(values: readonly (T | PromiseLike<T>)[]): Promise<T[]>; }
 >Promise : PromiseConstructor
 >all : { <T>(values: Iterable<T | PromiseLike<T>>): Promise<T[]>; <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>, T10 | PromiseLike<T10>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>; <T1, T2, T3, T4, T5, T6, T7, T8, T9>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>; <T1, T2, T3, T4, T5, T6, T7, T8>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8]>; <T1, T2, T3, T4, T5, T6, T7>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>]): Promise<[T1, T2, T3, T4, T5, T6, T7]>; <T1, T2, T3, T4, T5, T6>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>]): Promise<[T1, T2, T3, T4, T5, T6]>; <T1, T2, T3, T4, T5>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>]): Promise<[T1, T2, T3, T4, T5]>; <T1, T2, T3, T4>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>]): Promise<[T1, T2, T3, T4]>; <T1, T2, T3>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>]): Promise<[T1, T2, T3]>; <T1, T2>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>]): Promise<[T1, T2]>; <T>(values: readonly (T | PromiseLike<T>)[]): Promise<T[]>; }
->result.map(populateItems) : Promise<unknown>[]
+>result.map(populateItems) : Promise<any>[]
 >result.map : <U>(callbackfn: (value: MyModule.MyModel, index: number, array: MyModule.MyModel[]) => U, thisArg?: any) => U[]
 >result : MyModule.MyModel[]
 >map : <U>(callbackfn: (value: MyModule.MyModel, index: number, array: MyModule.MyModel[]) => U, thisArg?: any) => U[]
->populateItems : (order: any) => Promise<unknown>
+>populateItems : (order: any) => Promise<any>
 
       .then((orders: Array<MyModule.MyModel>) => {
->then : <TResult1 = unknown[], TResult2 = never>(onfulfilled?: (value: unknown[]) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
+>then : <TResult1 = any[], TResult2 = never>(onfulfilled?: (value: any[]) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<TResult1 | TResult2>
 >(orders: Array<MyModule.MyModel>) => {        resolve(orders);      } : (orders: Array<MyModule.MyModel>) => void
 >orders : MyModule.MyModel[]
 >MyModule : any

--- a/tests/baselines/reference/revealingConstructorInference.symbols
+++ b/tests/baselines/reference/revealingConstructorInference.symbols
@@ -1,0 +1,110 @@
+=== tests/cases/conformance/types/typeRelationships/typeInference/revealingConstructorInference.ts ===
+// uncalled
+const p0 = new Promise(resolve => {});
+>p0 : Symbol(p0, Decl(revealingConstructorInference.ts, 1, 5))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 1, 23))
+
+// called with no argument
+const p1 = new Promise(resolve => resolve());
+>p1 : Symbol(p1, Decl(revealingConstructorInference.ts, 4, 5))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 4, 23))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 4, 23))
+
+// called with argument
+const p2 = new Promise(resolve => resolve(1));
+>p2 : Symbol(p2, Decl(revealingConstructorInference.ts, 7, 5))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 7, 23))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 7, 23))
+
+// called with promise-like argument
+const p3 = new Promise(resolve => resolve(Promise.resolve(1)));
+>p3 : Symbol(p3, Decl(revealingConstructorInference.ts, 10, 5))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 10, 23))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 10, 23))
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+// called with multiple arguments
+const p4 = new Promise(resolve => {
+>p4 : Symbol(p4, Decl(revealingConstructorInference.ts, 13, 5))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 13, 23))
+
+    resolve(1);
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 13, 23))
+
+    resolve("a");
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 13, 23))
+
+});
+
+// called with multiple arguments (mix of non-promise and PromiseLike)
+const p5 = new Promise(resolve => {
+>p5 : Symbol(p5, Decl(revealingConstructorInference.ts, 19, 5))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 19, 23))
+
+    resolve(1);
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 19, 23))
+
+    resolve(Promise.resolve("a"));
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 19, 23))
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+});
+
+// called with argument in nested callback
+declare function soon(f: () => void): void;
+>soon : Symbol(soon, Decl(revealingConstructorInference.ts, 22, 3))
+>f : Symbol(f, Decl(revealingConstructorInference.ts, 25, 22))
+
+const p6 = new Promise(resolve => {
+>p6 : Symbol(p6, Decl(revealingConstructorInference.ts, 26, 5))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 26, 23))
+
+    soon(() => resolve(1));
+>soon : Symbol(soon, Decl(revealingConstructorInference.ts, 22, 3))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 26, 23))
+
+});
+
+// callback passed to another function
+declare function resolveWith<T>(f: (value: T) => void, value: T): void;
+>resolveWith : Symbol(resolveWith, Decl(revealingConstructorInference.ts, 28, 3))
+>T : Symbol(T, Decl(revealingConstructorInference.ts, 31, 29))
+>f : Symbol(f, Decl(revealingConstructorInference.ts, 31, 32))
+>value : Symbol(value, Decl(revealingConstructorInference.ts, 31, 36))
+>T : Symbol(T, Decl(revealingConstructorInference.ts, 31, 29))
+>value : Symbol(value, Decl(revealingConstructorInference.ts, 31, 54))
+>T : Symbol(T, Decl(revealingConstructorInference.ts, 31, 29))
+
+const p7 = new Promise(resolve => resolveWith(resolve, 1));
+>p7 : Symbol(p7, Decl(revealingConstructorInference.ts, 32, 5))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 32, 23))
+>resolveWith : Symbol(resolveWith, Decl(revealingConstructorInference.ts, 28, 3))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 32, 23))
+
+// lower priority inference
+const enum E { zero = 0 }
+>E : Symbol(E, Decl(revealingConstructorInference.ts, 32, 59))
+>zero : Symbol(E.zero, Decl(revealingConstructorInference.ts, 35, 14))
+
+const p8: Promise<number> = new Promise(resolve => resolve(E.zero));
+>p8 : Symbol(p8, Decl(revealingConstructorInference.ts, 36, 5))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 36, 40))
+>resolve : Symbol(resolve, Decl(revealingConstructorInference.ts, 36, 40))
+>E.zero : Symbol(E.zero, Decl(revealingConstructorInference.ts, 35, 14))
+>E : Symbol(E, Decl(revealingConstructorInference.ts, 32, 59))
+>zero : Symbol(E.zero, Decl(revealingConstructorInference.ts, 35, 14))
+

--- a/tests/baselines/reference/revealingConstructorInference.types
+++ b/tests/baselines/reference/revealingConstructorInference.types
@@ -1,0 +1,147 @@
+=== tests/cases/conformance/types/typeRelationships/typeInference/revealingConstructorInference.ts ===
+// uncalled
+const p0 = new Promise(resolve => {});
+>p0 : Promise<unknown>
+>new Promise(resolve => {}) : Promise<unknown>
+>Promise : PromiseConstructor
+>resolve => {} : (resolve: (value: unknown) => void) => void
+>resolve : (value: unknown) => void
+
+// called with no argument
+const p1 = new Promise(resolve => resolve());
+>p1 : Promise<void>
+>new Promise(resolve => resolve()) : Promise<void>
+>Promise : PromiseConstructor
+>resolve => resolve() : (resolve: (value: void | PromiseLike<void>) => void) => void
+>resolve : (value: void | PromiseLike<void>) => void
+>resolve() : void
+>resolve : (value: void | PromiseLike<void>) => void
+
+// called with argument
+const p2 = new Promise(resolve => resolve(1));
+>p2 : Promise<number>
+>new Promise(resolve => resolve(1)) : Promise<number>
+>Promise : PromiseConstructor
+>resolve => resolve(1) : (resolve: (value: number | PromiseLike<number>) => void) => void
+>resolve : (value: number | PromiseLike<number>) => void
+>resolve(1) : void
+>resolve : (value: number | PromiseLike<number>) => void
+>1 : 1
+
+// called with promise-like argument
+const p3 = new Promise(resolve => resolve(Promise.resolve(1)));
+>p3 : Promise<number>
+>new Promise(resolve => resolve(Promise.resolve(1))) : Promise<number>
+>Promise : PromiseConstructor
+>resolve => resolve(Promise.resolve(1)) : (resolve: (value: number | PromiseLike<number>) => void) => any
+>resolve : (value: number | PromiseLike<number>) => void
+>resolve(Promise.resolve(1)) : void
+>resolve : (value: number | PromiseLike<number>) => void
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
+>Promise : PromiseConstructor
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
+>1 : 1
+
+// called with multiple arguments
+const p4 = new Promise(resolve => {
+>p4 : Promise<string | number>
+>new Promise(resolve => {    resolve(1);    resolve("a");}) : Promise<string | number>
+>Promise : PromiseConstructor
+>resolve => {    resolve(1);    resolve("a");} : (resolve: (value: string | number | PromiseLike<string | number>) => void) => void
+>resolve : (value: string | number | PromiseLike<string | number>) => void
+
+    resolve(1);
+>resolve(1) : void
+>resolve : (value: string | number | PromiseLike<string | number>) => void
+>1 : 1
+
+    resolve("a");
+>resolve("a") : void
+>resolve : (value: string | number | PromiseLike<string | number>) => void
+>"a" : "a"
+
+});
+
+// called with multiple arguments (mix of non-promise and PromiseLike)
+const p5 = new Promise(resolve => {
+>p5 : Promise<string | number>
+>new Promise(resolve => {    resolve(1);    resolve(Promise.resolve("a"));}) : Promise<string | number>
+>Promise : PromiseConstructor
+>resolve => {    resolve(1);    resolve(Promise.resolve("a"));} : (resolve: (value: string | number | PromiseLike<string | number>) => void) => void
+>resolve : (value: string | number | PromiseLike<string | number>) => void
+
+    resolve(1);
+>resolve(1) : void
+>resolve : (value: string | number | PromiseLike<string | number>) => void
+>1 : 1
+
+    resolve(Promise.resolve("a"));
+>resolve(Promise.resolve("a")) : void
+>resolve : (value: string | number | PromiseLike<string | number>) => void
+>Promise.resolve("a") : Promise<string>
+>Promise.resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
+>Promise : PromiseConstructor
+>resolve : { (): Promise<void>; <T>(value: T | PromiseLike<T>): Promise<T>; }
+>"a" : "a"
+
+});
+
+// called with argument in nested callback
+declare function soon(f: () => void): void;
+>soon : (f: () => void) => void
+>f : () => void
+
+const p6 = new Promise(resolve => {
+>p6 : Promise<number>
+>new Promise(resolve => {    soon(() => resolve(1));}) : Promise<number>
+>Promise : PromiseConstructor
+>resolve => {    soon(() => resolve(1));} : (resolve: (value: number | PromiseLike<number>) => void) => void
+>resolve : (value: number | PromiseLike<number>) => void
+
+    soon(() => resolve(1));
+>soon(() => resolve(1)) : void
+>soon : (f: () => void) => void
+>() => resolve(1) : () => void
+>resolve(1) : void
+>resolve : (value: number | PromiseLike<number>) => void
+>1 : 1
+
+});
+
+// callback passed to another function
+declare function resolveWith<T>(f: (value: T) => void, value: T): void;
+>resolveWith : <T>(f: (value: T) => void, value: T) => void
+>f : (value: T) => void
+>value : T
+>value : T
+
+const p7 = new Promise(resolve => resolveWith(resolve, 1));
+>p7 : Promise<number>
+>new Promise(resolve => resolveWith(resolve, 1)) : Promise<number>
+>Promise : PromiseConstructor
+>resolve => resolveWith(resolve, 1) : (resolve: (value: number | PromiseLike<number>) => void) => void
+>resolve : (value: number | PromiseLike<number>) => void
+>resolveWith(resolve, 1) : void
+>resolveWith : <T>(f: (value: T) => void, value: T) => void
+>resolve : (value: number | PromiseLike<number>) => void
+>1 : 1
+
+// lower priority inference
+const enum E { zero = 0 }
+>E : E
+>zero : E.zero
+>0 : 0
+
+const p8: Promise<number> = new Promise(resolve => resolve(E.zero));
+>p8 : Promise<number>
+>new Promise(resolve => resolve(E.zero)) : Promise<number>
+>Promise : PromiseConstructor
+>resolve => resolve(E.zero) : (resolve: (value: number | PromiseLike<number>) => void) => void
+>resolve : (value: number | PromiseLike<number>) => void
+>resolve(E.zero) : void
+>resolve : (value: number | PromiseLike<number>) => void
+>E.zero : E
+>E : typeof E
+>zero : E
+

--- a/tests/cases/conformance/types/typeRelationships/typeInference/revealingConstructorInference.ts
+++ b/tests/cases/conformance/types/typeRelationships/typeInference/revealingConstructorInference.ts
@@ -1,0 +1,40 @@
+// @target: esnext
+// @noEmit: true
+
+// uncalled
+const p0 = new Promise(resolve => {});
+
+// called with no argument
+const p1 = new Promise(resolve => resolve());
+
+// called with argument
+const p2 = new Promise(resolve => resolve(1));
+
+// called with promise-like argument
+const p3 = new Promise(resolve => resolve(Promise.resolve(1)));
+
+// called with multiple arguments
+const p4 = new Promise(resolve => {
+    resolve(1);
+    resolve("a");
+});
+
+// called with multiple arguments (mix of non-promise and PromiseLike)
+const p5 = new Promise(resolve => {
+    resolve(1);
+    resolve(Promise.resolve("a"));
+});
+
+// called with argument in nested callback
+declare function soon(f: () => void): void;
+const p6 = new Promise(resolve => {
+    soon(() => resolve(1));
+});
+
+// callback passed to another function
+declare function resolveWith<T>(f: (value: T) => void, value: T): void;
+const p7 = new Promise(resolve => resolveWith(resolve, 1));
+
+// lower priority inference
+const enum E { zero = 0 }
+const p8: Promise<number> = new Promise(resolve => resolve(E.zero));


### PR DESCRIPTION
In #39817, we introduced a breaking change in the signature of `PromiseConstructor` to ensure it is more type-safe. This unfortunately results in new errors. One class of these errors relates to code like the following:

```ts
async function wait(ms) {
  await new Promise(resolve => setTimeout(() => resolve(), ms));
  //                                            ^^^^^^^^^
  //                                            error: Expected 1 argument(s) but got 0.
}
```

This is now an error due to the fact the type we infer for an untyped `Promise` with no contextual type is `unknown`. While this can be addressed by annotating `Promise` with the type `void` (i.e., `new Promise<void>(resolve => ...)`), this PR looks to address this case by introducing an inference heuristic around the "revealing constructor" pattern used by the `Promise` constructor. 

A "revealing constructor" is a class that accepts a callback in its constructor that the constructor then invokes, providing access to one or more privileged callbacks passed as arguments:

```ts
interface PromiseConstructor {
  /**
   * Creates a new Promise.
   * @param executor A callback used to initialize the promise. This callback is passed two arguments:
   * a resolve callback used to resolve the promise with a value or the result of another promise,
   * and a reject callback used to reject the promise with a provided reason or error.
   */
  new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
}
```

When you create a new `Promise`, the constructor will invoke the `executor` callback with two callbacks of its own: `resolve` and `reject`.

This PR introduces inference for this very specific heuristic, such that:

```ts
// Promise<void>
const p0 = new Promise(resolve => resolve()); 

// Promise<number>
const p1 = new Promise(resolve => resolve(1));

// Promise<number | string>
const p2 = new Promise(resolve => Math.random() ? resolve(Promise.resolve(1)) : resolve("hi"));

declare function callWith<T>(f: (value: T) => void, value: T): void;

// Promise<boolean>
const p3 = new Promise(resolve => callWith(resolve, true));
```

The specific heuristic used for inference is as follows:

Attempt to solve for `T` in `new C<T>(f => f(t))`:
- Restricted to `NewExpression`
- The construct signature for `T` must only accept a single parameter (*pA*)
- The parameter *pA* has a single call signature (*spA*) (i.e., `executor: (resolve: (value: T | PromiseLike<T>) => void) => void`)
- The signature *spA* has at least one parameter (*pB*)
- The parameter *pB* has a single call signature (*spB*) (i.e., `resolve: (value: T | PromiseLike<T>) => void`)
- The signature *spB* has a single parameter (*pC*)
- The parameter *pC* contains a type variable for which we are gathering inferences (i.e. `value: T | PromiseLike<T>`)
- A function expression or arrow function (*fpA*) is passed as the argument to the parameter *pA*
- The function *fpA* must have one parameter *ppB* that is untyped (and thus would be contextually typed by *pB*)

If the above conditions are met then:
- Determine the name in given to the parameter *ppB* in the function *fpA*.
- Find all references to parameter *ppB* in the body of the function *fpA*.
- If *ppB* is called directly, collect inferences for the type of the argument passed as the parameter.
- If *ppB* is passed as the argument to another function, we can attempt to use the contextual type of that parameter for inference.

These inferences are given a very low priority so that inference from contextual types will have a higher priority.

Related #40231, #39817
