### PR TITLE
fix(40469): "Convert to named function" refactoring is not suggested for non-arrow function expressions

### DIFF
--- a/tests/cases/fourslash/refactorConvertArrowFunctionOrFunctionExpression_Availability_Anon.ts
+++ b/tests/cases/fourslash/refactorConvertArrowFunctionOrFunctionExpression_Availability_Anon.ts
@@ -3,14 +3,14 @@
 //// /*z*/c/*y*/onst /*x*/f/*w*/oo = /*v*/f/*u*/unction() /*t*/{/*s*/ /*r*/r/*q*/eturn 42;};
 
 goTo.select("z", "y");
-verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to named function");
 verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to anonymous function");
-verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to arrow function");
+verify.refactorAvailable("Convert arrow function or function expression", "Convert to named function");
+verify.refactorAvailable("Convert arrow function or function expression", "Convert to arrow function");
 
 goTo.select("x", "w");
-verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to named function");
 verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to anonymous function");
-verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to arrow function");
+verify.refactorAvailable("Convert arrow function or function expression", "Convert to named function");
+verify.refactorAvailable("Convert arrow function or function expression", "Convert to arrow function");
 
 goTo.select("v", "u");
 verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to named function");

--- a/tests/cases/fourslash/refactorConvertArrowFunctionOrFunctionExpression_Availability_Anon_unusedName.ts
+++ b/tests/cases/fourslash/refactorConvertArrowFunctionOrFunctionExpression_Availability_Anon_unusedName.ts
@@ -3,14 +3,14 @@
 //// /*z*/c/*y*/onst /*x*/f/*w*/oo = /*v*/f/*u*/unction bar() /*t*/{/*s*/ /*r*/r/*q*/eturn 42;};
 
 goTo.select("z", "y");
-verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to named function");
 verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to anonymous function");
-verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to arrow function");
+verify.refactorAvailable("Convert arrow function or function expression", "Convert to named function");
+verify.refactorAvailable("Convert arrow function or function expression", "Convert to arrow function");
 
 goTo.select("x", "w");
-verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to named function");
 verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to anonymous function");
-verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to arrow function");
+verify.refactorAvailable("Convert arrow function or function expression", "Convert to named function");
+verify.refactorAvailable("Convert arrow function or function expression", "Convert to arrow function");
 
 goTo.select("v", "u");
 verify.not.refactorAvailable("Convert arrow function or function expression", "Convert to named function");


### PR DESCRIPTION
Fixes #40469
