### PR TITLE
fix(40432): `as` keyword is missing in completion lists within function bodies

### DIFF
--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1312,6 +1312,7 @@ namespace FourSlashInterface {
             "let",
             "package",
             "yield",
+            "as",
             "async",
             "await",
         ].map(keywordEntry);
@@ -1452,6 +1453,7 @@ namespace FourSlashInterface {
             "let",
             "package",
             "yield",
+            "as",
             "async",
             "await",
         ].map(keywordEntry);

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2576,7 +2576,6 @@ namespace ts.Completions {
                         || kind === SyntaxKind.ModuleKeyword
                         || kind === SyntaxKind.TypeKeyword
                         || kind === SyntaxKind.NamespaceKeyword
-                        || kind === SyntaxKind.AsKeyword
                         || isTypeKeyword(kind) && kind !== SyntaxKind.UndefinedKeyword;
                 case KeywordCompletionFilters.FunctionLikeBodyKeywords:
                     return isFunctionLikeBodyKeyword(kind);
@@ -2651,6 +2650,7 @@ namespace ts.Completions {
     function isFunctionLikeBodyKeyword(kind: SyntaxKind) {
         return kind === SyntaxKind.AsyncKeyword
             || kind === SyntaxKind.AwaitKeyword
+            || kind === SyntaxKind.AsKeyword
             || !isContextualKeyword(kind) && !isClassMemberCompletionKeyword(kind);
     }
 

--- a/tests/cases/fourslash/completionAsKeyword.ts
+++ b/tests/cases/fourslash/completionAsKeyword.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+////const x = this /*1*/
+////function foo() {
+////    const x = this /*2*/
+////}
+
+verify.completions({
+    marker: ["1", "2"],
+    includes: [{ name: "as", sortText: completion.SortText.GlobalsOrKeywords }]
+});


### PR DESCRIPTION
Fixes #40432