### PR TITLE
Support element access aliases: exports["x"] = x

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2406,7 +2406,7 @@ namespace ts {
                 || node.kind === SyntaxKind.ExportSpecifier
                 || node.kind === SyntaxKind.ExportAssignment && exportAssignmentIsAlias(<ExportAssignment>node)
                 || isBinaryExpression(node) && getAssignmentDeclarationKind(node) === AssignmentDeclarationKind.ModuleExports && exportAssignmentIsAlias(node)
-                || isPropertyAccessExpression(node)
+                || isAccessExpression(node)
                     && isBinaryExpression(node.parent)
                     && node.parent.left === node
                     && node.parent.operatorToken.kind === SyntaxKind.EqualsToken
@@ -2801,7 +2801,7 @@ namespace ts {
             return getTargetOfAliasLikeExpression(expression, dontRecursivelyResolve);
         }
 
-        function getTargetOfPropertyAccessExpression(node: PropertyAccessExpression, dontRecursivelyResolve: boolean): Symbol | undefined {
+        function getTargetOfAccessExpression(node: AccessExpression, dontRecursivelyResolve: boolean): Symbol | undefined {
             if (!(isBinaryExpression(node.parent) && node.parent.left === node && node.parent.operatorToken.kind === SyntaxKind.EqualsToken)) {
                 return undefined;
             }
@@ -2834,8 +2834,9 @@ namespace ts {
                     return resolveEntityName((node as ShorthandPropertyAssignment).name, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace, /*ignoreErrors*/ true, dontRecursivelyResolve);
                 case SyntaxKind.PropertyAssignment:
                     return getTargetOfPropertyAssignment(node as PropertyAssignment, dontRecursivelyResolve);
+                case SyntaxKind.ElementAccessExpression:
                 case SyntaxKind.PropertyAccessExpression:
-                    return getTargetOfPropertyAccessExpression(node as PropertyAccessExpression, dontRecursivelyResolve);
+                    return getTargetOfAccessExpression(node as AccessExpression, dontRecursivelyResolve);
                 default:
                     return Debug.fail();
             }

--- a/tests/baselines/reference/moduleExportAliasElementAccessExpression.symbols
+++ b/tests/baselines/reference/moduleExportAliasElementAccessExpression.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/salsa/moduleExportAliasElementAccessExpression.js ===
+function D () { }
+>D : Symbol(D, Decl(moduleExportAliasElementAccessExpression.js, 0, 0))
+
+exports["D"] = D;
+>exports : Symbol("tests/cases/conformance/salsa/moduleExportAliasElementAccessExpression", Decl(moduleExportAliasElementAccessExpression.js, 0, 0))
+>"D" : Symbol("D", Decl(moduleExportAliasElementAccessExpression.js, 0, 17))
+>D : Symbol(D, Decl(moduleExportAliasElementAccessExpression.js, 0, 0))
+

--- a/tests/baselines/reference/moduleExportAliasElementAccessExpression.types
+++ b/tests/baselines/reference/moduleExportAliasElementAccessExpression.types
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/salsa/moduleExportAliasElementAccessExpression.js ===
+function D () { }
+>D : () => void
+
+exports["D"] = D;
+>exports["D"] = D : () => void
+>exports["D"] : () => void
+>exports : typeof import("tests/cases/conformance/salsa/moduleExportAliasElementAccessExpression")
+>"D" : "D"
+>D : () => void
+

--- a/tests/cases/conformance/salsa/moduleExportAliasElementAccessExpression.ts
+++ b/tests/cases/conformance/salsa/moduleExportAliasElementAccessExpression.ts
@@ -1,0 +1,6 @@
+// @noEmit: true
+// @checkJs: true
+// @filename: moduleExportAliasElementAccessExpression.js
+
+function D () { }
+exports["D"] = D;


### PR DESCRIPTION
Fixes #40512
