### PR TITLE
fix(40510): Convert to optional chaining doesn't show up for expressions with bracket accessor

### DIFF
--- a/tests/cases/fourslash/refactorConvertToOptionalChainExpression_ElementAccessExpression1.ts
+++ b/tests/cases/fourslash/refactorConvertToOptionalChainExpression_ElementAccessExpression1.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+
+////const a = {
+////    b: { c: 1 }
+////}
+/////*a*/a && a['b'] && a['b']['c']/*b*/
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Convert to optional chain expression",
+    actionName: "Convert to optional chain expression",
+    actionDescription: "Convert to optional chain expression",
+    newContent:
+`const a = {
+    b: { c: 1 }
+}
+a?.['b']?.['c']`
+});

--- a/tests/cases/fourslash/refactorConvertToOptionalChainExpression_ElementAccessExpression2.ts
+++ b/tests/cases/fourslash/refactorConvertToOptionalChainExpression_ElementAccessExpression2.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+
+////const a = {
+////    b: { c: 1 }
+////}
+/////*a*/a && a.b && a.b['c']/*b*/
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Convert to optional chain expression",
+    actionName: "Convert to optional chain expression",
+    actionDescription: "Convert to optional chain expression",
+    newContent:
+`const a = {
+    b: { c: 1 }
+}
+a?.b?.['c']`
+});


### PR DESCRIPTION
Fixes #40510


