### PR TITLE
Remove technically unnecessary 'module' option from 'harness' config.

### DIFF
--- a/src/harness/tsconfig.json
+++ b/src/harness/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../tsconfig-base",
     "compilerOptions": {
         "outFile": "../../built/local/harness.js",
-        "moduleResolution": "node",
         "types": [
             "node", "mocha", "chai"
         ],


### PR DESCRIPTION
Fixes #40525 

https://github.com/microsoft/TypeScript/runs/1105196341?check_suite_focus=true#step:4:132