### PR TITLE
Fix error on duplicate commonjs exports

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2811,6 +2811,7 @@ namespace ts {
                 const isAlias = isAliasableExpression(node.right) && (isExportsIdentifier(node.left.expression) || isModuleExportsAccessExpression(node.left.expression));
                 const flags = isAlias ? SymbolFlags.Alias : SymbolFlags.Property | SymbolFlags.ExportValue;
                 const excludeFlags = isAlias ? SymbolFlags.AliasExcludes : SymbolFlags.None;
+                setParent(node.left, node);
                 declareSymbol(symbol.exports!, symbol, node.left, flags, excludeFlags);
             }
         }

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2810,9 +2810,8 @@ namespace ts {
             if (symbol) {
                 const isAlias = isAliasableExpression(node.right) && (isExportsIdentifier(node.left.expression) || isModuleExportsAccessExpression(node.left.expression));
                 const flags = isAlias ? SymbolFlags.Alias : SymbolFlags.Property | SymbolFlags.ExportValue;
-                const excludeFlags = isAlias ? SymbolFlags.AliasExcludes : SymbolFlags.None;
                 setParent(node.left, node);
-                declareSymbol(symbol.exports!, symbol, node.left, flags, excludeFlags);
+                declareSymbol(symbol.exports!, symbol, node.left, flags, SymbolFlags.None);
             }
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6828,6 +6828,7 @@ namespace ts {
                             break;
                         case SyntaxKind.BinaryExpression:
                         case SyntaxKind.PropertyAccessExpression:
+                        case SyntaxKind.ElementAccessExpression:
                             // Could be best encoded as though an export specifier or as though an export assignment
                             // If name is default or export=, do an export assignment
                             // Otherwise do an export specifier

--- a/tests/baselines/reference/moduleExportAliasElementAccessExpression.js
+++ b/tests/baselines/reference/moduleExportAliasElementAccessExpression.js
@@ -1,12 +1,17 @@
 //// [moduleExportAliasElementAccessExpression.js]
 function D () { }
 exports["D"] = D;
+ // (the only package I could find that uses spaces in identifiers is webidl-conversions)
+exports["Does not work yet"] = D;
 
 
 //// [moduleExportAliasElementAccessExpression.js]
 function D() { }
 exports["D"] = D;
+// (the only package I could find that uses spaces in identifiers is webidl-conversions)
+exports["Does not work yet"] = D;
 
 
 //// [moduleExportAliasElementAccessExpression.d.ts]
 export function D(): void;
+export { D as _Does_not_work_yet };

--- a/tests/baselines/reference/moduleExportAliasElementAccessExpression.js
+++ b/tests/baselines/reference/moduleExportAliasElementAccessExpression.js
@@ -1,0 +1,12 @@
+//// [moduleExportAliasElementAccessExpression.js]
+function D () { }
+exports["D"] = D;
+
+
+//// [moduleExportAliasElementAccessExpression.js]
+function D() { }
+exports["D"] = D;
+
+
+//// [moduleExportAliasElementAccessExpression.d.ts]
+export function D(): void;

--- a/tests/baselines/reference/moduleExportAliasElementAccessExpression.symbols
+++ b/tests/baselines/reference/moduleExportAliasElementAccessExpression.symbols
@@ -7,3 +7,9 @@ exports["D"] = D;
 >"D" : Symbol("D", Decl(moduleExportAliasElementAccessExpression.js, 0, 17))
 >D : Symbol(D, Decl(moduleExportAliasElementAccessExpression.js, 0, 0))
 
+ // (the only package I could find that uses spaces in identifiers is webidl-conversions)
+exports["Does not work yet"] = D;
+>exports : Symbol("tests/cases/conformance/salsa/moduleExportAliasElementAccessExpression", Decl(moduleExportAliasElementAccessExpression.js, 0, 0))
+>"Does not work yet" : Symbol("Does not work yet", Decl(moduleExportAliasElementAccessExpression.js, 1, 17))
+>D : Symbol(D, Decl(moduleExportAliasElementAccessExpression.js, 0, 0))
+

--- a/tests/baselines/reference/moduleExportAliasElementAccessExpression.types
+++ b/tests/baselines/reference/moduleExportAliasElementAccessExpression.types
@@ -9,3 +9,11 @@ exports["D"] = D;
 >"D" : "D"
 >D : () => void
 
+ // (the only package I could find that uses spaces in identifiers is webidl-conversions)
+exports["Does not work yet"] = D;
+>exports["Does not work yet"] = D : () => void
+>exports["Does not work yet"] : () => void
+>exports : typeof import("tests/cases/conformance/salsa/moduleExportAliasElementAccessExpression")
+>"Does not work yet" : "Does not work yet"
+>D : () => void
+

--- a/tests/baselines/reference/moduleExportDuplicateAlias.errors.txt
+++ b/tests/baselines/reference/moduleExportDuplicateAlias.errors.txt
@@ -1,16 +1,16 @@
-tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias.js(1,9): error TS2300: Duplicate identifier 'apply'.
+tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias.js(1,1): error TS2323: Cannot redeclare exported variable 'apply'.
 tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias.js(3,1): error TS2322: Type '() => void' is not assignable to type 'undefined'.
-tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias.js(3,9): error TS2300: Duplicate identifier 'apply'.
+tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias.js(3,1): error TS2323: Cannot redeclare exported variable 'apply'.
 
 
 ==== tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias.js (3 errors) ====
     exports.apply = undefined;
-            ~~~~~
-!!! error TS2300: Duplicate identifier 'apply'.
+    ~~~~~~~~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'apply'.
     function a() { }
     exports.apply = a;
     ~~~~~~~~~~~~~
 !!! error TS2322: Type '() => void' is not assignable to type 'undefined'.
-            ~~~~~
-!!! error TS2300: Duplicate identifier 'apply'.
+    ~~~~~~~~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'apply'.
     

--- a/tests/baselines/reference/moduleExportDuplicateAlias.errors.txt
+++ b/tests/baselines/reference/moduleExportDuplicateAlias.errors.txt
@@ -1,0 +1,16 @@
+tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias.js(1,9): error TS2300: Duplicate identifier 'apply'.
+tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias.js(3,1): error TS2322: Type '() => void' is not assignable to type 'undefined'.
+tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias.js(3,9): error TS2300: Duplicate identifier 'apply'.
+
+
+==== tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias.js (3 errors) ====
+    exports.apply = undefined;
+            ~~~~~
+!!! error TS2300: Duplicate identifier 'apply'.
+    function a() { }
+    exports.apply = a;
+    ~~~~~~~~~~~~~
+!!! error TS2322: Type '() => void' is not assignable to type 'undefined'.
+            ~~~~~
+!!! error TS2300: Duplicate identifier 'apply'.
+    

--- a/tests/baselines/reference/moduleExportDuplicateAlias.js
+++ b/tests/baselines/reference/moduleExportDuplicateAlias.js
@@ -1,0 +1,14 @@
+//// [moduleExportAliasDuplicateAlias.js]
+exports.apply = undefined;
+function a() { }
+exports.apply = a;
+
+
+//// [moduleExportAliasDuplicateAlias.js]
+exports.apply = undefined;
+function a() { }
+exports.apply = a;
+
+
+//// [moduleExportAliasDuplicateAlias.d.ts]
+export { undefined as apply };

--- a/tests/baselines/reference/moduleExportDuplicateAlias.symbols
+++ b/tests/baselines/reference/moduleExportDuplicateAlias.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias.js ===
+exports.apply = undefined;
+>exports.apply : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 0, 0))
+>exports : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 0, 0))
+>apply : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 0, 0))
+>undefined : Symbol(apply)
+
+function a() { }
+>a : Symbol(a, Decl(moduleExportAliasDuplicateAlias.js, 0, 26))
+
+exports.apply = a;
+>exports.apply : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 0, 0))
+>exports : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 1, 16))
+>apply : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 1, 16))
+>a : Symbol(a, Decl(moduleExportAliasDuplicateAlias.js, 0, 26))
+

--- a/tests/baselines/reference/moduleExportDuplicateAlias.symbols
+++ b/tests/baselines/reference/moduleExportDuplicateAlias.symbols
@@ -1,16 +1,16 @@
 === tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias.js ===
 exports.apply = undefined;
->exports.apply : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 0, 0))
->exports : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 0, 0))
->apply : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 0, 0))
+>exports.apply : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 0, 0), Decl(moduleExportAliasDuplicateAlias.js, 1, 16))
+>exports : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 0, 0), Decl(moduleExportAliasDuplicateAlias.js, 1, 16))
+>apply : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 0, 0), Decl(moduleExportAliasDuplicateAlias.js, 1, 16))
 >undefined : Symbol(apply)
 
 function a() { }
 >a : Symbol(a, Decl(moduleExportAliasDuplicateAlias.js, 0, 26))
 
 exports.apply = a;
->exports.apply : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 0, 0))
->exports : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 1, 16))
->apply : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 1, 16))
+>exports.apply : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 0, 0), Decl(moduleExportAliasDuplicateAlias.js, 1, 16))
+>exports : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 0, 0), Decl(moduleExportAliasDuplicateAlias.js, 1, 16))
+>apply : Symbol(apply, Decl(moduleExportAliasDuplicateAlias.js, 0, 0), Decl(moduleExportAliasDuplicateAlias.js, 1, 16))
 >a : Symbol(a, Decl(moduleExportAliasDuplicateAlias.js, 0, 26))
 

--- a/tests/baselines/reference/moduleExportDuplicateAlias.types
+++ b/tests/baselines/reference/moduleExportDuplicateAlias.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias.js ===
+exports.apply = undefined;
+>exports.apply = undefined : undefined
+>exports.apply : undefined
+>exports : typeof import("tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias")
+>apply : undefined
+>undefined : undefined
+
+function a() { }
+>a : () => void
+
+exports.apply = a;
+>exports.apply = a : () => void
+>exports.apply : undefined
+>exports : typeof import("tests/cases/conformance/salsa/moduleExportAliasDuplicateAlias")
+>apply : undefined
+>a : () => void
+

--- a/tests/cases/conformance/salsa/moduleExportAliasElementAccessExpression.ts
+++ b/tests/cases/conformance/salsa/moduleExportAliasElementAccessExpression.ts
@@ -1,6 +1,7 @@
-// @noEmit: true
+// @declaration: true
 // @checkJs: true
 // @filename: moduleExportAliasElementAccessExpression.js
+// @outdir: out
 
 function D () { }
 exports["D"] = D;

--- a/tests/cases/conformance/salsa/moduleExportAliasElementAccessExpression.ts
+++ b/tests/cases/conformance/salsa/moduleExportAliasElementAccessExpression.ts
@@ -5,3 +5,5 @@
 
 function D () { }
 exports["D"] = D;
+ // (the only package I could find that uses spaces in identifiers is webidl-conversions)
+exports["Does not work yet"] = D;

--- a/tests/cases/conformance/salsa/moduleExportDuplicateAlias.ts
+++ b/tests/cases/conformance/salsa/moduleExportDuplicateAlias.ts
@@ -1,0 +1,7 @@
+// @checkJs: true
+// @declaration: true
+// @filename: moduleExportAliasDuplicateAlias.js
+// @outdir: out
+exports.apply = undefined;
+function a() { }
+exports.apply = a;


### PR DESCRIPTION
Previously, the code missed setting the parent pointer for the lhs access expression.
Note that this was not previously an error; you can also avoid the error by setting the exclude flags back to `None`. But I don't think duplicate exports are that common, and non-checkjs users aren't going to see the error anyway.

Also add declaration emit of element access expressions, missed in my previous PR.

Fixes #40228
