### PR TITLE
Add quick fix to add 'void' to Promise resolved without value

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3039,6 +3039,10 @@
         "category": "Error",
         "code": 2793
     },
+    "Expected {0} arguments, but got {1}. Did you forget to include 'void' in your type argument to 'Promise'?": {
+        "category": "Error",
+        "code": 2794
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -5923,6 +5923,14 @@
         "category": "Message",
         "code": 95142
     },
+    "Add 'void' to Promise resolved without a value": {
+        "category": "Message",
+        "code": 95143
+    },
+    "Add 'void' to all Promises resolved without a value": {
+        "category": "Message",
+        "code": 95144
+    },
 
     "No value exists in scope for the shorthand property '{0}'. Either declare one or provide an initializer.": {
         "category": "Error",

--- a/src/services/codefixes/fixAddVoidToPromise.ts
+++ b/src/services/codefixes/fixAddVoidToPromise.ts
@@ -1,0 +1,87 @@
+/* @internal */
+namespace ts.codefix {
+    const fixName = "addVoidToPromise";
+    const fixId = "addVoidToPromise";
+    const errorCodes = [
+        Diagnostics.Expected_0_arguments_but_got_1.code
+    ];
+    registerCodeFix({
+        errorCodes,
+        fixIds: [fixId],
+        getCodeActions(context) {
+            const changes = textChanges.ChangeTracker.with(context, t => makeChange(t, context.sourceFile, context.span, context.program));
+            if (changes.length > 0) {
+                return [createCodeFixAction(fixName, changes, Diagnostics.Add_void_to_Promise_resolved_without_a_value, fixId, Diagnostics.Add_void_to_all_Promises_resolved_without_a_value)];
+            }
+        },
+        getAllCodeActions(context: CodeFixAllContext) {
+            return codeFixAll(context, errorCodes, (changes, diag) => makeChange(changes, diag.file, diag, context.program, new Set()));
+        }
+    });
+
+    function makeChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, span: TextSpan, program: Program, seen?: Set<ParameterDeclaration>) {
+        const node = getTokenAtPosition(sourceFile, span.start);
+        if (!isIdentifier(node) || !isCallExpression(node.parent) || node.parent.expression !== node) return;
+
+        const checker = program.getTypeChecker();
+        const symbol = checker.getSymbolAtLocation(node);
+
+        // decl should be `new Promise((<decl>) => {})`
+        const decl = symbol?.valueDeclaration;
+        if (!decl || !isParameter(decl) || !(isArrowFunction(decl.parent) || isFunctionExpression(decl.parent)) || !isNewExpression(decl.parent.parent) || !isIdentifier(decl.parent.parent.expression)) return;
+
+        // no need to make this change if we have already seen this parameter.
+        if (seen?.has(decl)) return;
+        seen?.add(decl);
+
+        // make sure its the global promise
+        const constructorSymbol = checker.getSymbolAtLocation(decl.parent.parent.expression);
+        if (!constructorSymbol || symbolName(constructorSymbol) !== "Promise" || !isGlobalDeclaration(constructorSymbol.valueDeclaration)) return;
+
+
+        const typeArguments = getEffectiveTypeArguments(decl.parent.parent);
+        if (some(typeArguments)) {
+            // append ` | void` to type argument
+            const typeArgument = typeArguments[0];
+            const needsParens = !isUnionTypeNode(typeArgument) && !isParenthesizedTypeNode(typeArgument) &&
+                isParenthesizedTypeNode(factory.createUnionTypeNode([typeArgument, factory.createKeywordTypeNode(SyntaxKind.VoidKeyword)]).types[0]);
+            if (needsParens) {
+                changes.insertText(sourceFile, typeArgument.pos, "(");
+            }
+            changes.insertText(sourceFile, typeArgument.end, needsParens ? ") | void" : " | void");
+        }
+        else {
+            // make sure the Promise is type is untyped (i.e., `unknown`)
+            const signature = checker.getResolvedSignature(node.parent);
+            const parameter = signature?.parameters[0];
+            const parameterType = parameter && checker.getTypeOfSymbolAtLocation(parameter, decl.parent.parent);
+            if (isInJSFile(decl)) {
+                if (!parameterType || parameterType.flags & TypeFlags.AnyOrUnknown) {
+                    // give the expression a type
+                    changes.insertText(sourceFile, decl.parent.parent.end, `)`);
+                    changes.insertText(sourceFile, skipTrivia(sourceFile.text, decl.parent.parent.pos), `/** @type {Promise<void>} */(`);
+                }
+            }
+            else {
+                if (!parameterType || parameterType.flags & TypeFlags.Unknown) {
+                    // add `void` type argument
+                    changes.insertText(sourceFile, decl.parent.parent.expression.end, "<void>");
+                }
+            }
+        }
+    }
+
+    function getEffectiveTypeArguments(node: NewExpression) {
+        if (isInJSFile(node)) {
+            if (isParenthesizedExpression(node.parent)) {
+                const jsDocType = getJSDocTypeTag(node.parent)?.typeExpression.type;
+                if (jsDocType && isTypeReferenceNode(jsDocType) && isIdentifier(jsDocType.typeName) && idText(jsDocType.typeName) === "Promise") {
+                    return jsDocType.typeArguments;
+                }
+            }
+        }
+        else {
+            return node.typeArguments;
+        }
+    }
+}

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -107,6 +107,7 @@
         "codefixes/splitTypeOnlyImport.ts",
         "codefixes/convertConstToLet.ts",
         "codefixes/fixExpectedComma.ts",
+        "codefixes/fixAddVoidToPromise.ts",
         "refactors/convertExport.ts",
         "refactors/convertImport.ts",
         "refactors/convertToOptionalChainExpression.ts",

--- a/tests/cases/fourslash/codeFixAddVoidToPromise.1.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromise.1.ts
@@ -7,7 +7,7 @@
 ////const p1 = new Promise(resolve => resolve());
 
 verify.codeFix({
-    errorCode: 2554,
+    errorCode: 2794,
     description: "Add 'void' to Promise resolved without a value",
     index: 0,
     newFileContent: `const p1 = new Promise<void>(resolve => resolve());`

--- a/tests/cases/fourslash/codeFixAddVoidToPromise.1.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromise.1.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+// @target: esnext
+// @lib: es2015
+// @strict: true
+
+////const p1 = new Promise(resolve => resolve());
+
+verify.codeFix({
+    errorCode: 2554,
+    description: "Add 'void' to Promise resolved without a value",
+    index: 0,
+    newFileContent: `const p1 = new Promise<void>(resolve => resolve());`
+});

--- a/tests/cases/fourslash/codeFixAddVoidToPromise.2.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromise.2.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+// @target: esnext
+// @lib: es2015
+// @strict: true
+
+////const p2 = new Promise<number>(resolve => resolve());
+
+verify.codeFix({
+    errorCode: 2554,
+    description: "Add 'void' to Promise resolved without a value",
+    index: 0,
+    newFileContent: `const p2 = new Promise<number | void>(resolve => resolve());`
+});

--- a/tests/cases/fourslash/codeFixAddVoidToPromise.2.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromise.2.ts
@@ -7,7 +7,7 @@
 ////const p2 = new Promise<number>(resolve => resolve());
 
 verify.codeFix({
-    errorCode: 2554,
+    errorCode: 2794,
     description: "Add 'void' to Promise resolved without a value",
     index: 0,
     newFileContent: `const p2 = new Promise<number | void>(resolve => resolve());`

--- a/tests/cases/fourslash/codeFixAddVoidToPromise.3.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromise.3.ts
@@ -7,7 +7,7 @@
 ////const p3 = new Promise<number | string>(resolve => resolve());
 
 verify.codeFix({
-    errorCode: 2554,
+    errorCode: 2794,
     description: "Add 'void' to Promise resolved without a value",
     index: 0,
     newFileContent: `const p3 = new Promise<number | string | void>(resolve => resolve());`

--- a/tests/cases/fourslash/codeFixAddVoidToPromise.3.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromise.3.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+// @target: esnext
+// @lib: es2015
+// @strict: true
+
+////const p3 = new Promise<number | string>(resolve => resolve());
+
+verify.codeFix({
+    errorCode: 2554,
+    description: "Add 'void' to Promise resolved without a value",
+    index: 0,
+    newFileContent: `const p3 = new Promise<number | string | void>(resolve => resolve());`
+});

--- a/tests/cases/fourslash/codeFixAddVoidToPromise.4.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromise.4.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+// @target: esnext
+// @lib: es2015
+// @strict: true
+
+////const p4 = new Promise<{ x: number } & { y: string }>(resolve => resolve());
+
+verify.codeFix({
+    errorCode: 2554,
+    description: "Add 'void' to Promise resolved without a value",
+    index: 0,
+    newFileContent: `const p4 = new Promise<({ x: number } & { y: string }) | void>(resolve => resolve());`
+});

--- a/tests/cases/fourslash/codeFixAddVoidToPromise.4.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromise.4.ts
@@ -7,7 +7,7 @@
 ////const p4 = new Promise<{ x: number } & { y: string }>(resolve => resolve());
 
 verify.codeFix({
-    errorCode: 2554,
+    errorCode: 2794,
     description: "Add 'void' to Promise resolved without a value",
     index: 0,
     newFileContent: `const p4 = new Promise<({ x: number } & { y: string }) | void>(resolve => resolve());`

--- a/tests/cases/fourslash/codeFixAddVoidToPromise.5.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromise.5.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts' />
+
+// @target: esnext
+// @lib: es2015
+// @strict: true
+
+////const p4: Promise<number> = new Promise(resolve => resolve());
+
+verify.not.codeFixAvailable();

--- a/tests/cases/fourslash/codeFixAddVoidToPromiseJS.1.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromiseJS.1.ts
@@ -9,7 +9,7 @@
 ////const p1 = new Promise(resolve => resolve());
 
 verify.codeFix({
-    errorCode: 2554,
+    errorCode: 2794,
     description: "Add 'void' to Promise resolved without a value",
     index: 2,
     newFileContent: `const p1 = /** @type {Promise<void>} */(new Promise(resolve => resolve()));`

--- a/tests/cases/fourslash/codeFixAddVoidToPromiseJS.1.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromiseJS.1.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+// @target: esnext
+// @lib: es2015
+// @strict: true
+// @allowJS: true
+// @checkJS: true
+// @filename: main.js
+////const p1 = new Promise(resolve => resolve());
+
+verify.codeFix({
+    errorCode: 2554,
+    description: "Add 'void' to Promise resolved without a value",
+    index: 2,
+    newFileContent: `const p1 = /** @type {Promise<void>} */(new Promise(resolve => resolve()));`
+});

--- a/tests/cases/fourslash/codeFixAddVoidToPromiseJS.2.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromiseJS.2.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+// @target: esnext
+// @lib: es2015
+// @strict: true
+// @allowJS: true
+// @checkJS: true
+// @filename: main.js
+////const p2 = /** @type {Promise<number>} */(new Promise(resolve => resolve()));
+
+verify.codeFix({
+    errorCode: 2554,
+    description: "Add 'void' to Promise resolved without a value",
+    index: 2,
+    newFileContent: `const p2 = /** @type {Promise<number | void>} */(new Promise(resolve => resolve()));`
+});

--- a/tests/cases/fourslash/codeFixAddVoidToPromiseJS.2.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromiseJS.2.ts
@@ -9,7 +9,7 @@
 ////const p2 = /** @type {Promise<number>} */(new Promise(resolve => resolve()));
 
 verify.codeFix({
-    errorCode: 2554,
+    errorCode: 2794,
     description: "Add 'void' to Promise resolved without a value",
     index: 2,
     newFileContent: `const p2 = /** @type {Promise<number | void>} */(new Promise(resolve => resolve()));`

--- a/tests/cases/fourslash/codeFixAddVoidToPromiseJS.3.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromiseJS.3.ts
@@ -9,7 +9,7 @@
 ////const p3 = /** @type {Promise<number | string>} */(new Promise(resolve => resolve()));
 
 verify.codeFix({
-    errorCode: 2554,
+    errorCode: 2794,
     description: "Add 'void' to Promise resolved without a value",
     index: 2,
     newFileContent: `const p3 = /** @type {Promise<number | string | void>} */(new Promise(resolve => resolve()));`

--- a/tests/cases/fourslash/codeFixAddVoidToPromiseJS.3.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromiseJS.3.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+// @target: esnext
+// @lib: es2015
+// @strict: true
+// @allowJS: true
+// @checkJS: true
+// @filename: main.js
+////const p3 = /** @type {Promise<number | string>} */(new Promise(resolve => resolve()));
+
+verify.codeFix({
+    errorCode: 2554,
+    description: "Add 'void' to Promise resolved without a value",
+    index: 2,
+    newFileContent: `const p3 = /** @type {Promise<number | string | void>} */(new Promise(resolve => resolve()));`
+});

--- a/tests/cases/fourslash/codeFixAddVoidToPromiseJS.4.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromiseJS.4.ts
@@ -9,7 +9,7 @@
 ////const p4 = /** @type {Promise<{ x: number } & { y: string }>} */(new Promise(resolve => resolve()));
 
 verify.codeFix({
-    errorCode: 2554,
+    errorCode: 2794,
     description: "Add 'void' to Promise resolved without a value",
     index: 2,
     newFileContent: `const p4 = /** @type {Promise<({ x: number } & { y: string }) | void>} */(new Promise(resolve => resolve()));`

--- a/tests/cases/fourslash/codeFixAddVoidToPromiseJS.4.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromiseJS.4.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+// @target: esnext
+// @lib: es2015
+// @strict: true
+// @allowJS: true
+// @checkJS: true
+// @filename: main.js
+////const p4 = /** @type {Promise<{ x: number } & { y: string }>} */(new Promise(resolve => resolve()));
+
+verify.codeFix({
+    errorCode: 2554,
+    description: "Add 'void' to Promise resolved without a value",
+    index: 2,
+    newFileContent: `const p4 = /** @type {Promise<({ x: number } & { y: string }) | void>} */(new Promise(resolve => resolve()));`
+});

--- a/tests/cases/fourslash/codeFixAddVoidToPromiseJS.5.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromiseJS.5.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts' />
+
+// @target: esnext
+// @lib: es2015
+// @strict: true
+// @allowJS: true
+// @checkJS: true
+// @filename: main.js
+/////** @type {Promise<number>} */
+////const p2 = new Promise(resolve => resolve());
+
+verify.not.codeFixAvailable("Add 'void' to Promise resolved without a value");

--- a/tests/cases/fourslash/codeFixAddVoidToPromiseJS_all.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromiseJS_all.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+// @target: esnext
+// @lib: es2015
+// @strict: true
+// @allowJS: true
+// @checkJS: true
+// @filename: main.js
+////const p1 = new Promise(resolve => resolve());
+////const p2 = /** @type {Promise<number>} */(new Promise(resolve => resolve()));
+////const p3 = /** @type {Promise<number | string>} */(new Promise(resolve => resolve()));
+////const p4 = /** @type {Promise<{ x: number } & { y: string }>} */(new Promise(resolve => resolve()));
+
+verify.codeFixAll({
+    fixId: "addVoidToPromise",
+    fixAllDescription: ts.Diagnostics.Add_void_to_all_Promises_resolved_without_a_value.message,
+    newFileContent: `const p1 = /** @type {Promise<void>} */(new Promise(resolve => resolve()));
+const p2 = /** @type {Promise<number | void>} */(new Promise(resolve => resolve()));
+const p3 = /** @type {Promise<number | string | void>} */(new Promise(resolve => resolve()));
+const p4 = /** @type {Promise<({ x: number } & { y: string }) | void>} */(new Promise(resolve => resolve()));`
+});

--- a/tests/cases/fourslash/codeFixAddVoidToPromise_all.ts
+++ b/tests/cases/fourslash/codeFixAddVoidToPromise_all.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+
+// @target: esnext
+// @lib: es2015
+// @strict: true
+
+////const p1 = new Promise(resolve => resolve());
+////const p2 = new Promise<number>(resolve => resolve());
+////const p3 = new Promise<number | string>(resolve => resolve());
+////const p4 = new Promise<{ x: number } & { y: string }>(resolve => resolve());
+
+verify.codeFixAll({
+    fixId: "addVoidToPromise",
+    fixAllDescription: ts.Diagnostics.Add_void_to_all_Promises_resolved_without_a_value.message,
+    newFileContent: `const p1 = new Promise<void>(resolve => resolve());
+const p2 = new Promise<number | void>(resolve => resolve());
+const p3 = new Promise<number | string | void>(resolve => resolve());
+const p4 = new Promise<({ x: number } & { y: string }) | void>(resolve => resolve());`
+});

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceComputedPropertyNameWellKnownSymbols.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceComputedPropertyNameWellKnownSymbols.ts
@@ -47,7 +47,7 @@ class C implements I<number> {
         throw new Error("Method not implemented.");
     }
     [Symbol.match]: boolean;
-    [Symbol.replace](...args: {}) {
+    [Symbol.replace](...args: any[]) {
         throw new Error("Method not implemented.");
     }
     [Symbol.search](str: string): number {
@@ -56,7 +56,7 @@ class C implements I<number> {
     [Symbol.species](): number {
         throw new Error("Method not implemented.");
     }
-    [Symbol.split](str: string, limit?: number): {} {
+    [Symbol.split](str: string, limit?: number): string[] {
         throw new Error("Method not implemented.");
     }
     [Symbol.toPrimitive](hint: "number"): number;
@@ -65,7 +65,7 @@ class C implements I<number> {
     [Symbol.toPrimitive](hint: any) {
         throw new Error("Method not implemented.");
     }
-    [Symbol.toStringTag]: string\;
+    [Symbol.toStringTag]: string;
     [Symbol.unscopables]: any;
 }`,
 });

--- a/tests/cases/fourslash/incrementalParsingDynamicImport1.ts
+++ b/tests/cases/fourslash/incrementalParsingDynamicImport1.ts
@@ -11,7 +11,7 @@
 //// })
 //// /*1*/
 
-verify.numberOfErrorsInCurrentFile(2);
+verify.numberOfErrorsInCurrentFile(1);
 goTo.marker("1");
 edit.insert("  ");
-verify.numberOfErrorsInCurrentFile(2);
+verify.numberOfErrorsInCurrentFile(1);

--- a/tests/cases/fourslash/incrementalParsingDynamicImport3.ts
+++ b/tests/cases/fourslash/incrementalParsingDynamicImport3.ts
@@ -11,4 +11,4 @@
 verify.numberOfErrorsInCurrentFile(0);
 goTo.marker("1");
 edit.insert("(");
-verify.numberOfErrorsInCurrentFile(3);
+verify.numberOfErrorsInCurrentFile(1);


### PR DESCRIPTION
This adds a quick fix to add `void` to a `Promise` that is resolved without a value, i.e. `new Promise(resolve => resolve())`.

The quick fix is designed to work both in TypeScript, and a few limited cases of JavaScript as well:

**TypeScript:**
- `new Promise(resolve => resolve())` -> `new Promise<void>(resolve => resolve())`
- `new Promise<number>(resolve => resolve())` -> `new Promise<number | void>(resolve => resolve())`
- `new Promise<number | string>(resolve => resolve())` -> `new Promise<number | string | void>(resolve => resolve())`
- `new Promise<{ x: number } & { y: number }>(resolve => resolve())` -> `new Promise<({ x: number } & { y: number }) | void>(resolve => resolve())`

**JavaScript:**

As there is no way to specify type arguments directly using JSDoc in a JS file, this works by inserting or modifying an `/** @type {} */(...)` cast around the call to `new Promise(...)`:

- `new Promise(resolve => resolve())` -> `/** @type {Promise<void>} */(new Promise(resolve => resolve()))`
- `/** @type {Promise<number>} */(new Promise(resolve => resolve()))` -> `/** @type {Promise<number | void>} */(new Promise(resolve => resolve()))`
- `/** @type {Promise<number | string>} */(new Promise(resolve => resolve()))` -> `/** @type {Promise<number | string | void>} */(new Promise(resolve => resolve()))`
- `/** @type {Promise<{ x: number } & { y: string }>} */(new Promise(resolve => resolve()))` -> `/** @type {Promise<({ x: number } & { y: string }) | void>} */(new Promise(resolve => resolve()))`

The quick fix is not supported on a `new Promise` with a contextual type in either TS or JS currently, as that could have further-reaching side-effects