### PR TITLE
Add pyright user test

### DIFF
--- a/tests/baselines/reference/docker/pyright.log
+++ b/tests/baselines/reference/docker/pyright.log
@@ -1,0 +1,9 @@
+Exit Code: 0
+Standard output:
+
+
+
+Standard error:
+lerna notice cli vX.X.X
+lerna info Executing command in 3 packages: "tsc --noEmit"
+lerna success exec Executed command in 3 packages: "tsc --noEmit"

--- a/tests/cases/docker/pyright/Dockerfile
+++ b/tests/cases/docker/pyright/Dockerfile
@@ -6,6 +6,5 @@ RUN npm i
 COPY --from=typescript/typescript /typescript/typescript-*.tgz /typescript.tgz
 RUN npm install /typescript.tgz --exact --ignore-scripts --save-dev
 RUN npx lerna exec --stream --concurrency 1 -- npm install /typescript.tgz --exact --ignore-scripts --save-dev
-WORKDIR /pyright/packages/pyright
 ENTRYPOINT [ "npx" ]
-CMD [ "webpack", "--mode", "production" ]
+CMD [ "lerna", "exec", "--stream",  "--concurrency", "1", "--no-bail", "--", "tsc", "--noEmit" ]

--- a/tests/cases/docker/pyright/Dockerfile
+++ b/tests/cases/docker/pyright/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:current
+RUN git clone https://github.com/microsoft/pyright.git /pyright
+WORKDIR /pyright
+RUN git pull
+RUN npm i
+COPY --from=typescript/typescript /typescript/typescript-*.tgz /typescript.tgz
+RUN npm install /typescript.tgz --exact --ignore-scripts --save-dev
+RUN npx lerna exec --stream --concurrency 1 -- npm install /typescript.tgz --exact --ignore-scripts --save-dev
+WORKDIR /pyright/packages/pyright
+ENTRYPOINT [ "npx" ]
+CMD [ "webpack", "--mode", "production" ]


### PR DESCRIPTION
Fixes #40360

The initial log will be:
```
Exit Code: 2
Standard output:
ERROR in /pyright/packages/pyright-internal/src/common/deferred.ts
../pyright-internal/src/common/deferred.ts
[tsl] ERROR in /pyright/packages/pyright-internal/src/common/deferred.ts(27,13)
      TS2322: Type '(value: T | PromiseLike<T>) => void' is not assignable to type '(value?: T | PromiseLike<T> | undefined) => void'.
  Types of parameters 'value' and 'value' are incompatible.
    Type 'T | PromiseLike<T> | undefined' is not assignable to type 'T | PromiseLike<T>'.
      Type 'undefined' is not assignable to type 'T | PromiseLike<T>'.
ERROR in /pyright/packages/pyright-internal/src/languageServerBase.ts
../pyright-internal/src/languageServerBase.ts
[tsl] ERROR in /pyright/packages/pyright-internal/src/languageServerBase.ts(235,24)
      TS1243: 'async' modifier cannot be used with 'abstract' modifier.
ERROR in /pyright/packages/pyright-internal/src/languageServerBase.ts
../pyright-internal/src/languageServerBase.ts
[tsl] ERROR in /pyright/packages/pyright-internal/src/languageServerBase.ts(244,24)
      TS1243: 'async' modifier cannot be used with 'abstract' modifier.
ERROR in /pyright/packages/pyright-internal/src/languageServerBase.ts
../pyright-internal/src/languageServerBase.ts
[tsl] ERROR in /pyright/packages/pyright-internal/src/languageServerBase.ts(249,14)
      TS1243: 'async' modifier cannot be used with 'abstract' modifier.



Standard error:
```
- it looks like they're a little broken by the `Promise` signature change _and_ by the `async abstract` change.
