### PR TITLE
`performanceTimestamp`: use `performance.now` on node

### DIFF
--- a/src/compiler/performanceTimestamp.ts
+++ b/src/compiler/performanceTimestamp.ts
@@ -1,6 +1,26 @@
 /*@internal*/
 namespace ts {
     declare const performance: { now?(): number } | undefined;
+    function tryGlobalPerformanceNow() { // browsers
+        if (typeof performance !== "undefined") return () => performance.now!();
+    }
+    function tryNodePerformanceNow() { // node
+        try {
+            const perf_hooks = require("perf_hooks") as typeof import("perf_hooks");
+            if (perf_hooks.performance) return () => perf_hooks.performance.now();
+        }
+        // eslint-disable-next-line no-empty
+        catch {
+        }
+    }
+    function tryDateNow() {
+        if (Date.now) return () => Date.now();
+    }
     /** Gets a timestamp with (at least) ms resolution */
-    export const timestamp = typeof performance !== "undefined" && performance.now ? () => performance.now!() : Date.now ? Date.now : () => +(new Date());
+    export const timestamp: () => number =
+        tryGlobalPerformanceNow()
+        || tryNodePerformanceNow()
+        || tryDateNow()
+        || (() => +(new Date()));
+
 }

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -1205,7 +1205,7 @@ interface Array<T> { length: number; [n: number]: T; }`
     function baselineOutputs(baseline: string[], output: readonly string[], start: number, end = output.length) {
         let baselinedOutput: string[] | undefined;
         for (let i = start; i < end; i++) {
-            (baselinedOutput ||= []).push(output[i].replace(/Elapsed::\s[0-9]+ms/g, "Elapsed:: *ms"));
+            (baselinedOutput ||= []).push(output[i].replace(/Elapsed::\s[0-9]+(?:\.\d+)?ms/g, "Elapsed:: *ms"));
         }
         if (baselinedOutput) baseline.push(baselinedOutput.join(""));
     }


### PR DESCRIPTION
On node, `performance` is found in `require("perf_hooks")`.

Fixes #40591.