### PR TITLE
Map over unions when getting iterated element type from contextual type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23651,7 +23651,10 @@ namespace ts {
         function getContextualTypeForElementExpression(arrayContextualType: Type | undefined, index: number): Type | undefined {
             return arrayContextualType && (
                 getTypeOfPropertyOfContextualType(arrayContextualType, "" + index as __String)
-                || getIteratedTypeOrElementType(IterationUse.Element, arrayContextualType, undefinedType, /*errorNode*/ undefined, /*checkAssignability*/ false));
+                || mapType(
+                    arrayContextualType,
+                    t => getIteratedTypeOrElementType(IterationUse.Element, t, undefinedType, /*errorNode*/ undefined, /*checkAssignability*/ false),
+                    /*noReductions*/ true));
         }
 
         // In a contextually typed conditional expression, the true/false expressions are contextually typed by the same type.

--- a/tests/baselines/reference/contextualTypeIterableUnions.js
+++ b/tests/baselines/reference/contextualTypeIterableUnions.js
@@ -1,0 +1,17 @@
+//// [contextualTypeIterableUnions.ts]
+declare class DMap<K, V>  {
+  constructor(iterable: Iterable<[K, V]> | undefined);
+}
+new DMap([["1", 2]]);
+
+const i1: Iterable<{ a: true }> | undefined = [{ a: true }];
+const i2: Iterable<{ a: true }> | Iterable<{ b: false }> = [{ b: false }];
+const i3: Iterable<number> | 1[] = [2];
+
+
+//// [contextualTypeIterableUnions.js]
+"use strict";
+new DMap([["1", 2]]);
+const i1 = [{ a: true }];
+const i2 = [{ b: false }];
+const i3 = [2];

--- a/tests/baselines/reference/contextualTypeIterableUnions.symbols
+++ b/tests/baselines/reference/contextualTypeIterableUnions.symbols
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/contextualTypeIterableUnions.ts ===
+declare class DMap<K, V>  {
+>DMap : Symbol(DMap, Decl(contextualTypeIterableUnions.ts, 0, 0))
+>K : Symbol(K, Decl(contextualTypeIterableUnions.ts, 0, 19))
+>V : Symbol(V, Decl(contextualTypeIterableUnions.ts, 0, 21))
+
+  constructor(iterable: Iterable<[K, V]> | undefined);
+>iterable : Symbol(iterable, Decl(contextualTypeIterableUnions.ts, 1, 14))
+>Iterable : Symbol(Iterable, Decl(lib.es2015.iterable.d.ts, --, --))
+>K : Symbol(K, Decl(contextualTypeIterableUnions.ts, 0, 19))
+>V : Symbol(V, Decl(contextualTypeIterableUnions.ts, 0, 21))
+}
+new DMap([["1", 2]]);
+>DMap : Symbol(DMap, Decl(contextualTypeIterableUnions.ts, 0, 0))
+
+const i1: Iterable<{ a: true }> | undefined = [{ a: true }];
+>i1 : Symbol(i1, Decl(contextualTypeIterableUnions.ts, 5, 5))
+>Iterable : Symbol(Iterable, Decl(lib.es2015.iterable.d.ts, --, --))
+>a : Symbol(a, Decl(contextualTypeIterableUnions.ts, 5, 20))
+>a : Symbol(a, Decl(contextualTypeIterableUnions.ts, 5, 48))
+
+const i2: Iterable<{ a: true }> | Iterable<{ b: false }> = [{ b: false }];
+>i2 : Symbol(i2, Decl(contextualTypeIterableUnions.ts, 6, 5))
+>Iterable : Symbol(Iterable, Decl(lib.es2015.iterable.d.ts, --, --))
+>a : Symbol(a, Decl(contextualTypeIterableUnions.ts, 6, 20))
+>Iterable : Symbol(Iterable, Decl(lib.es2015.iterable.d.ts, --, --))
+>b : Symbol(b, Decl(contextualTypeIterableUnions.ts, 6, 44))
+>b : Symbol(b, Decl(contextualTypeIterableUnions.ts, 6, 61))
+
+const i3: Iterable<number> | 1[] = [2];
+>i3 : Symbol(i3, Decl(contextualTypeIterableUnions.ts, 7, 5))
+>Iterable : Symbol(Iterable, Decl(lib.es2015.iterable.d.ts, --, --))
+

--- a/tests/baselines/reference/contextualTypeIterableUnions.types
+++ b/tests/baselines/reference/contextualTypeIterableUnions.types
@@ -1,0 +1,40 @@
+=== tests/cases/compiler/contextualTypeIterableUnions.ts ===
+declare class DMap<K, V>  {
+>DMap : DMap<K, V>
+
+  constructor(iterable: Iterable<[K, V]> | undefined);
+>iterable : Iterable<[K, V]> | undefined
+}
+new DMap([["1", 2]]);
+>new DMap([["1", 2]]) : DMap<string, number>
+>DMap : typeof DMap
+>[["1", 2]] : [string, number][]
+>["1", 2] : [string, number]
+>"1" : "1"
+>2 : 2
+
+const i1: Iterable<{ a: true }> | undefined = [{ a: true }];
+>i1 : Iterable<{ a: true; }> | undefined
+>a : true
+>true : true
+>[{ a: true }] : { a: true; }[]
+>{ a: true } : { a: true; }
+>a : true
+>true : true
+
+const i2: Iterable<{ a: true }> | Iterable<{ b: false }> = [{ b: false }];
+>i2 : Iterable<{ a: true; }> | Iterable<{ b: false; }>
+>a : true
+>true : true
+>b : false
+>false : false
+>[{ b: false }] : { b: false; }[]
+>{ b: false } : { b: false; }
+>b : false
+>false : false
+
+const i3: Iterable<number> | 1[] = [2];
+>i3 : Iterable<number> | 1[]
+>[2] : 2[]
+>2 : 2
+

--- a/tests/cases/compiler/contextualTypeIterableUnions.ts
+++ b/tests/cases/compiler/contextualTypeIterableUnions.ts
@@ -1,0 +1,11 @@
+// @strict: true
+// @target: esnext
+
+declare class DMap<K, V>  {
+  constructor(iterable: Iterable<[K, V]> | undefined);
+}
+new DMap([["1", 2]]);
+
+const i1: Iterable<{ a: true }> | undefined = [{ a: true }];
+const i2: Iterable<{ a: true }> | Iterable<{ b: false }> = [{ b: false }];
+const i3: Iterable<number> | 1[] = [2];


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #40587

#40350 makes `Iterable<T> | undefined` non-iterable, which is correct on its face, but we failed to map over unions when looking at contextual types, so `const x: Iterable<1> | undefined = [1]` was an error, because we were looking for the iteration types of the union (which has none) rather than looking at iteration types provided by each constituent in the union.
