### PR TITLE
Handle the mapping between Array and ReadonlyArray in isTypeDerivedFrom

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15349,7 +15349,7 @@ namespace ts {
                 source.flags & TypeFlags.InstantiableNonPrimitive ? isTypeDerivedFrom(getBaseConstraintOfType(source) || unknownType, target) :
                 target === globalObjectType ? !!(source.flags & (TypeFlags.Object | TypeFlags.NonPrimitive)) :
                 target === globalFunctionType ? !!(source.flags & TypeFlags.Object) && isFunctionObjectType(source as ObjectType) :
-                hasBaseType(source, getTargetType(target));
+                hasBaseType(source, getTargetType(target)) || (isArrayType(target) && !isReadonlyArrayType(target) && isTypeDerivedFrom(source, globalReadonlyArrayType));
         }
 
         /**

--- a/tests/baselines/reference/instanceofNarrowReadonlyArray.js
+++ b/tests/baselines/reference/instanceofNarrowReadonlyArray.js
@@ -1,0 +1,21 @@
+//// [instanceofNarrowReadonlyArray.ts]
+// @strict
+
+function narrow(x: readonly number[] | number): readonly number[] {
+    if (x instanceof Array) {
+        return x;
+    } else {
+        return [x];
+    }
+}
+
+//// [instanceofNarrowReadonlyArray.js]
+// @strict
+function narrow(x) {
+    if (x instanceof Array) {
+        return x;
+    }
+    else {
+        return [x];
+    }
+}

--- a/tests/baselines/reference/instanceofNarrowReadonlyArray.symbols
+++ b/tests/baselines/reference/instanceofNarrowReadonlyArray.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/instanceofNarrowReadonlyArray.ts ===
+// @strict
+
+function narrow(x: readonly number[] | number): readonly number[] {
+>narrow : Symbol(narrow, Decl(instanceofNarrowReadonlyArray.ts, 0, 0))
+>x : Symbol(x, Decl(instanceofNarrowReadonlyArray.ts, 2, 16))
+
+    if (x instanceof Array) {
+>x : Symbol(x, Decl(instanceofNarrowReadonlyArray.ts, 2, 16))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+        return x;
+>x : Symbol(x, Decl(instanceofNarrowReadonlyArray.ts, 2, 16))
+
+    } else {
+        return [x];
+>x : Symbol(x, Decl(instanceofNarrowReadonlyArray.ts, 2, 16))
+    }
+}

--- a/tests/baselines/reference/instanceofNarrowReadonlyArray.types
+++ b/tests/baselines/reference/instanceofNarrowReadonlyArray.types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/instanceofNarrowReadonlyArray.ts ===
+// @strict
+
+function narrow(x: readonly number[] | number): readonly number[] {
+>narrow : (x: readonly number[] | number) => readonly number[]
+>x : number | readonly number[]
+
+    if (x instanceof Array) {
+>x instanceof Array : boolean
+>x : number | readonly number[]
+>Array : ArrayConstructor
+
+        return x;
+>x : readonly number[]
+
+    } else {
+        return [x];
+>[x] : number[]
+>x : number
+    }
+}

--- a/tests/cases/compiler/instanceofNarrowReadonlyArray.ts
+++ b/tests/cases/compiler/instanceofNarrowReadonlyArray.ts
@@ -1,0 +1,9 @@
+// @strict
+
+function narrow(x: readonly number[] | number): readonly number[] {
+    if (x instanceof Array) {
+        return x;
+    } else {
+        return [x];
+    }
+}


### PR DESCRIPTION
Thus allowing `x instanceof Array` to narrow `ReadonlyArray` types as though they are `Array`s.

Fixes #40527
