### PR TITLE
Add argument types to `URL.createObjectURL`

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -15950,7 +15950,7 @@ interface URL {
 declare var URL: {
     prototype: URL;
     new(url: string, base?: string | URL): URL;
-    createObjectURL(object: any): string;
+    createObjectURL(object: File | Blob | MediaSource): string;
     revokeObjectURL(url: string): void;
 };
 


### PR DESCRIPTION
The function `URL.createObjectURL` currently has an argument of type `any`. However, this is not in line with the types it would like to be parsed.

I suggest changing the argument from type `object: any` to `object: File | Blob | MediaSource`.

This would make make the type more helpful and make it inline with the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL).

I might be missing a type of `null` or `undefined` on the union type but I'm not sure if there is a use case.