### PR TITLE
Fix missing renamed compiler flags

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13922,7 +13922,7 @@ namespace ts {
             }
 
             const shouldIncludeUndefined =
-                compilerOptions.noUncheckedIndexSignatures &&
+                compilerOptions.noUncheckedIndexedAccess &&
                 (accessFlags & (AccessFlags.Writing | AccessFlags.ExpressionPosition)) === AccessFlags.ExpressionPosition;
 
             // If the object type has a string index signature and no other members we know that the result will
@@ -20735,7 +20735,7 @@ namespace ts {
 
         function includeUndefinedInIndexSignature(type: Type | undefined): Type | undefined {
             if (!type) return type;
-            return compilerOptions.noUncheckedIndexSignatures ?
+            return compilerOptions.noUncheckedIndexedAccess ?
                 getUnionType([type, undefinedType]) :
                 type;
         }
@@ -25478,7 +25478,7 @@ namespace ts {
                     error(node, Diagnostics.Index_signature_in_type_0_only_permits_reading, typeToString(apparentType));
                 }
 
-                propType = (compilerOptions.noUncheckedIndexSignatures && !isAssignmentTarget(node)) ? getUnionType([indexInfo.type, undefinedType]) : indexInfo.type;
+                propType = (compilerOptions.noUncheckedIndexedAccess && !isAssignmentTarget(node)) ? getUnionType([indexInfo.type, undefinedType]) : indexInfo.type;
             }
             else {
                 if (prop.valueDeclaration?.flags & NodeFlags.Deprecated && isUncalledFunctionReference(node, prop)) {
@@ -29445,7 +29445,7 @@ namespace ts {
             // present (aka the tuple element property). This call also checks that the parentType is in
             // fact an iterable or array (depending on target language).
             const possiblyOutOfBoundsType = checkIteratedTypeOrElementType(IterationUse.Destructuring | IterationUse.PossiblyOutOfBounds, sourceType, undefinedType, node) || errorType;
-            let inBoundsType: Type | undefined = compilerOptions.noUncheckedIndexSignatures ? undefined: possiblyOutOfBoundsType;
+            let inBoundsType: Type | undefined = compilerOptions.noUncheckedIndexedAccess ? undefined: possiblyOutOfBoundsType;
             for (let i = 0; i < elements.length; i++) {
                 let type = possiblyOutOfBoundsType;
                 if (node.elements[i].kind === SyntaxKind.SpreadElement) {
@@ -33709,7 +33709,7 @@ namespace ts {
 
             const uplevelIteration = languageVersion >= ScriptTarget.ES2015;
             const downlevelIteration = !uplevelIteration && compilerOptions.downlevelIteration;
-            const possibleOutOfBounds = compilerOptions.noUncheckedIndexSignatures && !!(use & IterationUse.PossiblyOutOfBounds);
+            const possibleOutOfBounds = compilerOptions.noUncheckedIndexedAccess && !!(use & IterationUse.PossiblyOutOfBounds);
 
             // Get the iterated type of an `Iterable<T>` or `IterableIterator<T>` only in ES2015
             // or higher, when inside of an async generator or for-await-if, or when
@@ -33804,7 +33804,7 @@ namespace ts {
             const arrayElementType = getIndexTypeOfType(arrayType, IndexKind.Number);
             if (hasStringConstituent && arrayElementType) {
                 // This is just an optimization for the case where arrayOrStringType is string | string[]
-                if (arrayElementType.flags & TypeFlags.StringLike && !compilerOptions.noUncheckedIndexSignatures) {
+                if (arrayElementType.flags & TypeFlags.StringLike && !compilerOptions.noUncheckedIndexedAccess) {
                     return stringType;
                 }
 

--- a/tests/baselines/reference/noUncheckedIndexedAccess.errors.txt
+++ b/tests/baselines/reference/noUncheckedIndexedAccess.errors.txt
@@ -2,6 +2,8 @@ tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts(3,32): error TS2344
   Type 'undefined' is not assignable to type 'boolean'.
 tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts(12,7): error TS2322: Type 'boolean | undefined' is not assignable to type 'boolean'.
   Type 'undefined' is not assignable to type 'boolean'.
+tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts(13,7): error TS2322: Type 'boolean | undefined' is not assignable to type 'boolean'.
+  Type 'undefined' is not assignable to type 'boolean'.
 tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts(14,7): error TS2322: Type 'boolean | undefined' is not assignable to type 'boolean'.
   Type 'undefined' is not assignable to type 'boolean'.
 tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts(15,7): error TS2322: Type 'boolean | undefined' is not assignable to type 'boolean'.
@@ -49,7 +51,7 @@ tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts(79,7): error TS2322
 tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts(85,1): error TS2322: Type 'undefined' is not assignable to type 'string'.
 
 
-==== tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts (27 errors) ====
+==== tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts (28 errors) ====
     type CheckBooleanOnly<T extends boolean> = any;
     // Validate CheckBooleanOnly works - should error
     type T_ERR1 = CheckBooleanOnly<boolean | undefined>;
@@ -69,6 +71,9 @@ tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts(85,1): error TS2322
 !!! error TS2322: Type 'boolean | undefined' is not assignable to type 'boolean'.
 !!! error TS2322:   Type 'undefined' is not assignable to type 'boolean'.
     const e2: boolean = strMap.bar;
+          ~~
+!!! error TS2322: Type 'boolean | undefined' is not assignable to type 'boolean'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'boolean'.
     const e3: boolean = strMap[0];
           ~~
 !!! error TS2322: Type 'boolean | undefined' is not assignable to type 'boolean'.

--- a/tests/baselines/reference/noUncheckedIndexedAccess.types
+++ b/tests/baselines/reference/noUncheckedIndexedAccess.types
@@ -41,9 +41,9 @@ const e1: boolean = strMap["foo"];
 
 const e2: boolean = strMap.bar;
 >e2 : boolean
->strMap.bar : boolean
+>strMap.bar : boolean | undefined
 >strMap : { [s: string]: boolean; }
->bar : boolean
+>bar : boolean | undefined
 
 const e3: boolean = strMap[0];
 >e3 : boolean
@@ -146,9 +146,9 @@ const ok1: boolean | undefined = strMap["foo"];
 
 const ok2: boolean | undefined = strMap.bar;
 >ok2 : boolean | undefined
->strMap.bar : boolean
+>strMap.bar : boolean | undefined
 >strMap : { [s: string]: boolean; }
->bar : boolean
+>bar : boolean | undefined
 
 type T_OK1 = CheckBooleanOnly<(typeof strMap)[string]>;
 >T_OK1 : any

--- a/tests/baselines/reference/noUncheckedIndexedAccessDestructuring.errors.txt
+++ b/tests/baselines/reference/noUncheckedIndexedAccessDestructuring.errors.txt
@@ -1,12 +1,17 @@
+tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts(8,1): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts(12,9): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'string'.
 tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts(16,9): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'string'.
+tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts(23,1): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts(26,1): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts(34,5): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts(41,5): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts(50,2): error TS2322: Type 'string | undefined' is not assignable to type 'string'.
   Type 'undefined' is not assignable to type 'string'.
 tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts(59,8): error TS2322: Type 'number | undefined' is not assignable to type 'number'.
   Type 'undefined' is not assignable to type 'number'.
 
 
-==== tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts (4 errors) ====
+==== tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts (9 errors) ====
     declare const strArray: string[];
     declare const strStrTuple: [string, string];
     
@@ -15,6 +20,8 @@ tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts(59,8):
     // Destructuring from a simple array -> include undefined
     const [s1] = strArray;
     s1.toString(); // Should error, s1 possibly undefined
+    ~~
+!!! error TS2532: Object is possibly 'undefined'.
     
     // Destructuring a rest element -> do not include undefined
     const [...s2] = strArray;
@@ -34,9 +41,13 @@ tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts(59,8):
     
     const { t1 } = strMap;
     t1.toString(); // Should error, t1 possibly undefined
+    ~~
+!!! error TS2532: Object is possibly 'undefined'.
     
     const { ...t2 } = strMap;
     t2.z.toString(); // Should error
+    ~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     
     // Test intersections with declared properties
     declare const numMapPoint: { x: number, y: number} & { [s: string]: number };
@@ -45,6 +56,8 @@ tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts(59,8):
         x.toFixed(); // Should OK
         y.toFixed(); // Should OK
         z.toFixed(); // Should error
+        ~
+!!! error TS2532: Object is possibly 'undefined'.
     }
     
     {
@@ -52,6 +65,8 @@ tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts(59,8):
         x.toFixed(); // Should OK
         q.y.toFixed(); // Should OK
         q.z.toFixed(); // Should error
+        ~~~
+!!! error TS2532: Object is possibly 'undefined'.
     }
     
     

--- a/tests/baselines/reference/noUncheckedIndexedAccessDestructuring.types
+++ b/tests/baselines/reference/noUncheckedIndexedAccessDestructuring.types
@@ -15,7 +15,7 @@ const [s1] = strArray;
 s1.toString(); // Should error, s1 possibly undefined
 >s1.toString() : string
 >s1.toString : () => string
->s1 : string
+>s1 : string | undefined
 >toString : () => string
 
 // Destructuring a rest element -> do not include undefined
@@ -57,7 +57,7 @@ const { t1 } = strMap;
 t1.toString(); // Should error, t1 possibly undefined
 >t1.toString() : string
 >t1.toString : () => string
->t1 : string
+>t1 : string | undefined
 >toString : () => string
 
 const { ...t2 } = strMap;
@@ -67,9 +67,9 @@ const { ...t2 } = strMap;
 t2.z.toString(); // Should error
 >t2.z.toString() : string
 >t2.z.toString : () => string
->t2.z : string
+>t2.z : string | undefined
 >t2 : { [s: string]: string; }
->z : string
+>z : string | undefined
 >toString : () => string
 
 // Test intersections with declared properties
@@ -100,7 +100,7 @@ declare const numMapPoint: { x: number, y: number} & { [s: string]: number };
     z.toFixed(); // Should error
 >z.toFixed() : string
 >z.toFixed : (fractionDigits?: number | undefined) => string
->z : number
+>z : number | undefined
 >toFixed : (fractionDigits?: number | undefined) => string
 }
 
@@ -127,9 +127,9 @@ declare const numMapPoint: { x: number, y: number} & { [s: string]: number };
     q.z.toFixed(); // Should error
 >q.z.toFixed() : string
 >q.z.toFixed : (fractionDigits?: number | undefined) => string
->q.z : number
+>q.z : number | undefined
 >q : { [s: string]: number; y: number; }
->z : number
+>z : number | undefined
 >toFixed : (fractionDigits?: number | undefined) => string
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #40531  

Anyway I found these compilerOptions that seems has not been rename correctly. Does it expected?


