### PR TITLE
Fix premature closing of AutoImportProviderProject for unbuilt monorepos

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1956,7 +1956,7 @@ namespace ts.server {
         }
 
         hasRoots() {
-            return !!this.rootFileNames?.length;
+            return !!ts.some(this.rootFileNames);
         }
 
         markAsDirty() {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1935,6 +1935,7 @@ namespace ts.server {
             this.rootFileNames = initialRootNames;
         }
 
+        /*@internal*/
         isEmpty() {
             return !some(this.rootFileNames);
         }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1955,6 +1955,10 @@ namespace ts.server {
             return super.updateGraph();
         }
 
+        hasRoots() {
+            return !!this.rootFileNames?.length;
+        }
+
         markAsDirty() {
             this.rootFileNames = undefined;
             super.markAsDirty();

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1671,7 +1671,7 @@ namespace ts.server {
             }
             if (this.autoImportProviderHost) {
                 updateProjectIfDirty(this.autoImportProviderHost);
-                if (!this.autoImportProviderHost.hasRoots()) {
+                if (this.autoImportProviderHost.isEmpty()) {
                     this.autoImportProviderHost.close();
                     this.autoImportProviderHost = undefined;
                     return undefined;
@@ -1935,6 +1935,10 @@ namespace ts.server {
             this.rootFileNames = initialRootNames;
         }
 
+        isEmpty() {
+            return !some(this.rootFileNames);
+        }
+
         isOrphan() {
             return true;
         }
@@ -1953,10 +1957,6 @@ namespace ts.server {
             this.rootFileNames = rootFileNames;
             this.hostProject.getImportSuggestionsCache().clear();
             return super.updateGraph();
-        }
-
-        hasRoots() {
-            return !!ts.some(this.rootFileNames);
         }
 
         markAsDirty() {

--- a/src/testRunner/unittests/tsserver/autoImportProvider.ts
+++ b/src/testRunner/unittests/tsserver/autoImportProvider.ts
@@ -283,6 +283,25 @@ namespace ts.projectSystem {
             // Project for A is created - ensure it doesn't have an autoImportProvider
             assert.isUndefined(projectService.configuredProjects.get("/packages/a/tsconfig.json")!.getLanguageService().getAutoImportProvider());
         });
+
+        it("Does not close when root files are redirects that don't actually exist", () => {
+            const files = [
+                // packages/a
+                { path: "/packages/a/package.json", content: `{ "dependencies": { "b": "*" } }` },
+                { path: "/packages/a/tsconfig.json", content: `{ "compilerOptions": { "composite": true }, "references": [{ "path": "./node_modules/b" }] }` },
+                { path: "/packages/a/index.ts", content: "" },
+
+                // packages/b
+                { path: "/packages/a/node_modules/b/package.json", content: `{ "types": "dist/index.d.ts" }` },
+                { path: "/packages/a/node_modules/b/tsconfig.json", content: `{ "compilerOptions": { "composite": true, "outDir": "dist" } }` },
+                { path: "/packages/a/node_modules/b/index.ts", content: `export class B {}` }
+            ];
+
+            const { projectService, session } = setup(files);
+            openFilesForSession([files[2]], session);
+            assert.isDefined(projectService.configuredProjects.get("/packages/a/tsconfig.json")!.getPackageJsonAutoImportProvider());
+            assert.isDefined(projectService.configuredProjects.get("/packages/a/tsconfig.json")!.getPackageJsonAutoImportProvider());
+        });
     });
 
     function setup(files: File[]) {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9360,7 +9360,6 @@ declare namespace ts.server {
         private rootFileNames;
         isOrphan(): boolean;
         updateGraph(): boolean;
-        hasRoots(): boolean;
         markAsDirty(): void;
         getScriptFileNames(): string[];
         getLanguageService(): never;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9360,6 +9360,7 @@ declare namespace ts.server {
         private rootFileNames;
         isOrphan(): boolean;
         updateGraph(): boolean;
+        hasRoots(): boolean;
         markAsDirty(): void;
         getScriptFileNames(): string[];
         getLanguageService(): never;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Discovered while working on something else: if an AutoImportProviderProject only knows about declaration files that will exist according to TS source files and compiler options, but do not actually exist on disk yet, it gets closed unnecessarily because `hasRoots()` only considers files that actually exist.
