### PR TITLE
Proposal: importModuleSpecifierPreference: project-relative

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -16,7 +16,7 @@ namespace ts.moduleSpecifiers {
             relativePreference:
                 importModuleSpecifierPreference === "relative" ? RelativePreference.Relative :
                 importModuleSpecifierPreference === "non-relative" ? RelativePreference.NonRelative :
-                importModuleSpecifierPreference === "external-non-relative" ? RelativePreference.ExternalNonRelative :
+                importModuleSpecifierPreference === "project-relative" ? RelativePreference.ExternalNonRelative :
                 RelativePreference.Shortest,
             ending: getEnding(),
         };

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8149,7 +8149,7 @@ namespace ts {
         readonly includeCompletionsForModuleExports?: boolean;
         readonly includeAutomaticOptionalChainCompletions?: boolean;
         readonly includeCompletionsWithInsertText?: boolean;
-        readonly importModuleSpecifierPreference?: "shortest" | "external-non-relative" | "relative" | "non-relative";
+        readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */
         readonly importModuleSpecifierEnding?: "auto" | "minimal" | "index" | "js";
         readonly allowTextChangesInNewFiles?: boolean;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -7847,6 +7847,7 @@ namespace ts {
         realpath?(path: string): string;
         getSymlinkCache?(): SymlinkCache;
         getGlobalTypingsCacheLocation?(): string | undefined;
+        getNearestAncestorDirectoryWithPackageJson?(fileName: string, rootDir?: string): string | undefined;
 
         getSourceFiles(): readonly SourceFile[];
         readonly redirectTargetsMap: RedirectTargetsMap;
@@ -8148,7 +8149,7 @@ namespace ts {
         readonly includeCompletionsForModuleExports?: boolean;
         readonly includeAutomaticOptionalChainCompletions?: boolean;
         readonly includeCompletionsWithInsertText?: boolean;
-        readonly importModuleSpecifierPreference?: "auto" | "relative" | "non-relative";
+        readonly importModuleSpecifierPreference?: "shortest" | "external-non-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */
         readonly importModuleSpecifierEnding?: "auto" | "minimal" | "index" | "js";
         readonly allowTextChangesInNewFiles?: boolean;

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -2927,6 +2927,10 @@ namespace FourSlash {
             }
             const range = ts.firstOrUndefined(ranges);
 
+            if (preferences) {
+                this.configure(preferences);
+            }
+
             const codeFixes = this.getCodeFixes(fileName, errorCode, preferences).filter(f => f.fixName === ts.codefix.importFixName);
 
             if (codeFixes.length === 0) {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -3778,13 +3778,27 @@ namespace ts.server {
                         const info = packageJsonCache.getInDirectory(directory);
                         if (info) result.push(info);
                 }
-                if (rootPath && rootPath === this.toPath(directory)) {
+                if (rootPath && rootPath === directory) {
                     return true;
                 }
             };
 
             forEachAncestorDirectory(getDirectoryPath(filePath), processDirectory);
             return result;
+        }
+
+        /*@internal*/
+        getNearestAncestorDirectoryWithPackageJson(fileName: string): string | undefined {
+            return forEachAncestorDirectory(fileName, directory => {
+                switch (this.packageJsonCache.directoryHasPackageJson(this.toPath(directory))) {
+                    case Ternary.True: return directory;
+                    case Ternary.False: return undefined;
+                    case Ternary.Maybe:
+                        return this.host.fileExists(combinePaths(directory, "package.json"))
+                            ? directory
+                            : undefined;
+                }
+            });
         }
 
         /*@internal*/

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1626,6 +1626,11 @@ namespace ts.server {
         }
 
         /*@internal*/
+        getNearestAncestorDirectoryWithPackageJson(fileName: string): string | undefined {
+            return this.projectService.getNearestAncestorDirectoryWithPackageJson(fileName);
+        }
+
+        /*@internal*/
         getPackageJsonsForAutoImport(rootDir?: string): readonly PackageJsonInfo[] {
             const packageJsons = this.getPackageJsonsVisibleToFile(combinePaths(this.currentDirectory, inferredTypesContainingFile), rootDir);
             this.packageJsonsForAutoImport = new Set(packageJsons.map(p => p.fileName));
@@ -1953,6 +1958,10 @@ namespace ts.server {
             this.rootFileNames = rootFileNames;
             this.hostProject.getImportSuggestionsCache().clear();
             return super.updateGraph();
+        }
+
+        hasRoots() {
+            return !!this.rootFileNames?.length;
         }
 
         markAsDirty() {

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -3217,7 +3217,7 @@ namespace ts.server.protocol {
          * values, with insertion text to replace preceding `.` tokens with `?.`.
          */
         readonly includeAutomaticOptionalChainCompletions?: boolean;
-        readonly importModuleSpecifierPreference?: "auto" | "relative" | "non-relative";
+        readonly importModuleSpecifierPreference?: "shortest" | "external-non-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */
         readonly importModuleSpecifierEnding?: "auto" | "minimal" | "index" | "js";
         readonly allowTextChangesInNewFiles?: boolean;

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -3217,7 +3217,7 @@ namespace ts.server.protocol {
          * values, with insertion text to replace preceding `.` tokens with `?.`.
          */
         readonly includeAutomaticOptionalChainCompletions?: boolean;
-        readonly importModuleSpecifierPreference?: "shortest" | "external-non-relative" | "relative" | "non-relative";
+        readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */
         readonly importModuleSpecifierEnding?: "auto" | "minimal" | "index" | "js";
         readonly allowTextChangesInNewFiles?: boolean;

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -301,6 +301,8 @@ namespace ts {
         /* @internal */
         getPackageJsonsVisibleToFile?(fileName: string, rootDir?: string): readonly PackageJsonInfo[];
         /* @internal */
+        getNearestAncestorDirectoryWithPackageJson?(fileName: string, rootDir?: string): string | undefined;
+        /* @internal */
         getPackageJsonsForAutoImport?(rootDir?: string): readonly PackageJsonInfo[];
         /* @internal */
         getImportSuggestionsCache?(): Completions.ImportSuggestionsForFileCache;

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -301,7 +301,7 @@ namespace ts {
         /* @internal */
         getPackageJsonsVisibleToFile?(fileName: string, rootDir?: string): readonly PackageJsonInfo[];
         /* @internal */
-        getNearestAncestorDirectoryWithPackageJson?(fileName: string, rootDir?: string): string | undefined;
+        getNearestAncestorDirectoryWithPackageJson?(fileName: string): string | undefined;
         /* @internal */
         getPackageJsonsForAutoImport?(rootDir?: string): readonly PackageJsonInfo[];
         /* @internal */

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1773,7 +1773,8 @@ namespace ts {
             redirectTargetsMap: program.redirectTargetsMap,
             getProjectReferenceRedirect: fileName => program.getProjectReferenceRedirect(fileName),
             isSourceOfProjectReferenceRedirect: fileName => program.isSourceOfProjectReferenceRedirect(fileName),
-            getCompilerOptions: () => program.getCompilerOptions()
+            getCompilerOptions: () => program.getCompilerOptions(),
+            getNearestAncestorDirectoryWithPackageJson: maybeBind(host, host.getNearestAncestorDirectoryWithPackageJson),
         };
     }
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3868,7 +3868,7 @@ declare namespace ts {
         readonly includeCompletionsForModuleExports?: boolean;
         readonly includeAutomaticOptionalChainCompletions?: boolean;
         readonly includeCompletionsWithInsertText?: boolean;
-        readonly importModuleSpecifierPreference?: "shortest" | "external-non-relative" | "relative" | "non-relative";
+        readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */
         readonly importModuleSpecifierEnding?: "auto" | "minimal" | "index" | "js";
         readonly allowTextChangesInNewFiles?: boolean;
@@ -8984,7 +8984,7 @@ declare namespace ts.server.protocol {
          * values, with insertion text to replace preceding `.` tokens with `?.`.
          */
         readonly includeAutomaticOptionalChainCompletions?: boolean;
-        readonly importModuleSpecifierPreference?: "shortest" | "external-non-relative" | "relative" | "non-relative";
+        readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */
         readonly importModuleSpecifierEnding?: "auto" | "minimal" | "index" | "js";
         readonly allowTextChangesInNewFiles?: boolean;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3868,7 +3868,7 @@ declare namespace ts {
         readonly includeCompletionsForModuleExports?: boolean;
         readonly includeAutomaticOptionalChainCompletions?: boolean;
         readonly includeCompletionsWithInsertText?: boolean;
-        readonly importModuleSpecifierPreference?: "auto" | "relative" | "non-relative";
+        readonly importModuleSpecifierPreference?: "shortest" | "external-non-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */
         readonly importModuleSpecifierEnding?: "auto" | "minimal" | "index" | "js";
         readonly allowTextChangesInNewFiles?: boolean;
@@ -8984,7 +8984,7 @@ declare namespace ts.server.protocol {
          * values, with insertion text to replace preceding `.` tokens with `?.`.
          */
         readonly includeAutomaticOptionalChainCompletions?: boolean;
-        readonly importModuleSpecifierPreference?: "auto" | "relative" | "non-relative";
+        readonly importModuleSpecifierPreference?: "shortest" | "external-non-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */
         readonly importModuleSpecifierEnding?: "auto" | "minimal" | "index" | "js";
         readonly allowTextChangesInNewFiles?: boolean;
@@ -9360,6 +9360,7 @@ declare namespace ts.server {
         private rootFileNames;
         isOrphan(): boolean;
         updateGraph(): boolean;
+        hasRoots(): boolean;
         markAsDirty(): void;
         getScriptFileNames(): string[];
         getLanguageService(): never;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3868,7 +3868,7 @@ declare namespace ts {
         readonly includeCompletionsForModuleExports?: boolean;
         readonly includeAutomaticOptionalChainCompletions?: boolean;
         readonly includeCompletionsWithInsertText?: boolean;
-        readonly importModuleSpecifierPreference?: "shortest" | "external-non-relative" | "relative" | "non-relative";
+        readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */
         readonly importModuleSpecifierEnding?: "auto" | "minimal" | "index" | "js";
         readonly allowTextChangesInNewFiles?: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3868,7 +3868,7 @@ declare namespace ts {
         readonly includeCompletionsForModuleExports?: boolean;
         readonly includeAutomaticOptionalChainCompletions?: boolean;
         readonly includeCompletionsWithInsertText?: boolean;
-        readonly importModuleSpecifierPreference?: "auto" | "relative" | "non-relative";
+        readonly importModuleSpecifierPreference?: "shortest" | "external-non-relative" | "relative" | "non-relative";
         /** Determines whether we import `foo/index.ts` as "foo", "foo/index", or "foo/index.js" */
         readonly importModuleSpecifierEnding?: "auto" | "minimal" | "index" | "js";
         readonly allowTextChangesInNewFiles?: boolean;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -610,7 +610,7 @@ declare namespace FourSlashInterface {
         readonly includeCompletionsForModuleExports?: boolean;
         readonly includeInsertTextCompletions?: boolean;
         readonly includeAutomaticOptionalChainCompletions?: boolean;
-        readonly importModuleSpecifierPreference?: "auto" | "relative" | "non-relative";
+        readonly importModuleSpecifierPreference?: "shortest" | "external-non-relative" | "relative" | "non-relative";
         readonly importModuleSpecifierEnding?: "minimal" | "index" | "js";
     }
     interface CompletionsOptions {

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -610,7 +610,7 @@ declare namespace FourSlashInterface {
         readonly includeCompletionsForModuleExports?: boolean;
         readonly includeInsertTextCompletions?: boolean;
         readonly includeAutomaticOptionalChainCompletions?: boolean;
-        readonly importModuleSpecifierPreference?: "shortest" | "external-non-relative" | "relative" | "non-relative";
+        readonly importModuleSpecifierPreference?: "shortest" | "project-relative" | "relative" | "non-relative";
         readonly importModuleSpecifierEnding?: "minimal" | "index" | "js";
     }
     interface CompletionsOptions {

--- a/tests/cases/fourslash/server/importNameCodeFix_externalNonRelateive2.ts
+++ b/tests/cases/fourslash/server/importNameCodeFix_externalNonRelateive2.ts
@@ -30,15 +30,15 @@ format.setOption("newline", "\n");
 
 goTo.marker("internal2external");
 verify.importFixAtPosition([`import { shared } from "shared/constants";\n\nshared`], /*errorCode*/ undefined, {
-  importModuleSpecifierPreference: "external-non-relative"
+  importModuleSpecifierPreference: "project-relative"
 });
 
 goTo.marker("internal2internal");
 verify.importFixAtPosition([`import { utils } from "./utils";\n\nutils`], /*errorCode*/ undefined, {
-  importModuleSpecifierPreference: "external-non-relative"
+  importModuleSpecifierPreference: "project-relative"
 });
 
 goTo.marker("external2external");
 verify.importFixAtPosition([`import { shared } from "./constants";\n\nshared`], /*errorCode*/ undefined, {
-  importModuleSpecifierPreference: "external-non-relative"
+  importModuleSpecifierPreference: "project-relative"
 });

--- a/tests/cases/fourslash/server/importNameCodeFix_externalNonRelateive2.ts
+++ b/tests/cases/fourslash/server/importNameCodeFix_externalNonRelateive2.ts
@@ -1,0 +1,44 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /apps/app1/tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "module": "commonjs",
+////     "paths": {
+////       "shared/*": ["../../shared/*"]
+////     }
+////   },
+////   "include": ["src", "../../shared"]
+//// }
+
+// @Filename: /apps/app1/src/index.ts
+//// shared/*internal2external*/
+
+// @Filename: /apps/app1/src/app.ts
+//// utils/*internal2internal*/
+
+// @Filename: /apps/app1/src/utils.ts
+//// export const utils = 0;
+
+// @Filename: /shared/constants.ts
+//// export const shared = 0;
+
+// @Filename: /shared/data.ts
+//// shared/*external2external*/
+
+format.setOption("newline", "\n");
+
+goTo.marker("internal2external");
+verify.importFixAtPosition([`import { shared } from "shared/constants";\n\nshared`], /*errorCode*/ undefined, {
+  importModuleSpecifierPreference: "external-non-relative"
+});
+
+goTo.marker("internal2internal");
+verify.importFixAtPosition([`import { utils } from "./utils";\n\nutils`], /*errorCode*/ undefined, {
+  importModuleSpecifierPreference: "external-non-relative"
+});
+
+goTo.marker("external2external");
+verify.importFixAtPosition([`import { shared } from "./constants";\n\nshared`], /*errorCode*/ undefined, {
+  importModuleSpecifierPreference: "external-non-relative"
+});

--- a/tests/cases/fourslash/server/importNameCodeFix_externalNonRelative1.ts
+++ b/tests/cases/fourslash/server/importNameCodeFix_externalNonRelative1.ts
@@ -49,10 +49,10 @@ format.setOption("newline", "\n");
 
 goTo.marker("external");
 verify.importFixAtPosition([`import { Pkg2 } from "pkg-2/utils";\n\nPkg2`], /*errorCode*/ undefined, {
-  importModuleSpecifierPreference: "external-non-relative"
+  importModuleSpecifierPreference: "project-relative"
 });
 
 goTo.marker("internal");
 verify.importFixAtPosition([`import { Pkg2 } from "../../utils";\n\nPkg2`], /*errorCode*/ undefined, {
-  importModuleSpecifierPreference: "external-non-relative"
+  importModuleSpecifierPreference: "project-relative"
 });

--- a/tests/cases/fourslash/server/importNameCodeFix_externalNonRelative1.ts
+++ b/tests/cases/fourslash/server/importNameCodeFix_externalNonRelative1.ts
@@ -1,0 +1,58 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.base.json
+//// {
+////   "compilerOptions": {
+////     "module": "commonjs",
+////     "paths": {
+////       "pkg-1/*": ["./packages/pkg-1/src/*"],
+////       "pkg-2/*": ["./packages/pkg-2/src/*"]
+////     }
+////   }
+//// }
+
+// @Filename: /packages/pkg-1/package.json
+//// { "dependencies": { "pkg-2": "*" } }
+
+// @Filename: /packages/pkg-1/tsconfig.json
+//// {
+////   "extends": "../../tsconfig.base.json",
+////   "references": [
+////     { "path": "../pkg-2" }
+////   ]
+//// }
+
+// @Filename: /packages/pkg-1/src/index.ts
+//// Pkg2/*external*/
+
+// @Filename: /packages/pkg-2/package.json
+//// { "types": "dist/index.d.ts" }
+
+// @Filename: /packages/pkg-2/tsconfig.json
+//// {
+////   "extends": "../../tsconfig.base.json",
+////   "compilerOptions": { "outDir": "dist", "rootDir": "src", "composite": true }
+//// }
+
+// @Filename: /packages/pkg-2/src/index.ts
+//// import "./utils";
+
+// @Filename: /packages/pkg-2/src/utils.ts
+//// export const Pkg2 = {};
+
+// @Filename: /packages/pkg-2/src/blah/foo/data.ts
+//// Pkg2/*internal*/
+
+// @link: /packages/pkg-2 -> /packages/pkg-1/node_modules/pkg-2
+
+format.setOption("newline", "\n");
+
+goTo.marker("external");
+verify.importFixAtPosition([`import { Pkg2 } from "pkg-2/utils";\n\nPkg2`], /*errorCode*/ undefined, {
+  importModuleSpecifierPreference: "external-non-relative"
+});
+
+goTo.marker("internal");
+verify.importFixAtPosition([`import { Pkg2 } from "../../utils";\n\nPkg2`], /*errorCode*/ undefined, {
+  importModuleSpecifierPreference: "external-non-relative"
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #36624 

People often want to use `paths` aliases to refer to “external” code (cross-project/package/some other conceptual boundary), but use relative paths elsewhere. Auto-imports cannot help you do this today.

The problem is that the conceptual boundaries within which people want to use relative imports and across which they want to use `paths` aliases can’t always be inferred. Suppose I have a monorepo structure with a base tsconfig defining `paths` like

```
"paths": {
  "*": "./packages/*"
}
```

Because we are familiar with common monorepo patterns, it’s clear that the package boundaries are the direct subdirectories of `packages`. So within `./packages/foo` I’d use relative imports to import anything in that package, and `"bar"` to import `./packages/bar`. 

However, it’s also common for webpack-bundled apps to have a convenience alias for the project root:

```
"paths": {
  "@/*": "./src/*"
}
```

This is structurally identical, but serves a different purpose—I needn’t treat `./src/utils` and `./src/routes` as separate, siloed directory trees.

My original hope was to be able to split module specifier suggestion behavior based on how `paths` is defined, but I think that is too hand-wavy. Instead, this PR introduces two more conservative heuristics:

1. If the path from an importing file to the imported file goes outside the directory of the importing file’s tsconfig.json (or inferred/unconfigured project root) and a non-relative path is available, use it.
2. If the nearest package.json file to the importing file and the nearest package.json file to the imported file are not the same file, and a non-relative path is available, use it.

For everything else, use a relative path.

This should cover basically all monorepo / project references configurations. I can imagine scenarios where I want to conceptually silo directories within a single project where these heuristics wouldn’t help you, but I haven’t heard user feedback from anyone with a setup like that.

I am proposing renaming `importModuleSpecifierPreference: 'auto'` to `'shortest'` to be more descriptive, leaving it as the default (which means that clients sending `'auto'` will continue to work), and giving this new setting a brief but descriptive name. Right now it’s `'external-non-relative'`, which is terrible.