### PR TITLE
Fix indentation of arrow functions returning parenthesized expressions

### DIFF
--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -2461,8 +2461,7 @@ namespace FourSlash {
             const { fileName } = this.activeFile;
             const before = this.getFileContent(fileName);
             this.formatDocument();
-            const after = this.getFileContent(fileName);
-            this.assertObjectsEqual(after, before);
+            this.verifyFileContent(fileName, before);
         }
 
         public verifyTextAtCaretIs(text: string) {

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -558,10 +558,14 @@ namespace ts.formatting {
                 case SyntaxKind.FunctionDeclaration:
                 case SyntaxKind.FunctionExpression:
                 case SyntaxKind.MethodDeclaration:
-                case SyntaxKind.ArrowFunction:
                 case SyntaxKind.Constructor:
                 case SyntaxKind.GetAccessor:
                 case SyntaxKind.SetAccessor:
+                    return childKind !== SyntaxKind.Block;
+                case SyntaxKind.ArrowFunction:
+                    if (sourceFile && childKind === SyntaxKind.ParenthesizedExpression) {
+                        return rangeIsOnOneLine(sourceFile, child!);
+                    }
                     return childKind !== SyntaxKind.Block;
                 case SyntaxKind.ExportDeclaration:
                     return childKind !== SyntaxKind.NamedExports;

--- a/tests/cases/fourslash/formattingArrowFunctionParenthesizedExpression.ts
+++ b/tests/cases/fourslash/formattingArrowFunctionParenthesizedExpression.ts
@@ -1,0 +1,33 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: Bar.tsx
+//// export const Bar = ({
+////     foo,
+////     bar,
+//// }: any) => (
+////     <div>Hello world</div>
+//// )
+//// 
+//// export const Bar2 = ({
+////     foo,
+////     bar,
+//// }) => (<div>Hello world</div>)
+////
+//// export const Bar2 = ({
+////     foo,
+////     bar,
+//// }) => <div>Hello world</div>
+//// 
+//// export const Bar3 = ({
+////     foo,
+////     bar,
+//// }) =>
+////     (<div>Hello world</div>)
+////
+//// export const Bar3 = ({
+////     foo,
+////     bar,
+//// }) =>
+////     <div>Hello world</div>
+
+verify.formatDocumentChangesNothing();

--- a/tests/cases/fourslash/formattingArrowFunctionParenthesizedExpression.ts
+++ b/tests/cases/fourslash/formattingArrowFunctionParenthesizedExpression.ts
@@ -24,10 +24,24 @@
 //// }) =>
 ////     (<div>Hello world</div>)
 ////
-//// export const Bar3 = ({
+//// export const Bar4 = ({
 ////     foo,
 ////     bar,
 //// }) =>
+////     <div>Hello world</div>
+////
+//// export const Bar5 = () => (
+////     <div>Hello world</div>
+//// )
+//// 
+//// export const Bar6 = () => (<div>Hello world</div>)
+//// 
+//// export const Bar7 = () => <div>Hello world</div>
+//// 
+//// export const Bar8 = () =>
+////     (<div>Hello world</div>)
+//// 
+//// export const Bar9 = () =>
 ////     <div>Hello world</div>
 
 verify.formatDocumentChangesNothing();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #31237
