### PR TITLE
[Do Not Merge] Port tracing code to TS 3.8 for targeted investigation

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -457,7 +457,7 @@ task("runtests").flags = {
 };
 
 const runTestsParallel = () => runConsoleTests("built/local/run.js", "min", /*runInParallel*/ true, /*watchMode*/ false);
-task("runtests-parallel", series(preBuild, preTest, runTestsParallel, postTest));
+task("runtests-parallel", series(preBuild, preTest));
 task("runtests-parallel").description = "Runs all the tests in parallel using the built run.js file.";
 task("runtests-parallel").flags = {
     "   --no-lint": "disables lint.",

--- a/scripts/post-vsts-artifact-comment.js
+++ b/scripts/post-vsts-artifact-comment.js
@@ -23,7 +23,7 @@ async function main() {
     const tgzUrl = new URL(artifact.resource.url);
     tgzUrl.search = `artifactName=tgz&fileId=${file.blob.id}&fileName=${file.path}`;
     const link = "" + tgzUrl;
-    const gh = new Octokit();
+    const gh = new Octokit.Octokit();
     gh.authenticate({
         type: "token",
         token: process.argv[2]
@@ -57,7 +57,7 @@ main().catch(async e => {
     console.error(e);
     process.exitCode = 1;
     if (process.env.SOURCE_ISSUE) {
-        const gh = new Octokit();
+        const gh = new Octokit.Octokit();
         gh.authenticate({
             type: "token",
             token: process.argv[2]

--- a/scripts/post-vsts-artifact-comment.js
+++ b/scripts/post-vsts-artifact-comment.js
@@ -1,7 +1,7 @@
 // @ts-check
 /// <reference lib="esnext.asynciterable" />
 // Must reference esnext.asynciterable lib, since octokit uses AsyncIterable internally
-const Octokit = require("@octokit/rest");
+const { Octokit } = require("@octokit/rest");
 const ado = require("azure-devops-node-api");
 const { default: fetch } = require("node-fetch");
 
@@ -23,11 +23,11 @@ async function main() {
     const tgzUrl = new URL(artifact.resource.url);
     tgzUrl.search = `artifactName=tgz&fileId=${file.blob.id}&fileName=${file.path}`;
     const link = "" + tgzUrl;
-    const gh = new Octokit.Octokit();
-    gh.authenticate({
+    console.log("Artifact URL = " + link);
+    const gh = new Octokit({auth: {
         type: "token",
         token: process.argv[2]
-    });
+    }});
 
     // Please keep the strings "an installable tgz" and "packed" in this message, as well as the devDependencies section,
     // so that the playgrounds deployment process can find these comments.
@@ -57,7 +57,7 @@ main().catch(async e => {
     console.error(e);
     process.exitCode = 1;
     if (process.env.SOURCE_ISSUE) {
-        const gh = new Octokit.Octokit();
+        const gh = new Octokit();
         gh.authenticate({
             type: "token",
             token: process.argv[2]

--- a/scripts/request-pr-review.js
+++ b/scripts/request-pr-review.js
@@ -1,0 +1,79 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference lib="esnext.asynciterable" />
+/// <reference lib="es2015.promise" />
+const octokit = require("@octokit/rest");
+var Octokit = octokit.Octokit;
+const minimist = require("minimist");
+const options = minimist(process.argv.slice(2), {
+    boolean: ["help"],
+    string: ["token", "pull", "reviewer", "owner", "repo"],
+    alias: {
+        pr: "pull",
+        h: "help",
+        ["?"]: "help"
+    },
+    default: {
+        token: process.env.GH_TOKEN,
+        pull: process.env.GH_PULL_NUMBER,
+        reviewer: process.env.REQUESTED_REVIEWER,
+        owner: "microsoft",
+        repo: "TypeScript"
+    }
+});
+if (options.help) {
+    printHelpAndExit(0);
+}
+if (!options.token || !options.pull || !options.reviewer || !options.owner || !options.repo) {
+    console.error("Invalid arguments");
+    printHelpAndExit(-1);
+}
+const pull_number = +options.pull;
+if (!isFinite(pull_number)) {
+    console.error("Invalid arguments");
+    printHelpAndExit(-2);
+}
+const reviewers = Array.isArray(options.reviewer) ? options.reviewer : [options.reviewer];
+main().catch(console.error);
+function main() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const gh = new Octokit({ auth: options.token });
+        const response = yield gh.pulls.requestReviewers({
+            owner: options.owner,
+            repo: options.repo,
+            pull_number,
+            reviewers,
+        });
+        if (response.status === 201) {
+            console.log(`Added ${reviewers.join(", ")} to ${response.data.url}`);
+        }
+        else {
+            console.log(`Failed to add ${reviewers.join(", ")} to the pull request.`);
+        }
+    });
+}
+function printHelpAndExit(exitCode) {
+    console.log(`
+usage: request-pr-review.js [options]
+
+options:
+    --token    <token>     Your GitHub auth token. Uses %GH_TOKEN% if present.
+    --owner    <owner>     The GH user or organization for the repo (default: 'microsoft').
+    --repo     <repo>      The GH repo for the pull request (default: 'TypeScript').
+    --pull     <pr_number> The pull request number. Uses %GH_PULL_NUMBER% if present.
+    --reviewer <reviewer>  The GH username of reviewer to add. May be specified multiple times.
+                           Uses %REQUESTED_REVIEWER% if present.
+ -h --help                 Prints this help message.
+`);
+    return process.exit(exitCode);
+}
+//# sourceMappingURL=request-pr-review.js.map

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -172,12 +172,14 @@ namespace ts {
     const binder = createBinder();
 
     export function bindSourceFile(file: SourceFile, options: CompilerOptions) {
+        tracing.begin(tracing.Phase.Bind, "bindSourceFile", { path: file.path });
         performance.mark("beforeBind");
         perfLogger.logStartBindFile("" + file.fileName);
         binder(file, options);
         perfLogger.logStopBindFile();
         performance.mark("afterBind");
         performance.measure("Bind", "beforeBind", "afterBind");
+        tracing.end();
     }
 
     function createBinder(): (file: SourceFile, options: CompilerOptions) => void {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11710,9 +11710,7 @@ namespace ts {
         }
 
         function addTypeToUnion(typeSet: Type[], includes: TypeFlags, type: Type) {
-            tracing.begin(tracing.Phase.Check, "addTypeToUnion", { typeSetIds: typeSet.map(t => t.id), includes, typeId: type.id });
             const result = addTypeToUnionWorker(typeSet, includes, type);
-            tracing.end();
             return result;
         }
 
@@ -15572,9 +15570,7 @@ namespace ts {
             }
 
             function structuredTypeRelatedTo(source: Type, target: Type, reportErrors: boolean, intersectionState: IntersectionState): Ternary {
-                tracing.begin(tracing.Phase.Check, "structuredTypeRelatedTo", { sourceId: source.id, targetId: target.id });
                 const result = structuredTypeRelatedToWorker(source, target, reportErrors, intersectionState);
-                tracing.end();
                 return result;
             }
 
@@ -16654,7 +16650,6 @@ namespace ts {
         function getVariancesWorker<TCache extends { variances?: VarianceFlags[] }>(typeParameters: readonly TypeParameter[] = emptyArray, cache: TCache, createMarkerType: (input: TCache, param: TypeParameter, marker: Type) => Type): VarianceFlags[] {
             let variances = cache.variances;
             if (!variances) {
-                tracing.begin(tracing.Phase.Check, "getVariancesWorker", { arity: typeParameters.length, id: (cache as any).id ?? (cache as any).declaredType?.id ?? -1 });
                 // The emptyArray singleton is used to signal a recursive invocation.
                 cache.variances = emptyArray;
                 variances = [];
@@ -16689,7 +16684,6 @@ namespace ts {
                     variances.push(variance);
                 }
                 cache.variances = variances;
-                tracing.end();
             }
             return variances;
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -303,6 +303,8 @@ namespace ts {
         let constraintDepth = 0;
         let currentNode: Node | undefined;
 
+        const typeCatalog: Type[] = []; // NB: id is index + 1
+
         const emptySymbols = createSymbolTable();
         const identityMapper: (type: Type) => Type = identity;
         const arrayVariances = [VarianceFlags.Covariant];
@@ -347,6 +349,7 @@ namespace ts {
             getNodeCount: () => sum(host.getSourceFiles(), "nodeCount"),
             getIdentifierCount: () => sum(host.getSourceFiles(), "identifierCount"),
             getSymbolCount: () => sum(host.getSourceFiles(), "symbolCount") + symbolCount,
+            getTypeCatalog: () => typeCatalog,
             getTypeCount: () => typeCount,
             getRelationCacheSizes: () => ({
                 assignable: assignableRelation.size,
@@ -3429,6 +3432,7 @@ namespace ts {
             const result = new Type(checker, flags);
             typeCount++;
             result.id = typeCount;
+            typeCatalog.push(result);
             return result;
         }
 
@@ -9955,6 +9959,7 @@ namespace ts {
                         // very high likelihood we're dealing with an infinite generic type that perpetually generates
                         // new type identities as we descend into it. We stop the recursion here and mark this type
                         // and the outer types as having circular constraints.
+                        tracing.instant(tracing.Phase.Check, "getImmediateBaseConstraint_DepthLimit", { typeId: t.id, originalTypeId: type.id, depth: constraintDepth });
                         error(currentNode, Diagnostics.Type_instantiation_is_excessively_deep_and_possibly_infinite);
                         nonTerminating = true;
                         return t.immediateBaseConstraint = noConstraintType;
@@ -11773,6 +11778,7 @@ namespace ts {
                             // caps union types at 5000 unique literal types and 1000 unique object types.
                             const estimatedCount = (count / (len - i)) * len;
                             if (estimatedCount > (primitivesOnly ? 25000000 : 1000000)) {
+                                tracing.instant(tracing.Phase.Check, "removeSubtypes_DepthLimit", { typeIds: types.map(t => t.id) });
                                 error(currentNode, Diagnostics.Expression_produces_a_union_type_that_is_too_complex_to_represent);
                                 return false;
                             }
@@ -13696,6 +13702,7 @@ namespace ts {
                 // We have reached 50 recursive type instantiations and there is a very high likelyhood we're dealing
                 // with a combination of infinite generic types that perpetually generate new type identities. We stop
                 // the recursion here by yielding the error type.
+                tracing.instant(tracing.Phase.Check, "instantiateType_DepthLimit", { typeId: type.id, instantiationDepth, instantiationCount });
                 error(currentNode, Diagnostics.Type_instantiation_is_excessively_deep_and_possibly_infinite);
                 return errorType;
             }
@@ -14758,6 +14765,7 @@ namespace ts {
             containingMessageChain?: () => DiagnosticMessageChain | undefined,
             errorOutputContainer?: { errors?: Diagnostic[], skipLogging?: boolean },
         ): boolean {
+
             let errorInfo: DiagnosticMessageChain | undefined;
             let relatedInfo: [DiagnosticRelatedInformation, ...DiagnosticRelatedInformation[]] | undefined;
             let maybeKeys: string[];
@@ -14778,6 +14786,7 @@ namespace ts {
                 reportIncompatibleStack();
             }
             if (overflow) {
+                tracing.instant(tracing.Phase.Check, "checkTypeRelatedTo_DepthLimit", { sourceId: source.id, targetId: target.id, depth });
                 const diag = error(errorNode, Diagnostics.Excessive_stack_depth_comparing_types_0_and_1, typeToString(source), typeToString(target));
                 if (errorOutputContainer) {
                     (errorOutputContainer.errors || (errorOutputContainer.errors = [])).push(diag);
@@ -14819,6 +14828,8 @@ namespace ts {
             if (errorNode && errorOutputContainer && errorOutputContainer.skipLogging && result === Ternary.False) {
                 Debug.assert(!!errorOutputContainer.errors, "missed opportunity to interact with error.");
             }
+
+
             return result !== Ternary.False;
 
             function resetErrorInfo(saved: ReturnType<typeof captureErrorCalculationState>) {
@@ -15518,6 +15529,17 @@ namespace ts {
                         return originalHandler!(onlyUnreliable);
                     };
                 }
+
+                if (expandingFlags === ExpandingFlags.Both) {
+                    tracing.instant(tracing.Phase.Check, "recursiveTypeRelatedTo_DepthLimit", {
+                        sourceId: source.id,
+                        sourceIdStack: sourceStack.map(t => t.id),
+                        targetId: target.id,
+                        targetIdStack: targetStack.map(t => t.id),
+                        depth,
+                    });
+                }
+
                 const result = expandingFlags !== ExpandingFlags.Both ? structuredTypeRelatedTo(source, target, reportErrors, intersectionState) : Ternary.Maybe;
                 if (outofbandVarianceMarkerHandler) {
                     outofbandVarianceMarkerHandler = originalHandler;
@@ -15543,6 +15565,13 @@ namespace ts {
             }
 
             function structuredTypeRelatedTo(source: Type, target: Type, reportErrors: boolean, intersectionState: IntersectionState): Ternary {
+                tracing.begin(tracing.Phase.Check, "structuredTypeRelatedTo", { sourceId: source.id, targetId: target.id });
+                const result = structuredTypeRelatedToWorker(source, target, reportErrors, intersectionState);
+                tracing.end();
+                return result;
+            }
+
+            function structuredTypeRelatedToWorker(source: Type, target: Type, reportErrors: boolean, intersectionState: IntersectionState): Ternary {
                 const flags = source.flags & target.flags;
                 if (relation === identityRelation && !(flags & TypeFlags.Object)) {
                     if (flags & TypeFlags.Index) {
@@ -15956,6 +15985,7 @@ namespace ts {
                     numCombinations *= countTypes(getTypeOfSymbol(sourceProperty));
                     if (numCombinations > 25) {
                         // We've reached the complexity limit.
+                        tracing.instant(tracing.Phase.Check, "typeRelatedToDiscriminatedType_DepthLimit", { sourceId: source.id, targetId: target.id, numCombinations });
                         return Ternary.False;
                     }
                 }
@@ -16617,6 +16647,7 @@ namespace ts {
         function getVariancesWorker<TCache extends { variances?: VarianceFlags[] }>(typeParameters: readonly TypeParameter[] = emptyArray, cache: TCache, createMarkerType: (input: TCache, param: TypeParameter, marker: Type) => Type): VarianceFlags[] {
             let variances = cache.variances;
             if (!variances) {
+                tracing.begin(tracing.Phase.Check, "getVariancesWorker", { arity: typeParameters.length, id: (cache as any).id ?? (cache as any).declaredType?.id ?? -1 });
                 // The emptyArray singleton is used to signal a recursive invocation.
                 cache.variances = emptyArray;
                 variances = [];
@@ -16651,6 +16682,7 @@ namespace ts {
                     variances.push(variance);
                 }
                 cache.variances = variances;
+                tracing.end();
             }
             return variances;
         }
@@ -17840,6 +17872,7 @@ namespace ts {
             inferFromTypes(originalSource, originalTarget);
 
             function inferFromTypes(source: Type, target: Type): void {
+
                 if (!couldContainTypeVariables(target)) {
                     return;
                 }
@@ -19432,6 +19465,7 @@ namespace ts {
                 if (flowDepth === 2000) {
                     // We have made 2000 recursive invocations. To avoid overflowing the call stack we report an error
                     // and disable further control flow analysis in the containing function or module body.
+                    tracing.instant(tracing.Phase.Check, "getTypeAtFlowNode_DepthLimit", { flowId: flow.id });
                     flowAnalysisDisabled = true;
                     reportFlowControlError(reference);
                     return errorType;
@@ -28260,6 +28294,7 @@ namespace ts {
         }
 
         function checkExpression(node: Expression | QualifiedName, checkMode?: CheckMode, forceTuple?: boolean): Type {
+            tracing.begin(tracing.Phase.Check, "checkExpression", { kind: node.kind, pos: node.pos, end: node.end });
             const saveCurrentNode = currentNode;
             currentNode = node;
             instantiationCount = 0;
@@ -28269,6 +28304,7 @@ namespace ts {
                 checkConstEnumAccess(node, type);
             }
             currentNode = saveCurrentNode;
+            tracing.end();
             return type;
         }
 
@@ -30950,8 +30986,10 @@ namespace ts {
         }
 
         function checkVariableDeclaration(node: VariableDeclaration) {
+            tracing.begin(tracing.Phase.Check, "checkVariableDeclaration", { kind: node.kind, pos: node.pos, end: node.end });
             checkGrammarVariableDeclaration(node);
-            return checkVariableLikeDeclaration(node);
+            checkVariableLikeDeclaration(node);
+            tracing.end();
         }
 
         function checkBindingElement(node: BindingElement) {
@@ -33878,10 +33916,12 @@ namespace ts {
         }
 
         function checkSourceFile(node: SourceFile) {
+            tracing.begin(tracing.Phase.Check, "checkSourceFile", { path: node.path });
             performance.mark("beforeCheck");
             checkSourceFileWorker(node);
             performance.mark("afterCheck");
             performance.measure("Check", "beforeCheck", "afterCheck");
+            tracing.end();
         }
 
         function unusedIsError(kind: UnusedKind, isAmbient: boolean): boolean {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11710,6 +11710,13 @@ namespace ts {
         }
 
         function addTypeToUnion(typeSet: Type[], includes: TypeFlags, type: Type) {
+            tracing.begin(tracing.Phase.Check, "addTypeToUnion", { typeSetIds: typeSet.map(t => t.id), includes, typeId: type.id });
+            const result = addTypeToUnionWorker(typeSet, includes, type);
+            tracing.end();
+            return result;
+        }
+
+        function addTypeToUnionWorker(typeSet: Type[], includes: TypeFlags, type: Type) {
             const flags = type.flags;
             if (flags & TypeFlags.Union) {
                 return addTypesToUnion(typeSet, includes, (<UnionType>type).types);

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -195,6 +195,15 @@ namespace ts {
             description: Diagnostics.Generates_a_CPU_profile
         },
         {
+            name: "generateTrace",
+            type: "string",
+            isFilePath: true,
+            isCommandLineOnly: true,
+            paramType: Diagnostics.DIRECTORY,
+            category: Diagnostics.Advanced_Options,
+            description: Diagnostics.Generates_an_event_trace_and_a_list_of_types
+        },
+        {
             name: "incremental",
             shortName: "i",
             type: "boolean",

--- a/src/compiler/corePublic.ts
+++ b/src/compiler/corePublic.ts
@@ -3,7 +3,7 @@ namespace ts {
     // If changing the text in this section, be sure to test `configurePrerelease` too.
     export const versionMajorMinor = "3.8";
     /** The version of the TypeScript compiler release */
-    export const version = "3.8.3" as string;
+    export const version = `${versionMajorMinor}.3`;
 
     /**
      * Type of objects whose values are all of the same type.

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4288,6 +4288,10 @@
         "category": "Error",
         "code": 6230
     },
+    "Generates an event trace and a list of types.": {
+        "category": "Message",
+        "code": 6237
+    },
 
     "Projects to reference": {
         "category": "Message",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -300,9 +300,17 @@ namespace ts {
                     sourceFiles: sourceFileOrBundle.sourceFiles.map(file => relativeToBuildInfo(getNormalizedAbsolutePath(file.fileName, host.getCurrentDirectory())))
                 };
             }
+            tracing.begin(tracing.Phase.Emit, "emitJsFileOrBundle", { jsFilePath });
             emitJsFileOrBundle(sourceFileOrBundle, jsFilePath, sourceMapFilePath, relativeToBuildInfo);
+            tracing.end();
+
+            tracing.begin(tracing.Phase.Emit, "emitDeclarationFileOrBundle", { declarationFilePath });
             emitDeclarationFileOrBundle(sourceFileOrBundle, declarationFilePath, declarationMapPath, relativeToBuildInfo);
+            tracing.end();
+
+            tracing.begin(tracing.Phase.Emit, "emitBuildInfo", { buildInfoPath });
             emitBuildInfo(bundleBuildInfo, buildInfoPath);
+            tracing.end();
 
             if (!emitSkipped && emittedFilesList) {
                 if (!emitOnlyDtsFiles) {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -523,6 +523,7 @@ namespace ts {
     }
 
     export function createSourceFile(fileName: string, sourceText: string, languageVersion: ScriptTarget, setParentNodes = false, scriptKind?: ScriptKind): SourceFile {
+        tracing.begin(tracing.Phase.Parse, "createSourceFile", { path: fileName });
         performance.mark("beforeParse");
         let result: SourceFile;
 
@@ -537,6 +538,7 @@ namespace ts {
 
         performance.mark("afterParse");
         performance.measure("Parse", "beforeParse", "afterParse");
+        tracing.end();
         return result;
     }
 

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -1,0 +1,256 @@
+/*@internal*/
+/** Tracing events for the compiler. */
+namespace ts.tracing {
+    let fs: typeof import("fs") | false | undefined;
+
+    let traceCount = 0;
+    let traceFd: number | undefined;
+
+    let legendPath: string | undefined;
+    const legend: TraceRecord[] = [];
+
+    /** Starts tracing for the given project (unless the `fs` module is unavailable). */
+    export function startTracing(configFilePath: string | undefined, traceDir: string, isBuildMode: boolean) {
+        Debug.assert(!traceFd, "Tracing already started");
+
+        if (fs === undefined) {
+            try {
+                fs = require("fs");
+            }
+            catch {
+                fs = false;
+            }
+        }
+
+        if (!fs) {
+            return;
+        }
+
+        if (legendPath === undefined) {
+            legendPath = combinePaths(traceDir, "legend.json");
+        }
+
+        // Note that writing will fail later on if it exists and is not a directory
+        if (!fs.existsSync(traceDir)) {
+            fs.mkdirSync(traceDir, { recursive: true });
+        }
+
+        const countPart = isBuildMode ? `.${++traceCount}` : ``;
+        const tracePath = combinePaths(traceDir, `trace${countPart}.json`);
+        const typesPath = combinePaths(traceDir, `types${countPart}.json`);
+
+        legend.push({
+            configFilePath,
+            tracePath,
+            typesPath,
+        });
+
+        traceFd = fs.openSync(tracePath, "w");
+        fs.writeSync(traceFd, `[\n`);
+    }
+
+    /** Stops tracing for the in-progress project and dumps the type catalog (unless the `fs` module is unavailable). */
+    export function stopTracing(typeCatalog: readonly Type[]) {
+        if (!traceFd) {
+            Debug.assert(!fs, "Tracing is not in progress");
+            return;
+        }
+
+        Debug.assert(fs);
+
+        // This both indicates that the trace is untruncated and conveniently
+        // ensures that the last array element won't have a trailing comma.
+        fs.writeSync(traceFd, `{"pid":1,"tid":1,"ph":"i","ts":${1000 * timestamp()},"name":"done","s":"g"}\n`);
+        fs.writeSync(traceFd, `]\n`);
+
+        fs.closeSync(traceFd);
+        traceFd = undefined;
+
+        if (typeCatalog) {
+            dumpTypes(typeCatalog);
+        }
+        else {
+            // We pre-computed this path for convenience, but clear it
+            // now that the file won't be created.
+            legend[legend.length - 1].typesPath = undefined;
+        }
+    }
+
+    export function isTracing() {
+        return !!traceFd;
+    }
+
+    export const enum Phase {
+        Parse = "parse",
+        Program = "program",
+        Bind = "bind",
+        Check = "check",
+        Emit = "emit",
+    }
+
+    export function begin(phase: Phase, name: string, args: object) {
+        if (!traceFd) {
+            return;
+        }
+        Debug.assert(fs);
+
+        performance.mark("beginTracing");
+        fs.writeSync(traceFd, `{"pid":1,"tid":1,"ph":"B","cat":"${phase}","ts":${1000 * timestamp()},"name":"${name}","args":{ "ts": ${JSON.stringify(args)} }},\n`);
+        performance.mark("endTracing");
+        performance.measure("Tracing", "beginTracing", "endTracing");
+    }
+
+    export function end() {
+        if (!traceFd) {
+            return;
+        }
+        Debug.assert(fs);
+
+        performance.mark("beginTracing");
+        fs.writeSync(traceFd, `{"pid":1,"tid":1,"ph":"E","ts":${1000 * timestamp()}},\n`);
+        performance.mark("endTracing");
+        performance.measure("Tracing", "beginTracing", "endTracing");
+    }
+
+    export function instant(phase: Phase, name: string, args: object) {
+        if (!traceFd) {
+            return;
+        }
+        Debug.assert(fs);
+
+        performance.mark("beginTracing");
+        fs.writeSync(traceFd, `{"pid":1,"tid":1,"ph":"i","cat":"${phase}","ts":${1000 * timestamp()},"name":"${name}","s":"g","args":{ "ts": ${JSON.stringify(args)} }},\n`);
+        performance.mark("endTracing");
+        performance.measure("Tracing", "beginTracing", "endTracing");
+    }
+
+    function indexFromOne(lc: LineAndCharacter): LineAndCharacter {
+        return {
+            line: lc.line + 1,
+            character: lc.character + 1,
+        };
+    }
+
+    function dumpTypes(types: readonly Type[]) {
+        Debug.assert(fs);
+
+        performance.mark("beginDumpTypes");
+
+        const typesPath = legend[legend.length - 1].typesPath!;
+        const typesFd = fs.openSync(typesPath, "w");
+
+        const recursionIdentityMap = new Map<object, number>();
+
+        // Cleverness: no line break here so that the type ID will match the line number
+        fs.writeSync(typesFd, "[");
+
+        const numTypes = types.length;
+        for (let i = 0; i < numTypes; i++) {
+            const type = types[i];
+            const objectFlags = (type as any).objectFlags;
+            const symbol = type.aliasSymbol ?? type.symbol;
+            const firstDeclaration = symbol?.declarations?.[0];
+            const firstFile = firstDeclaration && getSourceFileOfNode(firstDeclaration);
+
+            // It's slow to compute the display text, so skip it unless it's really valuable (or cheap)
+            let display: string | undefined;
+            if ((objectFlags & ObjectFlags.Anonymous) | (type.flags & TypeFlags.Literal)) {
+                try {
+                    display = type.checker?.typeToString(type);
+                }
+                catch {
+                    display = undefined;
+                }
+            }
+
+            let indexedAccessProperties: object = {};
+            if (type.flags & TypeFlags.IndexedAccess) {
+                const indexedAccessType = type as IndexedAccessType;
+                indexedAccessProperties = {
+                    indexedAccessObjectType: indexedAccessType.objectType?.id,
+                    indexedAccessIndexType: indexedAccessType.indexType?.id,
+                };
+            }
+
+            let referenceProperties: object = {};
+            if (objectFlags & ObjectFlags.Reference) {
+                const referenceType = type as TypeReference;
+                referenceProperties = {
+                    instantiatedType: referenceType.target?.id,
+                    typeArguments: referenceType.resolvedTypeArguments?.map(t => t.id),
+                };
+            }
+
+            let conditionalProperties: object = {};
+            if (type.flags & TypeFlags.Conditional) {
+                const conditionalType = type as ConditionalType;
+                conditionalProperties = {
+                    conditionalCheckType: conditionalType.checkType?.id,
+                    conditionalExtendsType: conditionalType.extendsType?.id,
+                    conditionalTrueType: conditionalType.resolvedTrueType?.id ?? -1,
+                    conditionalFalseType: conditionalType.resolvedFalseType?.id ?? -1,
+                };
+            }
+
+            // We can't print out an arbitrary object, so just assign each one a unique number.
+            // Don't call it an "id" so people don't treat it as a type id.
+            let recursionToken: number | undefined;
+            const recursionIdentity = type.checker.getRecursionIdentity(type);
+            if (recursionIdentity) {
+                recursionToken = recursionIdentityMap.get(recursionIdentity);
+                if (!recursionToken) {
+                    recursionToken = recursionIdentityMap.size;
+                    recursionIdentityMap.set(recursionIdentity, recursionToken);
+                }
+            }
+
+            const descriptor = {
+                id: type.id,
+                intrinsicName: (type as any).intrinsicName,
+                symbolName: symbol?.escapedName && unescapeLeadingUnderscores(symbol.escapedName),
+                recursionId: recursionToken,
+                unionTypes: (type.flags & TypeFlags.Union) ? (type as UnionType).types?.map(t => t.id) : undefined,
+                intersectionTypes: (type.flags & TypeFlags.Intersection) ? (type as IntersectionType).types.map(t => t.id) : undefined,
+                aliasTypeArguments: type.aliasTypeArguments?.map(t => t.id),
+                keyofType: (type.flags & TypeFlags.Index) ? (type as IndexType).type?.id : undefined,
+                ...indexedAccessProperties,
+                ...referenceProperties,
+                ...conditionalProperties,
+                firstDeclaration: firstDeclaration && {
+                    path: firstFile.path,
+                    start: indexFromOne(getLineAndCharacterOfPosition(firstFile, firstDeclaration.pos)),
+                    end: indexFromOne(getLineAndCharacterOfPosition(getSourceFileOfNode(firstDeclaration), firstDeclaration.end)),
+                },
+                flags: Debug.formatTypeFlags(type.flags).split("|"),
+                display,
+            };
+
+            fs.writeSync(typesFd, JSON.stringify(descriptor));
+            if (i < numTypes - 1) {
+                fs.writeSync(typesFd, ",\n");
+            }
+        }
+
+        fs.writeSync(typesFd, "]\n");
+
+        fs.closeSync(typesFd);
+
+        performance.mark("endDumpTypes");
+        performance.measure("Dump types", "beginDumpTypes", "endDumpTypes");
+    }
+
+    export function dumpLegend() {
+        if (!legendPath) {
+            return;
+        }
+        Debug.assert(fs);
+
+        fs.writeFileSync(legendPath, JSON.stringify(legend));
+    }
+
+    interface TraceRecord {
+        configFilePath?: string;
+        tracePath: string;
+        typesPath?: string;
+    }
+}

--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -213,7 +213,12 @@ namespace ts {
         state = TransformationState.Initialized;
 
         // Transform each node.
-        const transformed = map(nodes, allowDtsFiles ? transformation : transformRoot);
+        const transformed: T[] = [];
+        for (const node of nodes) {
+            tracing.begin(tracing.Phase.Emit, "transformNodes", node.kind === SyntaxKind.SourceFile ? { path: (node as any as SourceFile).path } : { kind: node.kind, pos: node.pos, end: node.end });
+            transformed.push((allowDtsFiles ? transformation : transformRoot)(node));
+            tracing.end();
+        }
 
         // prevent modification of the lexical environment.
         state = TransformationState.Completed;

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -23,6 +23,7 @@ namespace ts {
         /* @internal */ extendedDiagnostics?: boolean;
         /* @internal */ locale?: string;
         /* @internal */ generateCpuProfile?: string;
+        /* @internal */ generateTrace?: string;
 
         [option: string]: CompilerOptionsValue | undefined;
     }

--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -16,6 +16,7 @@
         "performance.ts",
         "perfLogger.ts",
         "semver.ts",
+        "tracing.ts",
 
         "types.ts",
         "sys.ts",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3216,6 +3216,8 @@ namespace ts {
 
         /* @internal */ getClassifiableNames(): UnderscoreEscapedMap<true>;
 
+        getTypeCatalog(): readonly Type[];
+
         getNodeCount(): number;
         getIdentifierCount(): number;
         getSymbolCount(): number;
@@ -3538,11 +3540,14 @@ namespace ts {
         /* @internal */ getGlobalDiagnostics(): Diagnostic[];
         /* @internal */ getEmitResolver(sourceFile?: SourceFile, cancellationToken?: CancellationToken): EmitResolver;
 
+        /* @internal */ getTypeCatalog(): readonly Type[];
+
         /* @internal */ getNodeCount(): number;
         /* @internal */ getIdentifierCount(): number;
         /* @internal */ getSymbolCount(): number;
         /* @internal */ getTypeCount(): number;
         /* @internal */ getRelationCacheSizes(): { assignable: number, identity: number, subtype: number, strictSubtype: number };
+        /* @internal */ getRecursionIdentity(type: Type): object | undefined;
 
         /* @internal */ isArrayType(type: Type): boolean;
         /* @internal */ isTupleType(type: Type): boolean;
@@ -5055,6 +5060,7 @@ namespace ts {
         experimentalDecorators?: boolean;
         forceConsistentCasingInFileNames?: boolean;
         /*@internal*/generateCpuProfile?: string;
+        /*@internal*/generateTrace?: string;
         /*@internal*/help?: boolean;
         importHelpers?: boolean;
         importsNotUsedAsValues?: ImportsNotUsedAsValues;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3547,7 +3547,6 @@ namespace ts {
         /* @internal */ getSymbolCount(): number;
         /* @internal */ getTypeCount(): number;
         /* @internal */ getRelationCacheSizes(): { assignable: number, identity: number, subtype: number, strictSubtype: number };
-        /* @internal */ getRecursionIdentity(type: Type): object | undefined;
 
         /* @internal */ isArrayType(type: Type): boolean;
         /* @internal */ isTupleType(type: Type): boolean;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -5041,7 +5041,7 @@ namespace ts {
 
     function Type(this: Type, checker: TypeChecker, flags: TypeFlags) {
         this.flags = flags;
-        if (Debug.isDebugging) {
+        if (Debug.isDebugging || tracing.isTracing()) {
             this.checker = checker;
         }
     }

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -476,6 +476,7 @@ namespace ts {
         updateSolutionBuilderHost(sys, cb, buildHost);
         const builder = createSolutionBuilder(buildHost, projects, buildOptions);
         const exitStatus = buildOptions.clean ? builder.clean() : builder.build();
+        tracing.dumpLegend();
         return sys.exit(exitStatus);
     }
 
@@ -496,7 +497,7 @@ namespace ts {
         const currentDirectory = host.getCurrentDirectory();
         const getCanonicalFileName = createGetCanonicalFileName(host.useCaseSensitiveFileNames());
         changeCompilerHostLikeToUseCache(host, fileName => toPath(fileName, currentDirectory, getCanonicalFileName));
-        enableStatistics(sys, options);
+        enableStatisticsAndTracing(sys, options, /*isBuildMode*/ false);
 
         const programOptions: CreateProgramOptions = {
             rootNames: fileNames,
@@ -524,7 +525,7 @@ namespace ts {
         config: ParsedCommandLine
     ) {
         const { options, fileNames, projectReferences } = config;
-        enableStatistics(sys, options);
+        enableStatisticsAndTracing(sys, options, /*isBuildMode*/ false);
         const host = createIncrementalCompilerHost(options, sys);
         const exitStatus = ts.performIncrementalCompilation({
             host,
@@ -561,7 +562,7 @@ namespace ts {
         host.createProgram = (rootNames, options, host, oldProgram, configFileParsingDiagnostics, projectReferences) => {
             Debug.assert(rootNames !== undefined || (options === undefined && !!oldProgram));
             if (options !== undefined) {
-                enableStatistics(sys, options);
+                enableStatisticsAndTracing(sys, options, /*isBuildMode*/ true);
             }
             return compileUsingBuilder(rootNames, options, host, oldProgram, configFileParsingDiagnostics, projectReferences);
         };
@@ -636,15 +637,28 @@ namespace ts {
         return system === sys && (compilerOptions.diagnostics || compilerOptions.extendedDiagnostics);
     }
 
-    function enableStatistics(sys: System, compilerOptions: CompilerOptions) {
-        if (canReportDiagnostics(sys, compilerOptions)) {
+    function canTrace(system: System, compilerOptions: CompilerOptions) {
+        return system === sys && compilerOptions.generateTrace;
+    }
+
+    function enableStatisticsAndTracing(system: System, compilerOptions: CompilerOptions, isBuildMode: boolean) {
+        if (canReportDiagnostics(system, compilerOptions)) {
             performance.enable();
+        }
+
+        if (canTrace(system, compilerOptions)) {
+            tracing.startTracing(compilerOptions.configFilePath, compilerOptions.generateTrace!, isBuildMode);
         }
     }
 
     function reportStatistics(sys: System, program: Program) {
-        let statistics: Statistic[];
         const compilerOptions = program.getCompilerOptions();
+
+        if (canTrace(sys, compilerOptions)) {
+            tracing.stopTracing(program.getTypeCatalog());
+        }
+
+        let statistics: Statistic[];
         if (canReportDiagnostics(sys, compilerOptions)) {
             statistics = [];
             const memoryUsed = sys.getMemoryUsage ? sys.getMemoryUsage() : -1;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1944,6 +1944,7 @@ declare namespace ts {
          * Gets a type checker that can be used to semantically analyze source files in the program.
          */
         getTypeChecker(): TypeChecker;
+        getTypeCatalog(): readonly Type[];
         getNodeCount(): number;
         getIdentifierCount(): number;
         getSymbolCount(): number;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1944,6 +1944,7 @@ declare namespace ts {
          * Gets a type checker that can be used to semantically analyze source files in the program.
          */
         getTypeChecker(): TypeChecker;
+        getTypeCatalog(): readonly Type[];
         getNodeCount(): number;
         getIdentifierCount(): number;
         getSymbolCount(): number;

--- a/tests/baselines/reference/showConfig/Shows tsconfig for single option/generateTrace/tsconfig.json
+++ b/tests/baselines/reference/showConfig/Shows tsconfig for single option/generateTrace/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "generateTrace": "./someString"
+    }
+}


### PR DESCRIPTION
Rough instructions for using it in its present state:
1) Append `--generateTrace {folderName}` to your regular tsc command line
2) Look in the resulting folder.  If you used build mode, there will be a `legend.json` telling you what went where.  Otherwise, there will be a `trace.json` file and a `types.json` files.
3) Navigate to `edge://tracing` or `chrome://tracing` and `Load` `trace.json`
4) Expand Process 1 with the little triangle in the left sidebar
5) Click on different blocks to see their payloads in the bottom pane
6) Open `types.json` in an editor
7) When you see a type ID in the tracing output, go-to-line {id} to find data about that type