### PR TITLE
Parse quoted names in qualified names

### DIFF
--- a/src/compat/deprecations.ts
+++ b/src/compat/deprecations.ts
@@ -1215,7 +1215,7 @@ namespace ts {
     }, factoryDeprecation);
 
     /** @deprecated Use `factory.createJSDocParameterTag` or the factory supplied by your transformation context instead. */
-    export const createJSDocParamTag = Debug.deprecate(function createJSDocParamTag(name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, comment?: string): JSDocParameterTag {
+    export const createJSDocParamTag = Debug.deprecate(function createJSDocParamTag(name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression, comment?: string): JSDocParameterTag {
         return factory.createJSDocParameterTag(/*tagName*/ undefined, name, isBracketed, typeExpression, /*isNameFirst*/ false, comment);
     }, factoryDeprecation);
 

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -4218,7 +4218,7 @@ namespace ts {
         }
 
         // @api
-        function createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocParameterTag {
+        function createJSDocParameterTag(tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocParameterTag {
             const node = createBaseJSDocTag<JSDocParameterTag>(SyntaxKind.JSDocParameterTag, tagName ?? createIdentifier("param"), comment);
             node.typeExpression = typeExpression;
             node.name = name;
@@ -4228,7 +4228,7 @@ namespace ts {
         }
 
         // @api
-        function updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier = getDefaultTagName(node), name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocParameterTag {
+        function updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier = getDefaultTagName(node), name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocParameterTag {
             return node.tagName !== tagName
                 || node.name !== name
                 || node.isBracketed !== isBracketed
@@ -4240,7 +4240,7 @@ namespace ts {
         }
 
         // @api
-        function createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocPropertyTag {
+        function createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocPropertyTag {
             const node = createBaseJSDocTag<JSDocPropertyTag>(SyntaxKind.JSDocPropertyTag, tagName ?? createIdentifier("prop"), comment);
             node.typeExpression = typeExpression;
             node.name = name;
@@ -4250,7 +4250,7 @@ namespace ts {
         }
 
         // @api
-        function updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier = getDefaultTagName(node), name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocPropertyTag {
+        function updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier = getDefaultTagName(node), name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocPropertyTag {
             return node.tagName !== tagName
                 || node.name !== name
                 || node.isBracketed !== isBracketed

--- a/src/compiler/factory/utilities.ts
+++ b/src/compiler/factory/utilities.ts
@@ -37,12 +37,10 @@ namespace ts {
     function createJsxFactoryExpressionFromEntityName(factory: NodeFactory, jsxFactory: EntityName, parent: JsxOpeningLikeElement | JsxOpeningFragment): Expression {
         if (isQualifiedName(jsxFactory)) {
             const left = createJsxFactoryExpressionFromEntityName(factory, jsxFactory.left, parent);
-            const right = factory.createIdentifier(idText(jsxFactory.right)) as Mutable<Identifier>;
-            right.escapedText = jsxFactory.right.escapedText;
-            return factory.createPropertyAccessExpression(left, right);
+            return isStringLiteralLike(jsxFactory.right) ? factory.createElementAccessExpression(left, factory.createStringLiteral(jsxFactory.right.text)) : factory.createPropertyAccessExpression(left, factory.createIdentifier(idText(jsxFactory.right)));
         }
         else {
-            return createReactNamespace(idText(jsxFactory), parent);
+            return createReactNamespace(qualifiedNameText(jsxFactory), parent);
         }
     }
 
@@ -162,7 +160,7 @@ namespace ts {
             const left = createExpressionFromEntityName(factory, node.left);
             // TODO(rbuckton): Does this need to be parented?
             const right = setParent(setTextRange(factory.cloneNode(node.right), node.right), node.right.parent);
-            return setTextRange(factory.createPropertyAccessExpression(left, right), node);
+            return setTextRange(isStringLiteralLike(right) ? factory.createElementAccessExpression(left, right) : factory.createPropertyAccessExpression(left, right), node);
         }
         else {
             // TODO(rbuckton): Does this need to be parented?

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1094,7 +1094,6 @@ namespace ts {
         /*@internal*/ generatedImportReference?: ImportSpecifier; // Reference to the generated import specifier this identifier refers to
         isInJSDocNamespace?: boolean;                             // if the node is a member in a JSDoc namespace
         /*@internal*/ typeArguments?: NodeArray<TypeNode | TypeParameterDeclaration>; // Only defined on synthesized nodes. Though not syntactically valid, used in emitting diagnostics, quickinfo, and signature help.
-        /*@internal*/ jsdocDotPos?: number;                       // Identifier occurs in JSDoc-style generic: Id.<T>
     }
 
     // Transient identifier node (marked by id === -1)
@@ -1110,11 +1109,12 @@ namespace ts {
     export interface QualifiedName extends Node {
         readonly kind: SyntaxKind.QualifiedName;
         readonly left: EntityName;
-        readonly right: Identifier;
-        /*@internal*/ jsdocDotPos?: number;                      // QualifiedName occurs in JSDoc-style generic: Id1.Id2.<T>
+        readonly right: Identifier | StringLiteralLike;
     }
 
-    export type EntityName = Identifier | QualifiedName;
+    export type EntityName = Identifier | QualifiedName | StringLiteralLike;
+
+    export type EntityNameNoRootLiteral = Identifier | QualifiedName;
 
     export type PropertyName = Identifier | StringLiteral | NumericLiteral | ComputedPropertyName | PrivateIdentifier;
 
@@ -3249,7 +3249,7 @@ namespace ts {
 
     export interface JSDocPropertyLikeTag extends JSDocTag, Declaration {
         readonly parent: JSDoc;
-        readonly name: EntityName;
+        readonly name: EntityNameNoRootLiteral;
         readonly typeExpression?: JSDocTypeExpression;
         /** Whether the property name came before the type -- non-standard for JSDoc, but Typescript-like */
         readonly isNameFirst: boolean;
@@ -4054,7 +4054,7 @@ namespace ts {
         /* @internal */ getSuggestionForNonexistentProperty(name: Identifier | PrivateIdentifier | string, containingType: Type): string | undefined;
         /* @internal */ getSuggestedSymbolForNonexistentSymbol(location: Node, name: string, meaning: SymbolFlags): Symbol | undefined;
         /* @internal */ getSuggestionForNonexistentSymbol(location: Node, name: string, meaning: SymbolFlags): string | undefined;
-        /* @internal */ getSuggestedSymbolForNonexistentModule(node: Identifier, target: Symbol): Symbol | undefined;
+        /* @internal */ getSuggestedSymbolForNonexistentModule(node: Identifier | StringLiteralLike, target: Symbol): Symbol | undefined;
         /* @internal */ getSuggestionForNonexistentExport(node: Identifier, target: Symbol): string | undefined;
         getBaseConstraintOfType(type: Type): Type | undefined;
         getDefaultFromTypeParameter(type: Type): Type | undefined;
@@ -6724,8 +6724,8 @@ namespace ts {
         // Names
         //
 
-        createQualifiedName(left: EntityName, right: string | Identifier): QualifiedName;
-        updateQualifiedName(node: QualifiedName, left: EntityName, right: Identifier): QualifiedName;
+        createQualifiedName(left: EntityName, right: string | Identifier | StringLiteralLike): QualifiedName;
+        updateQualifiedName(node: QualifiedName, left: EntityName, right: Identifier | StringLiteralLike): QualifiedName;
         createComputedPropertyName(expression: Expression): ComputedPropertyName;
         updateComputedPropertyName(node: ComputedPropertyName, expression: Expression): ComputedPropertyName;
 
@@ -7041,10 +7041,10 @@ namespace ts {
         updateJSDocTemplateTag(node: JSDocTemplateTag, tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment: string | undefined): JSDocTemplateTag;
         createJSDocTypedefTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression | JSDocTypeLiteral, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string): JSDocTypedefTag;
         updateJSDocTypedefTag(node: JSDocTypedefTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | JSDocTypeLiteral | undefined, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | undefined): JSDocTypedefTag;
-        createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocParameterTag;
-        updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocParameterTag;
-        createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocPropertyTag;
-        updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocPropertyTag;
+        createJSDocParameterTag(tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocParameterTag;
+        updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocParameterTag;
+        createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocPropertyTag;
+        updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocPropertyTag;
         createJSDocTypeTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string): JSDocTypeTag;
         updateJSDocTypeTag(node: JSDocTypeTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | undefined): JSDocTypeTag;
         createJSDocSeeTag(tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string): JSDocSeeTag;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -890,10 +890,14 @@ namespace ts {
         }
     }
 
-    export function entityNameToString(name: EntityNameOrEntityNameExpression | JsxTagNameExpression | PrivateIdentifier): string {
+    export function entityNameToString(name: EntityNameOrEntityNameExpression | JsxTagNameExpression | PrivateIdentifier | StringLiteralLike): string {
         switch (name.kind) {
             case SyntaxKind.ThisKeyword:
                 return "this";
+            case SyntaxKind.StringLiteral:
+                return name.singleQuote ? `'${escapeString(name.text, CharacterCodes.singleQuote)}'` : `"${escapeString(name.text, CharacterCodes.doubleQuote)}"`;
+            case SyntaxKind.NoSubstitutionTemplateLiteral:
+                return `\`${escapeString(name.text, CharacterCodes.backtick)}\``;
             case SyntaxKind.PrivateIdentifier:
             case SyntaxKind.Identifier:
                 return getFullWidth(name) === 0 ? idText(name) : getTextOfNode(name);
@@ -4760,13 +4764,17 @@ namespace ts {
             case SyntaxKind.QualifiedName:
                 do {
                     node = node.left;
-                } while (node.kind !== SyntaxKind.Identifier);
+                } while (node.kind === SyntaxKind.QualifiedName);
+                Debug.assertNode(node, isIdentifier); // The only leftmost qualified name that's not identifier is import type node leftmost names
                 return node;
             case SyntaxKind.PropertyAccessExpression:
                 do {
                     node = node.expression;
                 } while (node.kind !== SyntaxKind.Identifier);
                 return node;
+            case SyntaxKind.StringLiteral:
+            case SyntaxKind.NoSubstitutionTemplateLiteral:
+                return Debug.failBadSyntaxKind(node);
         }
     }
 

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -467,6 +467,12 @@ namespace ts {
         }
         return unescapeLeadingUnderscores(symbol.escapedName);
     }
+    export function qualifiedNameTextRaw(identifierOrString: Identifier | PrivateIdentifier | StringLiteralLike): __String {
+        return isIdentifier(identifierOrString) || isPrivateIdentifier(identifierOrString) ? identifierOrString.escapedText : escapeLeadingUnderscores(identifierOrString.text);
+    }
+    export function qualifiedNameText(identifierOrString: Identifier | PrivateIdentifier | StringLiteralLike): string {
+        return isIdentifier(identifierOrString) || isPrivateIdentifier(identifierOrString) ? idText(identifierOrString) : identifierOrString.text;
+    }
 
     /**
      * A JSDocTypedef tag has an _optional_ name field - if a name is not directly present, we should
@@ -1151,7 +1157,9 @@ namespace ts {
     export function isEntityName(node: Node): node is EntityName {
         const kind = node.kind;
         return kind === SyntaxKind.QualifiedName
-            || kind === SyntaxKind.Identifier;
+            || kind === SyntaxKind.Identifier
+            || kind === SyntaxKind.StringLiteral
+            || kind === SyntaxKind.NoSubstitutionTemplateLiteral;
     }
 
     export function isPropertyName(node: Node): node is PropertyName {

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -482,7 +482,7 @@ namespace ts.codefix {
     }
 
     function replaceFirstIdentifierOfEntityName(name: EntityName, newIdentifier: Identifier): EntityName {
-        if (name.kind === SyntaxKind.Identifier) {
+        if (name.kind !== SyntaxKind.QualifiedName) {
             return newIdentifier;
         }
         return factory.createQualifiedName(replaceFirstIdentifierOfEntityName(name.left, newIdentifier), name.right);

--- a/src/services/refactors/extractType.ts
+++ b/src/services/refactors/extractType.ts
@@ -158,7 +158,7 @@ namespace ts.refactor {
                 }
             }
             else if (isTypeQueryNode(node)) {
-                if (isIdentifier(node.exprName)) {
+                if (!isQualifiedName(node.exprName)) {
                     const symbol = checker.resolveName(node.exprName.text, node.exprName, SymbolFlags.Value, /* excludeGlobals */ false);
                     if (symbol && rangeContainsSkipTrivia(statement, symbol.valueDeclaration, file) && !rangeContainsSkipTrivia(selection, symbol.valueDeclaration, file)) {
                         return true;

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference1.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference1.json
@@ -12,8 +12,7 @@
         "flags": "JSDoc",
         "modifierFlagsCache": 0,
         "transformFlags": 0,
-        "escapedText": "a",
-        "jsdocDotPos": 2
+        "escapedText": "a"
     },
     "typeArguments": {
         "0": {

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference2.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference2.json
@@ -12,8 +12,7 @@
         "flags": "JSDoc",
         "modifierFlagsCache": 0,
         "transformFlags": 0,
-        "escapedText": "a",
-        "jsdocDotPos": 2
+        "escapedText": "a"
     },
     "typeArguments": {
         "0": {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -634,9 +634,10 @@ declare namespace ts {
     export interface QualifiedName extends Node {
         readonly kind: SyntaxKind.QualifiedName;
         readonly left: EntityName;
-        readonly right: Identifier;
+        readonly right: Identifier | StringLiteralLike;
     }
-    export type EntityName = Identifier | QualifiedName;
+    export type EntityName = Identifier | QualifiedName | StringLiteralLike;
+    export type EntityNameNoRootLiteral = Identifier | QualifiedName;
     export type PropertyName = Identifier | StringLiteral | NumericLiteral | ComputedPropertyName | PrivateIdentifier;
     export type DeclarationName = Identifier | PrivateIdentifier | StringLiteralLike | NumericLiteral | ComputedPropertyName | ElementAccessExpression | BindingPattern | EntityNameExpression;
     export interface Declaration extends Node {
@@ -1836,7 +1837,7 @@ declare namespace ts {
     }
     export interface JSDocPropertyLikeTag extends JSDocTag, Declaration {
         readonly parent: JSDoc;
-        readonly name: EntityName;
+        readonly name: EntityNameNoRootLiteral;
         readonly typeExpression?: JSDocTypeExpression;
         /** Whether the property name came before the type -- non-standard for JSDoc, but Typescript-like */
         readonly isNameFirst: boolean;
@@ -3188,8 +3189,8 @@ declare namespace ts {
         createFalse(): FalseLiteral;
         createModifier<T extends ModifierSyntaxKind>(kind: T): ModifierToken<T>;
         createModifiersFromModifierFlags(flags: ModifierFlags): Modifier[];
-        createQualifiedName(left: EntityName, right: string | Identifier): QualifiedName;
-        updateQualifiedName(node: QualifiedName, left: EntityName, right: Identifier): QualifiedName;
+        createQualifiedName(left: EntityName, right: string | Identifier | StringLiteralLike): QualifiedName;
+        updateQualifiedName(node: QualifiedName, left: EntityName, right: Identifier | StringLiteralLike): QualifiedName;
         createComputedPropertyName(expression: Expression): ComputedPropertyName;
         updateComputedPropertyName(node: ComputedPropertyName, expression: Expression): ComputedPropertyName;
         createTypeParameterDeclaration(name: string | Identifier, constraint?: TypeNode, defaultType?: TypeNode): TypeParameterDeclaration;
@@ -3455,10 +3456,10 @@ declare namespace ts {
         updateJSDocTemplateTag(node: JSDocTemplateTag, tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment: string | undefined): JSDocTemplateTag;
         createJSDocTypedefTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression | JSDocTypeLiteral, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string): JSDocTypedefTag;
         updateJSDocTypedefTag(node: JSDocTypedefTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | JSDocTypeLiteral | undefined, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | undefined): JSDocTypedefTag;
-        createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocParameterTag;
-        updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocParameterTag;
-        createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocPropertyTag;
-        updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocPropertyTag;
+        createJSDocParameterTag(tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocParameterTag;
+        updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocParameterTag;
+        createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocPropertyTag;
+        updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocPropertyTag;
         createJSDocTypeTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string): JSDocTypeTag;
         updateJSDocTypeTag(node: JSDocTypeTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | undefined): JSDocTypeTag;
         createJSDocSeeTag(tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string): JSDocSeeTag;
@@ -4082,6 +4083,8 @@ declare namespace ts {
     function unescapeLeadingUnderscores(identifier: __String): string;
     function idText(identifierOrPrivateName: Identifier | PrivateIdentifier): string;
     function symbolName(symbol: Symbol): string;
+    function qualifiedNameTextRaw(identifierOrString: Identifier | PrivateIdentifier | StringLiteralLike): __String;
+    function qualifiedNameText(identifierOrString: Identifier | PrivateIdentifier | StringLiteralLike): string;
     function getNameOfJSDocTypedef(declaration: JSDocTypedefTag): Identifier | PrivateIdentifier | undefined;
     function getNameOfDeclaration(declaration: Declaration | Expression): DeclarationName | undefined;
     /**
@@ -10086,9 +10089,9 @@ declare namespace ts {
     /** @deprecated Use `factory.createModifiersFromModifierFlags` or the factory supplied by your transformation context instead. */
     const createModifiersFromModifierFlags: (flags: ModifierFlags) => Modifier[];
     /** @deprecated Use `factory.createQualifiedName` or the factory supplied by your transformation context instead. */
-    const createQualifiedName: (left: EntityName, right: string | Identifier) => QualifiedName;
+    const createQualifiedName: (left: EntityName, right: string | Identifier | StringLiteral | NoSubstitutionTemplateLiteral) => QualifiedName;
     /** @deprecated Use `factory.updateQualifiedName` or the factory supplied by your transformation context instead. */
-    const updateQualifiedName: (node: QualifiedName, left: EntityName, right: Identifier) => QualifiedName;
+    const updateQualifiedName: (node: QualifiedName, left: EntityName, right: Identifier | StringLiteral | NoSubstitutionTemplateLiteral) => QualifiedName;
     /** @deprecated Use `factory.createComputedPropertyName` or the factory supplied by your transformation context instead. */
     const createComputedPropertyName: (expression: Expression) => ComputedPropertyName;
     /** @deprecated Use `factory.updateComputedPropertyName` or the factory supplied by your transformation context instead. */
@@ -10142,7 +10145,7 @@ declare namespace ts {
     /** @deprecated Use `factory.updateTypePredicateNode` or the factory supplied by your transformation context instead. */
     const updateTypePredicateNodeWithModifier: (node: TypePredicateNode, assertsModifier: AssertsKeyword | undefined, parameterName: Identifier | ThisTypeNode, type: TypeNode | undefined) => TypePredicateNode;
     /** @deprecated Use `factory.createTypeReferenceNode` or the factory supplied by your transformation context instead. */
-    const createTypeReferenceNode: (typeName: string | Identifier | QualifiedName, typeArguments?: readonly TypeNode[] | undefined) => TypeReferenceNode;
+    const createTypeReferenceNode: (typeName: string | Identifier | StringLiteral | NoSubstitutionTemplateLiteral | QualifiedName, typeArguments?: readonly TypeNode[] | undefined) => TypeReferenceNode;
     /** @deprecated Use `factory.updateTypeReferenceNode` or the factory supplied by your transformation context instead. */
     const updateTypeReferenceNode: (node: TypeReferenceNode, typeName: EntityName, typeArguments: NodeArray<TypeNode> | undefined) => TypeReferenceNode;
     /** @deprecated Use `factory.createFunctionTypeNode` or the factory supplied by your transformation context instead. */
@@ -10194,9 +10197,9 @@ declare namespace ts {
     /** @deprecated Use `factory.updateInferTypeNode` or the factory supplied by your transformation context instead. */
     const updateInferTypeNode: (node: InferTypeNode, typeParameter: TypeParameterDeclaration) => InferTypeNode;
     /** @deprecated Use `factory.createImportTypeNode` or the factory supplied by your transformation context instead. */
-    const createImportTypeNode: (argument: TypeNode, qualifier?: Identifier | QualifiedName | undefined, typeArguments?: readonly TypeNode[] | undefined, isTypeOf?: boolean | undefined) => ImportTypeNode;
+    const createImportTypeNode: (argument: TypeNode, qualifier?: Identifier | StringLiteral | NoSubstitutionTemplateLiteral | QualifiedName | undefined, typeArguments?: readonly TypeNode[] | undefined, isTypeOf?: boolean | undefined) => ImportTypeNode;
     /** @deprecated Use `factory.updateImportTypeNode` or the factory supplied by your transformation context instead. */
-    const updateImportTypeNode: (node: ImportTypeNode, argument: TypeNode, qualifier: Identifier | QualifiedName | undefined, typeArguments: readonly TypeNode[] | undefined, isTypeOf?: boolean | undefined) => ImportTypeNode;
+    const updateImportTypeNode: (node: ImportTypeNode, argument: TypeNode, qualifier: Identifier | StringLiteral | NoSubstitutionTemplateLiteral | QualifiedName | undefined, typeArguments: readonly TypeNode[] | undefined, isTypeOf?: boolean | undefined) => ImportTypeNode;
     /** @deprecated Use `factory.createParenthesizedType` or the factory supplied by your transformation context instead. */
     const createParenthesizedType: (type: TypeNode) => ParenthesizedTypeNode;
     /** @deprecated Use `factory.updateParenthesizedType` or the factory supplied by your transformation context instead. */
@@ -10522,7 +10525,7 @@ declare namespace ts {
     /** @deprecated Use `factory.createJSDocComment` or the factory supplied by your transformation context instead. */
     const createJSDocComment: (comment?: string | undefined, tags?: readonly JSDocTag[] | undefined) => JSDoc;
     /** @deprecated Use `factory.createJSDocParameterTag` or the factory supplied by your transformation context instead. */
-    const createJSDocParameterTag: (tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | undefined) => JSDocParameterTag;
+    const createJSDocParameterTag: (tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | undefined) => JSDocParameterTag;
     /** @deprecated Use `factory.createJSDocClassTag` or the factory supplied by your transformation context instead. */
     const createJSDocClassTag: (tagName: Identifier | undefined, comment?: string | undefined) => JSDocClassTag;
     /** @deprecated Use `factory.createJSDocAugmentsTag` or the factory supplied by your transformation context instead. */
@@ -10540,7 +10543,7 @@ declare namespace ts {
     /** @deprecated Use `factory.createJSDocSignature` or the factory supplied by your transformation context instead. */
     const createJSDocSignature: (typeParameters: readonly JSDocTemplateTag[] | undefined, parameters: readonly JSDocParameterTag[], type?: JSDocReturnTag | undefined) => JSDocSignature;
     /** @deprecated Use `factory.createJSDocPropertyTag` or the factory supplied by your transformation context instead. */
-    const createJSDocPropertyTag: (tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | undefined) => JSDocPropertyTag;
+    const createJSDocPropertyTag: (tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | undefined) => JSDocPropertyTag;
     /** @deprecated Use `factory.createJSDocTypeLiteral` or the factory supplied by your transformation context instead. */
     const createJSDocTypeLiteral: (jsDocPropertyTags?: readonly JSDocPropertyLikeTag[] | undefined, isArrayType?: boolean | undefined) => JSDocTypeLiteral;
     /** @deprecated Use `factory.createJSDocImplementsTag` or the factory supplied by your transformation context instead. */
@@ -10768,7 +10771,7 @@ declare namespace ts {
     /** @deprecated Use `factory.updateExportDeclaration` or the factory supplied by your transformation context instead. */
     const updateExportDeclaration: (node: ExportDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, exportClause: NamedExportBindings | undefined, moduleSpecifier: Expression | undefined, isTypeOnly: boolean) => ExportDeclaration;
     /** @deprecated Use `factory.createJSDocParameterTag` or the factory supplied by your transformation context instead. */
-    const createJSDocParamTag: (name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, comment?: string | undefined) => JSDocParameterTag;
+    const createJSDocParamTag: (name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, comment?: string | undefined) => JSDocParameterTag;
     /** @deprecated Use `factory.createComma` or the factory supplied by your transformation context instead. */
     const createComma: (left: Expression, right: Expression) => Expression;
     /** @deprecated Use `factory.createLessThan` or the factory supplied by your transformation context instead. */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -634,9 +634,10 @@ declare namespace ts {
     export interface QualifiedName extends Node {
         readonly kind: SyntaxKind.QualifiedName;
         readonly left: EntityName;
-        readonly right: Identifier;
+        readonly right: Identifier | StringLiteralLike;
     }
-    export type EntityName = Identifier | QualifiedName;
+    export type EntityName = Identifier | QualifiedName | StringLiteralLike;
+    export type EntityNameNoRootLiteral = Identifier | QualifiedName;
     export type PropertyName = Identifier | StringLiteral | NumericLiteral | ComputedPropertyName | PrivateIdentifier;
     export type DeclarationName = Identifier | PrivateIdentifier | StringLiteralLike | NumericLiteral | ComputedPropertyName | ElementAccessExpression | BindingPattern | EntityNameExpression;
     export interface Declaration extends Node {
@@ -1836,7 +1837,7 @@ declare namespace ts {
     }
     export interface JSDocPropertyLikeTag extends JSDocTag, Declaration {
         readonly parent: JSDoc;
-        readonly name: EntityName;
+        readonly name: EntityNameNoRootLiteral;
         readonly typeExpression?: JSDocTypeExpression;
         /** Whether the property name came before the type -- non-standard for JSDoc, but Typescript-like */
         readonly isNameFirst: boolean;
@@ -3188,8 +3189,8 @@ declare namespace ts {
         createFalse(): FalseLiteral;
         createModifier<T extends ModifierSyntaxKind>(kind: T): ModifierToken<T>;
         createModifiersFromModifierFlags(flags: ModifierFlags): Modifier[];
-        createQualifiedName(left: EntityName, right: string | Identifier): QualifiedName;
-        updateQualifiedName(node: QualifiedName, left: EntityName, right: Identifier): QualifiedName;
+        createQualifiedName(left: EntityName, right: string | Identifier | StringLiteralLike): QualifiedName;
+        updateQualifiedName(node: QualifiedName, left: EntityName, right: Identifier | StringLiteralLike): QualifiedName;
         createComputedPropertyName(expression: Expression): ComputedPropertyName;
         updateComputedPropertyName(node: ComputedPropertyName, expression: Expression): ComputedPropertyName;
         createTypeParameterDeclaration(name: string | Identifier, constraint?: TypeNode, defaultType?: TypeNode): TypeParameterDeclaration;
@@ -3455,10 +3456,10 @@ declare namespace ts {
         updateJSDocTemplateTag(node: JSDocTemplateTag, tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment: string | undefined): JSDocTemplateTag;
         createJSDocTypedefTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression | JSDocTypeLiteral, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string): JSDocTypedefTag;
         updateJSDocTypedefTag(node: JSDocTypedefTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | JSDocTypeLiteral | undefined, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | undefined): JSDocTypedefTag;
-        createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocParameterTag;
-        updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocParameterTag;
-        createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocPropertyTag;
-        updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocPropertyTag;
+        createJSDocParameterTag(tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocParameterTag;
+        updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocParameterTag;
+        createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocPropertyTag;
+        updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocPropertyTag;
         createJSDocTypeTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string): JSDocTypeTag;
         updateJSDocTypeTag(node: JSDocTypeTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | undefined): JSDocTypeTag;
         createJSDocSeeTag(tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string): JSDocSeeTag;
@@ -4082,6 +4083,8 @@ declare namespace ts {
     function unescapeLeadingUnderscores(identifier: __String): string;
     function idText(identifierOrPrivateName: Identifier | PrivateIdentifier): string;
     function symbolName(symbol: Symbol): string;
+    function qualifiedNameTextRaw(identifierOrString: Identifier | PrivateIdentifier | StringLiteralLike): __String;
+    function qualifiedNameText(identifierOrString: Identifier | PrivateIdentifier | StringLiteralLike): string;
     function getNameOfJSDocTypedef(declaration: JSDocTypedefTag): Identifier | PrivateIdentifier | undefined;
     function getNameOfDeclaration(declaration: Declaration | Expression): DeclarationName | undefined;
     /**
@@ -6460,9 +6463,9 @@ declare namespace ts {
     /** @deprecated Use `factory.createModifiersFromModifierFlags` or the factory supplied by your transformation context instead. */
     const createModifiersFromModifierFlags: (flags: ModifierFlags) => Modifier[];
     /** @deprecated Use `factory.createQualifiedName` or the factory supplied by your transformation context instead. */
-    const createQualifiedName: (left: EntityName, right: string | Identifier) => QualifiedName;
+    const createQualifiedName: (left: EntityName, right: string | Identifier | StringLiteral | NoSubstitutionTemplateLiteral) => QualifiedName;
     /** @deprecated Use `factory.updateQualifiedName` or the factory supplied by your transformation context instead. */
-    const updateQualifiedName: (node: QualifiedName, left: EntityName, right: Identifier) => QualifiedName;
+    const updateQualifiedName: (node: QualifiedName, left: EntityName, right: Identifier | StringLiteral | NoSubstitutionTemplateLiteral) => QualifiedName;
     /** @deprecated Use `factory.createComputedPropertyName` or the factory supplied by your transformation context instead. */
     const createComputedPropertyName: (expression: Expression) => ComputedPropertyName;
     /** @deprecated Use `factory.updateComputedPropertyName` or the factory supplied by your transformation context instead. */
@@ -6516,7 +6519,7 @@ declare namespace ts {
     /** @deprecated Use `factory.updateTypePredicateNode` or the factory supplied by your transformation context instead. */
     const updateTypePredicateNodeWithModifier: (node: TypePredicateNode, assertsModifier: AssertsKeyword | undefined, parameterName: Identifier | ThisTypeNode, type: TypeNode | undefined) => TypePredicateNode;
     /** @deprecated Use `factory.createTypeReferenceNode` or the factory supplied by your transformation context instead. */
-    const createTypeReferenceNode: (typeName: string | Identifier | QualifiedName, typeArguments?: readonly TypeNode[] | undefined) => TypeReferenceNode;
+    const createTypeReferenceNode: (typeName: string | Identifier | StringLiteral | NoSubstitutionTemplateLiteral | QualifiedName, typeArguments?: readonly TypeNode[] | undefined) => TypeReferenceNode;
     /** @deprecated Use `factory.updateTypeReferenceNode` or the factory supplied by your transformation context instead. */
     const updateTypeReferenceNode: (node: TypeReferenceNode, typeName: EntityName, typeArguments: NodeArray<TypeNode> | undefined) => TypeReferenceNode;
     /** @deprecated Use `factory.createFunctionTypeNode` or the factory supplied by your transformation context instead. */
@@ -6568,9 +6571,9 @@ declare namespace ts {
     /** @deprecated Use `factory.updateInferTypeNode` or the factory supplied by your transformation context instead. */
     const updateInferTypeNode: (node: InferTypeNode, typeParameter: TypeParameterDeclaration) => InferTypeNode;
     /** @deprecated Use `factory.createImportTypeNode` or the factory supplied by your transformation context instead. */
-    const createImportTypeNode: (argument: TypeNode, qualifier?: Identifier | QualifiedName | undefined, typeArguments?: readonly TypeNode[] | undefined, isTypeOf?: boolean | undefined) => ImportTypeNode;
+    const createImportTypeNode: (argument: TypeNode, qualifier?: Identifier | StringLiteral | NoSubstitutionTemplateLiteral | QualifiedName | undefined, typeArguments?: readonly TypeNode[] | undefined, isTypeOf?: boolean | undefined) => ImportTypeNode;
     /** @deprecated Use `factory.updateImportTypeNode` or the factory supplied by your transformation context instead. */
-    const updateImportTypeNode: (node: ImportTypeNode, argument: TypeNode, qualifier: Identifier | QualifiedName | undefined, typeArguments: readonly TypeNode[] | undefined, isTypeOf?: boolean | undefined) => ImportTypeNode;
+    const updateImportTypeNode: (node: ImportTypeNode, argument: TypeNode, qualifier: Identifier | StringLiteral | NoSubstitutionTemplateLiteral | QualifiedName | undefined, typeArguments: readonly TypeNode[] | undefined, isTypeOf?: boolean | undefined) => ImportTypeNode;
     /** @deprecated Use `factory.createParenthesizedType` or the factory supplied by your transformation context instead. */
     const createParenthesizedType: (type: TypeNode) => ParenthesizedTypeNode;
     /** @deprecated Use `factory.updateParenthesizedType` or the factory supplied by your transformation context instead. */
@@ -6896,7 +6899,7 @@ declare namespace ts {
     /** @deprecated Use `factory.createJSDocComment` or the factory supplied by your transformation context instead. */
     const createJSDocComment: (comment?: string | undefined, tags?: readonly JSDocTag[] | undefined) => JSDoc;
     /** @deprecated Use `factory.createJSDocParameterTag` or the factory supplied by your transformation context instead. */
-    const createJSDocParameterTag: (tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | undefined) => JSDocParameterTag;
+    const createJSDocParameterTag: (tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | undefined) => JSDocParameterTag;
     /** @deprecated Use `factory.createJSDocClassTag` or the factory supplied by your transformation context instead. */
     const createJSDocClassTag: (tagName: Identifier | undefined, comment?: string | undefined) => JSDocClassTag;
     /** @deprecated Use `factory.createJSDocAugmentsTag` or the factory supplied by your transformation context instead. */
@@ -6914,7 +6917,7 @@ declare namespace ts {
     /** @deprecated Use `factory.createJSDocSignature` or the factory supplied by your transformation context instead. */
     const createJSDocSignature: (typeParameters: readonly JSDocTemplateTag[] | undefined, parameters: readonly JSDocParameterTag[], type?: JSDocReturnTag | undefined) => JSDocSignature;
     /** @deprecated Use `factory.createJSDocPropertyTag` or the factory supplied by your transformation context instead. */
-    const createJSDocPropertyTag: (tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | undefined) => JSDocPropertyTag;
+    const createJSDocPropertyTag: (tagName: Identifier | undefined, name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | undefined) => JSDocPropertyTag;
     /** @deprecated Use `factory.createJSDocTypeLiteral` or the factory supplied by your transformation context instead. */
     const createJSDocTypeLiteral: (jsDocPropertyTags?: readonly JSDocPropertyLikeTag[] | undefined, isArrayType?: boolean | undefined) => JSDocTypeLiteral;
     /** @deprecated Use `factory.createJSDocImplementsTag` or the factory supplied by your transformation context instead. */
@@ -7142,7 +7145,7 @@ declare namespace ts {
     /** @deprecated Use `factory.updateExportDeclaration` or the factory supplied by your transformation context instead. */
     const updateExportDeclaration: (node: ExportDeclaration, decorators: readonly Decorator[] | undefined, modifiers: readonly Modifier[] | undefined, exportClause: NamedExportBindings | undefined, moduleSpecifier: Expression | undefined, isTypeOnly: boolean) => ExportDeclaration;
     /** @deprecated Use `factory.createJSDocParameterTag` or the factory supplied by your transformation context instead. */
-    const createJSDocParamTag: (name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, comment?: string | undefined) => JSDocParameterTag;
+    const createJSDocParamTag: (name: EntityNameNoRootLiteral, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, comment?: string | undefined) => JSDocParameterTag;
     /** @deprecated Use `factory.createComma` or the factory supplied by your transformation context instead. */
     const createComma: (left: Expression, right: Expression) => Expression;
     /** @deprecated Use `factory.createLessThan` or the factory supplied by your transformation context instead. */

--- a/tests/baselines/reference/jsdocDisallowedInTypescript.errors.txt
+++ b/tests/baselines/reference/jsdocDisallowedInTypescript.errors.txt
@@ -1,75 +1,39 @@
 tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(2,15): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(4,15): error TS8020: JSDoc types can only be used inside documentation comments.
 tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(4,32): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(7,20): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(10,18): error TS8020: JSDoc types can only be used inside documentation comments.
 tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(11,18): error TS2554: Expected 1 arguments, but got 2.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(13,14): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(14,11): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(15,8): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(16,11): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(17,17): error TS8020: JSDoc types can only be used inside documentation comments.
 tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(18,5): error TS2322: Type 'undefined' is not assignable to type 'number | null'.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(18,17): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(20,16): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(21,16): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(22,17): error TS8020: JSDoc types can only be used inside documentation comments.
 
 
-==== tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts (16 errors) ====
+==== tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts (4 errors) ====
     // grammar error from checker
     var ara: Array.<number> = [1,2,3];
                   ~
 !!! error TS8020: JSDoc types can only be used inside documentation comments.
     
     function f(x: ?number, y: Array.<number>) {
-                  ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
                                    ~
 !!! error TS8020: JSDoc types can only be used inside documentation comments.
         return x ? x + y[1] : y[0];
     }
     function hof(ctor: function(new: number, string)) {
-                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
         return new ctor('hi');
     }
     function hof2(f: function(this: number, string): string) {
-                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
         return f(12, 'hullo');
                      ~~~~~~~
 !!! error TS2554: Expected 1 arguments, but got 2.
     }
     var whatevs: * = 1001;
-                 ~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
     var ques: ? = 'what';
-              ~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
     var g: function(number, number): number = (n,m) => n + m;
-           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
     var most: !string = 'definite';
-              ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
     var postfixdef: number! = 101;
-                    ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
     var postfixopt: number? = undefined;
         ~~~~~~~~~~
 !!! error TS2322: Type 'undefined' is not assignable to type 'number | null'.
-                    ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
     
     var nns: Array<?number>;
-                   ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
     var dns: Array<!number>;
-                   ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
     var anys: Array<*>;
-                    ~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
     
     

--- a/tests/baselines/reference/nonIdentifierNamedDirectExportsReferencable.js
+++ b/tests/baselines/reference/nonIdentifierNamedDirectExportsReferencable.js
@@ -1,0 +1,24 @@
+//// [tests/cases/conformance/types/namedTypes/nonIdentifierNamedDirectExportsReferencable.ts] ////
+
+//// [export.js]
+exports["a thing"] = class {
+    a;
+    b;
+}
+//// [usage.ts]
+import * as ns from "./export";
+
+export const instance: ns."a thing" = new ns["a thing"]();
+
+//// [export.js]
+exports["a thing"] = /** @class */ (function () {
+    function class_1() {
+    }
+    return class_1;
+}());
+//// [usage.js]
+"use strict";
+exports.__esModule = true;
+exports.instance = void 0;
+var ns = require("./export");
+exports.instance = new ns["a thing"]();

--- a/tests/baselines/reference/nonIdentifierNamedDirectExportsReferencable.symbols
+++ b/tests/baselines/reference/nonIdentifierNamedDirectExportsReferencable.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/types/namedTypes/export.js ===
+exports["a thing"] = class {
+>exports : Symbol("tests/cases/conformance/types/namedTypes/export", Decl(export.js, 0, 0))
+>"a thing" : Symbol("a thing", Decl(export.js, 0, 0))
+
+    a;
+>a : Symbol("a thing".a, Decl(export.js, 0, 28))
+
+    b;
+>b : Symbol("a thing".b, Decl(export.js, 1, 6))
+}
+=== tests/cases/conformance/types/namedTypes/usage.ts ===
+import * as ns from "./export";
+>ns : Symbol(ns, Decl(usage.ts, 0, 6))
+
+export const instance: ns."a thing" = new ns["a thing"]();
+>instance : Symbol(instance, Decl(usage.ts, 2, 12))
+>ns : Symbol(ns, Decl(usage.ts, 0, 6))
+>ns : Symbol(ns, Decl(usage.ts, 0, 6))
+>"a thing" : Symbol(ns["a thing"], Decl(export.js, 0, 0))
+

--- a/tests/baselines/reference/nonIdentifierNamedDirectExportsReferencable.types
+++ b/tests/baselines/reference/nonIdentifierNamedDirectExportsReferencable.types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/types/namedTypes/export.js ===
+exports["a thing"] = class {
+>exports["a thing"] = class {    a;    b;} : typeof "a thing"
+>exports["a thing"] : typeof "a thing"
+>exports : typeof import("tests/cases/conformance/types/namedTypes/export")
+>"a thing" : "a thing"
+>class {    a;    b;} : typeof "a thing"
+
+    a;
+>a : any
+
+    b;
+>b : any
+}
+=== tests/cases/conformance/types/namedTypes/usage.ts ===
+import * as ns from "./export";
+>ns : typeof ns
+
+export const instance: ns."a thing" = new ns["a thing"]();
+>instance : ns."a thing"
+>ns : any
+>new ns["a thing"]() : ns."a thing"
+>ns["a thing"] : typeof ns."a thing"
+>ns : typeof ns
+>"a thing" : "a thing"
+

--- a/tests/baselines/reference/nonIdentifierNamedExportsReferenceable.js
+++ b/tests/baselines/reference/nonIdentifierNamedExportsReferenceable.js
@@ -1,0 +1,27 @@
+//// [tests/cases/conformance/types/namedTypes/nonIdentifierNamedExportsReferenceable.ts] ////
+
+//// [a.ts]
+export enum Foo {
+    "1-1",
+    "1-2"
+}
+//// [b.ts]
+import {Foo} from "./a";
+
+export type FooFirst = Foo."1-1";
+
+export type FirstFoo = import("./a").Foo."1-1";
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+exports.Foo = void 0;
+var Foo;
+(function (Foo) {
+    Foo[Foo["1-1"] = 0] = "1-1";
+    Foo[Foo["1-2"] = 1] = "1-2";
+})(Foo = exports.Foo || (exports.Foo = {}));
+//// [b.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/nonIdentifierNamedExportsReferenceable.symbols
+++ b/tests/baselines/reference/nonIdentifierNamedExportsReferenceable.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/types/namedTypes/a.ts ===
+export enum Foo {
+>Foo : Symbol(Foo, Decl(a.ts, 0, 0))
+
+    "1-1",
+>"1-1" : Symbol(Foo["1-1"], Decl(a.ts, 0, 17))
+
+    "1-2"
+>"1-2" : Symbol(Foo["1-2"], Decl(a.ts, 1, 10))
+}
+=== tests/cases/conformance/types/namedTypes/b.ts ===
+import {Foo} from "./a";
+>Foo : Symbol(Foo, Decl(b.ts, 0, 8))
+
+export type FooFirst = Foo."1-1";
+>FooFirst : Symbol(FooFirst, Decl(b.ts, 0, 24))
+>Foo : Symbol(Foo, Decl(b.ts, 0, 8))
+
+export type FirstFoo = import("./a").Foo."1-1";
+>FirstFoo : Symbol(FirstFoo, Decl(b.ts, 2, 33))
+>Foo : Symbol(Foo, Decl(a.ts, 0, 0))
+

--- a/tests/baselines/reference/nonIdentifierNamedExportsReferenceable.types
+++ b/tests/baselines/reference/nonIdentifierNamedExportsReferenceable.types
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/types/namedTypes/a.ts ===
+export enum Foo {
+>Foo : Foo
+
+    "1-1",
+>"1-1" : Foo.1-1
+
+    "1-2"
+>"1-2" : Foo.1-2
+}
+=== tests/cases/conformance/types/namedTypes/b.ts ===
+import {Foo} from "./a";
+>Foo : typeof Foo
+
+export type FooFirst = Foo."1-1";
+>FooFirst : Foo.1-1
+>Foo : any
+
+export type FirstFoo = import("./a").Foo."1-1";
+>FirstFoo : Foo.1-1
+>Foo : any
+

--- a/tests/baselines/reference/nonIdentifierNamedLocalImportAlias.js
+++ b/tests/baselines/reference/nonIdentifierNamedLocalImportAlias.js
@@ -1,0 +1,51 @@
+//// [tests/cases/conformance/types/namedTypes/nonIdentifierNamedLocalImportAlias.ts] ////
+
+//// [export.js]
+exports["another one"] = class {
+    c;
+    d;
+};
+exports["a thing"] = exports;
+//// [usage.ts]
+import * as A from "./export";
+import Result = A."a thing";
+
+export const another: Result."another one" = new Result["another one"]();
+export const again: A."a thing"."a thing"."another one" = null as any as A."another one";
+export const type: typeof Result."a thing"."another one" = {} as any;
+
+import Result2 = A.'a thing';
+
+export const another2: Result.'another one' = new Result['another one']();
+export const again2: A.'a thing'.'a thing'.'another one' = null as any as A.'another one';
+export const type2: typeof Result.'a thing'.'another one' = {} as any;
+
+import Result3 = A.`a thing`;
+
+export const another3: Result.`another one` = new Result[`another one`]();
+export const again3: A.`a thing`.`a thing`.`another one` = null as any as A.`another one`;
+export const type3: typeof Result.`a thing`.`another one` = {} as any;
+
+
+//// [export.js]
+exports["another one"] = /** @class */ (function () {
+    function class_1() {
+    }
+    return class_1;
+}());
+exports["a thing"] = exports;
+//// [usage.js]
+"use strict";
+exports.__esModule = true;
+exports.type3 = exports.again3 = exports.another3 = exports.type2 = exports.again2 = exports.another2 = exports.type = exports.again = exports.another = void 0;
+var A = require("./export");
+var Result = A["a thing"];
+exports.another = new Result["another one"]();
+exports.again = null;
+exports.type = {};
+exports.another2 = new Result['another one']();
+exports.again2 = null;
+exports.type2 = {};
+exports.another3 = new Result["another one"]();
+exports.again3 = null;
+exports.type3 = {};

--- a/tests/baselines/reference/nonIdentifierNamedLocalImportAlias.symbols
+++ b/tests/baselines/reference/nonIdentifierNamedLocalImportAlias.symbols
@@ -1,0 +1,84 @@
+=== tests/cases/conformance/types/namedTypes/export.js ===
+exports["another one"] = class {
+>exports : Symbol("a thing", Decl(export.js, 0, 0))
+>"another one" : Symbol("another one", Decl(export.js, 0, 0))
+
+    c;
+>c : Symbol("another one".c, Decl(export.js, 0, 32))
+
+    d;
+>d : Symbol("another one".d, Decl(export.js, 1, 6))
+
+};
+exports["a thing"] = exports;
+>exports : Symbol("a thing", Decl(export.js, 0, 0))
+>"a thing" : Symbol("a thing", Decl(export.js, 3, 2))
+>exports : Symbol("a thing", Decl(export.js, 0, 0))
+
+=== tests/cases/conformance/types/namedTypes/usage.ts ===
+import * as A from "./export";
+>A : Symbol(A, Decl(usage.ts, 0, 6))
+
+import Result = A."a thing";
+>Result : Symbol(Result, Decl(usage.ts, 0, 30))
+>A : Symbol(A, Decl(usage.ts, 0, 6))
+
+export const another: Result."another one" = new Result["another one"]();
+>another : Symbol(another, Decl(usage.ts, 3, 12))
+>Result : Symbol(Result, Decl(usage.ts, 0, 30))
+>Result : Symbol(Result, Decl(usage.ts, 0, 30))
+>"another one" : Symbol(A["another one"], Decl(export.js, 0, 0))
+
+export const again: A."a thing"."a thing"."another one" = null as any as A."another one";
+>again : Symbol(again, Decl(usage.ts, 4, 12))
+>A : Symbol(A, Decl(usage.ts, 0, 6))
+>A : Symbol(A, Decl(usage.ts, 0, 6))
+
+export const type: typeof Result."a thing"."another one" = {} as any;
+>type : Symbol(type, Decl(usage.ts, 5, 12))
+>Result."a thing"."another one" : Symbol(A["another one"], Decl(export.js, 0, 0))
+>Result."a thing" : Symbol(A["a thing"], Decl(export.js, 3, 2))
+>Result : Symbol(Result, Decl(usage.ts, 0, 30))
+
+import Result2 = A.'a thing';
+>Result2 : Symbol(Result2, Decl(usage.ts, 5, 69))
+>A : Symbol(A, Decl(usage.ts, 0, 6))
+
+export const another2: Result.'another one' = new Result['another one']();
+>another2 : Symbol(another2, Decl(usage.ts, 9, 12))
+>Result : Symbol(Result, Decl(usage.ts, 0, 30))
+>Result : Symbol(Result, Decl(usage.ts, 0, 30))
+>'another one' : Symbol(A["another one"], Decl(export.js, 0, 0))
+
+export const again2: A.'a thing'.'a thing'.'another one' = null as any as A.'another one';
+>again2 : Symbol(again2, Decl(usage.ts, 10, 12))
+>A : Symbol(A, Decl(usage.ts, 0, 6))
+>A : Symbol(A, Decl(usage.ts, 0, 6))
+
+export const type2: typeof Result.'a thing'.'another one' = {} as any;
+>type2 : Symbol(type2, Decl(usage.ts, 11, 12))
+>Result.'a thing'.'another one' : Symbol(A["another one"], Decl(export.js, 0, 0))
+>Result.'a thing' : Symbol(A["a thing"], Decl(export.js, 3, 2))
+>Result : Symbol(Result, Decl(usage.ts, 0, 30))
+
+import Result3 = A.`a thing`;
+>Result3 : Symbol(Result3, Decl(usage.ts, 11, 70))
+>A : Symbol(A, Decl(usage.ts, 0, 6))
+
+export const another3: Result.`another one` = new Result[`another one`]();
+>another3 : Symbol(another3, Decl(usage.ts, 15, 12))
+>Result : Symbol(Result, Decl(usage.ts, 0, 30))
+>Result : Symbol(Result, Decl(usage.ts, 0, 30))
+>`another one` : Symbol(A["another one"], Decl(export.js, 0, 0))
+
+export const again3: A.`a thing`.`a thing`.`another one` = null as any as A.`another one`;
+>again3 : Symbol(again3, Decl(usage.ts, 16, 12))
+>A : Symbol(A, Decl(usage.ts, 0, 6))
+>A : Symbol(A, Decl(usage.ts, 0, 6))
+
+export const type3: typeof Result.`a thing`.`another one` = {} as any;
+>type3 : Symbol(type3, Decl(usage.ts, 17, 12))
+>Result.`a thing`.`another one` : Symbol(A["another one"], Decl(export.js, 0, 0))
+>Result.`a thing` : Symbol(A["a thing"], Decl(export.js, 3, 2))
+>Result : Symbol(Result, Decl(usage.ts, 0, 30))
+

--- a/tests/baselines/reference/nonIdentifierNamedLocalImportAlias.types
+++ b/tests/baselines/reference/nonIdentifierNamedLocalImportAlias.types
@@ -1,0 +1,116 @@
+=== tests/cases/conformance/types/namedTypes/export.js ===
+exports["another one"] = class {
+>exports["another one"] = class {    c;    d;} : typeof "another one"
+>exports["another one"] : typeof "another one"
+>exports : typeof "a thing"
+>"another one" : "another one"
+>class {    c;    d;} : typeof "another one"
+
+    c;
+>c : any
+
+    d;
+>d : any
+
+};
+exports["a thing"] = exports;
+>exports["a thing"] = exports : typeof "a thing"
+>exports["a thing"] : typeof "a thing"
+>exports : typeof "a thing"
+>"a thing" : "a thing"
+>exports : typeof "a thing"
+
+=== tests/cases/conformance/types/namedTypes/usage.ts ===
+import * as A from "./export";
+>A : typeof A
+
+import Result = A."a thing";
+>Result : typeof A
+>A : typeof A
+
+export const another: Result."another one" = new Result["another one"]();
+>another : A."another one"
+>Result : any
+>new Result["another one"]() : A."another one"
+>Result["another one"] : typeof A."another one"
+>Result : typeof A
+>"another one" : "another one"
+
+export const again: A."a thing"."a thing"."another one" = null as any as A."another one";
+>again : A."another one"
+>A : any
+>null as any as A."another one" : A."another one"
+>null as any : any
+>null : null
+>A : any
+
+export const type: typeof Result."a thing"."another one" = {} as any;
+>type : typeof A."another one"
+>Result."a thing"."another one" : typeof A."another one"
+>Result."a thing" : typeof A
+>Result : typeof A
+>"a thing" : typeof A
+>"another one" : typeof A."another one"
+>{} as any : any
+>{} : {}
+
+import Result2 = A.'a thing';
+>Result2 : typeof A
+>A : typeof A
+
+export const another2: Result.'another one' = new Result['another one']();
+>another2 : A."another one"
+>Result : any
+>new Result['another one']() : A."another one"
+>Result['another one'] : typeof A."another one"
+>Result : typeof A
+>'another one' : "another one"
+
+export const again2: A.'a thing'.'a thing'.'another one' = null as any as A.'another one';
+>again2 : A."another one"
+>A : any
+>null as any as A.'another one' : A."another one"
+>null as any : any
+>null : null
+>A : any
+
+export const type2: typeof Result.'a thing'.'another one' = {} as any;
+>type2 : typeof A."another one"
+>Result.'a thing'.'another one' : typeof A."another one"
+>Result.'a thing' : typeof A
+>Result : typeof A
+>'a thing' : typeof A
+>'another one' : typeof A."another one"
+>{} as any : any
+>{} : {}
+
+import Result3 = A.`a thing`;
+>Result3 : typeof A
+>A : typeof A
+
+export const another3: Result.`another one` = new Result[`another one`]();
+>another3 : A."another one"
+>Result : any
+>new Result[`another one`]() : A."another one"
+>Result[`another one`] : typeof A."another one"
+>Result : typeof A
+>`another one` : "another one"
+
+export const again3: A.`a thing`.`a thing`.`another one` = null as any as A.`another one`;
+>again3 : A."another one"
+>A : any
+>null as any as A.`another one` : A."another one"
+>null as any : any
+>null : null
+>A : any
+
+export const type3: typeof Result.`a thing`.`another one` = {} as any;
+>type3 : typeof A."another one"
+>Result.`a thing`.`another one` : typeof A."another one"
+>Result.`a thing` : typeof A
+>Result : typeof A
+>`a thing` : typeof A
+>`another one` : typeof A."another one"
+>{} as any : any
+>{} : {}
+

--- a/tests/baselines/reference/taggedTemplatesWithTypeArguments2.errors.txt
+++ b/tests/baselines/reference/taggedTemplatesWithTypeArguments2.errors.txt
@@ -6,9 +6,10 @@ tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts(35,5)
 tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts(36,9): error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
 tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts(36,14): error TS2754: 'super' may not use type arguments.
 tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts(36,34): error TS1034: 'super' must be followed by an argument list or member access.
+tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts(36,34): error TS2339: Property '`hello world`' does not exist on type 'SomeBase<number, string, T>'.
 
 
-==== tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts (8 errors) ====
+==== tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts (9 errors) ====
     export interface SomethingTaggable {
         <T>(t: TemplateStringsArray, ...args: T[]): SomethingNewable;
     }
@@ -61,6 +62,8 @@ tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts(36,34
 !!! error TS2754: 'super' may not use type arguments.
                                      ~~~~~~~~~~~~~
 !!! error TS1034: 'super' must be followed by an argument list or member access.
+                                     ~~~~~~~~~~~~~
+!!! error TS2339: Property '`hello world`' does not exist on type 'SomeBase<number, string, T>'.
         }
     ~~~~~
 !!! error TS2377: Constructors for derived classes must contain a 'super' call.

--- a/tests/baselines/reference/taggedTemplatesWithTypeArguments2.js
+++ b/tests/baselines/reference/taggedTemplatesWithTypeArguments2.js
@@ -56,7 +56,7 @@ class SomeBase {
 }
 class SomeDerived extends SomeBase {
     constructor() {
-        super. `hello world`;
+        super.`hello world`;
     }
 }
 export {};

--- a/tests/baselines/reference/taggedTemplatesWithTypeArguments2.types
+++ b/tests/baselines/reference/taggedTemplatesWithTypeArguments2.types
@@ -92,9 +92,7 @@ class SomeDerived<T> extends SomeBase<number, string, T> {
     constructor() {
         super<number, string, T> `hello world`;
 >super<number, string, T> `hello world` : any
->super<number, string, T> : any
 >super : SomeBase<number, string, T>
-> : any
->`hello world` : "hello world"
+>`hello world` : any
     }
 }

--- a/tests/cases/conformance/types/namedTypes/nonIdentifierNamedDirectExportsReferencable.ts
+++ b/tests/cases/conformance/types/namedTypes/nonIdentifierNamedDirectExportsReferencable.ts
@@ -1,0 +1,11 @@
+// @allowJs: true
+// @outDir: ./out
+// @filename: export.js
+exports["a thing"] = class {
+    a;
+    b;
+}
+// @filename: usage.ts
+import * as ns from "./export";
+
+export const instance: ns."a thing" = new ns["a thing"]();

--- a/tests/cases/conformance/types/namedTypes/nonIdentifierNamedExportsReferenceable.ts
+++ b/tests/cases/conformance/types/namedTypes/nonIdentifierNamedExportsReferenceable.ts
@@ -1,0 +1,11 @@
+// @filename: a.ts
+export enum Foo {
+    "1-1",
+    "1-2"
+}
+// @filename: b.ts
+import {Foo} from "./a";
+
+export type FooFirst = Foo."1-1";
+
+export type FirstFoo = import("./a").Foo."1-1";

--- a/tests/cases/conformance/types/namedTypes/nonIdentifierNamedLocalImportAlias.ts
+++ b/tests/cases/conformance/types/namedTypes/nonIdentifierNamedLocalImportAlias.ts
@@ -1,0 +1,27 @@
+// @allowJs: true
+// @outDir: ./out
+// @filename: export.js
+exports["another one"] = class {
+    c;
+    d;
+};
+exports["a thing"] = exports;
+// @filename: usage.ts
+import * as A from "./export";
+import Result = A."a thing";
+
+export const another: Result."another one" = new Result["another one"]();
+export const again: A."a thing"."a thing"."another one" = null as any as A."another one";
+export const type: typeof Result."a thing"."another one" = {} as any;
+
+import Result2 = A.'a thing';
+
+export const another2: Result.'another one' = new Result['another one']();
+export const again2: A.'a thing'.'a thing'.'another one' = null as any as A.'another one';
+export const type2: typeof Result.'a thing'.'another one' = {} as any;
+
+import Result3 = A.`a thing`;
+
+export const another3: Result.`another one` = new Result[`another one`]();
+export const again3: A.`a thing`.`a thing`.`another one` = null as any as A.`another one`;
+export const type3: typeof Result.`a thing`.`another one` = {} as any;


### PR DESCRIPTION
As I alluded to in #40679, the real root cause of #40152 is that we can't even reference the type-side of the non-identifier enum members via a type reference, because the reference syntax has no allowances for non-identifier names. This PR allows the type-side of non-identifier exports to be referenced within the type system via references of the form `NS."string name"`. Meaning you can now have code like this:
```ts
// @filename: export.js
exports["a thing"] = class {
    a;
    b;
}
// @filename: usage.ts
import * as ns from "./export";

export const instance: ns."a thing" = new ns["a thing"]();
```
Or like this:
```ts
// @filename: a.ts
export enum Foo {
    "1-1",
    "1-2"
}
// @filename: b.ts
import {Foo} from "./a";

export type FooFirst = Foo."1-1";
```

If we want to take this (and I think we do, between current enum and js exports and upcoming wasm exports), we probably want to do it after `master` has swapped to 4.2, since the 4.1 beta has been cut - so there's not much time pressure to look into this yet - I just wanted to have this ready and available for consideration and discussion. We may also want to pair it with additional syntax on the declaration side to allow the declaration of non-identifier export names in ambient contexts (eg, `export const "a thing": Type;`) - so js files (and upcoming wasm files) can be better represented with a declaration file.