### PR TITLE
Add currency sign to NumberFormatOptions type

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4284,6 +4284,7 @@ declare namespace Intl {
         style?: string;
         currency?: string;
         currencyDisplay?: string;
+        currencySign?: string;
         useGrouping?: boolean;
         minimumIntegerDigits?: number;
         minimumFractionDigits?: number;

--- a/tests/baselines/reference/numberFormatCurrencySign.js
+++ b/tests/baselines/reference/numberFormatCurrencySign.js
@@ -1,0 +1,6 @@
+//// [numberFormatCurrencySign.ts]
+const str = new Intl.NumberFormat('en-NZ', { style: 'currency', currency: 'NZD', currencySign: 'accounting' }).format(999999);
+
+
+//// [numberFormatCurrencySign.js]
+var str = new Intl.NumberFormat('en-NZ', { style: 'currency', currency: 'NZD', currencySign: 'accounting' }).format(999999);

--- a/tests/baselines/reference/numberFormatCurrencySign.symbols
+++ b/tests/baselines/reference/numberFormatCurrencySign.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/numberFormatCurrencySign.ts ===
+const str = new Intl.NumberFormat('en-NZ', { style: 'currency', currency: 'NZD', currencySign: 'accounting' }).format(999999);
+>str : Symbol(str, Decl(numberFormatCurrencySign.ts, 0, 5))
+>new Intl.NumberFormat('en-NZ', { style: 'currency', currency: 'NZD', currencySign: 'accounting' }).format : Symbol(Intl.NumberFormat.format, Decl(lib.es5.d.ts, --, --))
+>Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --))
+>NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>style : Symbol(style, Decl(numberFormatCurrencySign.ts, 0, 44))
+>currency : Symbol(currency, Decl(numberFormatCurrencySign.ts, 0, 63))
+>currencySign : Symbol(currencySign, Decl(numberFormatCurrencySign.ts, 0, 80))
+>format : Symbol(Intl.NumberFormat.format, Decl(lib.es5.d.ts, --, --))
+

--- a/tests/baselines/reference/numberFormatCurrencySign.types
+++ b/tests/baselines/reference/numberFormatCurrencySign.types
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/numberFormatCurrencySign.ts ===
+const str = new Intl.NumberFormat('en-NZ', { style: 'currency', currency: 'NZD', currencySign: 'accounting' }).format(999999);
+>str : string
+>new Intl.NumberFormat('en-NZ', { style: 'currency', currency: 'NZD', currencySign: 'accounting' }).format(999999) : string
+>new Intl.NumberFormat('en-NZ', { style: 'currency', currency: 'NZD', currencySign: 'accounting' }).format : (value: number) => string
+>new Intl.NumberFormat('en-NZ', { style: 'currency', currency: 'NZD', currencySign: 'accounting' }) : Intl.NumberFormat
+>Intl.NumberFormat : { (locales?: string | string[], options?: Intl.NumberFormatOptions): Intl.NumberFormat; new (locales?: string | string[], options?: Intl.NumberFormatOptions): Intl.NumberFormat; supportedLocalesOf(locales: string | string[], options?: Intl.NumberFormatOptions): string[]; }
+>Intl : typeof Intl
+>NumberFormat : { (locales?: string | string[], options?: Intl.NumberFormatOptions): Intl.NumberFormat; new (locales?: string | string[], options?: Intl.NumberFormatOptions): Intl.NumberFormat; supportedLocalesOf(locales: string | string[], options?: Intl.NumberFormatOptions): string[]; }
+>'en-NZ' : "en-NZ"
+>{ style: 'currency', currency: 'NZD', currencySign: 'accounting' } : { style: string; currency: string; currencySign: string; }
+>style : string
+>'currency' : "currency"
+>currency : string
+>'NZD' : "NZD"
+>currencySign : string
+>'accounting' : "accounting"
+>format : (value: number) => string
+>999999 : 999999
+

--- a/tests/cases/compiler/numberFormatCurrencySign.ts
+++ b/tests/cases/compiler/numberFormatCurrencySign.ts
@@ -1,0 +1,1 @@
+const str = new Intl.NumberFormat('en-NZ', { style: 'currency', currency: 'NZD', currencySign: 'accounting' }).format(999999);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

This adds the missing `currencySign` field to the `NumberFormatOptions` type. It is my first time working with this codebase, so there probably is a better place to put the corresponding test? (example taken from the issue).

Fixes #40622.
