### PR TITLE
Reorder LKG tasks so protocol build isn't using partial LKG

### DIFF
--- a/scripts/produceLKG.ts
+++ b/scripts/produceLKG.ts
@@ -15,10 +15,10 @@ async function produceLKG() {
     await copyLibFiles();
     await copyLocalizedDiagnostics();
     await copyTypesMap();
-    await buildProtocol();
     await copyScriptOutputs();
     await copyDeclarationOutputs();
     await writeGitAttributes();
+    await buildProtocol();
 }
 
 async function copyLibFiles() {

--- a/scripts/produceLKG.ts
+++ b/scripts/produceLKG.ts
@@ -17,8 +17,8 @@ async function produceLKG() {
     await copyTypesMap();
     await copyScriptOutputs();
     await copyDeclarationOutputs();
-    await writeGitAttributes();
     await buildProtocol();
+    await writeGitAttributes();
 }
 
 async function copyLibFiles() {


### PR DESCRIPTION
Fixes #40716
