### PR TITLE
fix(40685): JSDoc generation for arrow functions within object does not work

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -329,6 +329,7 @@ namespace ts.JsDoc {
             case SyntaxKind.MethodDeclaration:
             case SyntaxKind.Constructor:
             case SyntaxKind.MethodSignature:
+            case SyntaxKind.ArrowFunction:
                 const { parameters } = commentOwner as FunctionDeclaration | MethodDeclaration | ConstructorDeclaration | MethodSignature;
                 return { commentOwner, parameters };
 

--- a/tests/cases/fourslash/docCommentTemplateObjectLiteralMethods01.ts
+++ b/tests/cases/fourslash/docCommentTemplateObjectLiteralMethods01.ts
@@ -8,10 +8,15 @@ const multiLineOffset = 12;
 ////    foo() {
 ////        return undefined;
 ////    }
+////
 ////    /*1*/
 ////    [1 + 2 + 3 + Math.rand()](x: number, y: string, z = true) { }
+////
 ////    /*2*/
-////    m: function(a) {}
+////    m1: function(a) {}
+////
+////    /*3*/
+////    m2: (a: string, b: string) => {}
 ////}
 
 verify.docCommentTemplateAt("0", singleLineOffset, "/** */");
@@ -23,9 +28,16 @@ verify.docCommentTemplateAt("1", multiLineOffset,
      * @param y
      * @param z
      */`);
-    
+
 verify.docCommentTemplateAt("2", multiLineOffset,
    `/**
      * 
      * @param a
+     */`);
+
+verify.docCommentTemplateAt("3", multiLineOffset,
+   `/**
+     * 
+     * @param a
+     * @param b
      */`);


### PR DESCRIPTION
Fixes #40685