### PR TITLE
Simplify and optimize addTypesToUnion

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12921,8 +12921,6 @@ namespace ts {
         // Construct a type set from the given types.  Type ID order is applied, duplicates are removed,
         // and nested types of the given kind are flattened into the set.
         function makeUnion(types: readonly Type[]): [ Type[], TypeFlags ] {
-            tracing.begin(tracing.Phase.Check, "makeUnion", { typeIds: types.map(t => t.id) });
-
             const typeSet: Type[] = [];
             let includes: TypeFlags = 0;
 
@@ -12963,8 +12961,6 @@ namespace ts {
             }
 
             typeSet.sort((t1, t2) => t1.id - t2.id);
-
-            tracing.end();
 
             return [typeSet, includes];
         }


### PR DESCRIPTION
I was working on a perf issue with lots of big unions and noticed that `addTypesToUnion` appeared to be more complicated than it needed to be (e.g. the recursion made tracing harder).  In that unreasonable code, this cut check time by about 20%, but it probably won't matter for most consumers.  Simplicity is nice though.