### PR TITLE
Cache property name widening contexts

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5550,10 +5550,11 @@ namespace ts {
 
     /* @internal */
     export interface WideningContext {
-        parent?: WideningContext;       // Parent context
-        propertyName?: __String;        // Name of property in parent
-        siblings?: Type[];              // Types of siblings
-        resolvedProperties?: Symbol[];  // Properties occurring in sibling object literals
+        parent?: WideningContext;                          // Parent context
+        propertyName?: __String;                           // Name of property in parent
+        siblings?: Type[];                                 // Types of siblings
+        resolvedProperties?: Symbol[];                     // Properties occurring in sibling object literals
+        childContexts?: ESMap<__String, WideningContext>;  // WideningContexts with parent === this and propertyName as the key
     }
 
     /* @internal */


### PR DESCRIPTION
When creating a new `WideningContext` for a given property, check whether
there's an existing `WideningContext` with the same `parent` and
`propertyName`.  Otherwise, we won't adequately leverage the cache of
computed `siblings` stored on the `WideningContext`.

On my box, check time drops from 10 seconds to 0.3 seconds for [this example](https://www.typescriptlang.org/play?noImplicitAny=false&strictFunctionTypes=false&strictBindCallApply=false&ts=4.0.2#code/CYUwxgNghgTiAEYD2A7AzgF0a4BGAXPAEZJIQhQoDcAsAFCiSwLLpavABMhJZF19RtDjY2o4AGYepcpVoNwwlqkziALNL5zBi5qNUcArJtkCFTEawM4AbCf7yheq+xwB2e9vNL9rlMAAOTzMnSxU-YABOYMddMLEOXAAGGJ0LZQScXAJiGQc0nxdxXG5crRC4jOt-XCky01j032KNevy6egAzAFcUMAwAS1R4ToAKAEoAb3p4Wfg4DG6YFHhpujmN+AA6HdHE+AAyA9WZzbPO1AwAZQGALxBCXAAaU7ONjBAADwwAQQgBgDmKEInFemwAvuMXus3jstnscJFDsc1m9NiQYKAYAAlKDAAbdNCECTQtEbC4oa53B7wNSksmzCkYADqIEBAAsMIRDPSGQBbWAAgYoAAyIE6XPgNl5ZIFMCFKGxHMlbhlaIADnj8SgAWKJYQAmCNpC1XM4QiampkScYQyiFAwABrAEwJC9YAAYTISBghEiprOGKxXogPseSQDm2Qod98GykfJlxu90eoNtEKhRrNuw4bmtqIZxAdztd7pDYbjJKzZ2jFdwdOrm3VSDQA0GqEePMbGwA7gNgBh2Y9pd25rcAJL+L6PNyNk2N80cTj50ezWux3ABBNzEifK7svFIHuPf2r+ACz7M-uDkERs-stkAzkg55npms5Ugzjb2b-FAgAAJR9n3gTgq3TNEmWTGlOAbCC3k1YBtQBEEu3gwMfSxEER3QzYJynT4QVnXD51wxccGXI4zw4K0jhtQt4EQ5CQUNEjMzInMKORaicAkFdcN7a8h1A08BLmJjhRQ+AJCSOd2LRcj-Eog4eP8Qx+IYh9P2k18xMZS4PyfSUJG-M8-0A4DjPAhioOpYk4IYiSdXsuTI0UrhuL08R1KoryOD4uiCwZJyASVIziRsVyF04mplPowt7SdF03X8ctYwkVUzyDEB0q3M85QVYlRIYvlhSA7S1DvLyQsINRdIYj5vj+QFgVpUyvP-TAQGAQggoY89BWFWqJDPcEoo4+FElwDSEswnLcXxQlaoc2bMRyvVJTUNCGOynEKpwxyWzbIZWrUTKvIwJB1VqvKvL7AdhLUSJxoUmK8AClF8sG1rDCqmykzs+BDHqwtOo+Hr4v6gb5SGoG0wYsa2Lct6bBmu1i2SstvVjQxrNW4Nse5FaGXXbltsLWyUyBg7CxCgAVK7uXOxytUkgAhJAMEuvluVukqyss7lnqR6LJqyJI0bJRKSxSz1CalP78ZywgbBBkn5ZseG3lI16xf8AJJbRaXMdSjW8btObYxsYmyVJqVDBeuZwXkcEgA).