### PR TITLE
Fix unnecessary new lines in output represented incorrectly in the baselines

### DIFF
--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -1203,9 +1203,11 @@ interface Array<T> { length: number; [n: number]: T; }`
     }
 
     function baselineOutputs(baseline: string[], output: readonly string[], start: number, end = output.length) {
+        let baselinedOutput: string[] | undefined;
         for (let i = start; i < end; i++) {
-            baseline.push(output[i].replace(/Elapsed::\s[0-9]+ms/g, "Elapsed:: *ms"));
+            (baselinedOutput ||= []).push(output[i].replace(/Elapsed::\s[0-9]+ms/g, "Elapsed:: *ms"));
         }
+        if (baselinedOutput) baseline.push(baselinedOutput.join(""));
     }
 
     export type TestServerHostTrackingWrittenFiles = TestServerHost & { writtenFiles: ESMap<Path, number>; };

--- a/tests/baselines/reference/tsbuild/watchMode/configFileErrors/reports-syntax-errors-in-config-file.js
+++ b/tests/baselines/reference/tsbuild/watchMode/configFileErrors/reports-syntax-errors-in-config-file.js
@@ -35,12 +35,10 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [96mtsconfig.json[0m:[93m7[0m:[93m9[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m7[0m         "b.ts"
 [7m [0m [91m        ~~~~~~[0m
-
 
 [[90m12:00:24 AM[0m] Found 1 error. Watching for file changes.
 
@@ -90,12 +88,10 @@ Output::
 >> Screen clear
 [[90m12:00:28 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mtsconfig.json[0m:[93m8[0m:[93m9[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m8[0m         "b.ts"
 [7m [0m [91m        ~~~~~~[0m
-
 
 [[90m12:00:29 AM[0m] Found 1 error. Watching for file changes.
 
@@ -136,12 +132,10 @@ Output::
 >> Screen clear
 [[90m12:00:33 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mtsconfig.json[0m:[93m8[0m:[93m9[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m8[0m         "b.ts"
 [7m [0m [91m        ~~~~~~[0m
-
 
 [[90m12:00:34 AM[0m] Found 1 error. Watching for file changes.
 
@@ -180,12 +174,10 @@ Output::
 >> Screen clear
 [[90m12:00:38 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mtsconfig.json[0m:[93m8[0m:[93m9[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m8[0m         "b.ts"
 [7m [0m [91m        ~~~~~~[0m
-
 
 [[90m12:00:39 AM[0m] Found 1 error. Watching for file changes.
 
@@ -225,7 +217,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:43 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:54 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/demo/updates-with-bad-reference.js
+++ b/tests/baselines/reference/tsbuild/watchMode/demo/updates-with-bad-reference.js
@@ -148,73 +148,58 @@ Output::
 >> Screen clear
 [[90m12:00:46 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:47 AM[0m] Projects in this build: 
     * core/tsconfig.json
     * animals/tsconfig.json
     * zoo/tsconfig.json
     * tsconfig.json
 
-
 [[90m12:00:48 AM[0m] Project 'core/tsconfig.json' is out of date because output file 'lib/core/utilities.js' does not exist
 
-
 [[90m12:00:49 AM[0m] Building project '/user/username/projects/demo/core/tsconfig.json'...
-
 
 [96manimals/index.ts[0m:[93m1[0m:[93m20[0m - [91merror[0m[90m TS6059: [0mFile '/user/username/projects/demo/animals/animal.ts' is not under 'rootDir' '/user/username/projects/demo/core'. 'rootDir' is expected to contain all source files.
 
 [7m1[0m import Animal from './animal';
 [7m [0m [91m                   ~~~~~~~~~~[0m
 
-
 [96manimals/index.ts[0m:[93m1[0m:[93m20[0m - [91merror[0m[90m TS6307: [0mFile '/user/username/projects/demo/animals/animal.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern.
 
 [7m1[0m import Animal from './animal';
 [7m [0m [91m                   ~~~~~~~~~~[0m
-
 
 [96manimals/index.ts[0m:[93m4[0m:[93m32[0m - [91merror[0m[90m TS6059: [0mFile '/user/username/projects/demo/animals/dog.ts' is not under 'rootDir' '/user/username/projects/demo/core'. 'rootDir' is expected to contain all source files.
 
 [7m4[0m import { createDog, Dog } from './dog';
 [7m [0m [91m                               ~~~~~~~[0m
 
-
 [96manimals/index.ts[0m:[93m4[0m:[93m32[0m - [91merror[0m[90m TS6307: [0mFile '/user/username/projects/demo/animals/dog.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern.
 
 [7m4[0m import { createDog, Dog } from './dog';
 [7m [0m [91m                               ~~~~~~~[0m
-
 
 [96mcore/utilities.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS6133: [0m'A' is declared but its value is never read.
 
 [7m1[0m import * as A from '../animals';
 [7m [0m [91m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
 
-
 [96mcore/utilities.ts[0m:[93m1[0m:[93m20[0m - [91merror[0m[90m TS6059: [0mFile '/user/username/projects/demo/animals/index.ts' is not under 'rootDir' '/user/username/projects/demo/core'. 'rootDir' is expected to contain all source files.
 
 [7m1[0m import * as A from '../animals';
 [7m [0m [91m                   ~~~~~~~~~~~~[0m
-
 
 [96mcore/utilities.ts[0m:[93m1[0m:[93m20[0m - [91merror[0m[90m TS6307: [0mFile '/user/username/projects/demo/animals/index.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern.
 
 [7m1[0m import * as A from '../animals';
 [7m [0m [91m                   ~~~~~~~~~~~~[0m
 
-
 [[90m12:00:57 AM[0m] Project 'animals/tsconfig.json' can't be built because its dependency 'core' has errors
-
 
 [[90m12:00:58 AM[0m] Skipping build of project '/user/username/projects/demo/animals/tsconfig.json' because its dependency '/user/username/projects/demo/core' has errors
 
-
 [[90m12:00:59 AM[0m] Project 'zoo/tsconfig.json' can't be built because its dependency 'animals' was not built
 
-
 [[90m12:01:00 AM[0m] Skipping build of project '/user/username/projects/demo/zoo/tsconfig.json' because its dependency '/user/username/projects/demo/animals' was not built
-
 
 [[90m12:01:01 AM[0m] Found 7 errors. Watching for file changes.
 
@@ -401,54 +386,44 @@ Output::
 >> Screen clear
 [[90m12:01:05 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:01:06 AM[0m] Project 'core/tsconfig.json' is out of date because output file 'lib/core/utilities.js' does not exist
 
-
 [[90m12:01:07 AM[0m] Building project '/user/username/projects/demo/core/tsconfig.json'...
-
 
 [96manimals/index.ts[0m:[93m1[0m:[93m20[0m - [91merror[0m[90m TS6059: [0mFile '/user/username/projects/demo/animals/animal.ts' is not under 'rootDir' '/user/username/projects/demo/core'. 'rootDir' is expected to contain all source files.
 
 [7m1[0m import Animal from './animal';
 [7m [0m [91m                   ~~~~~~~~~~[0m
 
-
 [96manimals/index.ts[0m:[93m1[0m:[93m20[0m - [91merror[0m[90m TS6307: [0mFile '/user/username/projects/demo/animals/animal.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern.
 
 [7m1[0m import Animal from './animal';
 [7m [0m [91m                   ~~~~~~~~~~[0m
-
 
 [96manimals/index.ts[0m:[93m4[0m:[93m32[0m - [91merror[0m[90m TS6059: [0mFile '/user/username/projects/demo/animals/dog.ts' is not under 'rootDir' '/user/username/projects/demo/core'. 'rootDir' is expected to contain all source files.
 
 [7m4[0m import { createDog, Dog } from './dog';
 [7m [0m [91m                               ~~~~~~~[0m
 
-
 [96manimals/index.ts[0m:[93m4[0m:[93m32[0m - [91merror[0m[90m TS6307: [0mFile '/user/username/projects/demo/animals/dog.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern.
 
 [7m4[0m import { createDog, Dog } from './dog';
 [7m [0m [91m                               ~~~~~~~[0m
-
 
 [96mcore/utilities.ts[0m:[93m2[0m:[93m1[0m - [91merror[0m[90m TS6133: [0m'A' is declared but its value is never read.
 
 [7m2[0m import * as A from '../animals';
 [7m [0m [91m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
 
-
 [96mcore/utilities.ts[0m:[93m2[0m:[93m20[0m - [91merror[0m[90m TS6059: [0mFile '/user/username/projects/demo/animals/index.ts' is not under 'rootDir' '/user/username/projects/demo/core'. 'rootDir' is expected to contain all source files.
 
 [7m2[0m import * as A from '../animals';
 [7m [0m [91m                   ~~~~~~~~~~~~[0m
 
-
 [96mcore/utilities.ts[0m:[93m2[0m:[93m20[0m - [91merror[0m[90m TS6307: [0mFile '/user/username/projects/demo/animals/index.ts' is not listed within the file list of project '/user/username/projects/demo/core/tsconfig.json'. Projects must list all files or use an 'include' pattern.
 
 [7m2[0m import * as A from '../animals';
 [7m [0m [91m                   ~~~~~~~~~~~~[0m
-
 
 [[90m12:01:11 AM[0m] Found 7 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/demo/updates-with-circular-reference.js
+++ b/tests/baselines/reference/tsbuild/watchMode/demo/updates-with-circular-reference.js
@@ -152,19 +152,16 @@ Output::
 >> Screen clear
 [[90m12:00:46 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:47 AM[0m] Projects in this build: 
     * animals/tsconfig.json
     * zoo/tsconfig.json
     * core/tsconfig.json
     * tsconfig.json
 
-
 [91merror[0m[90m TS6202: [0mProject references may not form a circular graph. Cycle detected: /user/username/projects/demo/tsconfig.json
 /user/username/projects/demo/core/tsconfig.json
 /user/username/projects/demo/zoo/tsconfig.json
 /user/username/projects/demo/animals/tsconfig.json
-
 
 [[90m12:00:48 AM[0m] Found 1 error. Watching for file changes.
 
@@ -220,24 +217,17 @@ Output::
 >> Screen clear
 [[90m12:00:52 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:53 AM[0m] Project 'core/tsconfig.json' is out of date because output file 'lib/core/utilities.js' does not exist
-
 
 [[90m12:00:54 AM[0m] Building project '/user/username/projects/demo/core/tsconfig.json'...
 
-
 [[90m12:01:06 AM[0m] Project 'animals/tsconfig.json' is out of date because output file 'lib/animals/animal.js' does not exist
-
 
 [[90m12:01:07 AM[0m] Building project '/user/username/projects/demo/animals/tsconfig.json'...
 
-
 [[90m12:01:25 AM[0m] Project 'zoo/tsconfig.json' is out of date because output file 'lib/zoo/zoo.js' does not exist
 
-
 [[90m12:01:26 AM[0m] Building project '/user/username/projects/demo/zoo/tsconfig.json'...
-
 
 [[90m12:01:36 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/noEmitOnError/does-not-emit-any-files-on-error-with-incremental.js
+++ b/tests/baselines/reference/tsbuild/watchMode/noEmitOnError/does-not-emit-any-files-on-error-with-incremental.js
@@ -44,16 +44,12 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:32 AM[0m] Projects in this build: 
     * tsconfig.json
 
-
 [[90m12:00:33 AM[0m] Project 'tsconfig.json' is out of date because output file 'dev-build/shared/types/db.js' does not exist
 
-
 [[90m12:00:34 AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
-
 
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
@@ -64,7 +60,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:35 AM[0m] Found 1 error. Watching for file changes.
 
@@ -108,12 +103,9 @@ Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:40 AM[0m] Project 'tsconfig.json' is out of date because output file 'dev-build/shared/types/db.js' does not exist
 
-
 [[90m12:00:41 AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
-
 
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
@@ -124,7 +116,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:42 AM[0m] Found 1 error. Watching for file changes.
 
@@ -173,12 +164,9 @@ Output::
 >> Screen clear
 [[90m12:00:46 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:47 AM[0m] Project 'tsconfig.json' is out of date because output file 'dev-build/shared/types/db.js' does not exist
 
-
 [[90m12:00:48 AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
-
 
 [[90m12:01:07 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -296,18 +284,14 @@ Output::
 >> Screen clear
 [[90m12:01:11 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:01:12 AM[0m] Project 'tsconfig.json' is out of date because oldest output 'dev-build/shared/types/db.js' is older than newest input 'src/main.ts'
 
-
 [[90m12:01:13 AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
-
 
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:17 AM[0m] Found 1 error. Watching for file changes.
 
@@ -418,18 +402,14 @@ Output::
 >> Screen clear
 [[90m12:01:21 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:01:22 AM[0m] Project 'tsconfig.json' is out of date because oldest output 'dev-build/shared/types/db.js' is older than newest input 'src/main.ts'
 
-
 [[90m12:01:23 AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
-
 
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:24 AM[0m] Found 1 error. Watching for file changes.
 
@@ -476,15 +456,11 @@ Output::
 >> Screen clear
 [[90m12:01:28 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:01:29 AM[0m] Project 'tsconfig.json' is out of date because oldest output 'dev-build/shared/types/db.js' is older than newest input 'src/main.ts'
-
 
 [[90m12:01:30 AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
-
 [[90m12:01:38 AM[0m] Updating unchanged output timestamps of project '/user/username/projects/noEmitOnError/tsconfig.json'...
-
 
 [[90m12:01:39 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -585,15 +561,11 @@ Output::
 >> Screen clear
 [[90m12:01:43 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:01:44 AM[0m] Project 'tsconfig.json' is out of date because oldest output 'dev-build/shared/types/db.js' is older than newest input 'src/main.ts'
-
 
 [[90m12:01:45 AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
-
 [[90m12:01:47 AM[0m] Updating unchanged output timestamps of project '/user/username/projects/noEmitOnError/tsconfig.json'...
-
 
 [[90m12:01:48 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/noEmitOnError/does-not-emit-any-files-on-error.js
+++ b/tests/baselines/reference/tsbuild/watchMode/noEmitOnError/does-not-emit-any-files-on-error.js
@@ -44,16 +44,12 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:32 AM[0m] Projects in this build: 
     * tsconfig.json
 
-
 [[90m12:00:33 AM[0m] Project 'tsconfig.json' is out of date because output file 'dev-build/shared/types/db.js' does not exist
 
-
 [[90m12:00:34 AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
-
 
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
@@ -64,7 +60,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:35 AM[0m] Found 1 error. Watching for file changes.
 
@@ -108,12 +103,9 @@ Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:40 AM[0m] Project 'tsconfig.json' is out of date because output file 'dev-build/shared/types/db.js' does not exist
 
-
 [[90m12:00:41 AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
-
 
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
@@ -124,7 +116,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:42 AM[0m] Found 1 error. Watching for file changes.
 
@@ -173,12 +164,9 @@ Output::
 >> Screen clear
 [[90m12:00:46 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:47 AM[0m] Project 'tsconfig.json' is out of date because output file 'dev-build/shared/types/db.js' does not exist
 
-
 [[90m12:00:48 AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
-
 
 [[90m12:01:05 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -248,18 +236,14 @@ Output::
 >> Screen clear
 [[90m12:01:09 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:01:10 AM[0m] Project 'tsconfig.json' is out of date because oldest output 'dev-build/shared/types/db.js' is older than newest input 'src/main.ts'
 
-
 [[90m12:01:11 AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
-
 
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:12 AM[0m] Found 1 error. Watching for file changes.
 
@@ -304,18 +288,14 @@ Output::
 >> Screen clear
 [[90m12:01:16 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:01:17 AM[0m] Project 'tsconfig.json' is out of date because oldest output 'dev-build/shared/types/db.js' is older than newest input 'src/main.ts'
 
-
 [[90m12:01:18 AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
-
 
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:19 AM[0m] Found 1 error. Watching for file changes.
 
@@ -362,15 +342,11 @@ Output::
 >> Screen clear
 [[90m12:01:23 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:01:24 AM[0m] Project 'tsconfig.json' is out of date because oldest output 'dev-build/shared/types/db.js' is older than newest input 'src/main.ts'
-
 
 [[90m12:01:25 AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
-
 [[90m12:01:30 AM[0m] Updating unchanged output timestamps of project '/user/username/projects/noEmitOnError/tsconfig.json'...
-
 
 [[90m12:01:31 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -423,15 +399,11 @@ Output::
 >> Screen clear
 [[90m12:01:35 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:01:36 AM[0m] Project 'tsconfig.json' is out of date because oldest output 'dev-build/shared/types/db.js' is older than newest input 'src/main.ts'
-
 
 [[90m12:01:37 AM[0m] Building project '/user/username/projects/noEmitOnError/tsconfig.json'...
 
-
 [[90m12:01:39 AM[0m] Updating unchanged output timestamps of project '/user/username/projects/noEmitOnError/tsconfig.json'...
-
 
 [[90m12:01:40 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/creates-solution-in-watch-mode.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/creates-solution-in-watch-mode.js
@@ -107,7 +107,6 @@ Output::
 >> Screen clear
 [[90m12:00:45 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:14 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/incremental-updates-in-verbose-mode.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/incremental-updates-in-verbose-mode.js
@@ -107,30 +107,22 @@ Output::
 >> Screen clear
 [[90m12:00:45 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:46 AM[0m] Projects in this build: 
     * sample1/core/tsconfig.json
     * sample1/logic/tsconfig.json
     * sample1/tests/tsconfig.json
 
-
 [[90m12:00:47 AM[0m] Project 'sample1/core/tsconfig.json' is out of date because output file 'sample1/core/anotherModule.js' does not exist
-
 
 [[90m12:00:48 AM[0m] Building project '/user/username/projects/sample1/core/tsconfig.json'...
 
-
 [[90m12:01:03 AM[0m] Project 'sample1/logic/tsconfig.json' is out of date because output file 'sample1/logic/index.js' does not exist
-
 
 [[90m12:01:04 AM[0m] Building project '/user/username/projects/sample1/logic/tsconfig.json'...
 
-
 [[90m12:01:13 AM[0m] Project 'sample1/tests/tsconfig.json' is out of date because output file 'sample1/tests/index.js' does not exist
 
-
 [[90m12:01:14 AM[0m] Building project '/user/username/projects/sample1/tests/tsconfig.json'...
-
 
 [[90m12:01:21 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -457,18 +449,13 @@ Output::
 >> Screen clear
 [[90m12:01:25 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:01:26 AM[0m] Project 'sample1/logic/tsconfig.json' is out of date because oldest output 'sample1/logic/index.js' is older than newest input 'sample1/core'
-
 
 [[90m12:01:27 AM[0m] Building project '/user/username/projects/sample1/logic/tsconfig.json'...
 
-
 [[90m12:01:40 AM[0m] Project 'sample1/tests/tsconfig.json' is up to date with .d.ts files from its dependencies
 
-
 [[90m12:01:42 AM[0m] Updating output timestamps of project '/user/username/projects/sample1/tests/tsconfig.json'...
-
 
 [[90m12:01:43 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -606,18 +593,13 @@ Output::
 >> Screen clear
 [[90m12:01:47 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:01:48 AM[0m] Project 'sample1/logic/tsconfig.json' is out of date because oldest output 'sample1/logic/index.js' is older than newest input 'sample1/core'
-
 
 [[90m12:01:49 AM[0m] Building project '/user/username/projects/sample1/logic/tsconfig.json'...
 
-
 [[90m12:02:02 AM[0m] Project 'sample1/tests/tsconfig.json' is out of date because oldest output 'sample1/tests/index.js' is older than newest input 'sample1/logic/tsconfig.json'
 
-
 [[90m12:02:03 AM[0m] Building project '/user/username/projects/sample1/tests/tsconfig.json'...
-
 
 [[90m12:02:13 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/declarationEmitErrors/introduceError/when-file-with-no-error-changes.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/declarationEmitErrors/introduceError/when-file-with-no-error-changes.js
@@ -30,7 +30,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:36 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -151,12 +150,10 @@ Output::
 >> Screen clear
 [[90m12:00:40 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mapp/fileWithError.ts[0m:[93m1[0m:[93m12[0m - [91merror[0m[90m TS4094: [0mProperty 'p' of exported class expression may not be private or protected.
 
 [7m1[0m export var myClassWithError = class {
 [7m [0m [91m           ~~~~~~~~~~~~~~~~[0m
-
 
 [[90m12:00:41 AM[0m] Found 1 error. Watching for file changes.
 
@@ -200,12 +197,10 @@ Output::
 >> Screen clear
 [[90m12:00:45 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mapp/fileWithError.ts[0m:[93m1[0m:[93m12[0m - [91merror[0m[90m TS4094: [0mProperty 'p' of exported class expression may not be private or protected.
 
 [7m1[0m export var myClassWithError = class {
 [7m [0m [91m           ~~~~~~~~~~~~~~~~[0m
-
 
 [[90m12:00:46 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/declarationEmitErrors/introduceError/when-fixing-errors-only-changed-file-is-emitted.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/declarationEmitErrors/introduceError/when-fixing-errors-only-changed-file-is-emitted.js
@@ -30,7 +30,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:36 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -151,12 +150,10 @@ Output::
 >> Screen clear
 [[90m12:00:40 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mapp/fileWithError.ts[0m:[93m1[0m:[93m12[0m - [91merror[0m[90m TS4094: [0mProperty 'p' of exported class expression may not be private or protected.
 
 [7m1[0m export var myClassWithError = class {
 [7m [0m [91m           ~~~~~~~~~~~~~~~~[0m
-
 
 [[90m12:00:41 AM[0m] Found 1 error. Watching for file changes.
 
@@ -202,7 +199,6 @@ export var myClassWithError = class {
 Output::
 >> Screen clear
 [[90m12:00:45 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:56 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/declarationEmitErrors/when-file-with-no-error-changes.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/declarationEmitErrors/when-file-with-no-error-changes.js
@@ -30,12 +30,10 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [96mapp/fileWithError.ts[0m:[93m1[0m:[93m12[0m - [91merror[0m[90m TS4094: [0mProperty 'p' of exported class expression may not be private or protected.
 
 [7m1[0m export var myClassWithError = class {
 [7m [0m [91m           ~~~~~~~~~~~~~~~~[0m
-
 
 [[90m12:00:26 AM[0m] Found 1 error. Watching for file changes.
 
@@ -81,12 +79,10 @@ Output::
 >> Screen clear
 [[90m12:00:30 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mapp/fileWithError.ts[0m:[93m1[0m:[93m12[0m - [91merror[0m[90m TS4094: [0mProperty 'p' of exported class expression may not be private or protected.
 
 [7m1[0m export var myClassWithError = class {
 [7m [0m [91m           ~~~~~~~~~~~~~~~~[0m
-
 
 [[90m12:00:31 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/declarationEmitErrors/when-fixing-error-files-all-files-are-emitted.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/declarationEmitErrors/when-fixing-error-files-all-files-are-emitted.js
@@ -30,12 +30,10 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [96mapp/fileWithError.ts[0m:[93m1[0m:[93m12[0m - [91merror[0m[90m TS4094: [0mProperty 'p' of exported class expression may not be private or protected.
 
 [7m1[0m export var myClassWithError = class {
 [7m [0m [91m           ~~~~~~~~~~~~~~~~[0m
-
 
 [[90m12:00:26 AM[0m] Found 1 error. Watching for file changes.
 
@@ -83,7 +81,6 @@ export var myClassWithError = class {
 Output::
 >> Screen clear
 [[90m12:00:30 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:41 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/when-preserveWatchOutput-is-not-used.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/when-preserveWatchOutput-is-not-used.js
@@ -107,7 +107,6 @@ Output::
 >> Screen clear
 [[90m12:00:45 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:14 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -433,12 +432,10 @@ Output::
 >> Screen clear
 [[90m12:01:18 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msample1/logic/index.ts[0m:[93m8[0m:[93m5[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m8[0m let y: string = 10;
 [7m [0m [91m    ~[0m
-
 
 [[90m12:01:22 AM[0m] Found 1 error. Watching for file changes.
 
@@ -570,18 +567,15 @@ Output::
 >> Screen clear
 [[90m12:01:26 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msample1/core/index.ts[0m:[93m5[0m:[93m5[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m5[0m let x: string = 10;
 [7m [0m [91m    ~[0m
 
-
 [96msample1/logic/index.ts[0m:[93m8[0m:[93m5[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m8[0m let y: string = 10;
 [7m [0m [91m    ~[0m
-
 
 [[90m12:01:30 AM[0m] Found 2 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/when-preserveWatchOutput-is-passed-on-command-line.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/when-preserveWatchOutput-is-passed-on-command-line.js
@@ -106,7 +106,6 @@ export function run() {
 Output::
 [[90m12:00:45 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:14 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -434,12 +433,10 @@ let y: string = 10;
 Output::
 [[90m12:01:18 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msample1/logic/index.ts[0m:[93m8[0m:[93m5[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m8[0m let y: string = 10;
 [7m [0m [91m    ~[0m
-
 
 [[90m12:01:22 AM[0m] Found 1 error. Watching for file changes.
 
@@ -571,18 +568,15 @@ let x: string = 10;
 Output::
 [[90m12:01:26 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msample1/core/index.ts[0m:[93m5[0m:[93m5[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m5[0m let x: string = 10;
 [7m [0m [91m    ~[0m
 
-
 [96msample1/logic/index.ts[0m:[93m8[0m:[93m5[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m8[0m let y: string = 10;
 [7m [0m [91m    ~[0m
-
 
 [[90m12:01:30 AM[0m] Found 2 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/should-not-trigger-recompilation-because-of-program-emit-with-outDir-specified.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/should-not-trigger-recompilation-because-of-program-emit-with-outDir-specified.js
@@ -31,16 +31,12 @@ Output::
 >> Screen clear
 [[90m12:00:27 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Projects in this build: 
     * sample1/core/tsconfig.json
 
-
 [[90m12:00:29 AM[0m] Project 'sample1/core/tsconfig.json' is out of date because output file 'sample1/core/outDir/anotherModule.js' does not exist
 
-
 [[90m12:00:30 AM[0m] Building project '/user/username/projects/sample1/core/tsconfig.json'...
-
 
 [[90m12:00:44 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -174,15 +170,11 @@ Output::
 >> Screen clear
 [[90m12:00:47 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:48 AM[0m] Project 'sample1/core/tsconfig.json' is out of date because oldest output 'sample1/core/outDir/anotherModule.js' is older than newest input 'sample1/core/file3.ts'
-
 
 [[90m12:00:49 AM[0m] Building project '/user/username/projects/sample1/core/tsconfig.json'...
 
-
 [[90m12:00:58 AM[0m] Updating unchanged output timestamps of project '/user/username/projects/sample1/core/tsconfig.json'...
-
 
 [[90m12:00:59 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/should-not-trigger-recompilation-because-of-program-emit.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/should-not-trigger-recompilation-because-of-program-emit.js
@@ -38,16 +38,12 @@ Output::
 >> Screen clear
 [[90m12:00:27 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Projects in this build: 
     * sample1/core/tsconfig.json
 
-
 [[90m12:00:29 AM[0m] Project 'sample1/core/tsconfig.json' is out of date because output file 'sample1/core/anotherModule.js' does not exist
 
-
 [[90m12:00:30 AM[0m] Building project '/user/username/projects/sample1/core/tsconfig.json'...
-
 
 [[90m12:00:45 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -189,15 +185,11 @@ Output::
 >> Screen clear
 [[90m12:00:48 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:49 AM[0m] Project 'sample1/core/tsconfig.json' is out of date because oldest output 'sample1/core/anotherModule.js' is older than newest input 'sample1/core/file3.ts'
-
 
 [[90m12:00:50 AM[0m] Building project '/user/username/projects/sample1/core/tsconfig.json'...
 
-
 [[90m12:01:01 AM[0m] Updating unchanged output timestamps of project '/user/username/projects/sample1/core/tsconfig.json'...
-
 
 [[90m12:01:02 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/watches-config-files-that-are-not-present.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/watches-config-files-that-are-not-present.js
@@ -73,9 +73,7 @@ Output::
 >> Screen clear
 [[90m12:00:37 AM[0m] Starting compilation in watch mode...
 
-
 [91merror[0m[90m TS5083: [0mCannot read file '/user/username/projects/sample1/logic/tsconfig.json'.
-
 
 [[90m12:00:52 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/when-referenced-project-change-introduces-error-in-the-down-stream-project-and-then-fixes-it.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/when-referenced-project-change-introduces-error-in-the-down-stream-project-and-then-fixes-it.js
@@ -42,7 +42,6 @@ Output::
 >> Screen clear
 [[90m12:00:29 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:38 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -169,7 +168,6 @@ Output::
 >> Screen clear
 [[90m12:00:42 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mApp/app.ts[0m:[93m2[0m:[93m20[0m - [91merror[0m[90m TS2551: [0mProperty 'message' does not exist on type 'SomeObject'. Did you mean 'message2'?
 
 [7m2[0m createSomeObject().message;
@@ -179,7 +177,6 @@ Output::
     [7m2[0m     message2: string;
     [7m [0m [96m    ~~~~~~~~[0m
     'message2' is declared here.
-
 
 [[90m12:00:52 AM[0m] Found 1 error. Watching for file changes.
 
@@ -297,7 +294,6 @@ export function createSomeObject(): SomeObject
 Output::
 >> Screen clear
 [[90m12:00:56 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:09 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/when-referenced-using-prepend-builds-referencing-project-even-for-non-local-change.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/when-referenced-using-prepend-builds-referencing-project-even-for-non-local-change.js
@@ -30,7 +30,6 @@ Output::
 >> Screen clear
 [[90m12:00:29 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:46 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-circular-project-reference/builds-when-new-file-is-added,-and-its-subsequent-updates.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-circular-project-reference/builds-when-new-file-is-added,-and-its-subsequent-updates.js
@@ -81,7 +81,6 @@ Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:04 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-circular-project-reference/change-builds-changes-and-reports-found-errors-message.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-circular-project-reference/change-builds-changes-and-reports-found-errors-message.js
@@ -81,7 +81,6 @@ Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:04 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-circular-project-reference/non-local-change-does-not-start-build-of-referencing-projects.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-circular-project-reference/non-local-change-does-not-start-build-of-referencing-projects.js
@@ -81,7 +81,6 @@ Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:04 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-simple-project-reference-graph/builds-when-new-file-is-added,-and-its-subsequent-updates.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-simple-project-reference-graph/builds-when-new-file-is-added,-and-its-subsequent-updates.js
@@ -107,7 +107,6 @@ Output::
 >> Screen clear
 [[90m12:00:45 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:14 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-simple-project-reference-graph/change-builds-changes-and-reports-found-errors-message.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-simple-project-reference-graph/change-builds-changes-and-reports-found-errors-message.js
@@ -107,7 +107,6 @@ Output::
 >> Screen clear
 [[90m12:00:45 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:14 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-simple-project-reference-graph/non-local-change-does-not-start-build-of-referencing-projects.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-simple-project-reference-graph/non-local-change-does-not-start-build-of-referencing-projects.js
@@ -107,7 +107,6 @@ Output::
 >> Screen clear
 [[90m12:00:45 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:14 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/works-when-noUnusedParameters-changes-to-false.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/works-when-noUnusedParameters-changes-to-false.js
@@ -24,12 +24,10 @@ Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] Starting compilation in watch mode...
 
-
 [96mindex.ts[0m:[93m1[0m:[93m13[0m - [91merror[0m[90m TS6133: [0m'a' is declared but its value is never read.
 
 [7m1[0m const fn = (a: string, b: string) => b;
 [7m [0m [91m            ~[0m
-
 
 [[90m12:00:22 AM[0m] Found 1 error. Watching for file changes.
 
@@ -70,7 +68,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:26 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:29 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/reexport/Reports-errors-correctly.js
+++ b/tests/baselines/reference/tsbuild/watchMode/reexport/Reports-errors-correctly.js
@@ -69,24 +69,18 @@ Output::
 >> Screen clear
 [[90m12:00:35 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:36 AM[0m] Projects in this build: 
     * src/pure/tsconfig.json
     * src/main/tsconfig.json
     * src/tsconfig.json
 
-
 [[90m12:00:37 AM[0m] Project 'src/pure/tsconfig.json' is out of date because output file 'out/pure/index.js' does not exist
-
 
 [[90m12:00:38 AM[0m] Building project '/user/username/projects/reexport/src/pure/tsconfig.json'...
 
-
 [[90m12:00:54 AM[0m] Project 'src/main/tsconfig.json' is out of date because output file 'out/main/index.js' does not exist
 
-
 [[90m12:00:55 AM[0m] Building project '/user/username/projects/reexport/src/main/tsconfig.json'...
-
 
 [[90m12:01:01 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -244,18 +238,13 @@ Output::
 >> Screen clear
 [[90m12:01:05 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:01:06 AM[0m] Project 'src/pure/tsconfig.json' is out of date because oldest output 'out/pure/index.js' is older than newest input 'src/pure/session.ts'
-
 
 [[90m12:01:07 AM[0m] Building project '/user/username/projects/reexport/src/pure/tsconfig.json'...
 
-
 [[90m12:01:23 AM[0m] Project 'src/main/tsconfig.json' is out of date because oldest output 'out/main/index.js' is older than newest input 'src/pure/tsconfig.json'
 
-
 [[90m12:01:24 AM[0m] Building project '/user/username/projects/reexport/src/main/tsconfig.json'...
-
 
 [96msrc/main/index.ts[0m:[93m3[0m:[93m14[0m - [91merror[0m[90m TS2741: [0mProperty 'bar' is missing in type '{ foo: number; }' but required in type 'Session'.
 
@@ -266,7 +255,6 @@ Output::
     [7m3[0m     bar: number;
     [7m [0m [96m    ~~~[0m
     'bar' is declared here.
-
 
 [[90m12:01:25 AM[0m] Found 1 error. Watching for file changes.
 
@@ -392,21 +380,15 @@ Output::
 >> Screen clear
 [[90m12:01:29 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:01:30 AM[0m] Project 'src/pure/tsconfig.json' is out of date because oldest output 'out/pure/index.js' is older than newest input 'src/pure/session.ts'
-
 
 [[90m12:01:31 AM[0m] Building project '/user/username/projects/reexport/src/pure/tsconfig.json'...
 
-
 [[90m12:01:47 AM[0m] Failed to parse file 'src/main/tsconfig.json': Semantic errors.
-
 
 [[90m12:01:48 AM[0m] Building project '/user/username/projects/reexport/src/main/tsconfig.json'...
 
-
 [[90m12:01:50 AM[0m] Updating unchanged output timestamps of project '/user/username/projects/reexport/src/main/tsconfig.json'...
-
 
 [[90m12:01:51 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tsc/declarationEmit/when-pkg-references-sibling-package-through-indirect-symlink-moduleCaseChange.js
+++ b/tests/baselines/reference/tsc/declarationEmit/when-pkg-references-sibling-package-through-indirect-symlink-moduleCaseChange.js
@@ -62,21 +62,13 @@ Output::
 [7m2[0m export const ADMIN = MetadataAccessor.create<boolean>('1');
 [7m [0m [91m             ~~~~~[0m
 
-
 /a/lib/lib.d.ts
-
 /user/username/projects/myProject/pkg1/dist/types.d.ts
-
 /user/username/projects/myProject/pkg1/dist/index.d.ts
-
 /user/username/projects/myproject/pkg2/dist/types.d.ts
-
 /user/username/projects/myproject/pkg2/dist/index.d.ts
-
 /user/username/projects/myproject/pkg3/src/keys.ts
-
 /user/username/projects/myproject/pkg3/src/index.ts
-
 
 Found 1 error.
 

--- a/tests/baselines/reference/tsc/declarationEmit/when-pkg-references-sibling-package-through-indirect-symlink.js
+++ b/tests/baselines/reference/tsc/declarationEmit/when-pkg-references-sibling-package-through-indirect-symlink.js
@@ -62,21 +62,13 @@ Output::
 [7m2[0m export const ADMIN = MetadataAccessor.create<boolean>('1');
 [7m [0m [91m             ~~~~~[0m
 
-
 /a/lib/lib.d.ts
-
 /user/username/projects/myproject/pkg1/dist/types.d.ts
-
 /user/username/projects/myproject/pkg1/dist/index.d.ts
-
 /user/username/projects/myproject/pkg2/dist/types.d.ts
-
 /user/username/projects/myproject/pkg2/dist/index.d.ts
-
 /user/username/projects/myproject/pkg3/src/keys.ts
-
 /user/username/projects/myproject/pkg3/src/index.ts
-
 
 Found 1 error.
 

--- a/tests/baselines/reference/tsc/declarationEmit/when-same-version-is-referenced-through-source-and-another-symlinked-package-moduleCaseChange.js
+++ b/tests/baselines/reference/tsc/declarationEmit/when-same-version-is-referenced-through-source-and-another-symlinked-package-moduleCaseChange.js
@@ -88,105 +88,55 @@ interface Array<T> { length: number; [n: number]: T; }
 /a/lib/tsc.js -p plugin-one --listFiles
 Output::
 ======== Resolving module 'typescript-fsa' from '/user/username/projects/myproject/plugin-one/action.ts'. ========
-
 Module resolution kind is not specified, using 'NodeJs'.
-
 Loading module 'typescript-fsa' from 'node_modules' folder, target file type 'TypeScript'.
-
 Found 'package.json' at '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/package.json'.
-
 'package.json' does not have a 'typesVersions' field.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa.d.ts' does not exist.
-
 'package.json' does not have a 'typings' field.
-
 'package.json' does not have a 'types' field.
-
 'package.json' does not have a 'main' field.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts' exist - use it as a name resolution result.
-
 Resolving real path for '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts', result '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts'.
-
 ======== Module name 'typescript-fsa' was successfully resolved to '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts' with Package ID 'typescript-fsa/index.d.ts@3.0.0-beta-2'. ========
-
 ======== Resolving module 'plugin-two' from '/user/username/projects/myproject/plugin-one/index.ts'. ========
-
 Module resolution kind is not specified, using 'NodeJs'.
-
 Loading module 'plugin-two' from 'node_modules' folder, target file type 'TypeScript'.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/package.json' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two.d.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/index.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/index.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/index.d.ts' exist - use it as a name resolution result.
-
 Resolving real path for '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/index.d.ts', result '/user/username/projects/myProject/plugin-two/index.d.ts'.
-
 ======== Module name 'plugin-two' was successfully resolved to '/user/username/projects/myProject/plugin-two/index.d.ts'. ========
-
 ======== Resolving module 'typescript-fsa' from '/user/username/projects/myProject/plugin-two/index.d.ts'. ========
-
 Module resolution kind is not specified, using 'NodeJs'.
-
 Loading module 'typescript-fsa' from 'node_modules' folder, target file type 'TypeScript'.
-
 Found 'package.json' at '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/package.json'.
-
 'package.json' does not have a 'typesVersions' field.
-
 File '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa.ts' does not exist.
-
 File '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa.tsx' does not exist.
-
 File '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa.d.ts' does not exist.
-
 'package.json' does not have a 'typings' field.
-
 'package.json' does not have a 'types' field.
-
 'package.json' does not have a 'main' field.
-
 File '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.ts' does not exist.
-
 File '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.tsx' does not exist.
-
 File '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.d.ts' exist - use it as a name resolution result.
-
 Resolving real path for '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.d.ts', result '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.d.ts'.
-
 ======== Module name 'typescript-fsa' was successfully resolved to '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.d.ts' with Package ID 'typescript-fsa/index.d.ts@3.0.0-beta-2'. ========
-
 /a/lib/lib.d.ts
-
 /user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts
-
 /user/username/projects/myproject/plugin-one/action.ts
-
 /user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.d.ts
-
 /user/username/projects/myProject/plugin-two/index.d.ts
-
 /user/username/projects/myproject/plugin-one/index.ts
-
 
 
 Program root files: ["/user/username/projects/myproject/plugin-one/action.ts","/user/username/projects/myproject/plugin-one/index.ts"]

--- a/tests/baselines/reference/tsc/declarationEmit/when-same-version-is-referenced-through-source-and-another-symlinked-package-with-indirect-link-moduleCaseChange.js
+++ b/tests/baselines/reference/tsc/declarationEmit/when-same-version-is-referenced-through-source-and-another-symlinked-package-with-indirect-link-moduleCaseChange.js
@@ -90,127 +90,66 @@ interface Array<T> { length: number; [n: number]: T; }
 /a/lib/tsc.js -p plugin-one --listFiles
 Output::
 ======== Resolving module 'plugin-two' from '/user/username/projects/myproject/plugin-one/index.ts'. ========
-
 Module resolution kind is not specified, using 'NodeJs'.
-
 Loading module 'plugin-two' from 'node_modules' folder, target file type 'TypeScript'.
-
 Found 'package.json' at '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/package.json'.
-
 'package.json' does not have a 'typesVersions' field.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two.d.ts' does not exist.
-
 'package.json' does not have a 'typings' field.
-
 'package.json' does not have a 'types' field.
-
 'package.json' has 'main' field 'dist/commonjs/index.js' that references '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.js'.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.js' does not exist.
-
 Loading module as file / folder, candidate module location '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.js', target file type 'TypeScript'.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.js.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.js.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.js.d.ts' does not exist.
-
 File name '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.js' has a '.js' extension - stripping it.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.d.ts' exist - use it as a name resolution result.
-
 Resolving real path for '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.d.ts', result '/user/username/projects/myProject/plugin-two/dist/commonjs/index.d.ts'.
-
 ======== Module name 'plugin-two' was successfully resolved to '/user/username/projects/myProject/plugin-two/dist/commonjs/index.d.ts' with Package ID 'plugin-two/dist/commonjs/index.d.ts@0.1.3'. ========
-
 ======== Resolving module 'typescript-fsa' from '/user/username/projects/myproject/plugin-one/index.ts'. ========
-
 Module resolution kind is not specified, using 'NodeJs'.
-
 Loading module 'typescript-fsa' from 'node_modules' folder, target file type 'TypeScript'.
-
 Found 'package.json' at '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/package.json'.
-
 'package.json' does not have a 'typesVersions' field.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa.d.ts' does not exist.
-
 'package.json' does not have a 'typings' field.
-
 'package.json' does not have a 'types' field.
-
 'package.json' does not have a 'main' field.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts' exist - use it as a name resolution result.
-
 Resolving real path for '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts', result '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts'.
-
 ======== Module name 'typescript-fsa' was successfully resolved to '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts' with Package ID 'typescript-fsa/index.d.ts@3.0.0-beta-2'. ========
-
 ======== Resolving module 'typescript-fsa' from '/user/username/projects/myProject/plugin-two/dist/commonjs/index.d.ts'. ========
-
 Module resolution kind is not specified, using 'NodeJs'.
-
 Loading module 'typescript-fsa' from 'node_modules' folder, target file type 'TypeScript'.
-
 Directory '/user/username/projects/myProject/plugin-two/dist/commonjs/node_modules' does not exist, skipping all lookups in it.
-
 Directory '/user/username/projects/myProject/plugin-two/dist/node_modules' does not exist, skipping all lookups in it.
-
 Found 'package.json' at '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/package.json'.
-
 'package.json' does not have a 'typesVersions' field.
-
 File '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa.ts' does not exist.
-
 File '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa.tsx' does not exist.
-
 File '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa.d.ts' does not exist.
-
 'package.json' does not have a 'typings' field.
-
 'package.json' does not have a 'types' field.
-
 'package.json' does not have a 'main' field.
-
 File '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.ts' does not exist.
-
 File '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.tsx' does not exist.
-
 File '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.d.ts' exist - use it as a name resolution result.
-
 Resolving real path for '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.d.ts', result '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.d.ts'.
-
 ======== Module name 'typescript-fsa' was successfully resolved to '/user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.d.ts' with Package ID 'typescript-fsa/index.d.ts@3.0.0-beta-2'. ========
-
 /a/lib/lib.d.ts
-
 /user/username/projects/myProject/plugin-two/node_modules/typescript-fsa/index.d.ts
-
 /user/username/projects/myProject/plugin-two/dist/commonjs/index.d.ts
-
 /user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts
-
 /user/username/projects/myproject/plugin-one/index.ts
-
 
 
 Program root files: ["/user/username/projects/myproject/plugin-one/index.ts"]

--- a/tests/baselines/reference/tsc/declarationEmit/when-same-version-is-referenced-through-source-and-another-symlinked-package-with-indirect-link.js
+++ b/tests/baselines/reference/tsc/declarationEmit/when-same-version-is-referenced-through-source-and-another-symlinked-package-with-indirect-link.js
@@ -90,127 +90,66 @@ interface Array<T> { length: number; [n: number]: T; }
 /a/lib/tsc.js -p plugin-one --listFiles
 Output::
 ======== Resolving module 'plugin-two' from '/user/username/projects/myproject/plugin-one/index.ts'. ========
-
 Module resolution kind is not specified, using 'NodeJs'.
-
 Loading module 'plugin-two' from 'node_modules' folder, target file type 'TypeScript'.
-
 Found 'package.json' at '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/package.json'.
-
 'package.json' does not have a 'typesVersions' field.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two.d.ts' does not exist.
-
 'package.json' does not have a 'typings' field.
-
 'package.json' does not have a 'types' field.
-
 'package.json' has 'main' field 'dist/commonjs/index.js' that references '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.js'.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.js' does not exist.
-
 Loading module as file / folder, candidate module location '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.js', target file type 'TypeScript'.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.js.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.js.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.js.d.ts' does not exist.
-
 File name '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.js' has a '.js' extension - stripping it.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.d.ts' exist - use it as a name resolution result.
-
 Resolving real path for '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/dist/commonjs/index.d.ts', result '/user/username/projects/myproject/plugin-two/dist/commonjs/index.d.ts'.
-
 ======== Module name 'plugin-two' was successfully resolved to '/user/username/projects/myproject/plugin-two/dist/commonjs/index.d.ts' with Package ID 'plugin-two/dist/commonjs/index.d.ts@0.1.3'. ========
-
 ======== Resolving module 'typescript-fsa' from '/user/username/projects/myproject/plugin-one/index.ts'. ========
-
 Module resolution kind is not specified, using 'NodeJs'.
-
 Loading module 'typescript-fsa' from 'node_modules' folder, target file type 'TypeScript'.
-
 Found 'package.json' at '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/package.json'.
-
 'package.json' does not have a 'typesVersions' field.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa.d.ts' does not exist.
-
 'package.json' does not have a 'typings' field.
-
 'package.json' does not have a 'types' field.
-
 'package.json' does not have a 'main' field.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts' exist - use it as a name resolution result.
-
 Resolving real path for '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts', result '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts'.
-
 ======== Module name 'typescript-fsa' was successfully resolved to '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts' with Package ID 'typescript-fsa/index.d.ts@3.0.0-beta-2'. ========
-
 ======== Resolving module 'typescript-fsa' from '/user/username/projects/myproject/plugin-two/dist/commonjs/index.d.ts'. ========
-
 Module resolution kind is not specified, using 'NodeJs'.
-
 Loading module 'typescript-fsa' from 'node_modules' folder, target file type 'TypeScript'.
-
 Directory '/user/username/projects/myproject/plugin-two/dist/commonjs/node_modules' does not exist, skipping all lookups in it.
-
 Directory '/user/username/projects/myproject/plugin-two/dist/node_modules' does not exist, skipping all lookups in it.
-
 Found 'package.json' at '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/package.json'.
-
 'package.json' does not have a 'typesVersions' field.
-
 File '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa.d.ts' does not exist.
-
 'package.json' does not have a 'typings' field.
-
 'package.json' does not have a 'types' field.
-
 'package.json' does not have a 'main' field.
-
 File '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.d.ts' exist - use it as a name resolution result.
-
 Resolving real path for '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.d.ts', result '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.d.ts'.
-
 ======== Module name 'typescript-fsa' was successfully resolved to '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.d.ts' with Package ID 'typescript-fsa/index.d.ts@3.0.0-beta-2'. ========
-
 /a/lib/lib.d.ts
-
 /user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.d.ts
-
 /user/username/projects/myproject/plugin-two/dist/commonjs/index.d.ts
-
 /user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts
-
 /user/username/projects/myproject/plugin-one/index.ts
-
 
 
 Program root files: ["/user/username/projects/myproject/plugin-one/index.ts"]

--- a/tests/baselines/reference/tsc/declarationEmit/when-same-version-is-referenced-through-source-and-another-symlinked-package.js
+++ b/tests/baselines/reference/tsc/declarationEmit/when-same-version-is-referenced-through-source-and-another-symlinked-package.js
@@ -88,105 +88,55 @@ interface Array<T> { length: number; [n: number]: T; }
 /a/lib/tsc.js -p plugin-one --listFiles
 Output::
 ======== Resolving module 'typescript-fsa' from '/user/username/projects/myproject/plugin-one/action.ts'. ========
-
 Module resolution kind is not specified, using 'NodeJs'.
-
 Loading module 'typescript-fsa' from 'node_modules' folder, target file type 'TypeScript'.
-
 Found 'package.json' at '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/package.json'.
-
 'package.json' does not have a 'typesVersions' field.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa.d.ts' does not exist.
-
 'package.json' does not have a 'typings' field.
-
 'package.json' does not have a 'types' field.
-
 'package.json' does not have a 'main' field.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts' exist - use it as a name resolution result.
-
 Resolving real path for '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts', result '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts'.
-
 ======== Module name 'typescript-fsa' was successfully resolved to '/user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts' with Package ID 'typescript-fsa/index.d.ts@3.0.0-beta-2'. ========
-
 ======== Resolving module 'plugin-two' from '/user/username/projects/myproject/plugin-one/index.ts'. ========
-
 Module resolution kind is not specified, using 'NodeJs'.
-
 Loading module 'plugin-two' from 'node_modules' folder, target file type 'TypeScript'.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/package.json' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two.d.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/index.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/index.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/index.d.ts' exist - use it as a name resolution result.
-
 Resolving real path for '/user/username/projects/myproject/plugin-one/node_modules/plugin-two/index.d.ts', result '/user/username/projects/myproject/plugin-two/index.d.ts'.
-
 ======== Module name 'plugin-two' was successfully resolved to '/user/username/projects/myproject/plugin-two/index.d.ts'. ========
-
 ======== Resolving module 'typescript-fsa' from '/user/username/projects/myproject/plugin-two/index.d.ts'. ========
-
 Module resolution kind is not specified, using 'NodeJs'.
-
 Loading module 'typescript-fsa' from 'node_modules' folder, target file type 'TypeScript'.
-
 Found 'package.json' at '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/package.json'.
-
 'package.json' does not have a 'typesVersions' field.
-
 File '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa.d.ts' does not exist.
-
 'package.json' does not have a 'typings' field.
-
 'package.json' does not have a 'types' field.
-
 'package.json' does not have a 'main' field.
-
 File '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.ts' does not exist.
-
 File '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.tsx' does not exist.
-
 File '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.d.ts' exist - use it as a name resolution result.
-
 Resolving real path for '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.d.ts', result '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.d.ts'.
-
 ======== Module name 'typescript-fsa' was successfully resolved to '/user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.d.ts' with Package ID 'typescript-fsa/index.d.ts@3.0.0-beta-2'. ========
-
 /a/lib/lib.d.ts
-
 /user/username/projects/myproject/plugin-one/node_modules/typescript-fsa/index.d.ts
-
 /user/username/projects/myproject/plugin-one/action.ts
-
 /user/username/projects/myproject/plugin-two/node_modules/typescript-fsa/index.d.ts
-
 /user/username/projects/myproject/plugin-two/index.d.ts
-
 /user/username/projects/myproject/plugin-one/index.ts
-
 
 
 Program root files: ["/user/username/projects/myproject/plugin-one/action.ts","/user/username/projects/myproject/plugin-one/index.ts"]

--- a/tests/baselines/reference/tscWatch/consoleClearing/when-preserveWatchOutput-is-true-in-config-file/createWatchOfConfigFile.js
+++ b/tests/baselines/reference/tscWatch/consoleClearing/when-preserveWatchOutput-is-true-in-config-file/createWatchOfConfigFile.js
@@ -25,7 +25,6 @@ Output::
 12:00:13 AM - Starting compilation in watch mode...
 
 
-
 12:00:16 AM - Found 0 errors. Watching for file changes.
 
 
@@ -69,7 +68,6 @@ Input::
 Output::
 
 12:00:19 AM - File change detected. Starting incremental compilation...
-
 
 
 12:00:23 AM - Found 0 errors. Watching for file changes.

--- a/tests/baselines/reference/tscWatch/consoleClearing/when-preserveWatchOutput-is-true-in-config-file/when-createWatchProgram-is-invoked-with-configFileParseResult-on-WatchCompilerHostOfConfigFile.js
+++ b/tests/baselines/reference/tscWatch/consoleClearing/when-preserveWatchOutput-is-true-in-config-file/when-createWatchProgram-is-invoked-with-configFileParseResult-on-WatchCompilerHostOfConfigFile.js
@@ -23,7 +23,6 @@ interface Array<T> { length: number; [n: number]: T; }
 Output::
 [[90m12:00:13 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:16 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -67,7 +66,6 @@ Input::
 
 Output::
 [[90m12:00:19 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:23 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/consoleClearing/with---diagnostics.js
+++ b/tests/baselines/reference/tscWatch/consoleClearing/with---diagnostics.js
@@ -20,17 +20,11 @@ interface Array<T> { length: number; [n: number]: T; }
 Output::
 [[90m12:00:11 AM[0m] Starting compilation in watch mode...
 
-
 Current directory: / CaseSensitiveFileNames: false
-
 Synchronizing program
-
 CreatingProgramWith::
-
   roots: ["/f.ts"]
-
   options: {"watch":true,"diagnostics":true}
-
 [[90m12:00:14 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -70,22 +64,14 @@ Input::
 
 Output::
 FileWatcher:: Triggered with /f.ts 1:: WatchInfo: /f.ts 250 undefined Source file
-
 Scheduling update
-
 Elapsed:: *ms FileWatcher:: Triggered with /f.ts 1:: WatchInfo: /f.ts 250 undefined Source file
-
 [[90m12:00:17 AM[0m] File change detected. Starting incremental compilation...
 
-
 Synchronizing program
-
 CreatingProgramWith::
-
   roots: ["/f.ts"]
-
   options: {"watch":true,"diagnostics":true}
-
 [[90m12:00:21 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/consoleClearing/with---extendedDiagnostics.js
+++ b/tests/baselines/reference/tscWatch/consoleClearing/with---extendedDiagnostics.js
@@ -20,21 +20,13 @@ interface Array<T> { length: number; [n: number]: T; }
 Output::
 [[90m12:00:11 AM[0m] Starting compilation in watch mode...
 
-
 Current directory: / CaseSensitiveFileNames: false
-
 Synchronizing program
-
 CreatingProgramWith::
-
   roots: ["/f.ts"]
-
   options: {"watch":true,"extendedDiagnostics":true}
-
 FileWatcher:: Added:: WatchInfo: /f.ts 250 undefined Source file
-
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 250 undefined Source file
-
 [[90m12:00:14 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -74,22 +66,14 @@ Input::
 
 Output::
 FileWatcher:: Triggered with /f.ts 1:: WatchInfo: /f.ts 250 undefined Source file
-
 Scheduling update
-
 Elapsed:: *ms FileWatcher:: Triggered with /f.ts 1:: WatchInfo: /f.ts 250 undefined Source file
-
 [[90m12:00:17 AM[0m] File change detected. Starting incremental compilation...
 
-
 Synchronizing program
-
 CreatingProgramWith::
-
   roots: ["/f.ts"]
-
   options: {"watch":true,"extendedDiagnostics":true}
-
 [[90m12:00:21 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/consoleClearing/with---preserveWatchOutput.js
+++ b/tests/baselines/reference/tscWatch/consoleClearing/with---preserveWatchOutput.js
@@ -20,7 +20,6 @@ interface Array<T> { length: number; [n: number]: T; }
 Output::
 [[90m12:00:11 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:14 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -60,7 +59,6 @@ Input::
 
 Output::
 [[90m12:00:17 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:21 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/consoleClearing/without---diagnostics-or---extendedDiagnostics.js
+++ b/tests/baselines/reference/tscWatch/consoleClearing/without---diagnostics-or---extendedDiagnostics.js
@@ -21,7 +21,6 @@ Output::
 >> Screen clear
 [[90m12:00:11 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:14 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -62,7 +61,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:21 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-file-content/elides-const-enums-correctly-in-incremental-compilation.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-file-content/elides-const-enums-correctly-in-incremental-compilation.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -89,7 +88,6 @@ import { E2 } from "./file2"; const v: E2 = E2.V;function foo2() { return 2; }
 Output::
 >> Screen clear
 [[90m12:00:33 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:37 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-file-content/file-is-deleted-and-created-as-part-of-change.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-file-content/file-is-deleted-and-created-as-part-of-change.js
@@ -24,7 +24,6 @@ Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -73,7 +72,6 @@ var b = 10;
 Output::
 >> Screen clear
 [[90m12:00:28 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:32 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-file-content/handles-new-lines-carriageReturn-lineFeed.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-file-content/handles-new-lines-carriageReturn-lineFeed.js
@@ -22,7 +22,6 @@ Output::
 >> Screen clear
 [[90m12:00:11 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:14 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -67,7 +66,6 @@ var z = 3;
 Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:21 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-file-content/handles-new-lines-lineFeed.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-file-content/handles-new-lines-lineFeed.js
@@ -22,7 +22,6 @@ Output::
 >> Screen clear
 [[90m12:00:11 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:14 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -67,7 +66,6 @@ var z = 3;
 Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:21 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-file-content/should-emit-specified-file.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-file-content/should-emit-specified-file.js
@@ -30,7 +30,6 @@ Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:26 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -105,7 +104,6 @@ export function Foo() { return 10; }export function foo2() { return 2; }
 Output::
 >> Screen clear
 [[90m12:00:29 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:36 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-always-return-the-file-itself-if-'--isolatedModules'-is-specified.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-always-return-the-file-itself-if-'--isolatedModules'-is-specified.js
@@ -36,12 +36,10 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [96ma/b/globalFile3.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS1208: [0m'globalFile3.ts' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module.
 
 [7m1[0m interface GlobalFoo { age: number }
 [7m [0m [91m~~~~~~~~~[0m
-
 
 [[90m12:00:34 AM[0m] Found 1 error. Watching for file changes.
 
@@ -135,12 +133,10 @@ Output::
 >> Screen clear
 [[90m12:00:38 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/globalFile3.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS1208: [0m'globalFile3.ts' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module.
 
 [7m1[0m interface GlobalFoo { age: number }
 [7m [0m [91m~~~~~~~~~[0m
-
 
 [[90m12:00:42 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-always-return-the-file-itself-if-'--out'-or-'--outFile'-is-specified.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-always-return-the-file-itself-if-'--out'-or-'--outFile'-is-specified.js
@@ -36,7 +36,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:26 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -138,7 +137,6 @@ export var T: number;export function Foo() { };
 Output::
 >> Screen clear
 [[90m12:00:30 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:34 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-be-up-to-date-with-deleted-files.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-be-up-to-date-with-deleted-files.js
@@ -36,7 +36,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:34 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -129,7 +128,6 @@ export var T: number;export function Foo() { };
 Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:46 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-be-up-to-date-with-newly-created-files.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-be-up-to-date-with-newly-created-files.js
@@ -36,7 +36,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:34 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -131,7 +130,6 @@ import {Foo} from "./moduleFile1"; let y = Foo();
 Output::
 >> Screen clear
 [[90m12:00:40 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:52 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-be-up-to-date-with-the-reference-map-changes.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-be-up-to-date-with-the-reference-map-changes.js
@@ -36,7 +36,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:34 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -129,12 +128,10 @@ Output::
 >> Screen clear
 [[90m12:00:38 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/file1Consumer1.ts[0m:[93m1[0m:[93m16[0m - [91merror[0m[90m TS2304: [0mCannot find name 'Foo'.
 
 [7m1[0m export let y = Foo();
 [7m [0m [91m               ~~~[0m
-
 
 [[90m12:00:42 AM[0m] Found 1 error. Watching for file changes.
 
@@ -198,12 +195,10 @@ Output::
 >> Screen clear
 [[90m12:00:46 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/file1Consumer1.ts[0m:[93m1[0m:[93m16[0m - [91merror[0m[90m TS2304: [0mCannot find name 'Foo'.
 
 [7m1[0m export let y = Foo();
 [7m [0m [91m               ~~~[0m
-
 
 [[90m12:00:53 AM[0m] Found 1 error. Watching for file changes.
 
@@ -271,7 +266,6 @@ Output::
 >> Screen clear
 [[90m12:00:57 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:01:01 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -334,24 +328,20 @@ Output::
 >> Screen clear
 [[90m12:01:05 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/file1Consumer1.ts[0m:[93m1[0m:[93m9[0m - [91merror[0m[90m TS2305: [0mModule '"./moduleFile1"' has no exported member 'Foo'.
 
 [7m1[0m import {Foo} from "./moduleFile1";let y = Foo();
 [7m [0m [91m        ~~~[0m
-
 
 [96ma/b/file1Consumer2.ts[0m:[93m1[0m:[93m9[0m - [91merror[0m[90m TS2305: [0mModule '"./moduleFile1"' has no exported member 'Foo'.
 
 [7m1[0m import {Foo} from "./moduleFile1"; let z = 10;
 [7m [0m [91m        ~~~[0m
 
-
 [96ma/b/moduleFile1.ts[0m:[93m1[0m:[93m16[0m - [91merror[0m[90m TS2304: [0mCannot find name 'Foo'.
 
 [7m1[0m export let y = Foo();
 [7m [0m [91m               ~~~[0m
-
 
 [[90m12:01:15 AM[0m] Found 3 errors. Watching for file changes.
 
@@ -419,7 +409,6 @@ export var T: number;export function Foo() { };
 Output::
 >> Screen clear
 [[90m12:01:22 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:32 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-contains-only-itself-if-a-module-file's-shape-didn't-change,-and-all-files-referencing-it-if-its-shape-changed.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-contains-only-itself-if-a-module-file's-shape-didn't-change,-and-all-files-referencing-it-if-its-shape-changed.js
@@ -36,7 +36,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:34 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -129,7 +128,6 @@ Output::
 >> Screen clear
 [[90m12:00:38 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:48 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -198,12 +196,10 @@ Output::
 >> Screen clear
 [[90m12:00:52 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/moduleFile1.ts[0m:[93m1[0m:[93m46[0m - [91merror[0m[90m TS2584: [0mCannot find name 'console'. Do you need to change your target library? Try changing the `lib` compiler option to include 'dom'.
 
 [7m1[0m export var T: number;export function Foo() { console.log('hi'); };
 [7m [0m [91m                                             ~~~~~~~[0m
-
 
 [[90m12:00:56 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-detect-changes-in-non-root-files.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-detect-changes-in-non-root-files.js
@@ -36,7 +36,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -99,7 +98,6 @@ Output::
 >> Screen clear
 [[90m12:00:32 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:39 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -154,7 +152,6 @@ export var T: number;export function Foo() { };var T1: number;
 Output::
 >> Screen clear
 [[90m12:00:42 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:46 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-detect-non-existing-code-file.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-detect-non-existing-code-file.js
@@ -25,18 +25,15 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [96ma/b/referenceFile1.ts[0m:[93m1[0m:[93m22[0m - [91merror[0m[90m TS6053: [0mFile '/a/b/moduleFile2.ts' not found.
 
 [7m1[0m /// <reference path="./moduleFile2.ts" />
 [7m [0m [91m                     ~~~~~~~~~~~~~~~~[0m
 
-
 [96ma/b/referenceFile1.ts[0m:[93m2[0m:[93m16[0m - [91merror[0m[90m TS2304: [0mCannot find name 'Foo'.
 
 [7m2[0m export var x = Foo();
 [7m [0m [91m               ~~~[0m
-
 
 [[90m12:00:18 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -93,24 +90,20 @@ Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/referenceFile1.ts[0m:[93m1[0m:[93m22[0m - [91merror[0m[90m TS6053: [0mFile '/a/b/moduleFile2.ts' not found.
 
 [7m1[0m /// <reference path="./moduleFile2.ts" />
 [7m [0m [91m                     ~~~~~~~~~~~~~~~~[0m
-
 
 [96ma/b/referenceFile1.ts[0m:[93m2[0m:[93m16[0m - [91merror[0m[90m TS2304: [0mCannot find name 'Foo'.
 
 [7m2[0m export var x = Foo();export var yy = Foo();
 [7m [0m [91m               ~~~[0m
 
-
 [96ma/b/referenceFile1.ts[0m:[93m2[0m:[93m38[0m - [91merror[0m[90m TS2304: [0mCannot find name 'Foo'.
 
 [7m2[0m export var x = Foo();export var yy = Foo();
 [7m [0m [91m                                     ~~~[0m
-
 
 [[90m12:00:25 AM[0m] Found 3 errors. Watching for file changes.
 
@@ -166,18 +159,15 @@ Output::
 >> Screen clear
 [[90m12:00:28 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/referenceFile1.ts[0m:[93m2[0m:[93m16[0m - [91merror[0m[90m TS2304: [0mCannot find name 'Foo'.
 
 [7m2[0m export var x = Foo();export var yy = Foo();
 [7m [0m [91m               ~~~[0m
 
-
 [96ma/b/referenceFile1.ts[0m:[93m2[0m:[93m38[0m - [91merror[0m[90m TS2304: [0mCannot find name 'Foo'.
 
 [7m2[0m export var x = Foo();export var yy = Foo();
 [7m [0m [91m                                     ~~~[0m
-
 
 [[90m12:00:34 AM[0m] Found 2 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-detect-removed-code-file.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-detect-removed-code-file.js
@@ -28,12 +28,10 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [96ma/b/referenceFile1.ts[0m:[93m2[0m:[93m16[0m - [91merror[0m[90m TS2304: [0mCannot find name 'Foo'.
 
 [7m2[0m export var x = Foo();
 [7m [0m [91m               ~~~[0m
-
 
 [[90m12:00:22 AM[0m] Found 1 error. Watching for file changes.
 
@@ -98,18 +96,15 @@ Output::
 >> Screen clear
 [[90m12:00:24 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/referenceFile1.ts[0m:[93m1[0m:[93m22[0m - [91merror[0m[90m TS6053: [0mFile '/a/b/moduleFile1.ts' not found.
 
 [7m1[0m /// <reference path="./moduleFile1.ts" />
 [7m [0m [91m                     ~~~~~~~~~~~~~~~~[0m
 
-
 [96ma/b/referenceFile1.ts[0m:[93m2[0m:[93m16[0m - [91merror[0m[90m TS2304: [0mCannot find name 'Foo'.
 
 [7m2[0m export var x = Foo();
 [7m [0m [91m               ~~~[0m
-
 
 [[90m12:00:28 AM[0m] Found 2 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-return-all-files-if-a-global-file-changed-shape.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-return-all-files-if-a-global-file-changed-shape.js
@@ -36,7 +36,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:34 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -128,7 +127,6 @@ interface GlobalFoo { age: number }var T2: string;
 Output::
 >> Screen clear
 [[90m12:00:37 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:53 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-return-cascaded-affected-file-list.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-return-cascaded-affected-file-list.js
@@ -39,7 +39,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:38 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -141,7 +140,6 @@ Output::
 >> Screen clear
 [[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:48 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -208,7 +206,6 @@ export var T: number;export function Foo() { };
 Output::
 >> Screen clear
 [[90m12:00:52 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:02 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -283,7 +280,6 @@ import {Foo} from "./moduleFile1"; export var y = 10;export var T: number;export
 Output::
 >> Screen clear
 [[90m12:01:08 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:21 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-work-fine-for-files-with-circular-references.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-work-fine-for-files-with-circular-references.js
@@ -29,7 +29,6 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -94,7 +93,6 @@ export var t1 = 10;export var t3 = 10;
 Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:32 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-does-not-have-out-or-outFile.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-does-not-have-out-or-outFile.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:20 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -83,7 +82,6 @@ let x = 11
 Output::
 >> Screen clear
 [[90m12:00:24 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-out.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-out.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:18 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -77,7 +76,6 @@ let x = 11
 Output::
 >> Screen clear
 [[90m12:00:22 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:26 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-outFile.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-outFile.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:18 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -77,7 +76,6 @@ let x = 11
 Output::
 >> Screen clear
 [[90m12:00:22 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:26 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/with---outFile-and-multiple-declaration-files-in-the-program.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/with---outFile-and-multiple-declaration-files-in-the-program.js
@@ -33,12 +33,10 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [96ma/b/project/src/main2.ts[0m:[93m1[0m:[93m114[0m - [91merror[0m[90m TS2724: [0m'Common.SomeComponent.DynamicMenu' has no exported member named 'z'. Did you mean 'Z'?
 
 [7m1[0m namespace main.file4 { import DynamicMenu = Common.SomeComponent.DynamicMenu; export function foo(a: DynamicMenu.z) {  } }
 [7m [0m [91m                                                                                                                 ~[0m
-
 
 [[90m12:00:34 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/without---outFile-and-multiple-declaration-files-in-the-program.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/without---outFile-and-multiple-declaration-files-in-the-program.js
@@ -33,12 +33,10 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [96ma/b/project/src/main2.ts[0m:[93m1[0m:[93m114[0m - [91merror[0m[90m TS2724: [0m'Common.SomeComponent.DynamicMenu' has no exported member named 'z'. Did you mean 'Z'?
 
 [7m1[0m namespace main.file4 { import DynamicMenu = Common.SomeComponent.DynamicMenu; export function foo(a: DynamicMenu.z) {  } }
 [7m [0m [91m                                                                                                                 ~[0m
-
 
 [[90m12:00:36 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emit/when-module-emit-is-specified-as-node/when-instead-of-filechanged-recursive-directory-watcher-is-invoked.js
+++ b/tests/baselines/reference/tscWatch/emit/when-module-emit-is-specified-as-node/when-instead-of-filechanged-recursive-directory-watcher-is-invoked.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:31 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -83,7 +82,6 @@ var zz30 = 100;
 Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:41 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/deepImportChanges/updates-errors-when-deep-import-file-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/deepImportChanges/updates-errors-when-deep-import-file-changes.js
@@ -40,7 +40,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:32 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -130,7 +129,6 @@ export class C
 Output::
 >> Screen clear
 [[90m12:00:36 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:43 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/deepImportChanges/updates-errors-when-deep-import-through-declaration-file-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/deepImportChanges/updates-errors-when-deep-import-through-declaration-file-changes.js
@@ -40,7 +40,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -105,7 +104,6 @@ export class C
 Output::
 >> Screen clear
 [[90m12:00:32 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:33 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/file-not-exporting-a-deep-multilevel-import-that-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/file-not-exporting-a-deep-multilevel-import-that-changes.js
@@ -55,7 +55,6 @@ Output::
 >> Screen clear
 [[90m12:00:29 AM[0m] Starting compilation in watch mode...
 
-
 [96mc.ts[0m:[93m6[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ x: number; y: number; }' is not assignable to type 'Coords'.
   Object literal may only specify known properties, and 'x' does not exist in type 'Coords'.
 
@@ -67,12 +66,10 @@ Output::
     [7m [0m [96m    ~[0m
     The expected type comes from property 'c' which is declared here on type 'PointWrapper'
 
-
 [96md.ts[0m:[93m2[0m:[93m14[0m - [91merror[0m[90m TS2339: [0mProperty 'x' does not exist on type 'Coords'.
 
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
-
 
 [[90m12:00:40 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -181,7 +178,6 @@ Output::
 >> Screen clear
 [[90m12:00:44 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mc.ts[0m:[93m6[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ x: number; y: number; }' is not assignable to type 'Coords'.
   Object literal may only specify known properties, and 'x' does not exist in type 'Coords'.
 
@@ -193,12 +189,10 @@ Output::
     [7m [0m [96m    ~[0m
     The expected type comes from property 'c' which is declared here on type 'PointWrapper'
 
-
 [96md.ts[0m:[93m2[0m:[93m14[0m - [91merror[0m[90m TS2339: [0mProperty 'x' does not exist on type 'Coords'.
 
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
-
 
 [[90m12:00:51 AM[0m] Found 2 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/updates-errors-when-file-transitively-exported-file-changes/when-there-are-circular-import-and-exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/updates-errors-when-file-transitively-exported-file-changes/when-there-are-circular-import-and-exports.js
@@ -60,7 +60,6 @@ Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:54 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -225,7 +224,6 @@ export interface ITest {
 Output::
 >> Screen clear
 [[90m12:00:58 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:05 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/updates-errors-when-file-transitively-exported-file-changes/when-there-are-no-circular-import-and-exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/updates-errors-when-file-transitively-exported-file-changes/when-there-are-no-circular-import-and-exports.js
@@ -54,7 +54,6 @@ Output::
 >> Screen clear
 [[90m12:00:37 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:50 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -203,7 +202,6 @@ export interface ITest {
 Output::
 >> Screen clear
 [[90m12:00:54 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:01 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/with-noEmitOnError-with-incremental.js
@@ -38,7 +38,6 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -48,7 +47,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
@@ -163,7 +161,6 @@ Output::
 >> Screen clear
 [[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -173,7 +170,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:42 AM[0m] Found 1 error. Watching for file changes.
 
@@ -225,7 +221,6 @@ const a = {
 Output::
 >> Screen clear
 [[90m12:00:46 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:04 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -345,12 +340,10 @@ Output::
 >> Screen clear
 [[90m12:01:08 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:12 AM[0m] Found 1 error. Watching for file changes.
 
@@ -466,12 +459,10 @@ Output::
 >> Screen clear
 [[90m12:01:16 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:17 AM[0m] Found 1 error. Watching for file changes.
 
@@ -521,7 +512,6 @@ const a: string = "hello";
 Output::
 >> Screen clear
 [[90m12:01:21 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:28 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -624,7 +614,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:01:32 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:33 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/with-noEmitOnError.js
@@ -38,7 +38,6 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -48,7 +47,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 
@@ -100,7 +98,6 @@ Output::
 >> Screen clear
 [[90m12:00:36 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -110,7 +107,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
@@ -162,7 +158,6 @@ const a = {
 Output::
 >> Screen clear
 [[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:58 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -233,12 +228,10 @@ Output::
 >> Screen clear
 [[90m12:01:02 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:03 AM[0m] Found 1 error. Watching for file changes.
 
@@ -287,12 +280,10 @@ Output::
 >> Screen clear
 [[90m12:01:07 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:08 AM[0m] Found 1 error. Watching for file changes.
 
@@ -342,7 +333,6 @@ const a: string = "hello";
 Output::
 >> Screen clear
 [[90m12:01:12 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:16 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -396,7 +386,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:01:20 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:21 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/deepImportChanges/updates-errors-when-deep-import-file-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/deepImportChanges/updates-errors-when-deep-import-file-changes.js
@@ -40,7 +40,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:38 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -147,7 +146,6 @@ export class C
 Output::
 >> Screen clear
 [[90m12:00:42 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:55 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/deepImportChanges/updates-errors-when-deep-import-through-declaration-file-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/deepImportChanges/updates-errors-when-deep-import-through-declaration-file-changes.js
@@ -40,7 +40,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -109,7 +108,6 @@ export class C
 Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:35 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/file-not-exporting-a-deep-multilevel-import-that-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/file-not-exporting-a-deep-multilevel-import-that-changes.js
@@ -55,7 +55,6 @@ Output::
 >> Screen clear
 [[90m12:00:29 AM[0m] Starting compilation in watch mode...
 
-
 [96mc.ts[0m:[93m6[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ x: number; y: number; }' is not assignable to type 'Coords'.
   Object literal may only specify known properties, and 'x' does not exist in type 'Coords'.
 
@@ -67,12 +66,10 @@ Output::
     [7m [0m [96m    ~[0m
     The expected type comes from property 'c' which is declared here on type 'PointWrapper'
 
-
 [96md.ts[0m:[93m2[0m:[93m14[0m - [91merror[0m[90m TS2339: [0mProperty 'x' does not exist on type 'Coords'.
 
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
-
 
 [[90m12:00:50 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -211,7 +208,6 @@ Output::
 >> Screen clear
 [[90m12:00:54 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mc.ts[0m:[93m6[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ x: number; y: number; }' is not assignable to type 'Coords'.
   Object literal may only specify known properties, and 'x' does not exist in type 'Coords'.
 
@@ -223,12 +219,10 @@ Output::
     [7m [0m [96m    ~[0m
     The expected type comes from property 'c' which is declared here on type 'PointWrapper'
 
-
 [96md.ts[0m:[93m2[0m:[93m14[0m - [91merror[0m[90m TS2339: [0mProperty 'x' does not exist on type 'Coords'.
 
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
-
 
 [[90m12:01:07 AM[0m] Found 2 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/updates-errors-when-file-transitively-exported-file-changes/when-there-are-circular-import-and-exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/updates-errors-when-file-transitively-exported-file-changes/when-there-are-circular-import-and-exports.js
@@ -60,7 +60,6 @@ Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:08 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -265,7 +264,6 @@ export interface ITest {
 Output::
 >> Screen clear
 [[90m12:01:12 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:25 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/updates-errors-when-file-transitively-exported-file-changes/when-there-are-no-circular-import-and-exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/updates-errors-when-file-transitively-exported-file-changes/when-there-are-no-circular-import-and-exports.js
@@ -54,7 +54,6 @@ Output::
 >> Screen clear
 [[90m12:00:37 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:02 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -234,7 +233,6 @@ export interface ITest {
 Output::
 >> Screen clear
 [[90m12:01:06 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:19 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/with-noEmitOnError-with-incremental.js
@@ -38,7 +38,6 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -48,7 +47,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
@@ -164,7 +162,6 @@ Output::
 >> Screen clear
 [[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -174,7 +171,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:42 AM[0m] Found 1 error. Watching for file changes.
 
@@ -226,7 +222,6 @@ const a = {
 Output::
 >> Screen clear
 [[90m12:00:46 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:10 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -361,12 +356,10 @@ Output::
 >> Screen clear
 [[90m12:01:14 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:18 AM[0m] Found 1 error. Watching for file changes.
 
@@ -483,12 +476,10 @@ Output::
 >> Screen clear
 [[90m12:01:22 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:23 AM[0m] Found 1 error. Watching for file changes.
 
@@ -538,7 +529,6 @@ const a: string = "hello";
 Output::
 >> Screen clear
 [[90m12:01:27 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:37 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -643,7 +633,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:01:41 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:42 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/with-noEmitOnError.js
@@ -38,7 +38,6 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -48,7 +47,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 
@@ -100,7 +98,6 @@ Output::
 >> Screen clear
 [[90m12:00:36 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -110,7 +107,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
@@ -162,7 +158,6 @@ const a = {
 Output::
 >> Screen clear
 [[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:04 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -247,12 +242,10 @@ Output::
 >> Screen clear
 [[90m12:01:08 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:09 AM[0m] Found 1 error. Watching for file changes.
 
@@ -301,12 +294,10 @@ Output::
 >> Screen clear
 [[90m12:01:13 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:14 AM[0m] Found 1 error. Watching for file changes.
 
@@ -356,7 +347,6 @@ const a: string = "hello";
 Output::
 >> Screen clear
 [[90m12:01:18 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:25 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -411,7 +401,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:01:29 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:30 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/deepImportChanges/updates-errors-when-deep-import-file-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/deepImportChanges/updates-errors-when-deep-import-file-changes.js
@@ -40,7 +40,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:32 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -131,12 +130,10 @@ Output::
 >> Screen clear
 [[90m12:00:36 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m4[0m:[93m17[0m - [91merror[0m[90m TS2339: [0mProperty 'd' does not exist on type 'C'.
 
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
-
 
 [[90m12:00:43 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/deepImportChanges/updates-errors-when-deep-import-through-declaration-file-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/deepImportChanges/updates-errors-when-deep-import-through-declaration-file-changes.js
@@ -40,7 +40,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -106,12 +105,10 @@ Output::
 >> Screen clear
 [[90m12:00:32 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m4[0m:[93m17[0m - [91merror[0m[90m TS2339: [0mProperty 'd' does not exist on type 'C'.
 
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
-
 
 [[90m12:00:33 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/file-not-exporting-a-deep-multilevel-import-that-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/file-not-exporting-a-deep-multilevel-import-that-changes.js
@@ -55,7 +55,6 @@ Output::
 >> Screen clear
 [[90m12:00:29 AM[0m] Starting compilation in watch mode...
 
-
 [96mc.ts[0m:[93m6[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ x: number; y: number; }' is not assignable to type 'Coords'.
   Object literal may only specify known properties, and 'x' does not exist in type 'Coords'.
 
@@ -67,12 +66,10 @@ Output::
     [7m [0m [96m    ~[0m
     The expected type comes from property 'c' which is declared here on type 'PointWrapper'
 
-
 [96md.ts[0m:[93m2[0m:[93m14[0m - [91merror[0m[90m TS2339: [0mProperty 'x' does not exist on type 'Coords'.
 
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
-
 
 [[90m12:00:40 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -180,7 +177,6 @@ export interface Coords {
 Output::
 >> Screen clear
 [[90m12:00:44 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:51 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/updates-errors-when-file-transitively-exported-file-changes/when-there-are-circular-import-and-exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/updates-errors-when-file-transitively-exported-file-changes/when-there-are-circular-import-and-exports.js
@@ -60,7 +60,6 @@ Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:54 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -226,13 +225,11 @@ Output::
 >> Screen clear
 [[90m12:00:58 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mlib2/data.ts[0m:[93m5[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ title: string; }' is not assignable to type 'ITest'.
   Object literal may only specify known properties, but 'title' does not exist in type 'ITest'. Did you mean to write 'title2'?
 
 [7m5[0m             title: "title"
 [7m [0m [91m            ~~~~~~~~~~~~~~[0m
-
 
 [[90m12:01:05 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/updates-errors-when-file-transitively-exported-file-changes/when-there-are-no-circular-import-and-exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/updates-errors-when-file-transitively-exported-file-changes/when-there-are-no-circular-import-and-exports.js
@@ -54,7 +54,6 @@ Output::
 >> Screen clear
 [[90m12:00:37 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:50 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -204,13 +203,11 @@ Output::
 >> Screen clear
 [[90m12:00:54 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mlib2/data.ts[0m:[93m5[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ title: string; }' is not assignable to type 'ITest'.
   Object literal may only specify known properties, but 'title' does not exist in type 'ITest'. Did you mean to write 'title2'?
 
 [7m5[0m             title: "title"
 [7m [0m [91m            ~~~~~~~~~~~~~~[0m
-
 
 [[90m12:01:01 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/with-noEmitOnError-with-incremental.js
@@ -44,7 +44,6 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -54,7 +53,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
@@ -168,7 +166,6 @@ Output::
 >> Screen clear
 [[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -178,7 +175,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:42 AM[0m] Found 1 error. Watching for file changes.
 
@@ -230,7 +226,6 @@ const a = {
 Output::
 >> Screen clear
 [[90m12:00:46 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:04 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -349,12 +344,10 @@ Output::
 >> Screen clear
 [[90m12:01:08 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:12 AM[0m] Found 1 error. Watching for file changes.
 
@@ -469,12 +462,10 @@ Output::
 >> Screen clear
 [[90m12:01:16 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:17 AM[0m] Found 1 error. Watching for file changes.
 
@@ -524,7 +515,6 @@ const a: string = "hello";
 Output::
 >> Screen clear
 [[90m12:01:21 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:28 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -626,7 +616,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:01:32 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:33 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/with-noEmitOnError.js
@@ -44,7 +44,6 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -54,7 +53,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 
@@ -106,7 +104,6 @@ Output::
 >> Screen clear
 [[90m12:00:36 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -116,7 +113,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
@@ -168,7 +164,6 @@ const a = {
 Output::
 >> Screen clear
 [[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:58 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -239,12 +234,10 @@ Output::
 >> Screen clear
 [[90m12:01:02 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:03 AM[0m] Found 1 error. Watching for file changes.
 
@@ -293,12 +286,10 @@ Output::
 >> Screen clear
 [[90m12:01:07 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:08 AM[0m] Found 1 error. Watching for file changes.
 
@@ -348,7 +339,6 @@ const a: string = "hello";
 Output::
 >> Screen clear
 [[90m12:01:12 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:16 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -402,7 +392,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:01:20 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:21 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/deepImportChanges/updates-errors-when-deep-import-file-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/deepImportChanges/updates-errors-when-deep-import-file-changes.js
@@ -40,7 +40,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:38 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -148,12 +147,10 @@ Output::
 >> Screen clear
 [[90m12:00:42 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m4[0m:[93m17[0m - [91merror[0m[90m TS2339: [0mProperty 'd' does not exist on type 'C'.
 
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
-
 
 [[90m12:00:58 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/deepImportChanges/updates-errors-when-deep-import-through-declaration-file-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/deepImportChanges/updates-errors-when-deep-import-through-declaration-file-changes.js
@@ -40,7 +40,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -110,12 +109,10 @@ Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m4[0m:[93m17[0m - [91merror[0m[90m TS2339: [0mProperty 'd' does not exist on type 'C'.
 
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
-
 
 [[90m12:00:38 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/file-not-exporting-a-deep-multilevel-import-that-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/file-not-exporting-a-deep-multilevel-import-that-changes.js
@@ -55,7 +55,6 @@ Output::
 >> Screen clear
 [[90m12:00:29 AM[0m] Starting compilation in watch mode...
 
-
 [96mc.ts[0m:[93m6[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ x: number; y: number; }' is not assignable to type 'Coords'.
   Object literal may only specify known properties, and 'x' does not exist in type 'Coords'.
 
@@ -67,12 +66,10 @@ Output::
     [7m [0m [96m    ~[0m
     The expected type comes from property 'c' which is declared here on type 'PointWrapper'
 
-
 [96md.ts[0m:[93m2[0m:[93m14[0m - [91merror[0m[90m TS2339: [0mProperty 'x' does not exist on type 'Coords'.
 
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
-
 
 [[90m12:00:50 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -210,7 +207,6 @@ export interface Coords {
 Output::
 >> Screen clear
 [[90m12:00:54 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:13 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/updates-errors-when-file-transitively-exported-file-changes/when-there-are-circular-import-and-exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/updates-errors-when-file-transitively-exported-file-changes/when-there-are-circular-import-and-exports.js
@@ -60,7 +60,6 @@ Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:08 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -266,13 +265,11 @@ Output::
 >> Screen clear
 [[90m12:01:12 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mlib2/data.ts[0m:[93m5[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ title: string; }' is not assignable to type 'ITest'.
   Object literal may only specify known properties, but 'title' does not exist in type 'ITest'. Did you mean to write 'title2'?
 
 [7m5[0m             title: "title"
 [7m [0m [91m            ~~~~~~~~~~~~~~[0m
-
 
 [[90m12:01:40 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/updates-errors-when-file-transitively-exported-file-changes/when-there-are-no-circular-import-and-exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/updates-errors-when-file-transitively-exported-file-changes/when-there-are-no-circular-import-and-exports.js
@@ -54,7 +54,6 @@ Output::
 >> Screen clear
 [[90m12:00:37 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:02 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -235,13 +234,11 @@ Output::
 >> Screen clear
 [[90m12:01:06 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mlib2/data.ts[0m:[93m5[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ title: string; }' is not assignable to type 'ITest'.
   Object literal may only specify known properties, but 'title' does not exist in type 'ITest'. Did you mean to write 'title2'?
 
 [7m5[0m             title: "title"
 [7m [0m [91m            ~~~~~~~~~~~~~~[0m
-
 
 [[90m12:01:31 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/with-noEmitOnError-with-incremental.js
@@ -38,7 +38,6 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -48,7 +47,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
@@ -163,7 +161,6 @@ Output::
 >> Screen clear
 [[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -173,7 +170,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:42 AM[0m] Found 1 error. Watching for file changes.
 
@@ -225,7 +221,6 @@ const a = {
 Output::
 >> Screen clear
 [[90m12:00:46 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:10 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -359,12 +354,10 @@ Output::
 >> Screen clear
 [[90m12:01:14 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:18 AM[0m] Found 1 error. Watching for file changes.
 
@@ -480,12 +473,10 @@ Output::
 >> Screen clear
 [[90m12:01:22 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:23 AM[0m] Found 1 error. Watching for file changes.
 
@@ -535,7 +526,6 @@ const a: string = "hello";
 Output::
 >> Screen clear
 [[90m12:01:27 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:37 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -639,7 +629,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:01:41 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:42 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/with-noEmitOnError.js
@@ -38,7 +38,6 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -48,7 +47,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 
@@ -100,7 +98,6 @@ Output::
 >> Screen clear
 [[90m12:00:36 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -110,7 +107,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
@@ -162,7 +158,6 @@ const a = {
 Output::
 >> Screen clear
 [[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:04 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -247,12 +242,10 @@ Output::
 >> Screen clear
 [[90m12:01:08 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:09 AM[0m] Found 1 error. Watching for file changes.
 
@@ -301,12 +294,10 @@ Output::
 >> Screen clear
 [[90m12:01:13 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:14 AM[0m] Found 1 error. Watching for file changes.
 
@@ -356,7 +347,6 @@ const a: string = "hello";
 Output::
 >> Screen clear
 [[90m12:01:18 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:25 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -411,7 +401,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:01:29 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:30 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/deepImportChanges/updates-errors-when-deep-import-file-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/deepImportChanges/updates-errors-when-deep-import-file-changes.js
@@ -40,7 +40,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:32 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -131,12 +130,10 @@ Output::
 >> Screen clear
 [[90m12:00:36 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m4[0m:[93m17[0m - [91merror[0m[90m TS2339: [0mProperty 'd' does not exist on type 'C'.
 
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
-
 
 [[90m12:00:40 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/deepImportChanges/updates-errors-when-deep-import-through-declaration-file-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/deepImportChanges/updates-errors-when-deep-import-through-declaration-file-changes.js
@@ -40,7 +40,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -106,12 +105,10 @@ Output::
 >> Screen clear
 [[90m12:00:32 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m4[0m:[93m17[0m - [91merror[0m[90m TS2339: [0mProperty 'd' does not exist on type 'C'.
 
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
-
 
 [[90m12:00:33 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/file-not-exporting-a-deep-multilevel-import-that-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/file-not-exporting-a-deep-multilevel-import-that-changes.js
@@ -55,7 +55,6 @@ Output::
 >> Screen clear
 [[90m12:00:29 AM[0m] Starting compilation in watch mode...
 
-
 [96mc.ts[0m:[93m6[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ x: number; y: number; }' is not assignable to type 'Coords'.
   Object literal may only specify known properties, and 'x' does not exist in type 'Coords'.
 
@@ -67,12 +66,10 @@ Output::
     [7m [0m [96m    ~[0m
     The expected type comes from property 'c' which is declared here on type 'PointWrapper'
 
-
 [96md.ts[0m:[93m2[0m:[93m14[0m - [91merror[0m[90m TS2339: [0mProperty 'x' does not exist on type 'Coords'.
 
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
-
 
 [[90m12:00:40 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -180,7 +177,6 @@ export interface Coords {
 Output::
 >> Screen clear
 [[90m12:00:44 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:48 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/updates-errors-when-file-transitively-exported-file-changes/when-there-are-circular-import-and-exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/updates-errors-when-file-transitively-exported-file-changes/when-there-are-circular-import-and-exports.js
@@ -60,7 +60,6 @@ Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:54 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -226,13 +225,11 @@ Output::
 >> Screen clear
 [[90m12:00:58 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mlib2/data.ts[0m:[93m5[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ title: string; }' is not assignable to type 'ITest'.
   Object literal may only specify known properties, but 'title' does not exist in type 'ITest'. Did you mean to write 'title2'?
 
 [7m5[0m             title: "title"
 [7m [0m [91m            ~~~~~~~~~~~~~~[0m
-
 
 [[90m12:01:02 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/updates-errors-when-file-transitively-exported-file-changes/when-there-are-no-circular-import-and-exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/updates-errors-when-file-transitively-exported-file-changes/when-there-are-no-circular-import-and-exports.js
@@ -54,7 +54,6 @@ Output::
 >> Screen clear
 [[90m12:00:37 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:50 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -204,13 +203,11 @@ Output::
 >> Screen clear
 [[90m12:00:54 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mlib2/data.ts[0m:[93m5[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ title: string; }' is not assignable to type 'ITest'.
   Object literal may only specify known properties, but 'title' does not exist in type 'ITest'. Did you mean to write 'title2'?
 
 [7m5[0m             title: "title"
 [7m [0m [91m            ~~~~~~~~~~~~~~[0m
-
 
 [[90m12:00:58 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/with-noEmitOnError-with-incremental.js
@@ -38,7 +38,6 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -48,7 +47,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
@@ -163,7 +161,6 @@ Output::
 >> Screen clear
 [[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -173,7 +170,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:42 AM[0m] Found 1 error. Watching for file changes.
 
@@ -225,7 +221,6 @@ const a = {
 Output::
 >> Screen clear
 [[90m12:00:46 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:04 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -345,12 +340,10 @@ Output::
 >> Screen clear
 [[90m12:01:08 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:12 AM[0m] Found 1 error. Watching for file changes.
 
@@ -466,12 +459,10 @@ Output::
 >> Screen clear
 [[90m12:01:16 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:17 AM[0m] Found 1 error. Watching for file changes.
 
@@ -521,7 +512,6 @@ const a: string = "hello";
 Output::
 >> Screen clear
 [[90m12:01:21 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:28 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -624,7 +614,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:01:32 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:33 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/with-noEmitOnError.js
@@ -38,7 +38,6 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -48,7 +47,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 
@@ -100,7 +98,6 @@ Output::
 >> Screen clear
 [[90m12:00:36 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -110,7 +107,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
@@ -162,7 +158,6 @@ const a = {
 Output::
 >> Screen clear
 [[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:58 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -233,12 +228,10 @@ Output::
 >> Screen clear
 [[90m12:01:02 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:03 AM[0m] Found 1 error. Watching for file changes.
 
@@ -287,12 +280,10 @@ Output::
 >> Screen clear
 [[90m12:01:07 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:08 AM[0m] Found 1 error. Watching for file changes.
 
@@ -342,7 +333,6 @@ const a: string = "hello";
 Output::
 >> Screen clear
 [[90m12:01:12 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:16 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -396,7 +386,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:01:20 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:21 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/deepImportChanges/updates-errors-when-deep-import-file-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/deepImportChanges/updates-errors-when-deep-import-file-changes.js
@@ -40,7 +40,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:38 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -148,12 +147,10 @@ Output::
 >> Screen clear
 [[90m12:00:42 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m4[0m:[93m17[0m - [91merror[0m[90m TS2339: [0mProperty 'd' does not exist on type 'C'.
 
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
-
 
 [[90m12:00:55 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/deepImportChanges/updates-errors-when-deep-import-through-declaration-file-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/deepImportChanges/updates-errors-when-deep-import-through-declaration-file-changes.js
@@ -40,7 +40,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -110,12 +109,10 @@ Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m4[0m:[93m17[0m - [91merror[0m[90m TS2339: [0mProperty 'd' does not exist on type 'C'.
 
 [7m4[0m console.log(b.c.d);
 [7m [0m [91m                ~[0m
-
 
 [[90m12:00:38 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/file-not-exporting-a-deep-multilevel-import-that-changes.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/file-not-exporting-a-deep-multilevel-import-that-changes.js
@@ -55,7 +55,6 @@ Output::
 >> Screen clear
 [[90m12:00:29 AM[0m] Starting compilation in watch mode...
 
-
 [96mc.ts[0m:[93m6[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ x: number; y: number; }' is not assignable to type 'Coords'.
   Object literal may only specify known properties, and 'x' does not exist in type 'Coords'.
 
@@ -67,12 +66,10 @@ Output::
     [7m [0m [96m    ~[0m
     The expected type comes from property 'c' which is declared here on type 'PointWrapper'
 
-
 [96md.ts[0m:[93m2[0m:[93m14[0m - [91merror[0m[90m TS2339: [0mProperty 'x' does not exist on type 'Coords'.
 
 [7m2[0m getPoint().c.x;
 [7m [0m [91m             ~[0m
-
 
 [[90m12:00:50 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -210,7 +207,6 @@ export interface Coords {
 Output::
 >> Screen clear
 [[90m12:00:54 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:10 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/updates-errors-when-file-transitively-exported-file-changes/when-there-are-circular-import-and-exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/updates-errors-when-file-transitively-exported-file-changes/when-there-are-circular-import-and-exports.js
@@ -60,7 +60,6 @@ Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:08 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -266,13 +265,11 @@ Output::
 >> Screen clear
 [[90m12:01:12 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mlib2/data.ts[0m:[93m5[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ title: string; }' is not assignable to type 'ITest'.
   Object literal may only specify known properties, but 'title' does not exist in type 'ITest'. Did you mean to write 'title2'?
 
 [7m5[0m             title: "title"
 [7m [0m [91m            ~~~~~~~~~~~~~~[0m
-
 
 [[90m12:01:37 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/updates-errors-when-file-transitively-exported-file-changes/when-there-are-no-circular-import-and-exports.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/updates-errors-when-file-transitively-exported-file-changes/when-there-are-no-circular-import-and-exports.js
@@ -54,7 +54,6 @@ Output::
 >> Screen clear
 [[90m12:00:37 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:01:02 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -235,13 +234,11 @@ Output::
 >> Screen clear
 [[90m12:01:06 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mlib2/data.ts[0m:[93m5[0m:[93m13[0m - [91merror[0m[90m TS2322: [0mType '{ title: string; }' is not assignable to type 'ITest'.
   Object literal may only specify known properties, but 'title' does not exist in type 'ITest'. Did you mean to write 'title2'?
 
 [7m5[0m             title: "title"
 [7m [0m [91m            ~~~~~~~~~~~~~~[0m
-
 
 [[90m12:01:28 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/with-noEmitOnError-with-incremental.js
@@ -38,7 +38,6 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -48,7 +47,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
@@ -164,7 +162,6 @@ Output::
 >> Screen clear
 [[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -174,7 +171,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:42 AM[0m] Found 1 error. Watching for file changes.
 
@@ -226,7 +222,6 @@ const a = {
 Output::
 >> Screen clear
 [[90m12:00:46 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:10 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -361,12 +356,10 @@ Output::
 >> Screen clear
 [[90m12:01:14 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:18 AM[0m] Found 1 error. Watching for file changes.
 
@@ -483,12 +476,10 @@ Output::
 >> Screen clear
 [[90m12:01:22 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:23 AM[0m] Found 1 error. Watching for file changes.
 
@@ -538,7 +529,6 @@ const a: string = "hello";
 Output::
 >> Screen clear
 [[90m12:01:27 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:37 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -643,7 +633,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:01:41 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:42 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/with-noEmitOnError.js
@@ -38,7 +38,6 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -48,7 +47,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 
@@ -100,7 +98,6 @@ Output::
 >> Screen clear
 [[90m12:00:36 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m4[0m:[93m1[0m - [91merror[0m[90m TS1005: [0m',' expected.
 
 [7m4[0m ;
@@ -110,7 +107,6 @@ Output::
     [7m2[0m const a = {
     [7m [0m [96m          ~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
@@ -162,7 +158,6 @@ const a = {
 Output::
 >> Screen clear
 [[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:04 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -247,12 +242,10 @@ Output::
 >> Screen clear
 [[90m12:01:08 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:09 AM[0m] Found 1 error. Watching for file changes.
 
@@ -301,12 +294,10 @@ Output::
 >> Screen clear
 [[90m12:01:13 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96msrc/main.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const a: string = 10;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:01:14 AM[0m] Found 1 error. Watching for file changes.
 
@@ -356,7 +347,6 @@ const a: string = "hello";
 Output::
 >> Screen clear
 [[90m12:01:18 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:25 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -411,7 +401,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:01:29 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:30 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-changing-module-name-with-different-casing.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-changing-module-name-with-different-casing.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -95,12 +94,10 @@ Output::
 >> Screen clear
 [[90m12:00:32 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96muser/username/projects/myproject/another.ts[0m:[93m1[0m:[93m24[0m - [91merror[0m[90m TS1261: [0mAlready included file name '/user/username/projects/myproject/Logger.ts' differs from file name '/user/username/projects/myproject/logger.ts' only in casing.
 
 [7m1[0m import { logger } from "./Logger"; new logger();
 [7m [0m [91m                       ~~~~~~~~~~[0m
-
 
 [[90m12:00:36 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-renaming-file-with-different-casing.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-renaming-file-with-different-casing.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -93,12 +92,10 @@ Output::
 >> Screen clear
 [[90m12:00:32 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96muser/username/projects/myproject/another.ts[0m:[93m1[0m:[93m24[0m - [91merror[0m[90m TS1149: [0mFile name '/user/username/projects/myproject/logger.ts' differs from already included file name '/user/username/projects/myproject/Logger.ts' only in casing.
 
 [7m1[0m import { logger } from "./logger"; new logger();
 [7m [0m [91m                       ~~~~~~~~~~[0m
-
 
 [[90m12:00:33 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/incremental/incremental-with-circular-references-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/incremental-with-circular-references-watch.js
@@ -48,7 +48,6 @@ Output::
 >> Screen clear
 [[90m12:00:27 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:38 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -218,7 +217,6 @@ export interface A {
 Output::
 >> Screen clear
 [[90m12:00:42 AM[0m] Starting compilation in watch mode...
-
 
 [[90m12:00:58 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-with-errors-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-with-errors-incremental.js
@@ -30,7 +30,6 @@ Output::
 [7m [0m [91m             ~[0m
 
 
-
 Found 1 error.
 
 
@@ -134,7 +133,6 @@ Output::
 
 [7m1[0m export const y: string = 20;
 [7m [0m [91m             ~[0m
-
 
 
 Found 1 error.

--- a/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-with-errors-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-with-errors-watch.js
@@ -27,12 +27,10 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [96mfile2.ts[0m:[93m1[0m:[93m14[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m1[0m export const y: string = 20;
 [7m [0m [91m             ~[0m
-
 
 [[90m12:00:30 AM[0m] Found 1 error. Watching for file changes.
 
@@ -149,12 +147,10 @@ Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] Starting compilation in watch mode...
 
-
 [96mfile2.ts[0m:[93m1[0m:[93m14[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m1[0m export const y: string = 20;
 [7m [0m [91m             ~[0m
-
 
 [[90m12:00:41 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-without-errors-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-without-errors-watch.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -130,7 +129,6 @@ export const z = 10;
 Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] Starting compilation in watch mode...
-
 
 [[90m12:00:41 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/incremental/module-compilation/with---out-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/module-compilation/with---out-watch.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/incremental/own-file-emit-with-errors-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/own-file-emit-with-errors-incremental.js
@@ -30,7 +30,6 @@ Output::
 [7m [0m [91m      ~[0m
 
 
-
 Found 1 error.
 
 
@@ -123,7 +122,6 @@ Output::
 
 [7m1[0m const y: string = 20;
 [7m [0m [91m      ~[0m
-
 
 
 Found 1 error.

--- a/tests/baselines/reference/tscWatch/incremental/own-file-emit-with-errors-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/own-file-emit-with-errors-watch.js
@@ -27,12 +27,10 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [96mfile2.ts[0m:[93m1[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m1[0m const y: string = 20;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:00:30 AM[0m] Found 1 error. Watching for file changes.
 
@@ -138,12 +136,10 @@ Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] Starting compilation in watch mode...
 
-
 [96mfile2.ts[0m:[93m1[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m1[0m const y: string = 20;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/incremental/own-file-emit-without-errors/with-commandline-parameters-that-are-not-relative-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/own-file-emit-without-errors/with-commandline-parameters-that-are-not-relative-watch.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -120,7 +119,6 @@ const z = 10;
 Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] Starting compilation in watch mode...
-
 
 [[90m12:00:44 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/incremental/own-file-emit-without-errors/without-commandline-options-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/own-file-emit-without-errors/without-commandline-options-watch.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -119,7 +118,6 @@ const z = 10;
 Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] Starting compilation in watch mode...
-
 
 [[90m12:00:44 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/incremental/when-file-with-ambient-global-declaration-file-is-deleted-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/when-file-with-ambient-global-declaration-file-is-deleted-incremental.js
@@ -100,7 +100,6 @@ Output::
 [7m [0m [91m            ~~~~~~[0m
 
 
-
 Found 1 error.
 
 

--- a/tests/baselines/reference/tscWatch/incremental/when-file-with-ambient-global-declaration-file-is-deleted-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/when-file-with-ambient-global-declaration-file-is-deleted-watch.js
@@ -29,7 +29,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -116,12 +115,10 @@ Output::
 >> Screen clear
 [[90m12:00:30 AM[0m] Starting compilation in watch mode...
 
-
 [96mindex.ts[0m:[93m1[0m:[93m13[0m - [91merror[0m[90m TS2304: [0mCannot find name 'Config'.
 
 [7m1[0m console.log(Config.value);
 [7m [0m [91m            ~~~~~~[0m
-
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/incremental/with---out-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/with---out-watch.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/Configure-file-diagnostics-events-are-generated-when-the-config-file-has-errors.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Configure-file-diagnostics-events-are-generated-when-the-config-file-has-errors.js
@@ -29,18 +29,15 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [96ma/b/tsconfig.json[0m:[93m3[0m:[93m29[0m - [91merror[0m[90m TS5023: [0mUnknown compiler option 'foo'.
 
 [7m3[0m                             "foo": "bar",
 [7m [0m [91m                            ~~~~~[0m
 
-
 [96ma/b/tsconfig.json[0m:[93m4[0m:[93m29[0m - [91merror[0m[90m TS5025: [0mUnknown compiler option 'allowJS'. Did you mean 'allowJs'?
 
 [7m4[0m                             "allowJS": true
 [7m [0m [91m                            ~~~~~~~~~[0m
-
 
 [[90m12:00:18 AM[0m] Found 2 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/Options-Diagnostic-locations-reported-correctly-with-changes-in-configFile-contents-when-options-change.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Options-Diagnostic-locations-reported-correctly-with-changes-in-configFile-contents-when-options-change.js
@@ -32,24 +32,20 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [96ma/b/tsconfig.json[0m:[93m6[0m:[93m9[0m - [91merror[0m[90m TS5053: [0mOption 'mapRoot' cannot be specified with option 'inlineSourceMap'.
 
 [7m6[0m         "inlineSourceMap": true,
 [7m [0m [91m        ~~~~~~~~~~~~~~~~~[0m
-
 
 [96ma/b/tsconfig.json[0m:[93m7[0m:[93m9[0m - [91merror[0m[90m TS5053: [0mOption 'mapRoot' cannot be specified with option 'inlineSourceMap'.
 
 [7m7[0m         "mapRoot": "./"
 [7m [0m [91m        ~~~~~~~~~[0m
 
-
 [96ma/b/tsconfig.json[0m:[93m7[0m:[93m9[0m - [91merror[0m[90m TS5069: [0mOption 'mapRoot' cannot be specified without specifying option 'sourceMap' or option 'declarationMap'.
 
 [7m7[0m         "mapRoot": "./"
 [7m [0m [91m        ~~~~~~~~~[0m
-
 
 [[90m12:00:18 AM[0m] Found 3 errors. Watching for file changes.
 
@@ -103,24 +99,20 @@ Output::
 >> Screen clear
 [[90m12:00:22 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/tsconfig.json[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS5053: [0mOption 'mapRoot' cannot be specified with option 'inlineSourceMap'.
 
 [7m4[0m         "inlineSourceMap": true,
 [7m [0m [91m        ~~~~~~~~~~~~~~~~~[0m
-
 
 [96ma/b/tsconfig.json[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS5053: [0mOption 'mapRoot' cannot be specified with option 'inlineSourceMap'.
 
 [7m5[0m         "mapRoot": "./"
 [7m [0m [91m        ~~~~~~~~~[0m
 
-
 [96ma/b/tsconfig.json[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS5069: [0mOption 'mapRoot' cannot be specified without specifying option 'sourceMap' or option 'declarationMap'.
 
 [7m5[0m         "mapRoot": "./"
 [7m [0m [91m        ~~~~~~~~~[0m
-
 
 [[90m12:00:23 AM[0m] Found 3 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/Proper-errors-document-is-not-contained-in-project.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Proper-errors-document-is-not-contained-in-project.js
@@ -24,7 +24,6 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [96ma/b/tsconfig.json[0m:[93m1[0m:[93m2[0m - [91merror[0m[90m TS1005: [0m'}' expected.
 
 [7m1[0m {
@@ -34,7 +33,6 @@ Output::
     [7m1[0m {
     [7m [0m [96m~[0m
     The parser expected to find a '}' to match the '{' token here.
-
 
 [[90m12:00:18 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/Reports-errors-when-the-config-file-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Reports-errors-when-the-config-file-changes.js
@@ -24,7 +24,6 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:18 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -77,12 +76,10 @@ Output::
 >> Screen clear
 [[90m12:00:22 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/tsconfig.json[0m:[93m3[0m:[93m29[0m - [91merror[0m[90m TS5023: [0mUnknown compiler option 'haha'.
 
 [7m3[0m                             "haha": 123
 [7m [0m [91m                            ~~~~~~[0m
-
 
 [[90m12:00:23 AM[0m] Found 1 error. Watching for file changes.
 
@@ -128,7 +125,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:27 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--noUnusedLabels'-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--noUnusedLabels'-changes.js
@@ -24,7 +24,6 @@ Output::
 >> Screen clear
 [[90m12:00:13 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:16 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -71,12 +70,10 @@ Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS7028: [0mUnused label.
 
 [7m1[0m label: while (1) {}
 [7m [0m [91m~~~~~[0m
-
 
 [[90m12:00:20 AM[0m] Found 1 error. Watching for file changes.
 
@@ -119,7 +116,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/add-new-files-to-a-configured-program-without-file-list.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/add-new-files-to-a-configured-program-without-file-list.js
@@ -24,7 +24,6 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:18 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -72,7 +71,6 @@ let y = 1
 Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:27 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/add-the-missing-module-file-for-inferred-project-should-remove-the-module-not-found-error.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/add-the-missing-module-file-for-inferred-project-should-remove-the-module-not-found-error.js
@@ -21,12 +21,10 @@ Output::
 >> Screen clear
 [[90m12:00:13 AM[0m] Starting compilation in watch mode...
 
-
 [96ma/b/file1.ts[0m:[93m1[0m:[93m20[0m - [91merror[0m[90m TS2307: [0mCannot find module './moduleFile' or its corresponding type declarations.
 
 [7m1[0m import * as T from "./moduleFile"; T.bar();
 [7m [0m [91m                   ~~~~~~~~~~~~~~[0m
-
 
 [[90m12:00:16 AM[0m] Found 1 error. Watching for file changes.
 
@@ -74,7 +72,6 @@ export function bar() { }
 Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:25 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/can-correctly-update-configured-project-when-set-of-root-files-has-changed-(new-file-in-list-of-files).js
+++ b/tests/baselines/reference/tscWatch/programUpdates/can-correctly-update-configured-project-when-set-of-root-files-has-changed-(new-file-in-list-of-files).js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:20 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -73,7 +72,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:24 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/can-correctly-update-configured-project-when-set-of-root-files-has-changed-(new-file-on-disk).js
+++ b/tests/baselines/reference/tscWatch/programUpdates/can-correctly-update-configured-project-when-set-of-root-files-has-changed-(new-file-on-disk).js
@@ -24,7 +24,6 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:18 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -72,7 +71,6 @@ let y = 1
 Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:27 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/can-correctly-update-configured-project-when-set-of-root-files-has-changed-through-include.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/can-correctly-update-configured-project-when-set-of-root-files-has-changed-through-include.js
@@ -24,7 +24,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:26 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -77,7 +76,6 @@ export const y = 10;
 Output::
 >> Screen clear
 [[90m12:00:29 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:32 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/can-handle-tsconfig-file-name-with-difference-casing.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/can-handle-tsconfig-file-name-with-difference-casing.js
@@ -24,7 +24,6 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:18 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/can-update-configured-project-when-set-of-root-files-was-not-changed.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/can-update-configured-project-when-set-of-root-files-was-not-changed.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -81,7 +80,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:26 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:29 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/change-module-to-none.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/change-module-to-none.js
@@ -25,7 +25,6 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:18 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -75,12 +74,10 @@ Output::
 >> Screen clear
 [[90m12:00:22 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/f1.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS1148: [0mCannot use imports, exports, or module augmentations when '--module' is 'none'.
 
 [7m1[0m export {}
 [7m [0m [91m~~~~~~~~~[0m
-
 
 [[90m12:00:26 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/changes-in-files-are-reflected-in-project-structure.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/changes-in-files-are-reflected-in-project-structure.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -92,7 +91,6 @@ export * from "../c/f3"
 Output::
 >> Screen clear
 [[90m12:00:27 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:36 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/config-file-includes-the-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/config-file-includes-the-file.js
@@ -30,7 +30,6 @@ Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/config-file-is-deleted.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/config-file-is-deleted.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -81,7 +80,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:24 AM[0m] File change detected. Starting incremental compilation...
-
 
 [91merror[0m[90m TS5083: [0mCannot read file '/a/b/tsconfig.json'.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/correctly-handles-changes-in-lib-section-of-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/correctly-handles-changes-in-lib-section-of-config-file.js
@@ -28,12 +28,10 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [96msrc/app.ts[0m:[93m1[0m:[93m8[0m - [91merror[0m[90m TS2583: [0mCannot find name 'Promise'. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
 
 [7m1[0m var x: Promise<string>;
 [7m [0m [91m       ~~~~~~~[0m
-
 
 [[90m12:00:18 AM[0m] Found 1 error. Watching for file changes.
 
@@ -82,7 +80,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:22 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:26 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/create-configured-project-without-file-list.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/create-configured-project-without-file-list.js
@@ -36,7 +36,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/create-watch-without-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/create-watch-without-config-file.js
@@ -27,18 +27,15 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [96ma/b/c/app.ts[0m:[93m2[0m:[93m25[0m - [91merror[0m[90m TS2305: [0mModule '"./module"' has no exported member 'f'.
 
 [7m2[0m                 import {f} from "./module"
 [7m [0m [91m                        ~[0m
 
-
 [96ma/b/c/app.ts[0m:[93m3[0m:[93m17[0m - [91merror[0m[90m TS2584: [0mCannot find name 'console'. Do you need to change your target library? Try changing the `lib` compiler option to include 'dom'.
 
 [7m3[0m                 console.log(f)
 [7m [0m [91m                ~~~~~~~[0m
-
 
 [[90m12:00:20 AM[0m] Found 2 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure-2.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure-2.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:26 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -111,12 +110,10 @@ Output::
 >> Screen clear
 [[90m12:00:28 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/f1.ts[0m:[93m1[0m:[93m15[0m - [91merror[0m[90m TS7016: [0mCould not find a declaration file for module './f2'. '/a/b/f2.js' implicitly has an 'any' type.
 
 [7m1[0m export * from "./f2"
 [7m [0m [91m              ~~~~~~[0m
-
 
 [[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:26 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -111,12 +110,10 @@ Output::
 >> Screen clear
 [[90m12:00:28 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/f1.ts[0m:[93m1[0m:[93m15[0m - [91merror[0m[90m TS7016: [0mCould not find a declaration file for module './f2'. '/a/b/f2.js' implicitly has an 'any' type.
 
 [7m1[0m export * from "./f2"
 [7m [0m [91m              ~~~~~~[0m
-
 
 [[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/files-explicitly-excluded-in-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/files-explicitly-excluded-in-config-file.js
@@ -33,7 +33,6 @@ Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:26 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/handle-recreated-files-correctly.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/handle-recreated-files-correctly.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -82,7 +81,6 @@ Output::
 >> Screen clear
 [[90m12:00:24 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -126,7 +124,6 @@ let y = 1
 Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:38 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/handles-the-missing-files---that-were-added-to-program-because-they-were-added-with-tripleSlashRefs.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/handles-the-missing-files---that-were-added-to-program-because-they-were-added-with-tripleSlashRefs.js
@@ -22,18 +22,15 @@ Output::
 >> Screen clear
 [[90m12:00:13 AM[0m] Starting compilation in watch mode...
 
-
 [96ma/b/commonFile1.ts[0m:[93m1[0m:[93m22[0m - [91merror[0m[90m TS6053: [0mFile '/a/b/commonFile2.ts' not found.
 
 [7m1[0m /// <reference path="commonFile2.ts"/>
 [7m [0m [91m                     ~~~~~~~~~~~~~~[0m
 
-
 [96ma/b/commonFile1.ts[0m:[93m2[0m:[93m29[0m - [91merror[0m[90m TS2304: [0mCannot find name 'y'.
 
 [7m2[0m                     let x = y
 [7m [0m [91m                            ~[0m
-
 
 [[90m12:00:16 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -79,7 +76,6 @@ let y = 1
 Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:25 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/if-config-file-doesnt-have-errors,-they-are-not-reported.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/if-config-file-doesnt-have-errors,-they-are-not-reported.js
@@ -26,7 +26,6 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:18 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/non-existing-directories-listed-in-config-file-input-array-should-be-able-to-handle-@types-if-input-file-list-is-empty.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/non-existing-directories-listed-in-config-file-input-array-should-be-able-to-handle-@types-if-input-file-list-is-empty.js
@@ -30,12 +30,10 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [96mtsconfig.json[0m:[93m1[0m:[93m24[0m - [91merror[0m[90m TS18002: [0mThe 'files' list in config file '/a/tsconfig.json' is empty.
 
 [7m1[0m {"compiler":{},"files":[]}
 [7m [0m [91m                       ~~[0m
-
 
 [[90m12:00:24 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/non-existing-directories-listed-in-config-file-input-array-should-be-tolerated-without-crashing-the-server.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/non-existing-directories-listed-in-config-file-input-array-should-be-tolerated-without-crashing-the-server.js
@@ -27,9 +27,7 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [91merror[0m[90m TS18003: [0mNo inputs were found in config file '/a/b/tsconfig.json'. Specified 'include' paths were '["app/*","test/**/*","something"]' and 'exclude' paths were '[]'.
-
 
 [[90m12:00:16 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/rename-a-module-file-and-rename-back-should-restore-the-states-for-configured-projects.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/rename-a-module-file-and-rename-back-should-restore-the-states-for-configured-projects.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -94,12 +93,10 @@ Output::
 >> Screen clear
 [[90m12:00:27 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/file1.ts[0m:[93m1[0m:[93m20[0m - [91merror[0m[90m TS2307: [0mCannot find module './moduleFile' or its corresponding type declarations.
 
 [7m1[0m import * as T from "./moduleFile"; T.bar();
 [7m [0m [91m                   ~~~~~~~~~~~~~~[0m
-
 
 [[90m12:00:33 AM[0m] Found 1 error. Watching for file changes.
 
@@ -162,7 +159,6 @@ export function bar() { };
 Output::
 >> Screen clear
 [[90m12:00:37 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:43 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/rename-a-module-file-and-rename-back-should-restore-the-states-for-inferred-projects.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/rename-a-module-file-and-rename-back-should-restore-the-states-for-inferred-projects.js
@@ -24,7 +24,6 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:20 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -85,12 +84,10 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma/b/file1.ts[0m:[93m1[0m:[93m20[0m - [91merror[0m[90m TS2307: [0mCannot find module './moduleFile' or its corresponding type declarations.
 
 [7m1[0m import * as T from "./moduleFile"; T.bar();
 [7m [0m [91m                   ~~~~~~~~~~~~~~[0m
-
 
 [[90m12:00:29 AM[0m] Found 1 error. Watching for file changes.
 
@@ -132,7 +129,6 @@ export function bar() { };
 Output::
 >> Screen clear
 [[90m12:00:33 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:39 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/reports-errors-correctly-with-file-not-in-rootDir.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/reports-errors-correctly-with-file-not-in-rootDir.js
@@ -27,12 +27,10 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [96ma.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS6059: [0mFile '/user/username/projects/b.ts' is not under 'rootDir' '/user/username/projects/myproject'. 'rootDir' is expected to contain all source files.
 
 [7m1[0m import { x } from "../b";
 [7m [0m [91m                  ~~~~~~[0m
-
 
 [[90m12:00:34 AM[0m] Found 1 error. Watching for file changes.
 
@@ -96,12 +94,10 @@ Output::
 >> Screen clear
 [[90m12:00:38 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m3[0m:[93m19[0m - [91merror[0m[90m TS6059: [0mFile '/user/username/projects/b.ts' is not under 'rootDir' '/user/username/projects/myproject'. 'rootDir' is expected to contain all source files.
 
 [7m3[0m import { x } from "../b";
 [7m [0m [91m                  ~~~~~~[0m
-
 
 [[90m12:00:42 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/reports-errors-correctly-with-isolatedModules.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/reports-errors-correctly-with-isolatedModules.js
@@ -28,7 +28,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -91,12 +90,10 @@ Output::
 >> Screen clear
 [[90m12:00:32 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mb.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
 
 [7m2[0m const b: string = a;
 [7m [0m [91m      ~[0m
-
 
 [[90m12:00:36 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-handle-non-existing-directories-in-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-handle-non-existing-directories-in-config-file.js
@@ -24,7 +24,6 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:18 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-ignore-non-existing-files-specified-in-the-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-ignore-non-existing-files-specified-in-the-config-file.js
@@ -33,9 +33,7 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [91merror[0m[90m TS6053: [0mFile '/a/b/commonFile3.ts' not found.
-
 
 [[90m12:00:20 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/declarationDir-is-specified.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/declarationDir-is-specified.js
@@ -98,7 +98,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:40 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -203,7 +202,6 @@ export const y = 10;
 Output::
 >> Screen clear
 [[90m12:00:43 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:48 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/when-outDir-and-declarationDir-is-specified.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/when-outDir-and-declarationDir-is-specified.js
@@ -98,7 +98,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:46 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -203,7 +202,6 @@ export const y = 10;
 Output::
 >> Screen clear
 [[90m12:00:49 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:54 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/when-outDir-is-specified.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/when-outDir-is-specified.js
@@ -97,7 +97,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:36 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -194,7 +193,6 @@ export const y = 10;
 Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:42 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/with-outFile.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/with-outFile.js
@@ -97,7 +97,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:31 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -188,7 +187,6 @@ export const y = 10;
 Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:38 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/without-outDir-or-outFile-is-specified-with-declaration-enabled.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/without-outDir-or-outFile-is-specified-with-declaration-enabled.js
@@ -97,7 +97,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:34 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -202,7 +201,6 @@ export const y = 10;
 Output::
 >> Screen clear
 [[90m12:00:37 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:42 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/without-outDir-or-outFile-is-specified.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/without-outDir-or-outFile-is-specified.js
@@ -97,7 +97,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -194,7 +193,6 @@ export const y = 10;
 Output::
 >> Screen clear
 [[90m12:00:33 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:36 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-properly-handle-module-resolution-changes-in-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-properly-handle-module-resolution-changes-in-config-file.js
@@ -35,7 +35,6 @@ Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -93,7 +92,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:28 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:34 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-reflect-change-in-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-reflect-change-in-config-file.js
@@ -30,7 +30,6 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -87,7 +86,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:26 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/should-tolerate-config-file-errors-and-still-try-to-build-a-project.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-tolerate-config-file-errors-and-still-try-to-build-a-project.js
@@ -33,12 +33,10 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [96ma/b/tsconfig.json[0m:[93m4[0m:[93m29[0m - [91merror[0m[90m TS5023: [0mUnknown compiler option 'allowAnything'.
 
 [7m4[0m                             "allowAnything": true
 [7m [0m [91m                            ~~~~~~~~~~~~~~~[0m
-
 
 [[90m12:00:22 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/shouldnt-report-error-about-unused-function-incorrectly-when-file-changes-from-global-to-module.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/shouldnt-report-error-about-unused-function-incorrectly-when-file-changes-from-global-to-module.js
@@ -26,7 +26,6 @@ Output::
 >> Screen clear
 [[90m12:00:13 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:16 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -78,7 +77,6 @@ export function two() {
 Output::
 >> Screen clear
 [[90m12:00:20 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/types-should-load-from-config-file-path-if-config-exists.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/types-should-load-from-config-file-path-if-config-exists.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-for-decorators.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-for-decorators.js
@@ -31,18 +31,15 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [96ma.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS1371: [0mThis import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.
 
 [7m1[0m import {B} from './b'
 [7m [0m [91m~~~~~~~~~~~~~~~~~~~~~[0m
 
-
 [96ma.ts[0m:[93m3[0m:[93m14[0m - [91merror[0m[90m TS1219: [0mExperimental support for decorators is a feature that is subject to change in a future release. Set the 'experimentalDecorators' option in your 'tsconfig' or 'jsconfig' to remove this warning.
 
 [7m3[0m export class A {
 [7m [0m [91m             ~[0m
-
 
 [[90m12:00:20 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -112,12 +109,10 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS1371: [0mThis import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.
 
 [7m1[0m import {B} from './b'
 [7m [0m [91m~~~~~~~~~~~~~~~~~~~~~[0m
-
 
 [[90m12:00:24 AM[0m] Found 1 error. Watching for file changes.
 
@@ -164,7 +159,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:27 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:34 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-when-useDefineForClassFields-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-when-useDefineForClassFields-changes.js
@@ -25,12 +25,10 @@ Output::
 >> Screen clear
 [[90m12:00:13 AM[0m] Starting compilation in watch mode...
 
-
 [96ma.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2610: [0m'prop' is defined as an accessor in class 'C', but is overridden here in 'D' as an instance property.
 
 [7m2[0m class D extends C { prop = 1; }
 [7m [0m [91m                    ~~~~[0m
-
 
 [[90m12:00:16 AM[0m] Found 1 error. Watching for file changes.
 
@@ -86,12 +84,10 @@ Output::
 >> Screen clear
 [[90m12:00:20 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2610: [0m'prop' is defined as an accessor in class 'C', but is overridden here in 'D' as an instance property.
 
 [7m2[0m class D extends C { prop = 1; }
 [7m [0m [91m                    ~~~~[0m
-
 
 [[90m12:00:24 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-and-emit-when-importsNotUsedAsValues-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-and-emit-when-importsNotUsedAsValues-changes.js
@@ -28,7 +28,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:28 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -97,7 +96,6 @@ Output::
 >> Screen clear
 [[90m12:00:32 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:39 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -148,12 +146,10 @@ Output::
 >> Screen clear
 [[90m12:00:43 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mb.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS1371: [0mThis import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.
 
 [7m1[0m import {C} from './a';
 [7m [0m [91m~~~~~~~~~~~~~~~~~~~~~~[0m
-
 
 [[90m12:00:50 AM[0m] Found 1 error. Watching for file changes.
 
@@ -212,7 +208,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:54 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:01:01 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-correctly-when-declaration-emit-is-disabled-in-compiler-options.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-correctly-when-declaration-emit-is-disabled-in-compiler-options.js
@@ -31,7 +31,6 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -83,12 +82,10 @@ Output::
 >> Screen clear
 [[90m12:00:28 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m2[0m:[93m6[0m - [91merror[0m[90m TS2345: [0mArgument of type 'number' is not assignable to parameter of type 'string'.
 
 [7m2[0m test(4, 5);
 [7m [0m [91m     ~[0m
-
 
 [[90m12:00:29 AM[0m] Found 1 error. Watching for file changes.
 
@@ -140,7 +137,6 @@ Output::
 >> Screen clear
 [[90m12:00:33 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:34 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -191,18 +187,15 @@ Output::
 >> Screen clear
 [[90m12:00:38 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m2[0m:[93m9[0m - [91merror[0m[90m TS2345: [0mArgument of type 'number' is not assignable to parameter of type 'string'.
 
 [7m2[0m test(4, 5);
 [7m [0m [91m        ~[0m
 
-
 [96mb.ts[0m:[93m2[0m:[93m16[0m - [91merror[0m[90m TS2362: [0mThe left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
 
 [7m2[0m     return x + y / 5;
 [7m [0m [91m               ~[0m
-
 
 [[90m12:00:39 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -253,7 +246,6 @@ export default test;
 Output::
 >> Screen clear
 [[90m12:00:43 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:44 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-module-file-with-global-definitions-changes/with-default-options.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-module-file-with-global-definitions-changes/with-default-options.js
@@ -30,18 +30,15 @@ Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] Starting compilation in watch mode...
 
-
 [96m../../../../a/lib/lib.d.ts[0m:[93m13[0m:[93m14[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m13[0m     readonly fullscreen: boolean;
 [7m  [0m [91m             ~~~~~~~~~~[0m
 
-
 [96ma.ts[0m:[93m4[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m4[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:22 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -92,7 +89,6 @@ Output::
 >> Screen clear
 [[90m12:00:26 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -140,18 +136,15 @@ Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96m../../../../a/lib/lib.d.ts[0m:[93m13[0m:[93m14[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m13[0m     readonly fullscreen: boolean;
 [7m  [0m [91m             ~~~~~~~~~~[0m
 
-
 [96ma.ts[0m:[93m4[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m4[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:38 AM[0m] Found 2 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-module-file-with-global-definitions-changes/with-skipDefaultLibCheck.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-module-file-with-global-definitions-changes/with-skipDefaultLibCheck.js
@@ -30,12 +30,10 @@ Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] Starting compilation in watch mode...
 
-
 [96ma.ts[0m:[93m4[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m4[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:22 AM[0m] Found 1 error. Watching for file changes.
 
@@ -86,7 +84,6 @@ Output::
 >> Screen clear
 [[90m12:00:26 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -133,12 +130,10 @@ Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m4[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m4[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:38 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-module-file-with-global-definitions-changes/with-skipLibCheck.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-module-file-with-global-definitions-changes/with-skipLibCheck.js
@@ -30,12 +30,10 @@ Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] Starting compilation in watch mode...
 
-
 [96ma.ts[0m:[93m4[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m4[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:22 AM[0m] Found 1 error. Watching for file changes.
 
@@ -86,7 +84,6 @@ Output::
 >> Screen clear
 [[90m12:00:26 AM[0m] File change detected. Starting incremental compilation...
 
-
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -133,12 +130,10 @@ Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m4[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m4[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:38 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-non-module-file-changes/with-default-options.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-non-module-file-changes/with-default-options.js
@@ -27,18 +27,15 @@ Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] Starting compilation in watch mode...
 
-
 [96m../../../../a/lib/lib.d.ts[0m:[93m13[0m:[93m14[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m13[0m     readonly fullscreen: boolean;
 [7m  [0m [91m             ~~~~~~~~~~[0m
 
-
 [96ma.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:22 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -84,7 +81,6 @@ var y: number;
 Output::
 >> Screen clear
 [[90m12:00:26 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -134,18 +130,15 @@ Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96m../../../../a/lib/lib.d.ts[0m:[93m13[0m:[93m14[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m13[0m     readonly fullscreen: boolean;
 [7m  [0m [91m             ~~~~~~~~~~[0m
 
-
 [96ma.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:38 AM[0m] Found 2 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-non-module-file-changes/with-skipDefaultLibCheck.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-non-module-file-changes/with-skipDefaultLibCheck.js
@@ -27,12 +27,10 @@ Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] Starting compilation in watch mode...
 
-
 [96ma.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:22 AM[0m] Found 1 error. Watching for file changes.
 
@@ -78,7 +76,6 @@ var y: number;
 Output::
 >> Screen clear
 [[90m12:00:26 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -127,12 +124,10 @@ Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:38 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-non-module-file-changes/with-skipLibCheck.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-in-lib-file/when-non-module-file-changes/with-skipLibCheck.js
@@ -27,12 +27,10 @@ Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] Starting compilation in watch mode...
 
-
 [96ma.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:22 AM[0m] Found 1 error. Watching for file changes.
 
@@ -78,7 +76,6 @@ var y: number;
 Output::
 >> Screen clear
 [[90m12:00:26 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
@@ -127,12 +124,10 @@ Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:38 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-ambient-modules-of-program-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-ambient-modules-of-program-changes.js
@@ -26,7 +26,6 @@ Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -76,7 +75,6 @@ Output::
 >> Screen clear
 [[90m12:00:27 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m2[0m:[93m8[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'foo'.
 
 [7m2[0m   type foo = number;
@@ -87,7 +85,6 @@ Output::
     [7m [0m [96m       ~~~[0m
     'foo' was also declared here.
 
-
 [96mb.ts[0m:[93m2[0m:[93m8[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'foo'.
 
 [7m2[0m   type foo = number;
@@ -97,7 +94,6 @@ Output::
     [7m2[0m   type foo = number;
     [7m [0m [96m       ~~~[0m
     'foo' was also declared here.
-
 
 [[90m12:00:33 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -148,7 +144,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:35 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:39 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-forceConsistentCasingInFileNames-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-forceConsistentCasingInFileNames-changes.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:20 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -91,12 +90,10 @@ Output::
 >> Screen clear
 [[90m12:00:24 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96mb.ts[0m:[93m1[0m:[93m43[0m - [91merror[0m[90m TS1149: [0mFile name '/A.ts' differs from already included file name '/a.ts' only in casing.
 
 [7m1[0m import {C} from './a'; import * as A from './A';
 [7m [0m [91m                                          ~~~~~[0m
-
 
 [[90m12:00:25 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-noErrorTruncation-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-noErrorTruncation-changes.js
@@ -33,12 +33,10 @@ Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] Starting compilation in watch mode...
 
-
 [96ma.ts[0m:[93m10[0m:[93m1[0m - [91merror[0m[90m TS2367: [0mThis condition will always return 'false' since the types '{ reallyLongPropertyName1: string | number | bigint | boolean | symbol | object; reallyLongPropertyName2: string | number | bigint | boolean | symbol | object; reallyLongPropertyName3: string | ... 4 more ... | object; reallyLongPropertyName4: string | ... 4 more ... | object; reallyLongPropertyName5: string | ... 4...' and 'string' have no overlap.
 
 [7m10[0m v === 'foo';
 [7m  [0m [91m~~~~~~~~~~~[0m
-
 
 [[90m12:00:24 AM[0m] Found 1 error. Watching for file changes.
 
@@ -88,12 +86,10 @@ Output::
 >> Screen clear
 [[90m12:00:28 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m10[0m:[93m1[0m - [91merror[0m[90m TS2367: [0mThis condition will always return 'false' since the types '{ reallyLongPropertyName1: string | number | bigint | boolean | symbol | object; reallyLongPropertyName2: string | number | bigint | boolean | symbol | object; reallyLongPropertyName3: string | number | bigint | boolean | symbol | object; reallyLongPropertyName4: string | number | bigint | boolean | symbol | object; reallyLongPropertyName5: string | number | bigint | boolean | symbol | object; reallyLongPropertyName6: string | number | bigint | boolean | symbol | object; reallyLongPropertyName7: string | number | bigint | boolean | symbol | object; }' and 'string' have no overlap.
 
 [7m10[0m v === 'foo';
 [7m  [0m [91m~~~~~~~~~~~[0m
-
 
 [[90m12:00:29 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-strictNullChecks-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-when-strictNullChecks-changes.js
@@ -25,7 +25,6 @@ Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -74,12 +73,10 @@ Output::
 >> Screen clear
 [[90m12:00:28 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m2[0m:[93m1[0m - [91merror[0m[90m TS2531: [0mObject is possibly 'null'.
 
 [7m2[0m foo().hello
 [7m [0m [91m~~~~~[0m
-
 
 [[90m12:00:29 AM[0m] Found 1 error. Watching for file changes.
 
@@ -125,12 +122,10 @@ Output::
 >> Screen clear
 [[90m12:00:33 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m2[0m:[93m1[0m - [91merror[0m[90m TS2531: [0mObject is possibly 'null'.
 
 [7m2[0m foo().hello
 [7m [0m [91m~~~~~[0m
-
 
 [[90m12:00:34 AM[0m] Found 1 error. Watching for file changes.
 
@@ -175,7 +170,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:38 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:39 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-moduleResolution-when-resolveJsonModule-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-moduleResolution-when-resolveJsonModule-changes.js
@@ -27,12 +27,10 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [96ma.ts[0m:[93m1[0m:[93m23[0m - [91merror[0m[90m TS2732: [0mCannot find module './data.json'. Consider using '--resolveJsonModule' to import module with '.json' extension.
 
 [7m1[0m import * as data from './data.json'
 [7m [0m [91m                      ~~~~~~~~~~~~~[0m
-
 
 [[90m12:00:26 AM[0m] Found 1 error. Watching for file changes.
 
@@ -86,7 +84,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:30 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:34 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/watched-files-when-file-is-deleted-and-new-file-is-added-as-part-of-change.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/watched-files-when-file-is-deleted-and-new-file-is-added-as-part-of-change.js
@@ -24,7 +24,6 @@ Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -73,7 +72,6 @@ var a = 10;
 Output::
 >> Screen clear
 [[90m12:00:28 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:31 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/when-skipLibCheck-and-skipDefaultLibCheck-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/when-skipLibCheck-and-skipDefaultLibCheck-changes.js
@@ -34,24 +34,20 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [96m../../../../a/lib/lib.d.ts[0m:[93m13[0m:[93m14[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m13[0m     readonly fullscreen: boolean;
 [7m  [0m [91m             ~~~~~~~~~~[0m
-
 
 [96ma.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
 
-
 [96mb.d.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:26 AM[0m] Found 3 errors. Watching for file changes.
 
@@ -104,12 +100,10 @@ Output::
 >> Screen clear
 [[90m12:00:30 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:31 AM[0m] Found 1 error. Watching for file changes.
 
@@ -158,18 +152,15 @@ Output::
 >> Screen clear
 [[90m12:00:35 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
 
-
 [96mb.d.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:36 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -218,24 +209,20 @@ Output::
 >> Screen clear
 [[90m12:00:40 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96m../../../../a/lib/lib.d.ts[0m:[93m13[0m:[93m14[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m13[0m     readonly fullscreen: boolean;
 [7m  [0m [91m             ~~~~~~~~~~[0m
-
 
 [96ma.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
 
-
 [96mb.d.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:41 AM[0m] Found 3 errors. Watching for file changes.
 
@@ -283,18 +270,15 @@ Output::
 >> Screen clear
 [[90m12:00:45 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
 
-
 [96mb.d.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:46 AM[0m] Found 2 errors. Watching for file changes.
 
@@ -342,12 +326,10 @@ Output::
 >> Screen clear
 [[90m12:00:50 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96ma.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:51 AM[0m] Found 1 error. Watching for file changes.
 
@@ -396,24 +378,20 @@ Output::
 >> Screen clear
 [[90m12:00:55 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96m../../../../a/lib/lib.d.ts[0m:[93m13[0m:[93m14[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m13[0m     readonly fullscreen: boolean;
 [7m  [0m [91m             ~~~~~~~~~~[0m
-
 
 [96ma.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
 
-
 [96mb.d.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2687: [0mAll declarations of 'fullscreen' must have identical modifiers.
 
 [7m2[0m     fullscreen: boolean;
 [7m [0m [91m    ~~~~~~~~~~[0m
-
 
 [[90m12:00:56 AM[0m] Found 3 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/programUpdates/works-correctly-when-config-file-is-changed-but-its-content-havent.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/works-correctly-when-config-file-is-changed-but-its-content-havent.js
@@ -30,7 +30,6 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -82,7 +81,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:26 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/ignores-changes-in-node_modules-that-start-with-dot/watch-with-configFile.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/ignores-changes-in-node_modules-that-start-with-dot/watch-with-configFile.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:27 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/ignores-changes-in-node_modules-that-start-with-dot/watch-without-configFile.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/ignores-changes-in-node_modules-that-start-with-dot/watch-without-configFile.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:27 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/when-types-in-compiler-option-are-global-and-installed-at-later-point.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/when-types-in-compiler-option-are-global-and-installed-at-later-point.js
@@ -24,9 +24,7 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] Starting compilation in watch mode...
 
-
 [91merror[0m[90m TS2688: [0mCannot find type definition file for '@myapp/ts-types'.
-
 
 [[90m12:00:26 AM[0m] Found 1 error. Watching for file changes.
 
@@ -79,7 +77,6 @@ declare namespace myapp {
 Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:43 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/with-modules-linked-to-sibling-folder.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/with-modules-linked-to-sibling-folder.js
@@ -34,7 +34,6 @@ Output::
 >> Screen clear
 [[90m12:00:39 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:42 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-included-file-with-ambient-module-changes.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-included-file-with-ambient-module-changes.js
@@ -33,12 +33,10 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [96mfoo.ts[0m:[93m2[0m:[93m21[0m - [91merror[0m[90m TS2307: [0mCannot find module 'fs' or its corresponding type declarations.
 
 [7m2[0m import * as fs from "fs";
 [7m [0m [91m                    ~~~~[0m
-
 
 [[90m12:00:18 AM[0m] Found 1 error. Watching for file changes.
 
@@ -102,7 +100,6 @@ declare module "fs" {
 Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:25 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-module-resolution-changes-to-ambient-module.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-module-resolution-changes-to-ambient-module.js
@@ -21,12 +21,10 @@ Output::
 >> Screen clear
 [[90m12:00:13 AM[0m] Starting compilation in watch mode...
 
-
 [96mfoo.ts[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS2307: [0mCannot find module 'fs' or its corresponding type declarations.
 
 [7m1[0m import * as fs from "fs";
 [7m [0m [91m                    ~~~~[0m
-
 
 [[90m12:00:16 AM[0m] Found 1 error. Watching for file changes.
 
@@ -86,7 +84,6 @@ declare module "fs" {
 Output::
 >> Screen clear
 [[90m12:00:27 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:31 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-renaming-node_modules-folder-that-already-contains-@types-folder.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-renaming-node_modules-folder-that-already-contains-@types-folder.js
@@ -24,12 +24,10 @@ Output::
 >> Screen clear
 [[90m12:00:27 AM[0m] Starting compilation in watch mode...
 
-
 [96ma.ts[0m:[93m1[0m:[93m20[0m - [91merror[0m[90m TS2307: [0mCannot find module 'qqq' or its corresponding type declarations.
 
 [7m1[0m import * as q from "qqq";
 [7m [0m [91m                   ~~~~~[0m
-
 
 [[90m12:00:30 AM[0m] Found 1 error. Watching for file changes.
 
@@ -78,7 +76,6 @@ export {}
 Output::
 >> Screen clear
 [[90m12:00:34 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:38 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-reusing-program-with-files-from-external-library.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-reusing-program-with-files-from-external-library.js
@@ -32,7 +32,6 @@ Output::
 >> Screen clear
 [[90m12:00:29 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:37 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -106,7 +105,6 @@ module1("hello");
 Output::
 >> Screen clear
 [[90m12:00:40 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:44 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/uses-non-recursive-dynamic-polling-when-renaming-file-in-subfolder.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/uses-non-recursive-dynamic-polling-when-renaming-file-in-subfolder.js
@@ -24,7 +24,6 @@ Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -68,7 +67,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:26 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:29 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/uses-non-recursive-watchDirectory-when-renaming-file-in-subfolder.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/uses-non-recursive-watchDirectory-when-renaming-file-in-subfolder.js
@@ -24,7 +24,6 @@ Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -74,7 +73,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:26 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:29 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/uses-watchFile-when-renaming-file-in-subfolder.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/uses-watchFile-when-renaming-file-in-subfolder.js
@@ -24,7 +24,6 @@ Output::
 >> Screen clear
 [[90m12:00:19 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -74,7 +73,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:26 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:29 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/when-there-are-symlinks-to-folders-in-recursive-folders.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/when-there-are-symlinks-to-folders-in-recursive-folders.js
@@ -33,68 +33,37 @@ export {}
 Output::
 [[90m12:00:45 AM[0m] Starting compilation in watch mode...
 
-
 Current directory: /home/user/projects/myproject CaseSensitiveFileNames: false
-
 FileWatcher:: Added:: WatchInfo: /home/user/projects/myproject/tsconfig.json 2000 undefined Config file
-
 Synchronizing program
-
 CreatingProgramWith::
-
   roots: ["/home/user/projects/myproject/src/file.ts"]
-
   options: {"extendedDiagnostics":true,"traceResolution":true,"watch":true,"configFilePath":"/home/user/projects/myproject/tsconfig.json"}
-
 FileWatcher:: Added:: WatchInfo: /home/user/projects/myproject/src/file.ts 250 undefined Source file
-
 ======== Resolving module 'a' from '/home/user/projects/myproject/src/file.ts'. ========
-
 Module resolution kind is not specified, using 'NodeJs'.
-
 Loading module 'a' from 'node_modules' folder, target file type 'TypeScript'.
-
 Directory '/home/user/projects/myproject/src/node_modules' does not exist, skipping all lookups in it.
-
 File '/home/user/projects/myproject/node_modules/a/package.json' does not exist.
-
 File '/home/user/projects/myproject/node_modules/a.ts' does not exist.
-
 File '/home/user/projects/myproject/node_modules/a.tsx' does not exist.
-
 File '/home/user/projects/myproject/node_modules/a.d.ts' does not exist.
-
 File '/home/user/projects/myproject/node_modules/a/index.ts' does not exist.
-
 File '/home/user/projects/myproject/node_modules/a/index.tsx' does not exist.
-
 File '/home/user/projects/myproject/node_modules/a/index.d.ts' exist - use it as a name resolution result.
-
 Resolving real path for '/home/user/projects/myproject/node_modules/a/index.d.ts', result '/home/user/projects/myproject/node_modules/reala/index.d.ts'.
-
 ======== Module name 'a' was successfully resolved to '/home/user/projects/myproject/node_modules/reala/index.d.ts'. ========
-
 FileWatcher:: Added:: WatchInfo: /home/user/projects/myproject/node_modules/reala/index.d.ts 250 undefined Source file
-
 FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 250 undefined Source file
-
 DirectoryWatcher:: Added:: WatchInfo: /home/user/projects/myproject/src 1 undefined Failed Lookup Locations
-
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/user/projects/myproject/src 1 undefined Failed Lookup Locations
-
 DirectoryWatcher:: Added:: WatchInfo: /home/user/projects/myproject/node_modules 1 undefined Failed Lookup Locations
-
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/user/projects/myproject/node_modules 1 undefined Failed Lookup Locations
-
 DirectoryWatcher:: Added:: WatchInfo: /home/user/projects/myproject/node_modules/@types 1 undefined Type roots
-
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/user/projects/myproject/node_modules/@types 1 undefined Type roots
-
 [[90m12:00:48 AM[0m] Found 0 errors. Watching for file changes.
 
-
 DirectoryWatcher:: Added:: WatchInfo: /home/user/projects/myproject 1 undefined Wild card directory
-
 Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/user/projects/myproject 1 undefined Wild card directory
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory-renaming-a-file.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory-renaming-a-file.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:25 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:33 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -124,9 +123,7 @@ Output::
 >> Screen clear
 [[90m12:00:37 AM[0m] File change detected. Starting incremental compilation...
 
-
 [91merror[0m[90m TS6053: [0mFile '/user/username/projects/myproject/src/file2.ts' not found.
-
 
 [[90m12:00:41 AM[0m] Found 1 error. Watching for file changes.
 
@@ -175,12 +172,10 @@ Output::
 >> Screen clear
 [[90m12:00:42 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96muser/username/projects/myproject/src/file1.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2307: [0mCannot find module './file2' or its corresponding type declarations.
 
 [7m1[0m import { x } from "./file2";
 [7m [0m [91m                  ~~~~~~~~~[0m
-
 
 [[90m12:00:45 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory-with-outDir-and-declaration-enabled.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory-with-outDir-and-declaration-enabled.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:29 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:37 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -162,7 +161,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:40 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:45 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchDirectories/with-non-synchronous-watch-directory.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:29 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:32 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -118,12 +117,10 @@ Output::
 >> Screen clear
 [[90m12:00:36 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96muser/username/projects/myproject/src/file1.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2307: [0mCannot find module 'file2' or its corresponding type declarations.
 
 [7m1[0m import { x } from "file2";
 [7m [0m [91m                  ~~~~~~~[0m
-
 
 [[90m12:00:40 AM[0m] Found 1 error. Watching for file changes.
 
@@ -170,12 +167,10 @@ Output::
 >> Screen clear
 [[90m12:00:41 AM[0m] File change detected. Starting incremental compilation...
 
-
 [96muser/username/projects/myproject/src/file1.ts[0m:[93m1[0m:[93m19[0m - [91merror[0m[90m TS2307: [0mCannot find module 'file2' or its corresponding type declarations.
 
 [7m1[0m import { x } from "file2";
 [7m [0m [91m                  ~~~~~~~[0m
-
 
 [[90m12:00:42 AM[0m] Found 1 error. Watching for file changes.
 
@@ -371,7 +366,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:49 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:53 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchFile/using-dynamic-priority-polling.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchFile/using-dynamic-priority-polling.js
@@ -21,7 +21,6 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:18 AM[0m] Found 0 errors. Watching for file changes.
 
 
@@ -89,7 +88,6 @@ Input::
 Output::
 >> Screen clear
 [[90m12:00:22 AM[0m] File change detected. Starting incremental compilation...
-
 
 [[90m12:00:26 AM[0m] Found 0 errors. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-fallbackPolling-option.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-fallbackPolling-option.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-watchDirectory-option.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-watchDirectory-option.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-watchFile-as-watch-options-to-extend.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-watchFile-as-watch-options-to-extend.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
 
 

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-watchFile-option.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchOptions/with-watchFile-option.js
@@ -27,7 +27,6 @@ Output::
 >> Screen clear
 [[90m12:00:17 AM[0m] Starting compilation in watch mode...
 
-
 [[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
 
 


### PR DESCRIPTION
The watch baseline incorrectly added additional newline that this fixes. 
This is cherry pick from  #40011 as everytime i update that branch it gets out of hand to merge master with so many unrelated baseline changes