### PR TITLE
Remove old Typescript-*-Starter user tests

### DIFF
--- a/tests/cases/user/TypeScript-React-Starter/test.json
+++ b/tests/cases/user/TypeScript-React-Starter/test.json
@@ -1,4 +1,0 @@
-{
-    "cloneUrl": "https://github.com/Microsoft/TypeScript-React-Starter.git",
-    "types": ["jest", "node"]
-}

--- a/tests/cases/user/TypeScript-Vue-Starter/test.json
+++ b/tests/cases/user/TypeScript-Vue-Starter/test.json
@@ -1,4 +1,0 @@
-{
-    "cloneUrl": "https://github.com/Microsoft/TypeScript-Vue-Starter.git",
-    "types": ["jest"]
-}


### PR DESCRIPTION
This only removes the ones with repos that are now readonly; some repos are still getting updates, so I left them in as tests.

Neither one fails right now, so there's no .log files to delete from the baselines.