### PR TITLE
Fixed bug with toggleLineComment ends in a start line

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2077,6 +2077,11 @@ namespace ts {
 
             // Push all text changes.
             for (let i = firstLine; i <= lastLine; i++) {
+                // If the range is multiline and ends on a beginning of a line, don't comment/uncomment.
+                if (firstLine !== lastLine && lineStarts[i] === textRange.end) {
+                    continue;
+                }
+
                 const lineTextStart = lineTextStarts.get(i.toString());
 
                 // If the line is not an empty line; otherwise no-op.

--- a/tests/cases/fourslash/toggleLineComment11.ts
+++ b/tests/cases/fourslash/toggleLineComment11.ts
@@ -1,0 +1,44 @@
+// When textRange contain multiple lines and ends on a beginning of a line, don't comment/uncomment the last line.
+
+//@Filename: file.tsx
+//// [|const a = 0;
+//// const b = 1;
+//// |]const c = 2;
+//// 
+//// const d = <div>
+////     [|<div>
+////         SomeText
+//// |]    </div>
+//// </div>;
+////
+//// [|//const e = 0;
+//// //const f = 1;
+//// |]//const g = 2;
+//// 
+//// const h = <div>
+//// [|{/*<div>*/}
+//// {/*    SomeText*/}
+//// |]{/*</div>*/}
+//// </div>;
+
+
+verify.toggleLineComment(
+    `//const a = 0;
+//const b = 1;
+const c = 2;
+
+const d = <div>
+    {/*<div>*/}
+    {/*    SomeText*/}
+    </div>
+</div>;
+
+const e = 0;
+const f = 1;
+//const g = 2;
+
+const h = <div>
+<div>
+    SomeText
+{/*</div>*/}
+</div>;`);

--- a/tests/cases/fourslash/toggleMultilineComment1.ts
+++ b/tests/cases/fourslash/toggleMultilineComment1.ts
@@ -13,6 +13,10 @@
 //// let var9 = 3;*/|]
 //// 
 //// let var10[||] = 10;
+//// 
+//// [|let var11 = 11;
+//// let var12 = 12;
+//// |]let var13 = 13;
 
 verify.toggleMultilineComment(
     `let var1/* = 1;
@@ -27,4 +31,8 @@ let var7 = 1;
 let var8 = 2;
 let var9 = 3;
 
-let var10/**/ = 10;`);
+let var10/**/ = 10;
+
+/*let var11 = 11;
+let var12 = 12;
+*/let var13 = 13;`);

--- a/tests/cases/fourslash/uncommentSelection1.ts
+++ b/tests/cases/fourslash/uncommentSelection1.ts
@@ -19,6 +19,10 @@
 //// let var13 */= 3;
 //// 
 //// ////let var14 [||]= 14;
+////
+//// [|//let var15 = 15;
+//// //let var16 = 16;
+//// |]//let var17 = 17;
 
 verify.uncommentSelection(
     `let var1 = 1;
@@ -39,4 +43,8 @@ let var11 = 1;
 let var12 = 2;
 let var13 = 3;
 
-//let var14 = 14;`);
+//let var14 = 14;
+
+let var15 = 15;
+let var16 = 16;
+//let var17 = 17;`);


### PR DESCRIPTION
When toggling multiple single line comments ends in the start of a new line, we niether comment nor uncomment.

This behavior are the currently implemented in Visual Studio Code and Visual Studio's C# language.