### PR TITLE
Don’t offer non-relative non-`paths` path when baseUrl is undefined

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -174,7 +174,10 @@ namespace ts.moduleSpecifiers {
         const bundledPkgReference = bundledPackageName ? combinePaths(bundledPackageName, relativeToBaseUrl) : relativeToBaseUrl;
         const importRelativeToBaseUrl = removeExtensionAndIndexPostFix(bundledPkgReference, ending, compilerOptions);
         const fromPaths = paths && tryGetModuleNameFromPaths(removeFileExtension(bundledPkgReference), importRelativeToBaseUrl, paths);
-        const nonRelative = fromPaths === undefined ? importRelativeToBaseUrl : fromPaths;
+        const nonRelative = fromPaths === undefined && baseUrl !== undefined ? importRelativeToBaseUrl : fromPaths;
+        if (!nonRelative) {
+            return relativePath;
+        }
 
         if (relativePreference === RelativePreference.NonRelative) {
             return nonRelative;

--- a/tests/cases/fourslash/importNameCodeFix_pathsWithoutBaseUrl1.ts
+++ b/tests/cases/fourslash/importNameCodeFix_pathsWithoutBaseUrl1.ts
@@ -5,7 +5,7 @@
 ////   "compilerOptions": {
 ////     "module": "commonjs",
 ////     "paths": {
-////       "@app/*": ["lib/*"]
+////       "@app/*": ["./lib/*"]
 ////     }
 ////   }
 //// }

--- a/tests/cases/fourslash/importNameCodeFix_pathsWithoutBaseUrl2.ts
+++ b/tests/cases/fourslash/importNameCodeFix_pathsWithoutBaseUrl2.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /packages/test-package-1/tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "module": "commonjs",
+////     "paths": {
+////       "test-package-2/*": ["../test-package-2/src/*"]
+////     }
+////   }
+//// }
+
+// @Filename: /packages/test-package-1/src/common/logging.ts
+//// export class Logger {};
+
+// @Filename: /packages/test-package-1/src/something/index.ts
+//// Logger/**/
+
+
+goTo.marker("");
+verify.importFixAtPosition([`import { Logger } from "../common/logging";\n\nLogger`]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #40713
