### PR TITLE
Fix default property assigned prototype

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28123,8 +28123,7 @@ namespace ts {
                 decl = node;
             }
 
-            // TODO: Push allowDecl down to getexpandoinit
-            if (!decl || !allowDeclaration && (!name || !getExpandoInitializer(node, isPrototypeAccess(name)))) {
+            if (!decl || !name || (!allowDeclaration && !getExpandoInitializer(node, isPrototypeAccess(name)))) {
                 return undefined;
             }
             return getSymbolOfNode(decl);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8729,7 +8729,7 @@ namespace ts {
             let links = getSymbolLinks(symbol);
             const originalLinks = links;
             if (!links.type) {
-                const expando = symbol.valueDeclaration && getSymbolOfExpando(symbol.valueDeclaration);
+                const expando = symbol.valueDeclaration && getSymbolOfExpando(symbol.valueDeclaration, /*allowDeclaration*/ false);
                 if (expando) {
                     const merged = mergeJSSymbols(symbol, expando);
                     if (merged) {
@@ -28083,7 +28083,7 @@ namespace ts {
             return init ? getSymbolOfNode(init) : undefined;
         }
 
-        function getSymbolOfExpando(node: Node, allowDeclaration?: boolean): Symbol | undefined {
+        function getSymbolOfExpando(node: Node, allowDeclaration: boolean): Symbol | undefined {
             if (!node.parent) {
                 return undefined;
             }
@@ -28206,7 +28206,7 @@ namespace ts {
             }
 
             if (isInJSFile(node)) {
-                const jsSymbol = getSymbolOfExpando(node);
+                const jsSymbol = getSymbolOfExpando(node, /*allowDeclaration*/ false);
                 if (jsSymbol?.exports?.size) {
                     const jsAssignmentType = createAnonymousType(jsSymbol, jsSymbol.exports, emptyArray, emptyArray, undefined, undefined);
                     jsAssignmentType.objectFlags |= ObjectFlags.JSLiteral;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4004,6 +4004,7 @@ namespace ts {
         getAugmentedPropertiesOfType(type: Type): Symbol[];
 
         getRootSymbols(symbol: Symbol): readonly Symbol[];
+        getSymbolOfExpando(node: Node, allowDeclaration?: boolean): Symbol | undefined;
         getContextualType(node: Expression): Type | undefined;
         /* @internal */ getContextualType(node: Expression, contextFlags?: ContextFlags): Type | undefined; // eslint-disable-line @typescript-eslint/unified-signatures
         /* @internal */ getContextualTypeForObjectLiteralElement(element: ObjectLiteralElementLike): Type | undefined;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4004,7 +4004,7 @@ namespace ts {
         getAugmentedPropertiesOfType(type: Type): Symbol[];
 
         getRootSymbols(symbol: Symbol): readonly Symbol[];
-        getSymbolOfExpando(node: Node, allowDeclaration?: boolean): Symbol | undefined;
+        getSymbolOfExpando(node: Node, allowDeclaration: boolean): Symbol | undefined;
         getContextualType(node: Expression): Type | undefined;
         /* @internal */ getContextualType(node: Expression, contextFlags?: ContextFlags): Type | undefined; // eslint-disable-line @typescript-eslint/unified-signatures
         /* @internal */ getContextualTypeForObjectLiteralElement(element: ObjectLiteralElementLike): Type | undefined;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1937,48 +1937,6 @@ namespace ts {
         return getSourceTextOfNodeFromSourceFile(sourceFile, str).charCodeAt(0) === CharacterCodes.doubleQuote;
     }
 
-    export function getDeclarationOfExpando(node: Node): Node | undefined {
-        if (!node.parent) {
-            return undefined;
-        }
-        let name: Expression | BindingName | undefined;
-        let decl: Node | undefined;
-        if (isVariableDeclaration(node.parent) && node.parent.initializer === node) {
-            if (!isInJSFile(node) && !isVarConst(node.parent)) {
-                return undefined;
-            }
-            name = node.parent.name;
-            decl = node.parent;
-        }
-        else if (isBinaryExpression(node.parent)) {
-            const parentNode = node.parent;
-            const parentNodeOperator = node.parent.operatorToken.kind;
-            if (parentNodeOperator === SyntaxKind.EqualsToken && parentNode.right === node) {
-                name = parentNode.left;
-                decl = name;
-            }
-            else if (parentNodeOperator === SyntaxKind.BarBarToken || parentNodeOperator === SyntaxKind.QuestionQuestionToken) {
-                if (isVariableDeclaration(parentNode.parent) && parentNode.parent.initializer === parentNode) {
-                    name = parentNode.parent.name;
-                    decl = parentNode.parent;
-                }
-                else if (isBinaryExpression(parentNode.parent) && parentNode.parent.operatorToken.kind === SyntaxKind.EqualsToken && parentNode.parent.right === parentNode) {
-                    name = parentNode.parent.left;
-                    decl = name;
-                }
-
-                if (!name || !isBindableStaticNameExpression(name) || !isSameEntityName(name, parentNode.left)) {
-                    return undefined;
-                }
-            }
-        }
-
-        if (!name || !getExpandoInitializer(node, isPrototypeAccess(name))) {
-            return undefined;
-        }
-        return decl;
-    }
-
     export function isAssignmentDeclaration(decl: Declaration) {
         return isBinaryExpression(decl) || isAccessExpression(decl) || isIdentifier(decl) || isCallExpression(decl);
     }
@@ -2098,7 +2056,7 @@ namespace ts {
      * var min = window.min || {}
      * my.app = self.my.app || class { }
      */
-    function isSameEntityName(name: Expression, initializer: Expression): boolean {
+    export function isSameEntityName(name: Expression, initializer: Expression): boolean {
         if (isPropertyNameLiteral(name) && isPropertyNameLiteral(initializer)) {
             return getTextOfIdentifierOrLiteral(name) === getTextOfIdentifierOrLiteral(initializer);
         }

--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -196,7 +196,7 @@ namespace ts {
                 return true;
             }
 
-            const symbol = checker.getSymbolOfExpando(node);
+            const symbol = checker.getSymbolOfExpando(node, /*allowDeclaration*/ false);
             return !!(symbol && (symbol.exports?.size || symbol.members?.size));
         }
 

--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -37,7 +37,7 @@ namespace ts {
 
         function check(node: Node) {
             if (isJsFile) {
-                if (canBeConvertedToClass(node)) {
+                if (canBeConvertedToClass(node, checker)) {
                     diags.push(createDiagnosticForNode(isVariableDeclaration(node.parent) ? node.parent.name : node, Diagnostics.This_constructor_function_may_be_converted_to_a_class_declaration));
                 }
             }
@@ -190,14 +190,13 @@ namespace ts {
         return `${exp.pos.toString()}:${exp.end.toString()}`;
     }
 
-    function canBeConvertedToClass(node: Node): boolean {
+    function canBeConvertedToClass(node: Node, checker: TypeChecker): boolean {
         if (node.kind === SyntaxKind.FunctionExpression) {
             if (isVariableDeclaration(node.parent) && node.symbol.members?.size) {
                 return true;
             }
 
-            const decl = getDeclarationOfExpando(node);
-            const symbol = decl?.symbol;
+            const symbol = checker.getSymbolOfExpando(node);
             return !!(symbol && (symbol.exports?.size || symbol.members?.size));
         }
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2207,7 +2207,7 @@ declare namespace ts {
         getFullyQualifiedName(symbol: Symbol): string;
         getAugmentedPropertiesOfType(type: Type): Symbol[];
         getRootSymbols(symbol: Symbol): readonly Symbol[];
-        getSymbolOfExpando(node: Node, allowDeclaration?: boolean): Symbol | undefined;
+        getSymbolOfExpando(node: Node, allowDeclaration: boolean): Symbol | undefined;
         getContextualType(node: Expression): Type | undefined;
         /**
          * returns unknownSignature in the case of an error.

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2207,6 +2207,7 @@ declare namespace ts {
         getFullyQualifiedName(symbol: Symbol): string;
         getAugmentedPropertiesOfType(type: Type): Symbol[];
         getRootSymbols(symbol: Symbol): readonly Symbol[];
+        getSymbolOfExpando(node: Node, allowDeclaration?: boolean): Symbol | undefined;
         getContextualType(node: Expression): Type | undefined;
         /**
          * returns unknownSignature in the case of an error.

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2207,7 +2207,7 @@ declare namespace ts {
         getFullyQualifiedName(symbol: Symbol): string;
         getAugmentedPropertiesOfType(type: Type): Symbol[];
         getRootSymbols(symbol: Symbol): readonly Symbol[];
-        getSymbolOfExpando(node: Node, allowDeclaration?: boolean): Symbol | undefined;
+        getSymbolOfExpando(node: Node, allowDeclaration: boolean): Symbol | undefined;
         getContextualType(node: Expression): Type | undefined;
         /**
          * returns unknownSignature in the case of an error.

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2207,6 +2207,7 @@ declare namespace ts {
         getFullyQualifiedName(symbol: Symbol): string;
         getAugmentedPropertiesOfType(type: Type): Symbol[];
         getRootSymbols(symbol: Symbol): readonly Symbol[];
+        getSymbolOfExpando(node: Node, allowDeclaration?: boolean): Symbol | undefined;
         getContextualType(node: Expression): Type | undefined;
         /**
          * returns unknownSignature in the case of an error.

--- a/tests/baselines/reference/defaultPropertyAssignedClassWithPrototype.symbols
+++ b/tests/baselines/reference/defaultPropertyAssignedClassWithPrototype.symbols
@@ -1,0 +1,33 @@
+=== tests/cases/conformance/salsa/bug39167.js ===
+var test = {};
+>test : Symbol(test, Decl(bug39167.js, 0, 3), Decl(bug39167.js, 0, 14), Decl(bug39167.js, 2, 18))
+
+test.K = test.K ||
+>test.K : Symbol(test.K, Decl(bug39167.js, 0, 14), Decl(bug39167.js, 4, 5))
+>test : Symbol(test, Decl(bug39167.js, 0, 3), Decl(bug39167.js, 0, 14), Decl(bug39167.js, 2, 18))
+>K : Symbol(test.K, Decl(bug39167.js, 0, 14), Decl(bug39167.js, 4, 5))
+>test.K : Symbol(test.K, Decl(bug39167.js, 0, 14), Decl(bug39167.js, 4, 5))
+>test : Symbol(test, Decl(bug39167.js, 0, 3), Decl(bug39167.js, 0, 14), Decl(bug39167.js, 2, 18))
+>K : Symbol(test.K, Decl(bug39167.js, 0, 14), Decl(bug39167.js, 4, 5))
+
+    function () {}
+
+test.K.prototype = {
+>test.K.prototype : Symbol(test.K.prototype, Decl(bug39167.js, 2, 18))
+>test.K : Symbol(test.K, Decl(bug39167.js, 0, 14), Decl(bug39167.js, 4, 5))
+>test : Symbol(test, Decl(bug39167.js, 0, 3), Decl(bug39167.js, 0, 14), Decl(bug39167.js, 2, 18))
+>K : Symbol(test.K, Decl(bug39167.js, 0, 14), Decl(bug39167.js, 4, 5))
+>prototype : Symbol(test.K.prototype, Decl(bug39167.js, 2, 18))
+
+    add() {}
+>add : Symbol(add, Decl(bug39167.js, 4, 20))
+
+};
+
+new test.K().add;
+>new test.K().add : Symbol(add, Decl(bug39167.js, 4, 20))
+>test.K : Symbol(test.K, Decl(bug39167.js, 0, 14), Decl(bug39167.js, 4, 5))
+>test : Symbol(test, Decl(bug39167.js, 0, 3), Decl(bug39167.js, 0, 14), Decl(bug39167.js, 2, 18))
+>K : Symbol(test.K, Decl(bug39167.js, 0, 14), Decl(bug39167.js, 4, 5))
+>add : Symbol(add, Decl(bug39167.js, 4, 20))
+

--- a/tests/baselines/reference/defaultPropertyAssignedClassWithPrototype.types
+++ b/tests/baselines/reference/defaultPropertyAssignedClassWithPrototype.types
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/salsa/bug39167.js ===
+var test = {};
+>test : typeof test
+>{} : {}
+
+test.K = test.K ||
+>test.K = test.K ||    function () {} : typeof K
+>test.K : typeof K
+>test : typeof test
+>K : typeof K
+>test.K ||    function () {} : typeof K
+>test.K : typeof K
+>test : typeof test
+>K : typeof K
+
+    function () {}
+>function () {} : typeof K
+
+test.K.prototype = {
+>test.K.prototype = {    add() {}} : { add(): void; }
+>test.K.prototype : { add(): void; }
+>test.K : typeof K
+>test : typeof test
+>K : typeof K
+>prototype : { add(): void; }
+>{    add() {}} : { add(): void; }
+
+    add() {}
+>add : () => void
+
+};
+
+new test.K().add;
+>new test.K().add : () => void
+>new test.K() : K
+>test.K : typeof K
+>test : typeof test
+>K : typeof K
+>add : () => void
+

--- a/tests/cases/conformance/salsa/defaultPropertyAssignedClassWithPrototype.ts
+++ b/tests/cases/conformance/salsa/defaultPropertyAssignedClassWithPrototype.ts
@@ -1,0 +1,13 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: bug39167.js
+var test = {};
+test.K = test.K ||
+    function () {}
+
+test.K.prototype = {
+    add() {}
+};
+
+new test.K().add;


### PR DESCRIPTION
The check in getAssignedClassSymbol forgot to allow for default-property assignment declarations, in part because it wasn't using a utility function to do so.

Fixes #39167
