### PR TITLE
Fix crash resolving ImportTypeNode in JSDoc

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12274,7 +12274,7 @@ namespace ts {
                 if (symbol.valueDeclaration) {
                     const isImportTypeWithQualifier = node.kind === SyntaxKind.ImportType && (node as ImportTypeNode).qualifier;
                     // valueType might not have a symbol, eg, {import('./b').STRING_LITERAL}
-                    if (valueType.symbol && isImportTypeWithQualifier) {
+                    if (valueType.symbol && valueType.symbol !== symbol && isImportTypeWithQualifier) {
                         typeType = getTypeReferenceType(node, valueType.symbol);
                     }
                 }

--- a/tests/baselines/reference/jsdocImportTypeNodeNamespace.errors.txt
+++ b/tests/baselines/reference/jsdocImportTypeNodeNamespace.errors.txt
@@ -1,0 +1,18 @@
+tests/cases/compiler/Main.js(2,14): error TS2352: Conversion of type 'string' to type 'typeof _default' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+
+
+==== tests/cases/compiler/GeometryType.d.ts (0 errors) ====
+    // #40767
+    
+    declare namespace _default {
+      export const POINT: string;
+    }
+    export default _default;
+    
+==== tests/cases/compiler/Main.js (1 errors) ====
+    export default function () {
+      return /** @type {import('./GeometryType.js').default} */ ('Point');
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2352: Conversion of type 'string' to type 'typeof _default' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+    }
+    

--- a/tests/baselines/reference/jsdocImportTypeNodeNamespace.symbols
+++ b/tests/baselines/reference/jsdocImportTypeNodeNamespace.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/GeometryType.d.ts ===
+// #40767
+
+declare namespace _default {
+>_default : Symbol(_default, Decl(GeometryType.d.ts, 0, 0))
+
+  export const POINT: string;
+>POINT : Symbol(POINT, Decl(GeometryType.d.ts, 3, 14))
+}
+export default _default;
+>_default : Symbol(_default, Decl(GeometryType.d.ts, 0, 0))
+
+=== tests/cases/compiler/Main.js ===
+export default function () {
+No type information for this code.  return /** @type {import('./GeometryType.js').default} */ ('Point');
+No type information for this code.}
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/jsdocImportTypeNodeNamespace.types
+++ b/tests/baselines/reference/jsdocImportTypeNodeNamespace.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/GeometryType.d.ts ===
+// #40767
+
+declare namespace _default {
+>_default : typeof _default
+
+  export const POINT: string;
+>POINT : string
+}
+export default _default;
+>_default : typeof _default
+
+=== tests/cases/compiler/Main.js ===
+export default function () {
+  return /** @type {import('./GeometryType.js').default} */ ('Point');
+>('Point') : typeof import("tests/cases/compiler/GeometryType").default
+>'Point' : "Point"
+}
+

--- a/tests/cases/compiler/jsdocImportTypeNodeNamespace.ts
+++ b/tests/cases/compiler/jsdocImportTypeNodeNamespace.ts
@@ -1,0 +1,16 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// #40767
+
+// @Filename: GeometryType.d.ts
+declare namespace _default {
+  export const POINT: string;
+}
+export default _default;
+
+// @Filename: Main.js
+export default function () {
+  return /** @type {import('./GeometryType.js').default} */ ('Point');
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #40767 
