### PR TITLE
Match suffix _after_ prefix when inferring literals out of templates

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19801,7 +19801,7 @@ namespace ts {
             const lastIndex = texts.length - 1;
             const startText = texts[0];
             const endText = texts[lastIndex];
-            if (!(value.startsWith(startText) && value.endsWith(endText))) return undefined;
+            if (!(value.startsWith(startText) && value.slice(startText.length).endsWith(endText))) return undefined;
             const matches = [];
             const str = value.slice(startText.length, value.length - endText.length);
             let pos = 0;

--- a/tests/baselines/reference/templateLiteralTypesPatternsPrefixSuffixAssignability.errors.txt
+++ b/tests/baselines/reference/templateLiteralTypesPatternsPrefixSuffixAssignability.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/conformance/types/literal/templateLiteralTypesPatternsPrefixSuffixAssignability.ts(1,7): error TS2322: Type '":"' is not assignable to type '`:${string}:`'.
+tests/cases/conformance/types/literal/templateLiteralTypesPatternsPrefixSuffixAssignability.ts(3,7): error TS2322: Type '"::"' is not assignable to type '`:${string}:${string}:`'.
+
+
+==== tests/cases/conformance/types/literal/templateLiteralTypesPatternsPrefixSuffixAssignability.ts (2 errors) ====
+    const s1: `:${string}:` = ":"; // should error
+          ~~
+!!! error TS2322: Type '":"' is not assignable to type '`:${string}:`'.
+    const s2: `:${string}:` = "::"; // ok
+    const s3: `:${string}:${string}:` = "::"; // should error
+          ~~
+!!! error TS2322: Type '"::"' is not assignable to type '`:${string}:${string}:`'.
+    const s4: `:${string}:${string}:` = ":::"; // ok

--- a/tests/baselines/reference/templateLiteralTypesPatternsPrefixSuffixAssignability.js
+++ b/tests/baselines/reference/templateLiteralTypesPatternsPrefixSuffixAssignability.js
@@ -1,0 +1,11 @@
+//// [templateLiteralTypesPatternsPrefixSuffixAssignability.ts]
+const s1: `:${string}:` = ":"; // should error
+const s2: `:${string}:` = "::"; // ok
+const s3: `:${string}:${string}:` = "::"; // should error
+const s4: `:${string}:${string}:` = ":::"; // ok
+
+//// [templateLiteralTypesPatternsPrefixSuffixAssignability.js]
+var s1 = ":"; // should error
+var s2 = "::"; // ok
+var s3 = "::"; // should error
+var s4 = ":::"; // ok

--- a/tests/baselines/reference/templateLiteralTypesPatternsPrefixSuffixAssignability.symbols
+++ b/tests/baselines/reference/templateLiteralTypesPatternsPrefixSuffixAssignability.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/types/literal/templateLiteralTypesPatternsPrefixSuffixAssignability.ts ===
+const s1: `:${string}:` = ":"; // should error
+>s1 : Symbol(s1, Decl(templateLiteralTypesPatternsPrefixSuffixAssignability.ts, 0, 5))
+
+const s2: `:${string}:` = "::"; // ok
+>s2 : Symbol(s2, Decl(templateLiteralTypesPatternsPrefixSuffixAssignability.ts, 1, 5))
+
+const s3: `:${string}:${string}:` = "::"; // should error
+>s3 : Symbol(s3, Decl(templateLiteralTypesPatternsPrefixSuffixAssignability.ts, 2, 5))
+
+const s4: `:${string}:${string}:` = ":::"; // ok
+>s4 : Symbol(s4, Decl(templateLiteralTypesPatternsPrefixSuffixAssignability.ts, 3, 5))
+

--- a/tests/baselines/reference/templateLiteralTypesPatternsPrefixSuffixAssignability.types
+++ b/tests/baselines/reference/templateLiteralTypesPatternsPrefixSuffixAssignability.types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/types/literal/templateLiteralTypesPatternsPrefixSuffixAssignability.ts ===
+const s1: `:${string}:` = ":"; // should error
+>s1 : `:${string}:`
+>":" : ":"
+
+const s2: `:${string}:` = "::"; // ok
+>s2 : `:${string}:`
+>"::" : "::"
+
+const s3: `:${string}:${string}:` = "::"; // should error
+>s3 : `:${string}:${string}:`
+>"::" : "::"
+
+const s4: `:${string}:${string}:` = ":::"; // ok
+>s4 : `:${string}:${string}:`
+>":::" : ":::"
+

--- a/tests/cases/conformance/types/literal/templateLiteralTypesPatternsPrefixSuffixAssignability.ts
+++ b/tests/cases/conformance/types/literal/templateLiteralTypesPatternsPrefixSuffixAssignability.ts
@@ -1,0 +1,4 @@
+const s1: `:${string}:` = ":"; // should error
+const s2: `:${string}:` = "::"; // ok
+const s3: `:${string}:${string}:` = "::"; // should error
+const s4: `:${string}:${string}:` = ":::"; // ok


### PR DESCRIPTION
Fixes #40772
