### PR TITLE
lib: remove `length` field from SharedArrayBuffer

### DIFF
--- a/src/lib/es2017.sharedmemory.d.ts
+++ b/src/lib/es2017.sharedmemory.d.ts
@@ -17,7 +17,7 @@ interface SharedArrayBuffer {
 
 interface SharedArrayBufferConstructor {
     readonly prototype: SharedArrayBuffer;
-    new(byteLength: number): SharedArrayBuffer;
+    new (byteLength: number): SharedArrayBuffer;
 }
 declare var SharedArrayBuffer: SharedArrayBufferConstructor;
 

--- a/src/lib/es2017.sharedmemory.d.ts
+++ b/src/lib/es2017.sharedmemory.d.ts
@@ -7,10 +7,6 @@ interface SharedArrayBuffer {
      */
     readonly byteLength: number;
 
-    /*
-     * The SharedArrayBuffer constructor's length property whose value is 1.
-     */
-    length: number;
     /**
      * Returns a section of an SharedArrayBuffer.
      */
@@ -21,7 +17,7 @@ interface SharedArrayBuffer {
 
 interface SharedArrayBufferConstructor {
     readonly prototype: SharedArrayBuffer;
-    new (byteLength: number): SharedArrayBuffer;
+    new(byteLength: number): SharedArrayBuffer;
 }
 declare var SharedArrayBuffer: SharedArrayBufferConstructor;
 

--- a/tests/baselines/reference/useSharedArrayBuffer6.errors.txt
+++ b/tests/baselines/reference/useSharedArrayBuffer6.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/conformance/es2017/useSharedArrayBuffer6.ts(2,6): error TS2339: Property 'length' does not exist on type 'SharedArrayBuffer'.
+
+
+==== tests/cases/conformance/es2017/useSharedArrayBuffer6.ts (1 errors) ====
+    var foge = new SharedArrayBuffer(1024);
+    foge.length; // should error
+         ~~~~~~
+!!! error TS2339: Property 'length' does not exist on type 'SharedArrayBuffer'.
+    
+    var length = SharedArrayBuffer.length;
+    

--- a/tests/baselines/reference/useSharedArrayBuffer6.js
+++ b/tests/baselines/reference/useSharedArrayBuffer6.js
@@ -1,9 +1,11 @@
 //// [useSharedArrayBuffer6.ts]
 var foge = new SharedArrayBuffer(1024);
-var species = foge[Symbol.species];
-var stringTag = foge[Symbol.toStringTag];
+foge.length; // should error
+
+var length = SharedArrayBuffer.length;
+
 
 //// [useSharedArrayBuffer6.js]
 var foge = new SharedArrayBuffer(1024);
-var species = foge[Symbol.species];
-var stringTag = foge[Symbol.toStringTag];
+foge.length; // should error
+var length = SharedArrayBuffer.length;

--- a/tests/baselines/reference/useSharedArrayBuffer6.symbols
+++ b/tests/baselines/reference/useSharedArrayBuffer6.symbols
@@ -3,17 +3,12 @@ var foge = new SharedArrayBuffer(1024);
 >foge : Symbol(foge, Decl(useSharedArrayBuffer6.ts, 0, 3))
 >SharedArrayBuffer : Symbol(SharedArrayBuffer, Decl(lib.es2017.sharedmemory.d.ts, --, --), Decl(lib.es2017.sharedmemory.d.ts, --, --))
 
-var species = foge[Symbol.species];
->species : Symbol(species, Decl(useSharedArrayBuffer6.ts, 1, 3))
+foge.length; // should error
 >foge : Symbol(foge, Decl(useSharedArrayBuffer6.ts, 0, 3))
->Symbol.species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->species : Symbol(SymbolConstructor.species, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
-var stringTag = foge[Symbol.toStringTag];
->stringTag : Symbol(stringTag, Decl(useSharedArrayBuffer6.ts, 2, 3))
->foge : Symbol(foge, Decl(useSharedArrayBuffer6.ts, 0, 3))
->Symbol.toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->toStringTag : Symbol(SymbolConstructor.toStringTag, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+var length = SharedArrayBuffer.length;
+>length : Symbol(length, Decl(useSharedArrayBuffer6.ts, 3, 3))
+>SharedArrayBuffer.length : Symbol(Function.length, Decl(lib.es5.d.ts, --, --))
+>SharedArrayBuffer : Symbol(SharedArrayBuffer, Decl(lib.es2017.sharedmemory.d.ts, --, --), Decl(lib.es2017.sharedmemory.d.ts, --, --))
+>length : Symbol(Function.length, Decl(lib.es5.d.ts, --, --))
 

--- a/tests/baselines/reference/useSharedArrayBuffer6.types
+++ b/tests/baselines/reference/useSharedArrayBuffer6.types
@@ -5,19 +5,14 @@ var foge = new SharedArrayBuffer(1024);
 >SharedArrayBuffer : SharedArrayBufferConstructor
 >1024 : 1024
 
-var species = foge[Symbol.species];
->species : SharedArrayBuffer
->foge[Symbol.species] : SharedArrayBuffer
+foge.length; // should error
+>foge.length : any
 >foge : SharedArrayBuffer
->Symbol.species : symbol
->Symbol : SymbolConstructor
->species : symbol
+>length : any
 
-var stringTag = foge[Symbol.toStringTag];
->stringTag : "SharedArrayBuffer"
->foge[Symbol.toStringTag] : "SharedArrayBuffer"
->foge : SharedArrayBuffer
->Symbol.toStringTag : symbol
->Symbol : SymbolConstructor
->toStringTag : symbol
+var length = SharedArrayBuffer.length;
+>length : number
+>SharedArrayBuffer.length : number
+>SharedArrayBuffer : SharedArrayBufferConstructor
+>length : number
 

--- a/tests/cases/conformance/es2017/useSharedArrayBuffer6.ts
+++ b/tests/cases/conformance/es2017/useSharedArrayBuffer6.ts
@@ -2,5 +2,6 @@
 // @lib: es6,es2017.sharedmemory
 
 var foge = new SharedArrayBuffer(1024);
-var species = foge[Symbol.species];
-var stringTag = foge[Symbol.toStringTag];
+foge.length; // should error
+
+var length = SharedArrayBuffer.length;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #40857

I didn't find instructions on adding tests for lib, if a test is required please give me some code pointer, thanks.