### PR TITLE
ghc osd issue 40622 add currencySign to NumberFormatOptions

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4284,6 +4284,7 @@ declare namespace Intl {
         style?: string;
         currency?: string;
         currencyDisplay?: string;
+        currencySign?: string;
         useGrouping?: boolean;
         minimumIntegerDigits?: number;
         minimumFractionDigits?: number;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
https://github.com/microsoft/TypeScript/issues/40622

1. Test `const str = new Intl.NumberFormat('en-NZ', { style: 'currency', currency: 'NZD', currencySign: 'accounting' }).format(999999);` in local file
run gulp and node ./built/local/tsc.js --watch test.ts
----- no errors

2. pass all tests when run: gulp runtests-parallel
[13:25:26] Using gulpfile ~/Project/GHC/TypeScript/gulpfile.js
[13:25:26] Starting 'runtests-parallel'...
[13:25:26] Starting 'generateLibs'...
[13:25:26] Starting 'buildScripts'...
[13:25:26] Finished 'generateLibs' after 419 ms
[13:25:27] Finished 'buildScripts' after 640 ms
[13:25:27] Starting 'generateDiagnostics'...
[13:25:27] Finished 'generateDiagnostics' after 908 μs
[13:25:27] Starting 'buildShims'...
[13:25:27] Starting 'buildDebugTools'...
[13:25:27] Finished 'buildShims' after 565 ms
[13:25:27] Finished 'buildDebugTools' after 565 ms
[13:25:27] Starting 'buildTsc'...
[13:25:27] Starting 'buildTests'...
[13:25:27] Starting 'buildTypescriptServicesOut'...
[13:25:27] Starting 'buildServerLibraryOut'...
[13:25:28] Finished 'buildTsc' after 1.02 s
[13:25:28] Finished 'buildTests' after 1.03 s
[13:25:28] Finished 'buildTypescriptServicesOut' after 1.03 s
[13:25:28] Starting 'createTypescriptServicesJs'...
[13:25:28] Finished 'buildServerLibraryOut' after 1.03 s
[13:25:28] Starting 'createServerLibraryJs'...
[13:25:28] Finished 'createTypescriptServicesJs' after 137 ms
[13:25:28] Starting 'createTypescriptServicesDts'...
[13:25:29] Finished 'createServerLibraryJs' after 157 ms
[13:25:29] Starting 'createServerLibraryDts'...
[13:25:29] Finished 'createTypescriptServicesDts' after 28 ms
[13:25:29] Starting 'createTypescriptJs'...
[13:25:29] Finished 'createServerLibraryDts' after 20 ms
[13:25:29] Finished 'createTypescriptJs' after 87 ms
[13:25:29] Starting 'createTypescriptDts'...
[13:25:29] Finished 'createTypescriptDts' after 15 ms
[13:25:29] Starting 'createTypescriptStandaloneDts'...
[13:25:29] Finished 'createTypescriptStandaloneDts' after 17 ms
[13:25:29] Starting 'runTestsParallel'...
[13:25:29] Running tests with config: {"light":true,"workerCount":4,"taskConfigsFolder":"/var/folders/nx/ss2r962117l845qbn468zlqr0000gn/T/ts-tests2","noColor":false,"timeout":40000,"keepFailed":false}
[13:25:29] > node built/local/run.js
Discovered 223 unittest suites.
Discovering runner-based tests...
Discovered 15193 test files in 3647ms.
Starting to run tests using 4 threads...
Batching initial test lists...
Batched into 4 groups with approximate total time of 19m in each group. (90.0% of total tests batched)

  [․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․]
[Worker 1] (node:39033) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 uncaughtException listeners added. Use emitter.setMaxListeners() to increase limit

[Worker 0] (node:39032) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 uncaughtException listeners added. Use emitter.setMaxListeners() to increase limit

[Worker 3] (node:39035) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 uncaughtException listeners added. Use emitter.setMaxListeners() to increase limit

[Worker 2] (node:39034) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 uncaughtException listeners added. Use emitter.setMaxListeners() to increase limit
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬] ✓ 73116 passing (20m)


  73116 passing (20m)

[13:45:12] Finished 'runTestsParallel' after 20 min
[13:45:12] Starting 'postTest'...
[13:45:12] Starting 'buildEslintRules'...
[13:45:19] Finished 'buildEslintRules' after 6.09 s
[13:45:19] Starting 'lintFoldStart'...
[13:45:19] Finished 'lintFoldStart' after 1.4 ms
[13:45:19] Starting 'lint-scripts'...
[13:45:19] Linting: node_modules/eslint/bin/eslint --cache --cache-location scripts/.eslintcache --format autolinkable-stylish --rulesdir scripts/eslint/built/rules --ext .ts scripts
[13:45:19] > /usr/local/bin/node node_modules/eslint/bin/eslint --cache --cache-location scripts/.eslintcache --format autolinkable-stylish --rulesdir scripts/eslint/built/rules --ext .ts scripts
[13:45:22] Finished 'lint-scripts' after 3.82 s
[13:45:22] Starting 'lint-compiler'...
[13:45:22] Linting: node_modules/eslint/bin/eslint --cache --cache-location src/.eslintcache --format autolinkable-stylish --rulesdir scripts/eslint/built/rules --ext .ts src
[13:45:22] > /usr/local/bin/node node_modules/eslint/bin/eslint --cache --cache-location src/.eslintcache --format autolinkable-stylish --rulesdir scripts/eslint/built/rules --ext .ts src
[13:45:35] Finished 'lint-compiler' after 13 s
[13:45:35] Starting 'lintFoldEnd'...
[13:45:35] Finished 'lintFoldEnd' after 1.03 ms
[13:45:35] Finished 'postTest' after 23 s
[13:45:35] Finished 'runtests-parallel' after 20 min
