### PR TITLE
BigInt type constructor should not accept any type

### DIFF
--- a/lib/lib.es2020.bigint.d.ts
+++ b/lib/lib.es2020.bigint.d.ts
@@ -35,7 +35,7 @@ interface BigInt {
 }
 
 interface BigIntConstructor {
-    (value?: any): bigint;
+    (value: string | number | bigint | boolean | object): bigint;
     readonly prototype: BigInt;
 
     /**

--- a/lib/lib.es2020.bigint.d.ts
+++ b/lib/lib.es2020.bigint.d.ts
@@ -35,7 +35,7 @@ interface BigInt {
 }
 
 interface BigIntConstructor {
-    (value: string | number | bigint | boolean | object): bigint;
+    (value?: string | number | bigint | boolean | object): bigint;
     readonly prototype: BigInt;
 
     /**


### PR DESCRIPTION
BigInt type constructor should not accept any type - [38980](https://github.com/microsoft/TypeScript/issues/38980)

Branch made on 01/10. 
PR Made on 01/10.

Fixes #38980
