### PR TITLE
Handle noEmit and noEmitOnError with SemanticDiagnosticsBuilder

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -1037,7 +1037,8 @@ namespace ts {
                 savedAffectedFilesPendingEmitIndex = state.affectedFilesPendingEmitIndex;
             }
 
-            if (kind === BuilderProgramKind.EmitAndSemanticDiagnosticsBuilderProgram) assertSourceFileOkWithoutNextAffectedCall(state, targetSourceFile);
+            if (kind === BuilderProgramKind.EmitAndSemanticDiagnosticsBuilderProgram)
+                assertSourceFileOkWithoutNextAffectedCall(state, targetSourceFile);
             const result = handleNoEmitOptions(builderProgram, targetSourceFile, writeFile, cancellationToken);
             if (result) return result;
 

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -1019,31 +1019,31 @@ namespace ts {
          * in that order would be used to write the files
          */
         function emit(targetSourceFile?: SourceFile, writeFile?: WriteFileCallback, cancellationToken?: CancellationToken, emitOnlyDtsFiles?: boolean, customTransformers?: CustomTransformers): EmitResult {
-            if (kind === BuilderProgramKind.EmitAndSemanticDiagnosticsBuilderProgram) {
-                assertSourceFileOkWithoutNextAffectedCall(state, targetSourceFile);
-                const result = handleNoEmitOptions(builderProgram, targetSourceFile, writeFile, cancellationToken);
-                if (result) return result;
-                if (!targetSourceFile) {
-                    // Emit and report any errors we ran into.
-                    let sourceMaps: SourceMapEmitResult[] = [];
-                    let emitSkipped = false;
-                    let diagnostics: Diagnostic[] | undefined;
-                    let emittedFiles: string[] = [];
+            if (kind === BuilderProgramKind.EmitAndSemanticDiagnosticsBuilderProgram) assertSourceFileOkWithoutNextAffectedCall(state, targetSourceFile);
+            const result = handleNoEmitOptions(builderProgram, targetSourceFile, writeFile, cancellationToken);
+            if (result) return result;
 
-                    let affectedEmitResult: AffectedFileResult<EmitResult>;
-                    while (affectedEmitResult = emitNextAffectedFile(writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers)) {
-                        emitSkipped = emitSkipped || affectedEmitResult.result.emitSkipped;
-                        diagnostics = addRange(diagnostics, affectedEmitResult.result.diagnostics);
-                        emittedFiles = addRange(emittedFiles, affectedEmitResult.result.emittedFiles);
-                        sourceMaps = addRange(sourceMaps, affectedEmitResult.result.sourceMaps);
-                    }
-                    return {
-                        emitSkipped,
-                        diagnostics: diagnostics || emptyArray,
-                        emittedFiles,
-                        sourceMaps
-                    };
+            // Emit only affected files if using builder for emit
+            if (!targetSourceFile && kind === BuilderProgramKind.EmitAndSemanticDiagnosticsBuilderProgram) {
+                // Emit and report any errors we ran into.
+                let sourceMaps: SourceMapEmitResult[] = [];
+                let emitSkipped = false;
+                let diagnostics: Diagnostic[] | undefined;
+                let emittedFiles: string[] = [];
+
+                let affectedEmitResult: AffectedFileResult<EmitResult>;
+                while (affectedEmitResult = emitNextAffectedFile(writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers)) {
+                    emitSkipped = emitSkipped || affectedEmitResult.result.emitSkipped;
+                    diagnostics = addRange(diagnostics, affectedEmitResult.result.diagnostics);
+                    emittedFiles = addRange(emittedFiles, affectedEmitResult.result.emittedFiles);
+                    sourceMaps = addRange(sourceMaps, affectedEmitResult.result.sourceMaps);
                 }
+                return {
+                    emitSkipped,
+                    diagnostics: diagnostics || emptyArray,
+                    emittedFiles,
+                    sourceMaps
+                };
             }
             return Debug.checkDefined(state.program).emit(targetSourceFile, writeFile || maybeBind(host, host.writeFile), cancellationToken, emitOnlyDtsFiles, customTransformers);
         }

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -1069,7 +1069,8 @@ namespace ts {
                 }
 
                 // Add file to affected file pending emit to handle for later emit time
-                if (kind === BuilderProgramKind.EmitAndSemanticDiagnosticsBuilderProgram) {
+                // Apart for emit builder do this for tsbuildinfo, do this for non emit builder when noEmit is set as tsbuildinfo is written and reused between emitters
+                if (kind === BuilderProgramKind.EmitAndSemanticDiagnosticsBuilderProgram || state.compilerOptions.noEmit) {
                     addToAffectedFilesPendingEmit(state, (affected as SourceFile).resolvedPath, BuilderFileEmit.Full);
                 }
 

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -1037,8 +1037,9 @@ namespace ts {
                 savedAffectedFilesPendingEmitIndex = state.affectedFilesPendingEmitIndex;
             }
 
-            if (kind === BuilderProgramKind.EmitAndSemanticDiagnosticsBuilderProgram)
+            if (kind === BuilderProgramKind.EmitAndSemanticDiagnosticsBuilderProgram) {
                 assertSourceFileOkWithoutNextAffectedCall(state, targetSourceFile);
+            }
             const result = handleNoEmitOptions(builderProgram, targetSourceFile, writeFile, cancellationToken);
             if (result) return result;
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -936,6 +936,7 @@ namespace ts {
             getOptionsDiagnostics,
             getGlobalDiagnostics,
             getSemanticDiagnostics,
+            getCachedSemanticDiagnostics,
             getSuggestionDiagnostics,
             getDeclarationDiagnostics,
             getBindAndCheckDiagnostics,
@@ -1654,6 +1655,12 @@ namespace ts {
 
         function getSemanticDiagnostics(sourceFile?: SourceFile, cancellationToken?: CancellationToken): readonly Diagnostic[] {
             return getDiagnosticsHelper(sourceFile, getSemanticDiagnosticsForFile, cancellationToken);
+        }
+
+        function getCachedSemanticDiagnostics(sourceFile?: SourceFile): readonly Diagnostic[] | undefined {
+           return sourceFile
+                ? cachedBindAndCheckDiagnosticsForFile.perFile?.get(sourceFile.path)
+                : cachedBindAndCheckDiagnosticsForFile.allDiagnostics;
         }
 
         function getBindAndCheckDiagnostics(sourceFile: SourceFile, cancellationToken?: CancellationToken): readonly Diagnostic[] {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3762,6 +3762,8 @@ namespace ts {
         /* @internal */ getDiagnosticsProducingTypeChecker(): TypeChecker;
         /* @internal */ dropDiagnosticsProducingTypeChecker(): void;
 
+        /* @internal */ getCachedSemanticDiagnostics(sourceFile?: SourceFile): readonly Diagnostic[] | undefined;
+
         /* @internal */ getClassifiableNames(): Set<__String>;
 
         getTypeCatalog(): readonly Type[];

--- a/src/testRunner/unittests/tscWatch/watchApi.ts
+++ b/src/testRunner/unittests/tscWatch/watchApi.ts
@@ -125,10 +125,15 @@ namespace ts.tscWatch {
     });
 
     describe("unittests:: tsc-watch:: watchAPI:: when watchHost uses createSemanticDiagnosticsBuilderProgram", () => {
-        it("verifies that noEmit is handled on createSemanticDiagnosticsBuilderProgram and typechecking happens only on affected files", () => {
+        function getWatch<T extends BuilderProgram>(config: File, optionsToExtend: CompilerOptions | undefined, sys: System, createProgram: CreateProgram<T>) {
+            const watchCompilerHost = createWatchCompilerHost(config.path, optionsToExtend, sys, createProgram);
+            return createWatchProgram(watchCompilerHost);
+        }
+
+        function setup<T extends BuilderProgram>(createProgram: CreateProgram<T>, configText: string) {
             const config: File = {
                 path: `${projectRoot}/tsconfig.json`,
-                content: "{}"
+                content: configText
             };
             const mainFile: File = {
                 path: `${projectRoot}/main.ts`,
@@ -139,13 +144,11 @@ namespace ts.tscWatch {
                 content: "export const y = 10;"
             };
             const sys = createWatchedSystem([config, mainFile, otherFile, libFile]);
-            const watchCompilerHost = createWatchCompilerHost(
-                config.path,
-                { noEmit: true },
-                sys,
-                createSemanticDiagnosticsBuilderProgram
-            );
-            const watch = createWatchProgram(watchCompilerHost);
+            const watch = getWatch(config, { noEmit: true }, sys, createProgram);
+            return { sys, watch, mainFile, otherFile, config };
+        }
+        it("verifies that noEmit is handled on createSemanticDiagnosticsBuilderProgram and typechecking happens only on affected files", () => {
+            const { sys, watch, mainFile, otherFile } = setup(createSemanticDiagnosticsBuilderProgram, "{}");
             checkProgramActualFiles(watch.getProgram().getProgram(), [mainFile.path, otherFile.path, libFile.path]);
             sys.appendFile(mainFile.path, "\n// SomeComment");
             sys.runQueuedTimeoutCallbacks();
@@ -153,6 +156,50 @@ namespace ts.tscWatch {
             assert.deepEqual(program.getCachedSemanticDiagnostics(program.getSourceFile(mainFile.path)), []);
             // Should not retrieve diagnostics for other file thats not changed
             assert.deepEqual(program.getCachedSemanticDiagnostics(program.getSourceFile(otherFile.path)), /*expected*/ undefined);
+        });
+
+        it("noEmit with composite writes the tsbuildinfo with pending affected files correctly", () => {
+            const configText = JSON.stringify({ compilerOptions: { composite: true } });
+            const { sys, watch, config, mainFile } = setup(createSemanticDiagnosticsBuilderProgram, configText);
+            const { sys: emitSys, watch: emitWatch } = setup(createEmitAndSemanticDiagnosticsBuilderProgram, configText);
+            verifyOutputs(sys, emitSys);
+
+            watch.close();
+            emitWatch.close();
+
+            // Emit on both sys should result in same output
+            verifyBuilder(createEmitAndSemanticDiagnosticsBuilderProgram, createEmitAndSemanticDiagnosticsBuilderProgram);
+
+            // Change file
+            sys.appendFile(mainFile.path, "\n// SomeComment");
+            emitSys.appendFile(mainFile.path, "\n// SomeComment");
+
+            // Verify noEmit results in same output
+            verifyBuilder(createSemanticDiagnosticsBuilderProgram, createEmitAndSemanticDiagnosticsBuilderProgram, { noEmit: true });
+
+            // Emit on both sys should result in same output
+            verifyBuilder(createEmitAndSemanticDiagnosticsBuilderProgram, createEmitAndSemanticDiagnosticsBuilderProgram);
+
+            // Change file
+            sys.appendFile(mainFile.path, "\n// SomeComment");
+            emitSys.appendFile(mainFile.path, "\n// SomeComment");
+
+            // Emit on both the builders should result in same files
+            verifyBuilder(createSemanticDiagnosticsBuilderProgram, createEmitAndSemanticDiagnosticsBuilderProgram);
+
+            function verifyOutputs(sys: System, emitSys: System) {
+                for (const output of [`${projectRoot}/main.js`, `${projectRoot}/main.d.ts`, `${projectRoot}/other.js`, `${projectRoot}/other.d.ts`, `${projectRoot}/tsconfig.tsbuildinfo`]) {
+                    assert.strictEqual(sys.readFile(output), emitSys.readFile(output), `Output file text for ${output}`);
+                }
+            }
+
+            function verifyBuilder<T extends BuilderProgram, U extends BuilderProgram>(createProgram: CreateProgram<T>, createEmitProgram: CreateProgram<U>, optionsToExtend?: CompilerOptions) {
+                const watch = getWatch(config, /*optionsToExtend*/ optionsToExtend, sys, createProgram);
+                const emitWatch = getWatch(config, /*optionsToExtend*/ optionsToExtend, emitSys, createEmitProgram);
+                verifyOutputs(sys, emitSys);
+                watch.close();
+                emitWatch.close();
+            }
         });
     });
 }


### PR DESCRIPTION
This ensures that diagnostics are checked through cache/or cached in builder instead of getting it from Program when emit is called and its going to fail in these two scenarios. We already do this for `EmitAndSemanticDiagnosticsBuilder`
Note that actual emit when succeeds on `SemanticDiagnosticsBuilder` is going to be redirected to program as intended as the emit is not tracked by the builder and would need to typecheck file before emitting as always but this ensures that cases where it fails to emit are handled.
Fixes #40808
