### PR TITLE
Limit export= js declaration emit to only json source files

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6800,7 +6800,9 @@ namespace ts {
                             }
                             // else fall through and treat commonjs require just like import=
                         case SyntaxKind.ImportEqualsDeclaration:
-                             if (target.escapedName === InternalSymbolName.ExportEquals) {
+                            // This _specifically_ only exists to handle json declarations - where we make aliases, but since
+                            // we emit no declarations for the json document, must not refer to it in the declarations
+                            if (target.escapedName === InternalSymbolName.ExportEquals && some(target.declarations, isJsonSourceFile)) {
                                 serializeMaybeAliasAssignment(symbol);
                                 break;
                             }

--- a/tests/baselines/reference/jsDeclarationsExportedClassAliases.js
+++ b/tests/baselines/reference/jsDeclarationsExportedClassAliases.js
@@ -1,0 +1,60 @@
+//// [tests/cases/conformance/jsdoc/declarations/jsDeclarationsExportedClassAliases.ts] ////
+
+//// [errors.js]
+class FancyError extends Error {
+    constructor(status) {
+        super(`error with status ${status}`);
+    }
+}
+
+module.exports = {
+    FancyError
+};
+
+//// [index.js]
+// issue arises here on compilation
+const errors = require("./errors");
+
+module.exports = {
+    errors
+};
+
+//// [errors.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var FancyError = /** @class */ (function (_super) {
+    __extends(FancyError, _super);
+    function FancyError(status) {
+        return _super.call(this, "error with status " + status) || this;
+    }
+    return FancyError;
+}(Error));
+module.exports = {
+    FancyError: FancyError
+};
+//// [index.js]
+// issue arises here on compilation
+var errors = require("./errors");
+module.exports = {
+    errors: errors
+};
+
+
+//// [errors.d.ts]
+export class FancyError extends Error {
+    constructor(status: any);
+}
+//// [index.d.ts]
+import errors = require("./errors");
+export { errors };

--- a/tests/baselines/reference/jsDeclarationsExportedClassAliases.symbols
+++ b/tests/baselines/reference/jsDeclarationsExportedClassAliases.symbols
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/jsdoc/declarations/utils/index.js ===
+// issue arises here on compilation
+const errors = require("./errors");
+>errors : Symbol(errors, Decl(index.js, 1, 5))
+>require : Symbol(require)
+>"./errors" : Symbol("tests/cases/conformance/jsdoc/declarations/utils/errors", Decl(errors.js, 0, 0))
+
+module.exports = {
+>module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/utils/index", Decl(index.js, 0, 0))
+>module : Symbol(export=, Decl(index.js, 1, 35))
+>exports : Symbol(export=, Decl(index.js, 1, 35))
+
+    errors
+>errors : Symbol(errors, Decl(index.js, 3, 18))
+
+};
+=== tests/cases/conformance/jsdoc/declarations/utils/errors.js ===
+class FancyError extends Error {
+>FancyError : Symbol(FancyError, Decl(errors.js, 0, 0))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    constructor(status) {
+>status : Symbol(status, Decl(errors.js, 1, 16))
+
+        super(`error with status ${status}`);
+>super : Symbol(ErrorConstructor, Decl(lib.es5.d.ts, --, --))
+>status : Symbol(status, Decl(errors.js, 1, 16))
+    }
+}
+
+module.exports = {
+>module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/utils/errors", Decl(errors.js, 0, 0))
+>module : Symbol(export=, Decl(errors.js, 4, 1))
+>exports : Symbol(export=, Decl(errors.js, 4, 1))
+
+    FancyError
+>FancyError : Symbol(FancyError, Decl(errors.js, 6, 18))
+
+};
+

--- a/tests/baselines/reference/jsDeclarationsExportedClassAliases.types
+++ b/tests/baselines/reference/jsDeclarationsExportedClassAliases.types
@@ -1,0 +1,47 @@
+=== tests/cases/conformance/jsdoc/declarations/utils/index.js ===
+// issue arises here on compilation
+const errors = require("./errors");
+>errors : { FancyError: typeof FancyError; }
+>require("./errors") : { FancyError: typeof FancyError; }
+>require : any
+>"./errors" : "./errors"
+
+module.exports = {
+>module.exports = {    errors} : { errors: { FancyError: typeof FancyError; }; }
+>module.exports : { errors: { FancyError: typeof FancyError; }; }
+>module : { "\"tests/cases/conformance/jsdoc/declarations/utils/index\"": { errors: { FancyError: typeof FancyError; }; }; }
+>exports : { errors: { FancyError: typeof FancyError; }; }
+>{    errors} : { errors: { FancyError: typeof FancyError; }; }
+
+    errors
+>errors : { FancyError: typeof FancyError; }
+
+};
+=== tests/cases/conformance/jsdoc/declarations/utils/errors.js ===
+class FancyError extends Error {
+>FancyError : FancyError
+>Error : Error
+
+    constructor(status) {
+>status : any
+
+        super(`error with status ${status}`);
+>super(`error with status ${status}`) : void
+>super : ErrorConstructor
+>`error with status ${status}` : string
+>status : any
+    }
+}
+
+module.exports = {
+>module.exports = {    FancyError} : { FancyError: typeof FancyError; }
+>module.exports : { FancyError: typeof FancyError; }
+>module : { "\"tests/cases/conformance/jsdoc/declarations/utils/errors\"": { FancyError: typeof FancyError; }; }
+>exports : { FancyError: typeof FancyError; }
+>{    FancyError} : { FancyError: typeof FancyError; }
+
+    FancyError
+>FancyError : typeof FancyError
+
+};
+

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsExportedClassAliases.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsExportedClassAliases.ts
@@ -1,0 +1,22 @@
+// @allowJs: true
+// @checkJs: true
+// @outDir: ./out
+// @declaration: true
+// @filename: utils/errors.js
+class FancyError extends Error {
+    constructor(status) {
+        super(`error with status ${status}`);
+    }
+}
+
+module.exports = {
+    FancyError
+};
+
+// @filename: utils/index.js
+// issue arises here on compilation
+const errors = require("./errors");
+
+module.exports = {
+    errors
+};


### PR DESCRIPTION
There was a special case in js declaration emit that was a bit overbroad in its condition.

Fixes #40859
