### PR TITLE
Properly compare path prefixes when generating module paths

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -235,7 +235,7 @@ namespace ts.moduleSpecifiers {
             : discoverProbableSymlinks(host.getSourceFiles(), getCanonicalFileName, cwd);
 
         const symlinkedDirectories = links.getSymlinkedDirectories();
-        const compareStrings = (!host.useCaseSensitiveFileNames || host.useCaseSensitiveFileNames()) ? compareStringsCaseSensitive : compareStringsCaseInsensitive;
+        const useCaseSensitiveFileNames = !host.useCaseSensitiveFileNames || host.useCaseSensitiveFileNames();
         const result = symlinkedDirectories && forEachEntry(symlinkedDirectories, (resolved, path) => {
             if (resolved === false) return undefined;
             if (startsWithDirectory(importingFileName, resolved.realPath, getCanonicalFileName)) {
@@ -243,7 +243,7 @@ namespace ts.moduleSpecifiers {
             }
 
             return forEach(targets, target => {
-                if (compareStrings(target.slice(0, resolved.real.length), resolved.real) !== Comparison.EqualTo) {
+                if (!containsPath(resolved.real, target, !useCaseSensitiveFileNames)) {
                     return;
                 }
 

--- a/tests/baselines/reference/declarationEmitSymlinkPaths.js
+++ b/tests/baselines/reference/declarationEmitSymlinkPaths.js
@@ -1,0 +1,49 @@
+//// [tests/cases/compiler/declarationEmitSymlinkPaths.ts] ////
+
+//// [package.json]
+{
+    "name": "search",
+    "version": "0.0.1",
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "sideEffects": false
+}
+//// [index.d.ts]
+export declare function test<T> (a: () => T): () => T;
+//// [NotificationAPIUtils.ts]
+export type NotificationRequest = {};
+export type NotificationResponse = {};
+export function getNotification(): NotificationResponse {
+  return {};
+}
+//// [NotificationStore.ts]
+import { test } from "search/lib/index";
+import { getNotification } from "../API/NotificationAPIUtils";
+
+export const NotificationScenario = test(
+  getNotification
+);
+
+//// [NotificationAPIUtils.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getNotification = void 0;
+function getNotification() {
+    return {};
+}
+exports.getNotification = getNotification;
+//// [NotificationStore.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.NotificationScenario = void 0;
+var index_1 = require("search/lib/index");
+var NotificationAPIUtils_1 = require("../API/NotificationAPIUtils");
+exports.NotificationScenario = index_1.test(NotificationAPIUtils_1.getNotification);
+
+
+//// [NotificationAPIUtils.d.ts]
+export declare type NotificationRequest = {};
+export declare type NotificationResponse = {};
+export declare function getNotification(): NotificationResponse;
+//// [NotificationStore.d.ts]
+export declare const NotificationScenario: () => import("../API/NotificationAPIUtils").NotificationResponse;

--- a/tests/baselines/reference/declarationEmitSymlinkPaths.symbols
+++ b/tests/baselines/reference/declarationEmitSymlinkPaths.symbols
@@ -1,0 +1,36 @@
+=== /packages/search/lib/index.d.ts ===
+export declare function test<T> (a: () => T): () => T;
+>test : Symbol(test, Decl(index.d.ts, 0, 0))
+>T : Symbol(T, Decl(index.d.ts, 0, 29))
+>a : Symbol(a, Decl(index.d.ts, 0, 33))
+>T : Symbol(T, Decl(index.d.ts, 0, 29))
+>T : Symbol(T, Decl(index.d.ts, 0, 29))
+
+=== /packages/search-prefix/src/API/NotificationAPIUtils.ts ===
+export type NotificationRequest = {};
+>NotificationRequest : Symbol(NotificationRequest, Decl(NotificationAPIUtils.ts, 0, 0))
+
+export type NotificationResponse = {};
+>NotificationResponse : Symbol(NotificationResponse, Decl(NotificationAPIUtils.ts, 0, 37))
+
+export function getNotification(): NotificationResponse {
+>getNotification : Symbol(getNotification, Decl(NotificationAPIUtils.ts, 1, 38))
+>NotificationResponse : Symbol(NotificationResponse, Decl(NotificationAPIUtils.ts, 0, 37))
+
+  return {};
+}
+=== /packages/search-prefix/src/Store/NotificationStore.ts ===
+import { test } from "search/lib/index";
+>test : Symbol(test, Decl(NotificationStore.ts, 0, 8))
+
+import { getNotification } from "../API/NotificationAPIUtils";
+>getNotification : Symbol(getNotification, Decl(NotificationStore.ts, 1, 8))
+
+export const NotificationScenario = test(
+>NotificationScenario : Symbol(NotificationScenario, Decl(NotificationStore.ts, 3, 12))
+>test : Symbol(test, Decl(NotificationStore.ts, 0, 8))
+
+  getNotification
+>getNotification : Symbol(getNotification, Decl(NotificationStore.ts, 1, 8))
+
+);

--- a/tests/baselines/reference/declarationEmitSymlinkPaths.types
+++ b/tests/baselines/reference/declarationEmitSymlinkPaths.types
@@ -1,0 +1,34 @@
+=== /packages/search/lib/index.d.ts ===
+export declare function test<T> (a: () => T): () => T;
+>test : <T>(a: () => T) => () => T
+>a : () => T
+
+=== /packages/search-prefix/src/API/NotificationAPIUtils.ts ===
+export type NotificationRequest = {};
+>NotificationRequest : NotificationRequest
+
+export type NotificationResponse = {};
+>NotificationResponse : NotificationResponse
+
+export function getNotification(): NotificationResponse {
+>getNotification : () => NotificationResponse
+
+  return {};
+>{} : {}
+}
+=== /packages/search-prefix/src/Store/NotificationStore.ts ===
+import { test } from "search/lib/index";
+>test : <T>(a: () => T) => () => T
+
+import { getNotification } from "../API/NotificationAPIUtils";
+>getNotification : () => import("/packages/search-prefix/src/API/NotificationAPIUtils").NotificationResponse
+
+export const NotificationScenario = test(
+>NotificationScenario : () => import("/packages/search-prefix/src/API/NotificationAPIUtils").NotificationResponse
+>test(  getNotification) : () => import("/packages/search-prefix/src/API/NotificationAPIUtils").NotificationResponse
+>test : <T>(a: () => T) => () => T
+
+  getNotification
+>getNotification : () => import("/packages/search-prefix/src/API/NotificationAPIUtils").NotificationResponse
+
+);

--- a/tests/cases/compiler/declarationEmitSymlinkPaths.ts
+++ b/tests/cases/compiler/declarationEmitSymlinkPaths.ts
@@ -1,0 +1,29 @@
+// @declaration: true
+// @outDir: /packages/search-prefix/lib
+// @rootDir: /packages/search-prefix/src
+// @target: es5
+// @filename: /packages/search/package.json
+{
+    "name": "search",
+    "version": "0.0.1",
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "sideEffects": false
+}
+// @filename: /packages/search/lib/index.d.ts
+export declare function test<T> (a: () => T): () => T;
+// @filename: /packages/search-prefix/src/API/NotificationAPIUtils.ts
+export type NotificationRequest = {};
+export type NotificationResponse = {};
+export function getNotification(): NotificationResponse {
+  return {};
+}
+// @filename: /packages/search-prefix/src/Store/NotificationStore.ts
+import { test } from "search/lib/index";
+import { getNotification } from "../API/NotificationAPIUtils";
+
+export const NotificationScenario = test(
+  getNotification
+);
+// @link: /packages/search -> /node_modules/search
+// @link: /packages/search-prefix -> /node_modules/search-prefix


### PR DESCRIPTION
The string comparison previously being done saw a path starting with `/packages/search` and assumed it applied to something in `/packages/search-prefix`, which was incorrect. A path-structure-aware comparison needs to be performed (which we fortunately already have a helper for).

Fixes #40852
