### PR TITLE
Limit when we allow nested unique symbols to be serialized

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5812,7 +5812,7 @@ namespace ts {
                 }
                 const oldFlags = context.flags;
                 if (type.flags & TypeFlags.UniqueESSymbol &&
-                    type.symbol === symbol) {
+                    type.symbol === symbol && (!context.enclosingDeclaration || some(symbol.declarations, d => getSourceFileOfNode(d) === getSourceFileOfNode(context.enclosingDeclaration!)))) {
                     context.flags |= NodeBuilderFlags.AllowUniqueESSymbolType;
                 }
                 const result = typeToTypeNodeHelper(type, context);

--- a/tests/baselines/reference/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.errors.txt
+++ b/tests/baselines/reference/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/b.ts(2,14): error TS2527: The inferred type of 'A1' references an inaccessible 'unique symbol' type. A type annotation is necessary.
+
+
+==== tests/cases/compiler/a.ts (0 errors) ====
+    type AX = { readonly A: unique symbol };
+    export const A: AX = 0 as any;
+==== tests/cases/compiler/b.ts (1 errors) ====
+    import { A } from './a';
+    export const A1 = A;
+                 ~~
+!!! error TS2527: The inferred type of 'A1' references an inaccessible 'unique symbol' type. A type annotation is necessary.

--- a/tests/baselines/reference/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.js
+++ b/tests/baselines/reference/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.ts] ////
+
+//// [a.ts]
+type AX = { readonly A: unique symbol };
+export const A: AX = 0 as any;
+//// [b.ts]
+import { A } from './a';
+export const A1 = A;
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+exports.A = void 0;
+exports.A = 0;
+//// [b.js]
+"use strict";
+exports.__esModule = true;
+exports.A1 = void 0;
+var a_1 = require("./a");
+exports.A1 = a_1.A;
+
+
+//// [a.d.ts]
+declare type AX = {
+    readonly A: unique symbol;
+};
+export declare const A: AX;
+export {};

--- a/tests/baselines/reference/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.symbols
+++ b/tests/baselines/reference/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/a.ts ===
+type AX = { readonly A: unique symbol };
+>AX : Symbol(AX, Decl(a.ts, 0, 0))
+>A : Symbol(A, Decl(a.ts, 0, 11))
+
+export const A: AX = 0 as any;
+>A : Symbol(A, Decl(a.ts, 1, 12))
+>AX : Symbol(AX, Decl(a.ts, 0, 0))
+
+=== tests/cases/compiler/b.ts ===
+import { A } from './a';
+>A : Symbol(A, Decl(b.ts, 0, 8))
+
+export const A1 = A;
+>A1 : Symbol(A1, Decl(b.ts, 1, 12))
+>A : Symbol(A, Decl(b.ts, 0, 8))
+

--- a/tests/baselines/reference/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.types
+++ b/tests/baselines/reference/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.types
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/a.ts ===
+type AX = { readonly A: unique symbol };
+>AX : AX
+>A : unique symbol
+
+export const A: AX = 0 as any;
+>A : AX
+>0 as any : any
+>0 : 0
+
+=== tests/cases/compiler/b.ts ===
+import { A } from './a';
+>A : { readonly A: unique symbol; }
+
+export const A1 = A;
+>A1 : { readonly A: unique symbol; }
+>A : { readonly A: unique symbol; }
+

--- a/tests/cases/compiler/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.ts
+++ b/tests/cases/compiler/declarationEmitExpressionWithNonlocalPrivateUniqueSymbol.ts
@@ -1,0 +1,7 @@
+// @declaration: true
+// @filename: a.ts
+type AX = { readonly A: unique symbol };
+export const A: AX = 0 as any;
+// @filename: b.ts
+import { A } from './a';
+export const A1 = A;


### PR DESCRIPTION
to when their declaration is within the same file as the context. Within the same context, the symbol should be referred to by `typeof declname` (or be the declaration `unique symbol` node itself), so this _should_ be sufficient.

Fixes #40786
