### PR TITLE
Update the Enum Members Error to be like TS2713

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3105,7 +3105,7 @@ namespace ts {
                         const suggestion = getSuggestedSymbolForNonexistentModule(right, namespace);
                         suggestion ?
                             error(right, Diagnostics._0_has_no_exported_member_named_1_Did_you_mean_2, namespaceName, declarationName, symbolToString(suggestion)) :
-                            error(right, Diagnostics.Namespace_0_has_no_exported_member_1, namespaceName, declarationName);
+                            error(right, Diagnostics.Cannot_access_0_1_because_0_is_a_type_but_not_a_namespace_Did_you_mean_to_retrieve_the_type_of_the_property_1_in_0_with_0_1, namespaceName, declarationName);
                     }
                     return undefined;
                 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes # [20358](https://github.com/microsoft/TypeScript/issues/20358)

#### TODO:
* [ ] Add a test case
* [ ] Pass in the correct parts for the error message (Color.Red.toString) {1},{2} not {0},{1}