### PR TITLE
Adding hints for missing bracket in class and enum

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -15,7 +15,7 @@
         "category": "Error",
         "code": 1006
     },
-    "The parser expected to find a '}' to match the '{' token here.": {
+    "The parser expected to find a '{0}' to match the '{1}' token here.": {
         "category": "Error",
         "code": 1007
     },

--- a/tests/baselines/reference/classMemberWithMissingIdentifier.errors.txt
+++ b/tests/baselines/reference/classMemberWithMissingIdentifier.errors.txt
@@ -10,6 +10,7 @@ tests/cases/compiler/classMemberWithMissingIdentifier.ts(3,1): error TS1128: Dec
 !!! error TS1146: Declaration expected.
                ~
 !!! error TS1005: ';' expected.
+!!! related TS1007 tests/cases/compiler/classMemberWithMissingIdentifier.ts:2:12: The parser expected to find a '}' to match the '{' token here.
     }
     ~
 !!! error TS1128: Declaration or statement expected.

--- a/tests/baselines/reference/classMemberWithMissingIdentifier2.errors.txt
+++ b/tests/baselines/reference/classMemberWithMissingIdentifier2.errors.txt
@@ -14,6 +14,7 @@ tests/cases/compiler/classMemberWithMissingIdentifier2.ts(3,1): error TS1128: De
 !!! error TS1146: Declaration expected.
                ~
 !!! error TS1005: ';' expected.
+!!! related TS1007 tests/cases/compiler/classMemberWithMissingIdentifier2.ts:2:12: The parser expected to find a '}' to match the '{' token here.
                      ~
 !!! error TS1005: ',' expected.
                       ~~~~~~

--- a/tests/baselines/reference/constructorWithIncompleteTypeAnnotation.errors.txt
+++ b/tests/baselines/reference/constructorWithIncompleteTypeAnnotation.errors.txt
@@ -142,6 +142,7 @@ tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(261,1): error TS
                     if (retValue != 0) {
                                  ~~
 !!! error TS1005: ',' expected.
+!!! related TS1007 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts:28:30: The parser expected to find a '}' to match the '{' token here.
                                      ~
 !!! error TS1005: ';' expected.
     

--- a/tests/baselines/reference/objectLiteralWithSemicolons4.errors.txt
+++ b/tests/baselines/reference/objectLiteralWithSemicolons4.errors.txt
@@ -10,4 +10,4 @@ tests/cases/compiler/objectLiteralWithSemicolons4.ts(3,1): error TS1005: ',' exp
     ;
     ~
 !!! error TS1005: ',' expected.
-!!! related TS1007 tests/cases/compiler/objectLiteralWithSemicolons4.ts:1:9: The parser expected to find a '}' to match the '{' token here.
+!!! related TS1007 tests/cases/compiler/objectLiteralWithSemicolons4.ts:3:1: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/parseErrorIncorrectReturnToken.errors.txt
+++ b/tests/baselines/reference/parseErrorIncorrectReturnToken.errors.txt
@@ -25,7 +25,7 @@ tests/cases/compiler/parseErrorIncorrectReturnToken.ts(12,1): error TS1128: Decl
         m(n: number) => string {
                      ~~
 !!! error TS1005: '{' expected.
-!!! related TS1007 tests/cases/compiler/parseErrorIncorrectReturnToken.ts:8:9: The parser expected to find a '}' to match the '{' token here.
+!!! related TS1007 tests/cases/compiler/parseErrorIncorrectReturnToken.ts:9:18: The parser expected to find a '}' to match the '{' token here.
                         ~~~~~~
 !!! error TS2693: 'string' only refers to a type, but is being used as a value here.
                                ~

--- a/tests/cases/compiler/missingCloseBraceInClass.ts
+++ b/tests/cases/compiler/missingCloseBraceInClass.ts
@@ -1,0 +1,6 @@
+class Car {
+    type: string
+
+    getType() {
+        return this.type
+    }

--- a/tests/cases/compiler/missingCloseBraceInEnum.ts
+++ b/tests/cases/compiler/missingCloseBraceInEnum.ts
@@ -1,0 +1,4 @@
+enum Fruits {
+    Banana,
+    Apple,
+    Mango


### PR DESCRIPTION
Adding close brace hints to class and enums, as well as slight refactor.

Fixes #35597 
