### PR TITLE
Use npm ci for nightly builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup and publish nightly
       run: |
         npm whoami
-        npm i
+        npm ci
         gulp configure-nightly
         gulp LKG
         gulp runtests-parallel


### PR DESCRIPTION
Using [npm ci](https://docs.npmjs.com/cli/ci.html) keeps the builds reproducible.

In this PR, we keep the nightly build en par with the [CI build workflow](https://github.com/microsoft/TypeScript/blob/master/.github/workflows/ci.yml#L33) as well as the [releasable package workflow](https://github.com/microsoft/TypeScript/blob/master/.github/workflows/release-branch-artifact.yaml#L24).
The used package-lock.json is updated [an hour before this workflow](https://github.com/microsoft/TypeScript/blob/master/.github/workflows/update-package-lock.yaml#L7), there should not be any lockfile conflicts.

Feel free to just close this PR if the change is undesired for reasons that I overlooked.