### PR TITLE
Fix function merged with export as namespace sourcefile

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -32040,7 +32040,7 @@ namespace ts {
             for (const current of declarations) {
                 const node = <SignatureDeclaration | ClassDeclaration | ClassExpression>current;
                 const inAmbientContext = node.flags & NodeFlags.Ambient;
-                const inAmbientContextOrInterface = node.parent.kind === SyntaxKind.InterfaceDeclaration || node.parent.kind === SyntaxKind.TypeLiteral || inAmbientContext;
+                const inAmbientContextOrInterface = node.parent && (node.parent.kind === SyntaxKind.InterfaceDeclaration || node.parent.kind === SyntaxKind.TypeLiteral) || inAmbientContext;
                 if (inAmbientContextOrInterface) {
                     // check if declarations are consecutive only if they are non-ambient
                     // 1. ambient declarations can be interleaved

--- a/tests/baselines/reference/sourceFileMergeWithFunction.js
+++ b/tests/baselines/reference/sourceFileMergeWithFunction.js
@@ -1,0 +1,14 @@
+//// [tests/cases/conformance/salsa/sourceFileMergeWithFunction.ts] ////
+
+//// [types.d.ts]
+declare function foo(props: any): any;
+export default foo;
+export as namespace foo;
+
+//// [foo.ts]
+/// <reference path="types.d.ts" />
+declare function foo(): any;
+
+
+//// [foo.js]
+/// <reference path="types.d.ts" />

--- a/tests/baselines/reference/sourceFileMergeWithFunction.symbols
+++ b/tests/baselines/reference/sourceFileMergeWithFunction.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/salsa/foo.ts ===
+/// <reference path="types.d.ts" />
+declare function foo(): any;
+>foo : Symbol(foo, Decl(types.d.ts, 0, 0), Decl(foo.ts, 0, 0))
+
+=== tests/cases/conformance/salsa/types.d.ts ===
+declare function foo(props: any): any;
+>foo : Symbol(foo, Decl(types.d.ts, 0, 0))
+>props : Symbol(props, Decl(types.d.ts, 0, 21))
+
+export default foo;
+>foo : Symbol(foo, Decl(types.d.ts, 0, 0))
+
+export as namespace foo;
+>foo : Symbol(foo, Decl(types.d.ts, 1, 19))
+

--- a/tests/baselines/reference/sourceFileMergeWithFunction.types
+++ b/tests/baselines/reference/sourceFileMergeWithFunction.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/salsa/foo.ts ===
+/// <reference path="types.d.ts" />
+declare function foo(): any;
+>foo : typeof import("tests/cases/conformance/salsa/types")
+
+=== tests/cases/conformance/salsa/types.d.ts ===
+declare function foo(props: any): any;
+>foo : (props: any) => any
+>props : any
+
+export default foo;
+>foo : (props: any) => any
+
+export as namespace foo;
+>foo : typeof import("tests/cases/conformance/salsa/types")
+

--- a/tests/cases/conformance/salsa/sourceFileMergeWithFunction.ts
+++ b/tests/cases/conformance/salsa/sourceFileMergeWithFunction.ts
@@ -1,0 +1,8 @@
+// @Filename: types.d.ts
+declare function foo(props: any): any;
+export default foo;
+export as namespace foo;
+
+// @Filename: foo.ts
+/// <reference path="types.d.ts" />
+declare function foo(): any;


### PR DESCRIPTION
Previously it crashed because the function-checking code didn't expect a node with no parent.

Fixes #40261
