### PR TITLE
Add a 'rel' attribute to the HTML Form element.

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -6772,6 +6772,12 @@ interface HTMLFormElement extends HTMLElement {
      * Sets or retrieves the window or frame at which to target content.
      */
     target: string;
+            
+    /**
+     * Creates a hyperlink or annotation depending on the value.
+     */
+    rel: string;
+            
     /**
      * Returns whether a form will validate when it is submitted, without having to submit it.
      */


### PR DESCRIPTION
Just ran into this, thought I'd add it.

This attribute is referenced here: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form

Fixes #40940
