### PR TITLE
fix(40671): Enable "Convert to template string" on expressions that don't start with a string

### DIFF
--- a/src/services/refactors/convertStringOrTemplateLiteral.ts
+++ b/src/services/refactors/convertStringOrTemplateLiteral.ts
@@ -73,10 +73,19 @@ namespace ts.refactor.convertStringOrTemplateLiteral {
     }
 
     function getParentBinaryExpression(expr: Node) {
-        while (isBinaryExpression(expr.parent) && isNotEqualsOperator(expr.parent)) {
-            expr = expr.parent;
-        }
-        return expr;
+        const container = findAncestor(expr.parent, n => {
+            switch (n.kind) {
+                case SyntaxKind.PropertyAccessExpression:
+                case SyntaxKind.ElementAccessExpression:
+                    return false;
+                case SyntaxKind.BinaryExpression:
+                    return !(isBinaryExpression(n.parent) && isNotEqualsOperator(n.parent));
+                default:
+                    return "quit";
+            }
+        });
+
+        return container || expr;
     }
 
     function isStringConcatenationValid(node: Node): boolean {

--- a/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_ToTemplateBinaryExprWithElementAccess.ts
+++ b/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_ToTemplateBinaryExprWithElementAccess.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+////const a = { prop: 1 };
+////const b = /*x*/a["prop"]/*y*/ + "a" + "b";
+
+goTo.select("x", "y");
+edit.applyRefactor({
+    refactorName: "Convert to template string",
+    actionName: "Convert to template string",
+    actionDescription: ts.Diagnostics.Convert_to_template_string.message,
+    newContent: [
+        "const a = { prop: 1 };",
+        "const b = `${a[\"prop\"]}ab`;"
+    ].join("\n")
+});

--- a/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_ToTemplateBinaryExprWithPropertyAccess.ts
+++ b/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_ToTemplateBinaryExprWithPropertyAccess.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+////const a = { prop: 1 };
+////const b = /*x*/a.prop/*y*/ + "a" + "b";
+
+goTo.select("x", "y");
+edit.applyRefactor({
+    refactorName: "Convert to template string",
+    actionName: "Convert to template string",
+    actionDescription: ts.Diagnostics.Convert_to_template_string.message,
+    newContent: [
+        "const a = { prop: 1 };",
+        "const b = `${a.prop}ab`;"
+    ].join("\n")
+});


### PR DESCRIPTION
Fixes #40671