### PR TITLE
Add editor configurable filename-based ATA

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1133,7 +1133,11 @@ namespace ts {
                 name: "exclude",
                 type: "string"
             }
-        }
+        },
+        {
+            name: "inferTypingsFromFilenames",
+            type: "boolean",
+        },
     ];
 
     /* @internal */

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1135,7 +1135,7 @@ namespace ts {
             }
         },
         {
-            name: "inferTypingsFromFilenames",
+            name: "disableFilenameBasedTypeAcquisition",
             type: "boolean",
         },
     ];

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8148,7 +8148,6 @@ namespace ts {
         readonly providePrefixAndSuffixTextForRename?: boolean;
         readonly includePackageJsonAutoImports?: "auto" | "on" | "off";
         readonly provideRefactorNotApplicableReason?: boolean;
-        readonly automaticallyAcquireTypesBasedOnFilenames?: boolean;
     }
 
     /** Represents a bigint literal value without requiring bigint support */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5845,6 +5845,7 @@ namespace ts {
         include?: string[];
         exclude?: string[];
         [option: string]: string[] | boolean | undefined;
+        inferTypings?: boolean;
     }
 
     export enum ModuleKind {
@@ -8147,6 +8148,7 @@ namespace ts {
         readonly providePrefixAndSuffixTextForRename?: boolean;
         readonly includePackageJsonAutoImports?: "auto" | "on" | "off";
         readonly provideRefactorNotApplicableReason?: boolean;
+        readonly automaticallyAcquireTypesBasedOnFilenames?: boolean;
     }
 
     /** Represents a bigint literal value without requiring bigint support */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5844,7 +5844,7 @@ namespace ts {
         enable?: boolean;
         include?: string[];
         exclude?: string[];
-        inferTypingsFromFilenames?: boolean;
+        disableFilenameBasedTypeAcquisition?: boolean;
         [option: string]: CompilerOptionsValue | undefined;
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5845,7 +5845,7 @@ namespace ts {
         include?: string[];
         exclude?: string[];
         [option: string]: string[] | boolean | undefined;
-        inferTypings?: boolean;
+        inferTypingsFromFilenames?: boolean;
     }
 
     export enum ModuleKind {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5844,8 +5844,8 @@ namespace ts {
         enable?: boolean;
         include?: string[];
         exclude?: string[];
-        [option: string]: string[] | boolean | undefined;
         inferTypingsFromFilenames?: boolean;
+        [option: string]: CompilerOptionsValue | undefined;
     }
 
     export enum ModuleKind {

--- a/src/jsTyping/jsTyping.ts
+++ b/src/jsTyping/jsTyping.ts
@@ -149,8 +149,7 @@ namespace ts.JsTyping {
             const nodeModulesPath = combinePaths(searchDir, "node_modules");
             getTypingNamesFromPackagesFolder(nodeModulesPath, filesToWatch);
         });
-        // filename-based ATA must be explicitly disabled
-        if(typeAcquisition.inferTypingsFromFilenames !== false) {
+        if(!typeAcquisition.disableFilenameBasedTypeAcquisition) {
             getTypingNamesFromSourceFileNames(fileNames);
         }
         // add typings for unresolved imports

--- a/src/jsTyping/jsTyping.ts
+++ b/src/jsTyping/jsTyping.ts
@@ -149,8 +149,10 @@ namespace ts.JsTyping {
             const nodeModulesPath = combinePaths(searchDir, "node_modules");
             getTypingNamesFromPackagesFolder(nodeModulesPath, filesToWatch);
         });
-        getTypingNamesFromSourceFileNames(fileNames);
-
+        // filename-based ATA must be explicitly disabled
+        if(typeAcquisition.inferTypings !== false) {
+            getTypingNamesFromSourceFileNames(fileNames);
+        }
         // add typings for unresolved imports
         if (unresolvedImports) {
             const module = deduplicate<string>(

--- a/src/jsTyping/jsTyping.ts
+++ b/src/jsTyping/jsTyping.ts
@@ -150,7 +150,7 @@ namespace ts.JsTyping {
             getTypingNamesFromPackagesFolder(nodeModulesPath, filesToWatch);
         });
         // filename-based ATA must be explicitly disabled
-        if(typeAcquisition.inferTypings !== false) {
+        if(typeAcquisition.inferTypingsFromFilenames !== false) {
             getTypingNamesFromSourceFileNames(fileNames);
         }
         // add typings for unresolved imports

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -263,7 +263,7 @@ namespace ts.server {
         return result;
     }
 
-    export function convertTypeAcquisition(protocolOptions: protocol.ExternalProjectCompilerOptions): TypeAcquisition | undefined {
+    export function convertTypeAcquisition(protocolOptions: protocol.InferredProjectCompilerOptions): TypeAcquisition | undefined {
         let result: TypeAcquisition | undefined;
         typeAcquisitionDeclarations.forEach((option) => {
             const propertyValue = protocolOptions[option.name];
@@ -995,7 +995,7 @@ namespace ts.server {
             }
         }
 
-        setCompilerOptionsForInferredProjects(projectCompilerOptions: protocol.ExternalProjectCompilerOptions, projectRootPath?: string): void {
+        setCompilerOptionsForInferredProjects(projectCompilerOptions: protocol.InferredProjectCompilerOptions, projectRootPath?: string): void {
             Debug.assert(projectRootPath === undefined || this.useInferredProjectPerProjectRoot, "Setting compiler options per project root path is only supported when useInferredProjectPerProjectRoot is enabled");
 
             const compilerOptions = convertCompilerOptions(projectCompilerOptions);
@@ -1031,6 +1031,7 @@ namespace ts.server {
                     !project.projectRootPath || !this.compilerOptionsForInferredProjectsPerProjectRoot.has(project.projectRootPath)) {
                     project.setCompilerOptions(compilerOptions);
                     project.setWatchOptions(watchOptions);
+                    project.setTypeAcquisition(typeAcquisition);
                     project.compileOnSaveEnabled = compilerOptions.compileOnSave!;
                     project.markAsDirty();
                     this.delayUpdateProjectGraph(project);

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -304,7 +304,6 @@ namespace ts.server {
         hostInfo: string;
         extraFileExtensions?: FileExtensionInfo[];
         watchOptions?: WatchOptions;
-        typeAcquisition?: TypeAcquisition;
     }
 
     export interface OpenConfiguredProjectResult {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -263,6 +263,16 @@ namespace ts.server {
         return result;
     }
 
+    export function convertTypeAcquisition(protocolOptions: protocol.ExternalProjectCompilerOptions): TypeAcquisition | undefined {
+        let result: TypeAcquisition | undefined;
+        typeAcquisitionDeclarations.forEach((option) => {
+            const propertyValue = protocolOptions[option.name];
+            if (propertyValue === undefined) return;
+            (result || (result = {}))[option.name] = propertyValue;
+        });
+        return result;
+    }
+
     export function tryConvertScriptKindName(scriptKindName: protocol.ScriptKindName | ScriptKind): ScriptKind {
         return isString(scriptKindName) ? convertScriptKindName(scriptKindName) : scriptKindName;
     }
@@ -991,7 +1001,7 @@ namespace ts.server {
 
             const compilerOptions = convertCompilerOptions(projectCompilerOptions);
             const watchOptions = convertWatchOptions(projectCompilerOptions);
-            const typeAcquisition = this.hostConfiguration.typeAcquisition;
+            const typeAcquisition = convertTypeAcquisition(projectCompilerOptions);
 
             // always set 'allowNonTsExtensions' for inferred projects since user cannot configure it from the outside
             // previously we did not expose a way for user to change these settings and this option was enabled by default
@@ -2774,10 +2784,6 @@ namespace ts.server {
                 if (args.watchOptions) {
                     this.hostConfiguration.watchOptions = convertWatchOptions(args.watchOptions);
                     this.logger.info(`Host watch options changed to ${JSON.stringify(this.hostConfiguration.watchOptions)}, it will be take effect for next watches.`);
-                }
-
-                if(args.typeAcquisition) {
-                    this.hostConfiguration.typeAcquisition = args.typeAcquisition;
                 }
             }
         }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -3535,8 +3535,8 @@ namespace ts.server {
             const { rootFiles } = proj;
             const typeAcquisition = proj.typeAcquisition!;
             Debug.assert(!!typeAcquisition, "proj.typeAcquisition should be set by now");
-            // If type acquisition has been explicitly disabled, do not exclude anything from the project
-            if (typeAcquisition.enable === false || typeAcquisition.inferTypingsFromFilenames === false) {
+
+            if (typeAcquisition.enable === false || typeAcquisition.disableFilenameBasedTypeAcquisition) {
                 return [];
             }
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -3647,7 +3647,7 @@ namespace ts.server {
                 const typeAcquisition = convertEnableAutoDiscoveryToEnable(proj.typingOptions);
                 proj.typeAcquisition = typeAcquisition;
             }
-            proj.typeAcquisition = proj.typeAcquisition || this.hostConfiguration.typeAcquisition || {};
+            proj.typeAcquisition = proj.typeAcquisition || {};
             proj.typeAcquisition.include = proj.typeAcquisition.include || [];
             proj.typeAcquisition.exclude = proj.typeAcquisition.exclude || [];
             if (proj.typeAcquisition.enable === undefined) {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1840,7 +1840,7 @@ namespace ts.server {
                 enable: allRootFilesAreJsOrDts(this),
                 include: ts.emptyArray,
                 exclude: ts.emptyArray,
-                inferTypingsFromFilenames: true
+                disableFilenameBasedTypeAcquisition: false
             };
         }
     }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1836,11 +1836,11 @@ namespace ts.server {
         }
 
         getTypeAcquisition(): TypeAcquisition {
-            return {
+            return this.typeAcquisition || {
                 enable: allRootFilesAreJsOrDts(this),
                 include: ts.emptyArray,
                 exclude: ts.emptyArray,
-                inferTypings: this.typeAcquisition?.inferTypings
+                inferTypingsFromFilenames: true
             };
         }
     }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1732,6 +1732,8 @@ namespace ts.server {
 
         private _isJsInferredProject = false;
 
+        private typeAcquisition: TypeAcquisition | undefined;
+
         toggleJsInferredProject(isJsInferredProject: boolean) {
             if (isJsInferredProject !== this._isJsInferredProject) {
                 this._isJsInferredProject = isJsInferredProject;
@@ -1770,7 +1772,8 @@ namespace ts.server {
             watchOptions: WatchOptions | undefined,
             projectRootPath: NormalizedPath | undefined,
             currentDirectory: string | undefined,
-            pluginConfigOverrides: ESMap<string, any> | undefined) {
+            pluginConfigOverrides: ESMap<string, any> | undefined,
+            typeAcquisition: TypeAcquisition | undefined) {
             super(InferredProject.newName(),
                 ProjectKind.Inferred,
                 projectService,
@@ -1783,6 +1786,7 @@ namespace ts.server {
                 watchOptions,
                 projectService.host,
                 currentDirectory);
+            this.typeAcquisition = typeAcquisition;
             this.projectRootPath = projectRootPath && projectService.toCanonicalFileName(projectRootPath);
             if (!projectRootPath && !projectService.useSingleInferredProject) {
                 this.canonicalCurrentDirectory = projectService.toCanonicalFileName(this.currentDirectory);
@@ -1827,11 +1831,16 @@ namespace ts.server {
             super.close();
         }
 
+        setTypeAcquisition(newTypeAcquisition: TypeAcquisition): void {
+            this.typeAcquisition = this.removeLocalTypingsFromTypeAcquisition(newTypeAcquisition);
+        }
+
         getTypeAcquisition(): TypeAcquisition {
             return {
                 enable: allRootFilesAreJsOrDts(this),
                 include: ts.emptyArray,
-                exclude: ts.emptyArray
+                exclude: ts.emptyArray,
+                inferTypings: this.typeAcquisition?.inferTypings
             };
         }
     }

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1333,7 +1333,7 @@ namespace ts.server.protocol {
      * For external projects, some of the project settings are sent together with
      * compiler settings.
      */
-    export type ExternalProjectCompilerOptions = CompilerOptions & CompileOnSaveMixin & WatchOptions;
+    export type ExternalProjectCompilerOptions = CompilerOptions & CompileOnSaveMixin & WatchOptions & TypeAcquisition;
 
     /**
      * Contains information about current project version
@@ -1482,8 +1482,6 @@ namespace ts.server.protocol {
         extraFileExtensions?: FileExtensionInfo[];
 
         watchOptions?: WatchOptions;
-
-        typeAcquisition?: TypeAcquisition;
     }
 
     export const enum WatchFileKind {

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1333,7 +1333,7 @@ namespace ts.server.protocol {
      * For external projects, some of the project settings are sent together with
      * compiler settings.
      */
-    export type ExternalProjectCompilerOptions = CompilerOptions & CompileOnSaveMixin & WatchOptions & TypeAcquisition;
+    export type ExternalProjectCompilerOptions = CompilerOptions & CompileOnSaveMixin & WatchOptions;
 
     /**
      * Contains information about current project version
@@ -1763,6 +1763,11 @@ namespace ts.server.protocol {
     }
 
     /**
+     * External projects have a typeAcquisition option so they need to be added separately to compiler options for inferred projects.
+     */
+    export type InferredProjectCompilerOptions = ExternalProjectCompilerOptions & TypeAcquisition;
+
+    /**
      * Request to set compiler options for inferred projects.
      * External projects are opened / closed explicitly.
      * Configured projects are opened when user opens loose file that has 'tsconfig.json' or 'jsconfig.json' anywhere in one of containing folders.
@@ -1783,7 +1788,7 @@ namespace ts.server.protocol {
         /**
          * Compiler options to be used with inferred projects.
          */
-        options: ExternalProjectCompilerOptions;
+        options: InferredProjectCompilerOptions;
 
         /**
          * Specifies the project root path used to scope compiler options.

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1482,6 +1482,8 @@ namespace ts.server.protocol {
         extraFileExtensions?: FileExtensionInfo[];
 
         watchOptions?: WatchOptions;
+
+        typeAcquisition?: TypeAcquisition;
     }
 
     export const enum WatchFileKind {

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -402,7 +402,7 @@ namespace ts.projectSystem {
                 projectName,
                 fileNames: [libFile.path, file1.path, constructorFile.path, bliss.path],
                 compilerOptions: { allowNonTsExtensions: true, noEmitForJsFiles: true },
-                typeAcquisition: { include: ["blissfuljs"], exclude: [], enable: true },
+                typeAcquisition: { include: ["blissfuljs"], exclude: [], enable: true, inferTypings: true },
                 unresolvedImports: ["s"],
                 projectRootPath: "/",
                 cachePath,

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -402,7 +402,7 @@ namespace ts.projectSystem {
                 projectName,
                 fileNames: [libFile.path, file1.path, constructorFile.path, bliss.path],
                 compilerOptions: { allowNonTsExtensions: true, noEmitForJsFiles: true },
-                typeAcquisition: { include: ["blissfuljs"], exclude: [], enable: true, inferTypingsFromFilenames: true },
+                typeAcquisition: { include: ["blissfuljs"], exclude: [], enable: true },
                 unresolvedImports: ["s"],
                 projectRootPath: "/",
                 cachePath,

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -402,7 +402,7 @@ namespace ts.projectSystem {
                 projectName,
                 fileNames: [libFile.path, file1.path, constructorFile.path, bliss.path],
                 compilerOptions: { allowNonTsExtensions: true, noEmitForJsFiles: true },
-                typeAcquisition: { include: ["blissfuljs"], exclude: [], enable: true, inferTypings: true },
+                typeAcquisition: { include: ["blissfuljs"], exclude: [], enable: true, inferTypingsFromFilenames: true },
                 unresolvedImports: ["s"],
                 projectRootPath: "/",
                 cachePath,

--- a/src/testRunner/unittests/tsserver/typingsInstaller.ts
+++ b/src/testRunner/unittests/tsserver/typingsInstaller.ts
@@ -1375,7 +1375,7 @@ namespace ts.projectSystem {
             assert.deepEqual(result.newTypingNames, ["jquery", "chroma-js"]);
         });
 
-        it("should not infer typings from filenames with inferTypings:false ", () => {
+        it("should not infer typings from filenames with inferTypingsFromFilenames:false ", () => {
             const app = {
                 path: "/a/b/app.js",
                 content: ""
@@ -1393,7 +1393,7 @@ namespace ts.projectSystem {
 
             const host = createServerHost([app, jquery, chroma]);
             const logger = trackingLogger();
-            const result = JsTyping.discoverTypings(host, logger.log, [app.path, jquery.path, chroma.path], getDirectoryPath(<Path>app.path), safeList, emptyMap, { enable: true, inferTypings: false }, emptyArray, emptyMap);
+            const result = JsTyping.discoverTypings(host, logger.log, [app.path, jquery.path, chroma.path], getDirectoryPath(<Path>app.path), safeList, emptyMap, { enable: true, inferTypingsFromFilenames: false }, emptyArray, emptyMap);
             const finish = logger.finish();
             assert.deepEqual(finish, [
                 "Inferred typings from unresolved imports: []",

--- a/src/testRunner/unittests/tsserver/typingsInstaller.ts
+++ b/src/testRunner/unittests/tsserver/typingsInstaller.ts
@@ -207,9 +207,9 @@ namespace ts.projectSystem {
             checkProjectActualFiles(p, [file1.path, jquery.path]);
         });
 
-        it("inferred project - type acquisition with inferTypingsFromFile:false", () => {
+        it("inferred project - type acquisition with disableFilenameBasedTypeAcquisition:true", () => {
             // Tests:
-            // Exclude file from filename-based type acquisition with inferTypingsFromFile:false
+            // Exclude file with disableFilenameBasedTypeAcquisition:true
             const jqueryJs = {
                 path: "/a/b/jquery.js",
                 content: ""
@@ -235,7 +235,7 @@ namespace ts.projectSystem {
             projectService.setCompilerOptionsForInferredProjects({
                 allowJs: true,
                 enable: true,
-                inferTypingsFromFilenames: false
+                disableFilenameBasedTypeAcquisition: true
             });
             projectService.openClientFile(jqueryJs.path);
 
@@ -479,9 +479,9 @@ namespace ts.projectSystem {
             installer.checkPendingCommands(/*expectedCount*/ 0);
         });
 
-        it("external project - type acquisition with inferTypingsFromFilenames: false", () => {
+        it("external project - type acquisition with disableFilenameBasedTypeAcquisition:true", () => {
             // Tests:
-            // Exclude file from filename-based type acquisition with inferTypingsFromFile:false
+            // Exclude file with disableFilenameBasedTypeAcquisition:true
             const jqueryJs = {
                 path: "/a/b/jquery.js",
                 content: ""
@@ -509,7 +509,7 @@ namespace ts.projectSystem {
                 projectFileName,
                 options: { allowJS: true, moduleResolution: ModuleResolutionKind.NodeJs },
                 rootFiles: [toExternalFile(jqueryJs.path)],
-                typeAcquisition: { enable: true, inferTypingsFromFilenames: false }
+                typeAcquisition: { enable: true, disableFilenameBasedTypeAcquisition: true }
             });
 
             const p = projectService.externalProjects[0];

--- a/src/testRunner/unittests/tsserver/typingsInstaller.ts
+++ b/src/testRunner/unittests/tsserver/typingsInstaller.ts
@@ -1375,6 +1375,33 @@ namespace ts.projectSystem {
             assert.deepEqual(result.newTypingNames, ["jquery", "chroma-js"]);
         });
 
+        it("should not infer typings from filenames with inferTypings:false ", () => {
+            const app = {
+                path: "/a/b/app.js",
+                content: ""
+            };
+            const jquery = {
+                path: "/a/b/jquery.js",
+                content: ""
+            };
+            const chroma = {
+                path: "/a/b/chroma.min.js",
+                content: ""
+            };
+
+            const safeList = new Map(getEntries({ jquery: "jquery", chroma: "chroma-js" }));
+
+            const host = createServerHost([app, jquery, chroma]);
+            const logger = trackingLogger();
+            const result = JsTyping.discoverTypings(host, logger.log, [app.path, jquery.path, chroma.path], getDirectoryPath(<Path>app.path), safeList, emptyMap, { enable: true, inferTypings: false }, emptyArray, emptyMap);
+            const finish = logger.finish();
+            assert.deepEqual(finish, [
+                "Inferred typings from unresolved imports: []",
+                'Result: {"cachedTypingPaths":[],"newTypingNames":[],"filesToWatch":["/a/b/bower_components","/a/b/node_modules"]}',
+            ], finish.join("\r\n"));
+            assert.deepEqual(result.newTypingNames, []);
+        });
+
         it("should return node for core modules", () => {
             const f = {
                 path: "/a/b/app.js",

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2891,8 +2891,8 @@ declare namespace ts {
         enable?: boolean;
         include?: string[];
         exclude?: string[];
-        [option: string]: string[] | boolean | undefined;
         inferTypingsFromFilenames?: boolean;
+        [option: string]: CompilerOptionsValue | undefined;
     }
     export enum ModuleKind {
         None = 0,
@@ -7502,7 +7502,7 @@ declare namespace ts.server.protocol {
      * For external projects, some of the project settings are sent together with
      * compiler settings.
      */
-    type ExternalProjectCompilerOptions = CompilerOptions & CompileOnSaveMixin & WatchOptions;
+    type ExternalProjectCompilerOptions = CompilerOptions & CompileOnSaveMixin & WatchOptions & TypeAcquisition;
     interface FileWithProjectReferenceRedirectInfo {
         /**
          * Name of file
@@ -7558,7 +7558,6 @@ declare namespace ts.server.protocol {
          */
         extraFileExtensions?: FileExtensionInfo[];
         watchOptions?: WatchOptions;
-        typeAcquisition?: TypeAcquisition;
     }
     enum WatchFileKind {
         FixedPollingInterval = "FixedPollingInterval",
@@ -9563,6 +9562,7 @@ declare namespace ts.server {
     export function convertFormatOptions(protocolOptions: protocol.FormatCodeSettings): FormatCodeSettings;
     export function convertCompilerOptions(protocolOptions: protocol.ExternalProjectCompilerOptions): CompilerOptions & protocol.CompileOnSaveMixin;
     export function convertWatchOptions(protocolOptions: protocol.ExternalProjectCompilerOptions): WatchOptions | undefined;
+    export function convertTypeAcquisition(protocolOptions: protocol.ExternalProjectCompilerOptions): TypeAcquisition | undefined;
     export function tryConvertScriptKindName(scriptKindName: protocol.ScriptKindName | ScriptKind): ScriptKind;
     export function convertScriptKindName(scriptKindName: protocol.ScriptKindName): ScriptKind.Unknown | ScriptKind.JS | ScriptKind.JSX | ScriptKind.TS | ScriptKind.TSX;
     export interface HostConfiguration {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2892,7 +2892,7 @@ declare namespace ts {
         include?: string[];
         exclude?: string[];
         [option: string]: string[] | boolean | undefined;
-        inferTypings?: boolean;
+        inferTypingsFromFilenames?: boolean;
     }
     export enum ModuleKind {
         None = 0,

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9632,6 +9632,8 @@ declare namespace ts.server {
         private compilerOptionsForInferredProjectsPerProjectRoot;
         private watchOptionsForInferredProjects;
         private watchOptionsForInferredProjectsPerProjectRoot;
+        private typeAcquisitionForInferredProjects;
+        private typeAcquisitionForInferredProjectsPerProjectRoot;
         /**
          * Project size for configured or external projects
          */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3870,7 +3870,6 @@ declare namespace ts {
         readonly providePrefixAndSuffixTextForRename?: boolean;
         readonly includePackageJsonAutoImports?: "auto" | "on" | "off";
         readonly provideRefactorNotApplicableReason?: boolean;
-        readonly automaticallyAcquireTypesBasedOnFilenames?: boolean;
     }
     /** Represents a bigint literal value without requiring bigint support */
     export interface PseudoBigInt {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2892,6 +2892,7 @@ declare namespace ts {
         include?: string[];
         exclude?: string[];
         [option: string]: string[] | boolean | undefined;
+        inferTypings?: boolean;
     }
     export enum ModuleKind {
         None = 0,
@@ -3869,6 +3870,7 @@ declare namespace ts {
         readonly providePrefixAndSuffixTextForRename?: boolean;
         readonly includePackageJsonAutoImports?: "auto" | "on" | "off";
         readonly provideRefactorNotApplicableReason?: boolean;
+        readonly automaticallyAcquireTypesBasedOnFilenames?: boolean;
     }
     /** Represents a bigint literal value without requiring bigint support */
     export interface PseudoBigInt {
@@ -7557,6 +7559,7 @@ declare namespace ts.server.protocol {
          */
         extraFileExtensions?: FileExtensionInfo[];
         watchOptions?: WatchOptions;
+        typeAcquisition?: TypeAcquisition;
     }
     enum WatchFileKind {
         FixedPollingInterval = "FixedPollingInterval",
@@ -9353,6 +9356,7 @@ declare namespace ts.server {
     class InferredProject extends Project {
         private static readonly newName;
         private _isJsInferredProject;
+        private typeAcquisition;
         toggleJsInferredProject(isJsInferredProject: boolean): void;
         setCompilerOptions(options?: CompilerOptions): void;
         /** this is canonical project root path */
@@ -9361,6 +9365,7 @@ declare namespace ts.server {
         removeRoot(info: ScriptInfo): void;
         isProjectWithSingleRoot(): boolean;
         close(): void;
+        setTypeAcquisition(newTypeAcquisition: TypeAcquisition): void;
         getTypeAcquisition(): TypeAcquisition;
     }
     class AutoImportProviderProject extends Project {
@@ -9567,6 +9572,7 @@ declare namespace ts.server {
         hostInfo: string;
         extraFileExtensions?: FileExtensionInfo[];
         watchOptions?: WatchOptions;
+        typeAcquisition?: TypeAcquisition;
     }
     export interface OpenConfiguredProjectResult {
         configFileName?: NormalizedPath;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2892,6 +2892,7 @@ declare namespace ts {
         include?: string[];
         exclude?: string[];
         [option: string]: string[] | boolean | undefined;
+        inferTypings?: boolean;
     }
     export enum ModuleKind {
         None = 0,
@@ -3869,6 +3870,7 @@ declare namespace ts {
         readonly providePrefixAndSuffixTextForRename?: boolean;
         readonly includePackageJsonAutoImports?: "auto" | "on" | "off";
         readonly provideRefactorNotApplicableReason?: boolean;
+        readonly automaticallyAcquireTypesBasedOnFilenames?: boolean;
     }
     /** Represents a bigint literal value without requiring bigint support */
     export interface PseudoBigInt {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2892,7 +2892,7 @@ declare namespace ts {
         include?: string[];
         exclude?: string[];
         [option: string]: string[] | boolean | undefined;
-        inferTypings?: boolean;
+        inferTypingsFromFilenames?: boolean;
     }
     export enum ModuleKind {
         None = 0,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2891,7 +2891,7 @@ declare namespace ts {
         enable?: boolean;
         include?: string[];
         exclude?: string[];
-        inferTypingsFromFilenames?: boolean;
+        disableFilenameBasedTypeAcquisition?: boolean;
         [option: string]: CompilerOptionsValue | undefined;
     }
     export enum ModuleKind {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2891,8 +2891,8 @@ declare namespace ts {
         enable?: boolean;
         include?: string[];
         exclude?: string[];
-        [option: string]: string[] | boolean | undefined;
         inferTypingsFromFilenames?: boolean;
+        [option: string]: CompilerOptionsValue | undefined;
     }
     export enum ModuleKind {
         None = 0,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3870,7 +3870,6 @@ declare namespace ts {
         readonly providePrefixAndSuffixTextForRename?: boolean;
         readonly includePackageJsonAutoImports?: "auto" | "on" | "off";
         readonly provideRefactorNotApplicableReason?: boolean;
-        readonly automaticallyAcquireTypesBasedOnFilenames?: boolean;
     }
     /** Represents a bigint literal value without requiring bigint support */
     export interface PseudoBigInt {


### PR DESCRIPTION
Filename-based ATA is sometimes undesirable in external and inferred projects. This change allows that behavior to be configured without needing to add a tsconfig.
* Adds `disableFilenameBasedTypeAcquisition` to `typeAcquisition`, to control whether or not typings are inferred _based on .js filenames_.
* Allows `typeAcquisition` to be configured by editors for _non-configured_ (no tsconfig) projects.

Fixes #40123 
