### PR TITLE
Reuse Module Resolutions Within Project References During Initial Program Creation

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1221,6 +1221,9 @@ namespace ts {
             function doesStructuralPermitResolutionsReuse(): boolean {
                 switch (structuralIsReused) {
                     case StructureIsReused.Not: return false;
+                    case StructureIsReused.SafeProjectReferenceModules:
+                        return file.resolvedModules !== undefined &&
+                            isSourceOfProjectReferenceRedirect(file.originalFileName);
                     case StructureIsReused.SafeModules: return true;
                     case StructureIsReused.Completely: return true;
 
@@ -1293,7 +1296,10 @@ namespace ts {
 
         function tryReuseStructureFromOldProgram(): StructureIsReused {
             if (!oldProgram) {
-                return StructureIsReused.Not;
+                // During initial program creation, root files may import files from project
+                // references that were previously loaded. Those resolutions are safe to reuse
+                // since another program instance kept them up to date.
+                return StructureIsReused.SafeProjectReferenceModules;
             }
 
             // check properties that can affect structure of the program or module resolution strategy

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3824,9 +3824,10 @@ namespace ts {
     /* @internal */
     /** "Structure" refers to the SourceFile graph of a Program linked by module resolutions. */
     export const enum StructureIsReused {
-        Not         = 0,      // The entire Program must be (re)created.
-        SafeModules = 1 << 0, // SourceFile objects need to be rediscovered, but module resolutions can be reused.
-        Completely  = 1 << 1, // SourceFile objects and module resolutions can be reused from an old Program.
+        Not                         = 0,      // The entire Program must be (re)created.
+        SafeProjectReferenceModules = 1 << 0, // SourceFile objects need to be rediscovered, but module resolutions within project reference sources may be reused.
+        SafeModules                 = 1 << 1, // SourceFile objects need to be rediscovered, but module resolutions can be reused.
+        Completely                  = 1 << 2, // SourceFile objects and module resolutions can be reused from an old Program.
     }
 
     export type CustomTransformerFactory = (context: TransformationContext) => CustomTransformer;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3822,10 +3822,11 @@ namespace ts {
     }
 
     /* @internal */
+    /** "Structure" refers to the SourceFile graph of a Program linked by module resolutions. */
     export const enum StructureIsReused {
-        Not         = 0,
-        SafeModules = 1 << 0,
-        Completely  = 1 << 1,
+        Not         = 0,      // The entire Program must be (re)created.
+        SafeModules = 1 << 0, // SourceFile objects need to be rediscovered, but module resolutions can be reused.
+        Completely  = 1 << 1, // SourceFile objects and module resolutions can be reused from an old Program.
     }
 
     export type CustomTransformerFactory = (context: TransformationContext) => CustomTransformer;


### PR DESCRIPTION
Related to #40356 and Build-Free Editing (#32028)

`tsserver` creates a `Program` for each `ConfiguredProject`. If a project contains [project references](https://www.typescriptlang.org/docs/handbook/project-references.html), `createProgram` will traverse the source files of those referenced projects recursively.

When multiple projects are loaded, shared dependencies will have their module resolutions re-traversed. I think we can relax that behavior a bit to gain some performance improvements. The assumption is that the [`SourceFile.resolvedModules`](https://github.com/microsoft/TypeScript/blob/5c55fc0a217635184b94b0f0a42ffb5395a3bdd2/src/compiler/types.ts#L3492) map will be kept up-to-date by other `Program` objects running in `tsserver` by the time a new `Program` is created. **If this assumption is false, this PR should be rejected.**

I recommend reviewing commit by commit. The first 2 commits don't change any behavior and are small refactors to make the actual change easier to fit in.

Thanks to whoever reviews this. I'm sure changes will be requested.

## Performance Differences

For an extremely contrived test case, this improved initial load time of a project by 72.21%. See [ts-module-resolution-cache-testing](https://github.com/gluxon/ts-module-resolution-cache-testing) for the test repo. Packages and `a` and `b` are small but share a large dependency `c`.

Load time before this change (parent commit 5c55fc0a2): 
- package a: 25,450ms
- package b: 9,774ms

Load time after this change:
- package a: 25,365ms
- package b: 2,716ms

These timings are non-scientific. I didn't average them over multiple runs.

## Further Improvements

- This PR only applies to initial program creation and not program reuse. Non-trivial refactoring in [`tryReuseStructureFromOldProgram`](https://github.com/microsoft/TypeScript/blob/5c55fc0a217635184b94b0f0a42ffb5395a3bdd2/src/compiler/program.ts#L1234) would be required to make the later happen.
- We currently recreate the structure of a program entirely when any project reference tsconfig changes. I wonder if it's possible to track which project reference's config changed and only update resolutions of affected source files. It's tricky because affected files would be both files within the project reference and files that import from it.