### PR TITLE
Don't emit duplicate triple-slash directives when using API to print a .d.ts

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -5135,7 +5135,12 @@ namespace ts {
             hasWrittenComment = false;
 
             if (isEmittedNode) {
-                forEachLeadingCommentToEmit(pos, emitLeadingComment);
+                if (pos === 0 && currentSourceFile?.isDeclarationFile) {
+                    forEachLeadingCommentToEmit(pos, emitNonTripleSlashLeadingComment);
+                }
+                else {
+                    forEachLeadingCommentToEmit(pos, emitLeadingComment);
+                }
             }
             else if (pos === 0) {
                 // If the node will not be emitted in JS, remove all the comments(normal, pinned and ///) associated with the node,
@@ -5152,6 +5157,12 @@ namespace ts {
 
         function emitTripleSlashLeadingComment(commentPos: number, commentEnd: number, kind: SyntaxKind, hasTrailingNewLine: boolean, rangePos: number) {
             if (isTripleSlashComment(commentPos, commentEnd)) {
+                emitLeadingComment(commentPos, commentEnd, kind, hasTrailingNewLine, rangePos);
+            }
+        }
+
+        function emitNonTripleSlashLeadingComment(commentPos: number, commentEnd: number, kind: SyntaxKind, hasTrailingNewLine: boolean, rangePos: number) {
+            if (!isTripleSlashComment(commentPos, commentEnd)) {
                 emitLeadingComment(commentPos, commentEnd, kind, hasTrailingNewLine, rangePos);
             }
         }

--- a/src/testRunner/unittests/printer.ts
+++ b/src/testRunner/unittests/printer.ts
@@ -93,6 +93,33 @@ namespace ts {
             });
         });
 
+        describe("No duplicate ref directives when emiting .d.ts->.d.ts", () => {
+            it("without statements", () => {
+                const host = new fakes.CompilerHost(new vfs.FileSystem(true, {
+                    files: {
+                        "/test.d.ts": `/// <reference types="node" />\n/// <reference path="./src/test.d.ts />\n`
+                    }
+                }));
+                const program = createProgram(["/test.d.ts"], { }, host);
+                const file = program.getSourceFile("/test.d.ts")!;
+                const printer = createPrinter({ newLine: NewLineKind.CarriageReturnLineFeed });
+                const output = printer.printFile(file);
+                assert.equal(output.split(/\r?\n/g).length, 3);
+            });
+            it("with statements", () => {
+                const host = new fakes.CompilerHost(new vfs.FileSystem(true, {
+                    files: {
+                        "/test.d.ts": `/// <reference types="node" />\n/// <reference path="./src/test.d.ts />\nvar a: number;\n`
+                    }
+                }));
+                const program = createProgram(["/test.d.ts"], { }, host);
+                const file = program.getSourceFile("/test.d.ts")!;
+                const printer = createPrinter({ newLine: NewLineKind.CarriageReturnLineFeed });
+                const output = printer.printFile(file);
+                assert.equal(output.split(/\r?\n/g).length, 4);
+            });
+        });
+
         describe("printBundle", () => {
             const printsCorrectly = makePrintsCorrectly("printsBundleCorrectly");
             let bundle: Bundle;


### PR DESCRIPTION
We have a special case when we emit declaration files where we emit `/// <reference ...` directives stored on the `SourceFile` as a result of declaration transforms as part of the call to `emitTripleSlashDirectivesIfNeeded`. This was intended for when our compiler transforms a `.ts` to a `.d.ts`. However, if you use the `createPrinter` API directly to print a raw `.d.ts` file, we end up emitting the directives _twice_. Once from the call to `emitTripleSlashDirectivesIfNeeded`, and again from a later call to `emitLeadingComments`.  

This PR changes `emitLeadingComments` to elide `/// <reference ...` directives from the top of a source file if that source file is a declaration file, which avoids the duplication.

Fixes #36242
