### PR TITLE
fix(40933): Better Error Message for a New Ecmascript Property With a Name Similar to an Existing Property

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25902,18 +25902,18 @@ namespace ts {
                     relatedInfo = createDiagnosticForNode(propNode, Diagnostics.Did_you_forget_to_use_await);
                 }
                 else {
-                    const suggestion = getSuggestedSymbolForNonexistentProperty(propNode, containingType);
-                    if (suggestion !== undefined) {
-                        const suggestedName = symbolName(suggestion);
-                        errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_mean_2, declarationNameToString(propNode), typeToString(containingType), suggestedName);
-                        relatedInfo = suggestion.valueDeclaration && createDiagnosticForNode(suggestion.valueDeclaration, Diagnostics._0_is_declared_here, suggestedName);
+                    const missingProperty = declarationNameToString(propNode);
+                    const container = typeToString(containingType);
+                    const libSuggestion = getSuggestedLibForNonExistentProperty(missingProperty, containingType);
+                    if (libSuggestion !== undefined) {
+                        errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1_Do_you_need_to_change_your_target_library_Try_changing_the_lib_compiler_option_to_2_or_later, missingProperty, container, libSuggestion);
                     }
                     else {
-                        const missingProperty = declarationNameToString(propNode);
-                        const container = typeToString(containingType);
-                        const lib = getSuggestedLibForNonExistentProperty(missingProperty, containingType);
-                        if (lib) {
-                            errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1_Do_you_need_to_change_your_target_library_Try_changing_the_lib_compiler_option_to_2_or_later, missingProperty, container, lib);
+                        const suggestion = getSuggestedSymbolForNonexistentProperty(propNode, containingType);
+                        if (suggestion !== undefined) {
+                            const suggestedName = symbolName(suggestion);
+                            errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_mean_2, missingProperty, container, suggestedName);
+                            relatedInfo = suggestion.valueDeclaration && createDiagnosticForNode(suggestion.valueDeclaration, Diagnostics._0_is_declared_here, suggestedName);
                         }
                         else {
                             errorInfo = chainDiagnosticMessages(elaborateNeverIntersection(errorInfo, containingType), Diagnostics.Property_0_does_not_exist_on_type_1, missingProperty, container);

--- a/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2015.errors.txt
+++ b/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2015.errors.txt
@@ -20,9 +20,9 @@ tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(25,30): error T
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(26,40): error TS2550: Property 'from' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(27,38): error TS2550: Property 'of' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(28,44): error TS2550: Property 'assign' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(29,59): error TS2551: Property 'getOwnPropertySymbols' does not exist on type 'ObjectConstructor'. Did you mean 'getOwnPropertyNames'?
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(29,59): error TS2550: Property 'getOwnPropertySymbols' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(31,40): error TS2550: Property 'is' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(32,52): error TS2551: Property 'setPrototypeOf' does not exist on type 'ObjectConstructor'. Did you mean 'getPrototypeOf'?
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(32,52): error TS2550: Property 'setPrototypeOf' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(33,46): error TS2550: Property 'isFinite' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(34,47): error TS2550: Property 'isInteger' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(35,43): error TS2550: Property 'isNaN' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
@@ -31,20 +31,20 @@ tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(37,48): error T
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(38,46): error TS2550: Property 'parseInt' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(39,28): error TS2550: Property 'clz32' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(40,27): error TS2550: Property 'imul' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(41,27): error TS2551: Property 'sign' does not exist on type 'Math'. Did you mean 'sin'?
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(42,28): error TS2551: Property 'log10' does not exist on type 'Math'. Did you mean 'LOG10E'?
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(43,27): error TS2551: Property 'log2' does not exist on type 'Math'. Did you mean 'LOG2E'?
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(41,27): error TS2550: Property 'sign' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(42,28): error TS2550: Property 'log10' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(43,27): error TS2550: Property 'log2' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(44,28): error TS2550: Property 'log1p' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(45,28): error TS2550: Property 'expm1' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(46,27): error TS2551: Property 'cosh' does not exist on type 'Math'. Did you mean 'cos'?
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(47,27): error TS2551: Property 'sinh' does not exist on type 'Math'. Did you mean 'sin'?
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(48,27): error TS2551: Property 'tanh' does not exist on type 'Math'. Did you mean 'tan'?
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(49,28): error TS2551: Property 'acosh' does not exist on type 'Math'. Did you mean 'acos'?
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(50,28): error TS2551: Property 'asinh' does not exist on type 'Math'. Did you mean 'asin'?
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(51,28): error TS2551: Property 'atanh' does not exist on type 'Math'. Did you mean 'atan'?
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(46,27): error TS2550: Property 'cosh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(47,27): error TS2550: Property 'sinh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(48,27): error TS2550: Property 'tanh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(49,28): error TS2550: Property 'acosh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(50,28): error TS2550: Property 'asinh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(51,28): error TS2550: Property 'atanh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(52,28): error TS2550: Property 'hypot' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(53,28): error TS2550: Property 'trunc' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(54,29): error TS2551: Property 'fround' does not exist on type 'Math'. Did you mean 'round'?
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(54,29): error TS2550: Property 'fround' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(55,27): error TS2550: Property 'cbrt' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(56,16): error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(57,16): error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
@@ -159,16 +159,14 @@ tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(91,34): error T
 !!! error TS2550: Property 'assign' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testObjectConstructorGetOwnPropertySymbols = Object.getOwnPropertySymbols({});
                                                               ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2551: Property 'getOwnPropertySymbols' does not exist on type 'ObjectConstructor'. Did you mean 'getOwnPropertyNames'?
-!!! related TS2728 /.ts/lib.es5.d.ts:179:5: 'getOwnPropertyNames' is declared here.
+!!! error TS2550: Property 'getOwnPropertySymbols' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testObjectConstructorKeys = Object.keys({});
     const testObjectConstructorIs = Object.is({}, {});
                                            ~~
 !!! error TS2550: Property 'is' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testObjectConstructorSetPrototypeOf = Object.setPrototypeOf({}, {});
                                                        ~~~~~~~~~~~~~~
-!!! error TS2551: Property 'setPrototypeOf' does not exist on type 'ObjectConstructor'. Did you mean 'getPrototypeOf'?
-!!! related TS2728 /.ts/lib.es5.d.ts:164:5: 'getPrototypeOf' is declared here.
+!!! error TS2550: Property 'setPrototypeOf' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testNumberConstructorIsFinite = Number.isFinite(0);
                                                  ~~~~~~~~
 !!! error TS2550: Property 'isFinite' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
@@ -195,16 +193,13 @@ tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(91,34): error T
 !!! error TS2550: Property 'imul' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testMathSign = Math.sign(0);
                               ~~~~
-!!! error TS2551: Property 'sign' does not exist on type 'Math'. Did you mean 'sin'?
-!!! related TS2728 /.ts/lib.es5.d.ts:713:5: 'sin' is declared here.
+!!! error TS2550: Property 'sign' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testMathLog10 = Math.log10(0);
                                ~~~~~
-!!! error TS2551: Property 'log10' does not exist on type 'Math'. Did you mean 'LOG10E'?
-!!! related TS2728 /.ts/lib.es5.d.ts:627:14: 'LOG10E' is declared here.
+!!! error TS2550: Property 'log10' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testMathLog2 = Math.log2(0);
                               ~~~~
-!!! error TS2551: Property 'log2' does not exist on type 'Math'. Did you mean 'LOG2E'?
-!!! related TS2728 /.ts/lib.es5.d.ts:625:14: 'LOG2E' is declared here.
+!!! error TS2550: Property 'log2' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testMathLog1p = Math.log1p(0);
                                ~~~~~
 !!! error TS2550: Property 'log1p' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
@@ -213,28 +208,22 @@ tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(91,34): error T
 !!! error TS2550: Property 'expm1' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testMathCosh = Math.cosh(0);
                               ~~~~
-!!! error TS2551: Property 'cosh' does not exist on type 'Math'. Did you mean 'cos'?
-!!! related TS2728 /.ts/lib.es5.d.ts:670:5: 'cos' is declared here.
+!!! error TS2550: Property 'cosh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testMathSinh = Math.sinh(0);
                               ~~~~
-!!! error TS2551: Property 'sinh' does not exist on type 'Math'. Did you mean 'sin'?
-!!! related TS2728 /.ts/lib.es5.d.ts:713:5: 'sin' is declared here.
+!!! error TS2550: Property 'sinh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testMathTanh = Math.tanh(0);
                               ~~~~
-!!! error TS2551: Property 'tanh' does not exist on type 'Math'. Did you mean 'tan'?
-!!! related TS2728 /.ts/lib.es5.d.ts:723:5: 'tan' is declared here.
+!!! error TS2550: Property 'tanh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testMathAcosh = Math.acosh(0);
                                ~~~~~
-!!! error TS2551: Property 'acosh' does not exist on type 'Math'. Did you mean 'acos'?
-!!! related TS2728 /.ts/lib.es5.d.ts:644:5: 'acos' is declared here.
+!!! error TS2550: Property 'acosh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testMathAsinh = Math.asinh(0);
                                ~~~~~
-!!! error TS2551: Property 'asinh' does not exist on type 'Math'. Did you mean 'asin'?
-!!! related TS2728 /.ts/lib.es5.d.ts:649:5: 'asin' is declared here.
+!!! error TS2550: Property 'asinh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testMathAtanh = Math.atanh(0);
                                ~~~~~
-!!! error TS2551: Property 'atanh' does not exist on type 'Math'. Did you mean 'atan'?
-!!! related TS2728 /.ts/lib.es5.d.ts:654:5: 'atan' is declared here.
+!!! error TS2550: Property 'atanh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testMathHypot = Math.hypot(0,0);
                                ~~~~~
 !!! error TS2550: Property 'hypot' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
@@ -243,8 +232,7 @@ tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(91,34): error T
 !!! error TS2550: Property 'trunc' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testMathFround = Math.fround(0);
                                 ~~~~~~
-!!! error TS2551: Property 'fround' does not exist on type 'Math'. Did you mean 'round'?
-!!! related TS2728 /.ts/lib.es5.d.ts:708:5: 'round' is declared here.
+!!! error TS2550: Property 'fround' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     const testMathCbrt = Math.cbrt(0);
                               ~~~~
 !!! error TS2550: Property 'cbrt' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.

--- a/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2016Plus.errors.txt
+++ b/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2016Plus.errors.txt
@@ -3,7 +3,7 @@ tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(5,31): erro
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(6,29): error TS2550: Property 'padEnd' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(7,44): error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(8,45): error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(9,63): error TS2551: Property 'getOwnPropertyDescriptors' does not exist on type 'ObjectConstructor'. Did you mean 'getOwnPropertyDescriptor'?
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(9,63): error TS2550: Property 'getOwnPropertyDescriptors' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(10,64): error TS2550: Property 'formatToParts' does not exist on type 'DateTimeFormat'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(11,21): error TS2583: Cannot find name 'Atomics'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(12,35): error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
@@ -54,8 +54,7 @@ tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(44,70): err
 !!! error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
     const testObjectConstructorGetOwnPropertyDescriptors = Object.getOwnPropertyDescriptors({});
                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2551: Property 'getOwnPropertyDescriptors' does not exist on type 'ObjectConstructor'. Did you mean 'getOwnPropertyDescriptor'?
-!!! related TS2728 /.ts/lib.es5.d.ts:172:5: 'getOwnPropertyDescriptor' is declared here.
+!!! error TS2550: Property 'getOwnPropertyDescriptors' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
     const testIntlFormatToParts = new Intl.DateTimeFormat("en-US").formatToParts();
                                                                    ~~~~~~~~~~~~~
 !!! error TS2550: Property 'formatToParts' does not exist on type 'DateTimeFormat'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.

--- a/tests/baselines/reference/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.errors.txt
+++ b/tests/baselines/reference/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(4,18): error TS2550: Property 'from' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(10,13): error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(17,5): error TS2339: Property 'name' does not exist on type '() => void'.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(20,6): error TS2551: Property 'sign' does not exist on type 'Math'. Did you mean 'sin'?
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(20,6): error TS2550: Property 'sign' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(25,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(29,18): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(33,13): error TS2304: Cannot find name 'Proxy'.
@@ -40,8 +40,7 @@ tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.t
     // Using ES6 math
     Math.sign(1);
          ~~~~
-!!! error TS2551: Property 'sign' does not exist on type 'Math'. Did you mean 'sin'?
-!!! related TS2728 /.ts/lib.es5.d.ts:713:5: 'sin' is declared here.
+!!! error TS2550: Property 'sign' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
     
     // Using ES6 object
     var o = {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #40933
