### PR TITLE
Add elaboration when call fails all overloads but succeeds against the implementation signature

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -274,7 +274,7 @@ namespace ts {
             result.relatedInformation = relatedInformation ?
                 relatedInformation.length ?
                     relatedInformation.map(r => convertToDiagnosticRelatedInformation(r, newProgram, toPath)) :
-                    emptyArray :
+                    [] :
                 undefined;
             return result;
         });
@@ -824,7 +824,7 @@ namespace ts {
             result.relatedInformation = relatedInformation ?
                 relatedInformation.length ?
                     relatedInformation.map(r => convertToReusableDiagnosticRelatedInformation(r, relativeToBuildInfo)) :
-                    emptyArray :
+                    [] :
                 undefined;
             return result;
         });

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27328,7 +27328,7 @@ namespace ts {
 
             return getCandidateForOverloadFailure(node, candidates, args, !!candidatesOutArray);
 
-            function addImplementationSuccessElaboration(failed: Signature, diagnostic : Diagnostic) {
+            function addImplementationSuccessElaboration(failed: Signature, diagnostic: Diagnostic) {
                 const oldCandidatesForArgumentError = candidatesForArgumentError;
                 const oldCandidateForArgumentArityError = candidateForArgumentArityError;
                 const oldCandidateForTypeArgumentError = candidateForTypeArgumentError;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27227,10 +27227,10 @@ namespace ts {
             // is just important for choosing the best signature. So in the case where there is only one
             // signature, the subtype pass is useless. So skipping it is an optimization.
             if (candidates.length > 1) {
-                result = chooseOverload(candidates, subtypeRelation, signatureHelpTrailingComma);
+                result = chooseOverload(candidates, subtypeRelation, isSingleNonGenericCandidate, signatureHelpTrailingComma);
             }
             if (!result) {
-                result = chooseOverload(candidates, assignableRelation, signatureHelpTrailingComma);
+                result = chooseOverload(candidates, assignableRelation, isSingleNonGenericCandidate, signatureHelpTrailingComma);
             }
             if (result) {
                 return result;
@@ -27255,6 +27255,7 @@ namespace ts {
                                 if (last.declaration && candidatesForArgumentError.length > 3) {
                                     addRelatedInfo(d, createDiagnosticForNode(last.declaration, Diagnostics.The_last_overload_is_declared_here));
                                 }
+                                addImplementationSuccessElaboration(last, d);
                                 diagnostics.add(d);
                             }
                         }
@@ -27290,14 +27291,19 @@ namespace ts {
                         const chain = chainDiagnosticMessages(
                             map(diags, d => typeof d.messageText === "string" ? (d as DiagnosticMessageChain) : d.messageText),
                             Diagnostics.No_overload_matches_this_call);
-                        const related = flatMap(diags, d => (d as Diagnostic).relatedInformation) as DiagnosticRelatedInformation[];
+                        // The below is a spread to guarantee we get a new (mutable) array - our `flatMap` helper tries to do "smart" optimizations where it reuses input
+                        // arrays and the emptyArray singleton where possible, which is decidedly not what we want while we're still constructing this diagnostic
+                        const related = [...flatMap(diags, d => (d as Diagnostic).relatedInformation) as DiagnosticRelatedInformation[]];
+                        let diag: Diagnostic;
                         if (every(diags, d => d.start === diags[0].start && d.length === diags[0].length && d.file === diags[0].file)) {
                             const { file, start, length } = diags[0];
-                            diagnostics.add({ file, start, length, code: chain.code, category: chain.category, messageText: chain, relatedInformation: related });
+                            diag = { file, start, length, code: chain.code, category: chain.category, messageText: chain, relatedInformation: related };
                         }
                         else {
-                            diagnostics.add(createDiagnosticForNodeFromMessageChain(node, chain, related));
+                            diag = createDiagnosticForNodeFromMessageChain(node, chain, related);
                         }
+                        addImplementationSuccessElaboration(candidatesForArgumentError[0], diag);
+                        diagnostics.add(diag);
                     }
                 }
                 else if (candidateForArgumentArityError) {
@@ -27322,7 +27328,30 @@ namespace ts {
 
             return getCandidateForOverloadFailure(node, candidates, args, !!candidatesOutArray);
 
-            function chooseOverload(candidates: Signature[], relation: ESMap<string, RelationComparisonResult>, signatureHelpTrailingComma = false) {
+            function addImplementationSuccessElaboration(failed: Signature, d: Diagnostic) {
+                const oldCandidatesForArgumentError = candidatesForArgumentError;
+                const oldCandidateForArgumentArityError = candidateForArgumentArityError;
+                const oldCandidateForTypeArgumentError = candidateForTypeArgumentError;
+
+                const declCount = length(failed.declaration?.symbol.declarations);
+                const isOverload = declCount > 1;
+                const implDecl = isOverload ? failed.declaration?.symbol.declarations[declCount - 1] : undefined;
+
+
+                if (isOverload && implDecl && nodeIsPresent((implDecl as FunctionLikeDeclaration).body)) {
+                    const candidate = getSignatureFromDeclaration(implDecl as FunctionLikeDeclaration);
+                    const isSingleNonGenericCandidate = !candidate.typeParameters;
+                    if (!!chooseOverload([candidate], assignableRelation, isSingleNonGenericCandidate)) {
+                        addRelatedInfo(d, createDiagnosticForNode(implDecl, Diagnostics.The_call_would_have_succeeded_against_this_implementation_but_implementation_signatures_of_overloads_are_not_externally_visible));
+                    }
+                }
+
+                candidatesForArgumentError = oldCandidatesForArgumentError;
+                candidateForArgumentArityError = oldCandidateForArgumentArityError;
+                candidateForTypeArgumentError = oldCandidateForTypeArgumentError;
+            }
+
+            function chooseOverload(candidates: Signature[], relation: ESMap<string, RelationComparisonResult>, isSingleNonGenericCandidate: boolean, signatureHelpTrailingComma = false) {
                 candidatesForArgumentError = undefined;
                 candidateForArgumentArityError = undefined;
                 candidateForTypeArgumentError = undefined;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27335,14 +27335,12 @@ namespace ts {
 
                 const declCount = length(failed.declaration?.symbol.declarations);
                 const isOverload = declCount > 1;
-                const implDecl = isOverload ? failed.declaration?.symbol.declarations[declCount - 1] : undefined;
-
-
-                if (isOverload && implDecl && nodeIsPresent((implDecl as FunctionLikeDeclaration).body)) {
+                const implDecl = isOverload ? find(failed.declaration?.symbol.declarations || emptyArray, d => nodeIsPresent((d as FunctionLikeDeclaration).body)) : undefined;
+                if (implDecl) {
                     const candidate = getSignatureFromDeclaration(implDecl as FunctionLikeDeclaration);
                     const isSingleNonGenericCandidate = !candidate.typeParameters;
-                    if (!!chooseOverload([candidate], assignableRelation, isSingleNonGenericCandidate)) {
-                        addRelatedInfo(diagnostic , createDiagnosticForNode(implDecl, Diagnostics.The_call_would_have_succeeded_against_this_implementation_but_implementation_signatures_of_overloads_are_not_externally_visible));
+                    if (chooseOverload([candidate], assignableRelation, isSingleNonGenericCandidate)) {
+                        addRelatedInfo(diagnostic, createDiagnosticForNode(implDecl, Diagnostics.The_call_would_have_succeeded_against_this_implementation_but_implementation_signatures_of_overloads_are_not_externally_visible));
                     }
                 }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27328,7 +27328,7 @@ namespace ts {
 
             return getCandidateForOverloadFailure(node, candidates, args, !!candidatesOutArray);
 
-            function addImplementationSuccessElaboration(failed: Signature, d: Diagnostic) {
+            function addImplementationSuccessElaboration(failed: Signature, diagnostic : Diagnostic) {
                 const oldCandidatesForArgumentError = candidatesForArgumentError;
                 const oldCandidateForArgumentArityError = candidateForArgumentArityError;
                 const oldCandidateForTypeArgumentError = candidateForTypeArgumentError;
@@ -27342,7 +27342,7 @@ namespace ts {
                     const candidate = getSignatureFromDeclaration(implDecl as FunctionLikeDeclaration);
                     const isSingleNonGenericCandidate = !candidate.typeParameters;
                     if (!!chooseOverload([candidate], assignableRelation, isSingleNonGenericCandidate)) {
-                        addRelatedInfo(d, createDiagnosticForNode(implDecl, Diagnostics.The_call_would_have_succeeded_against_this_implementation_but_implementation_signatures_of_overloads_are_not_externally_visible));
+                        addRelatedInfo(diagnostic , createDiagnosticForNode(implDecl, Diagnostics.The_call_would_have_succeeded_against_this_implementation_but_implementation_signatures_of_overloads_are_not_externally_visible));
                     }
                 }
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3043,7 +3043,10 @@
         "category": "Error",
         "code": 2792
     },
-
+    "The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.": {
+        "category": "Error",
+        "code": 2793
+    },
     "Expected {0} arguments, but got {1}. Did you forget to include 'void' in your type argument to 'Promise'?": {
         "category": "Error",
         "code": 2794

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6653,6 +6653,7 @@ namespace ts {
         if (!diagnostic.relatedInformation) {
             diagnostic.relatedInformation = [];
         }
+        Debug.assert(diagnostic.relatedInformation !== emptyArray, "Diagnostic had empty array singleton for related info, but is still being constructed!");
         diagnostic.relatedInformation.push(...relatedInformation);
         return diagnostic;
     }

--- a/tests/baselines/reference/constructorOverloads1.errors.txt
+++ b/tests/baselines/reference/constructorOverloads1.errors.txt
@@ -49,7 +49,7 @@ tests/cases/compiler/constructorOverloads1.ts(17,18): error TS2769: No overload 
 !!! error TS2769:     Argument of type 'Foo' is not assignable to parameter of type 'string'.
 !!! error TS2769:   Overload 2 of 2, '(n: number): Foo', gave the following error.
 !!! error TS2769:     Argument of type 'Foo' is not assignable to parameter of type 'number'.
-!!! related TS2793 tests/cases/compiler/constructorOverloads1.ts:7:5: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
+!!! related TS2793 tests/cases/compiler/constructorOverloads1.ts:4:5: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var f4 = new Foo([f1,f2,f3]);
                      ~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
@@ -57,7 +57,7 @@ tests/cases/compiler/constructorOverloads1.ts(17,18): error TS2769: No overload 
 !!! error TS2769:     Argument of type 'Foo[]' is not assignable to parameter of type 'string'.
 !!! error TS2769:   Overload 2 of 2, '(n: number): Foo', gave the following error.
 !!! error TS2769:     Argument of type 'Foo[]' is not assignable to parameter of type 'number'.
-!!! related TS2793 tests/cases/compiler/constructorOverloads1.ts:7:5: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
+!!! related TS2793 tests/cases/compiler/constructorOverloads1.ts:4:5: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     
     f1.bar1();
     f1.bar2();

--- a/tests/baselines/reference/constructorOverloads1.errors.txt
+++ b/tests/baselines/reference/constructorOverloads1.errors.txt
@@ -49,6 +49,7 @@ tests/cases/compiler/constructorOverloads1.ts(17,18): error TS2769: No overload 
 !!! error TS2769:     Argument of type 'Foo' is not assignable to parameter of type 'string'.
 !!! error TS2769:   Overload 2 of 2, '(n: number): Foo', gave the following error.
 !!! error TS2769:     Argument of type 'Foo' is not assignable to parameter of type 'number'.
+!!! related TS2793 tests/cases/compiler/constructorOverloads1.ts:7:5: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var f4 = new Foo([f1,f2,f3]);
                      ~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
@@ -56,6 +57,7 @@ tests/cases/compiler/constructorOverloads1.ts(17,18): error TS2769: No overload 
 !!! error TS2769:     Argument of type 'Foo[]' is not assignable to parameter of type 'string'.
 !!! error TS2769:   Overload 2 of 2, '(n: number): Foo', gave the following error.
 !!! error TS2769:     Argument of type 'Foo[]' is not assignable to parameter of type 'number'.
+!!! related TS2793 tests/cases/compiler/constructorOverloads1.ts:7:5: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     
     f1.bar1();
     f1.bar2();

--- a/tests/baselines/reference/functionOverloads2.errors.txt
+++ b/tests/baselines/reference/functionOverloads2.errors.txt
@@ -16,3 +16,4 @@ tests/cases/compiler/functionOverloads2.ts(4,13): error TS2769: No overload matc
 !!! error TS2769:     Argument of type 'boolean' is not assignable to parameter of type 'string'.
 !!! error TS2769:   Overload 2 of 2, '(bar: number): number', gave the following error.
 !!! error TS2769:     Argument of type 'boolean' is not assignable to parameter of type 'number'.
+!!! related TS2793 tests/cases/compiler/functionOverloads2.ts:3:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.

--- a/tests/baselines/reference/functionOverloads27.errors.txt
+++ b/tests/baselines/reference/functionOverloads27.errors.txt
@@ -8,4 +8,5 @@ tests/cases/compiler/functionOverloads27.ts(4,13): error TS2345: Argument of typ
     var x = foo(5);
                 ~
 !!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+!!! related TS2793 tests/cases/compiler/functionOverloads27.ts:3:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     

--- a/tests/baselines/reference/functionOverloads40.errors.txt
+++ b/tests/baselines/reference/functionOverloads40.errors.txt
@@ -18,4 +18,5 @@ tests/cases/compiler/functionOverloads40.ts(4,15): error TS2769: No overload mat
 !!! error TS2769:     Type 'string' is not assignable to type 'boolean'.
 !!! related TS6500 tests/cases/compiler/functionOverloads40.ts:1:19: The expected type comes from property 'a' which is declared here on type '{ a: number; }'
 !!! related TS6500 tests/cases/compiler/functionOverloads40.ts:2:19: The expected type comes from property 'a' which is declared here on type '{ a: boolean; }'
+!!! related TS2793 tests/cases/compiler/functionOverloads40.ts:3:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     

--- a/tests/baselines/reference/heterogeneousArrayAndOverloads.errors.txt
+++ b/tests/baselines/reference/heterogeneousArrayAndOverloads.errors.txt
@@ -17,5 +17,6 @@ tests/cases/compiler/heterogeneousArrayAndOverloads.ts(9,26): error TS2769: No o
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(arg1: number[]): any', gave the following error.
 !!! error TS2769:     Type 'string' is not assignable to type 'number'.
+!!! related TS2793 tests/cases/compiler/heterogeneousArrayAndOverloads.ts:4:5: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
         }
     }

--- a/tests/baselines/reference/incompatibleTypes.errors.txt
+++ b/tests/baselines/reference/incompatibleTypes.errors.txt
@@ -99,6 +99,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
 !!! error TS2769:     Argument of type 'C1' is not assignable to parameter of type 'IFoo2'.
 !!! error TS2769:       The types returned by 'p1(...)' are incompatible between these types.
 !!! error TS2769:         Type 'string' is not assignable to type 'number'.
+!!! related TS2793 tests/cases/compiler/incompatibleTypes.ts:39:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     
     
     function of1(n: { a: { a: string; }; b: string; }): number;
@@ -114,6 +115,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
 !!! error TS2769:   Overload 2 of 2, '(s: { c: { b: string; }; d: string; }): string', gave the following error.
 !!! error TS2769:     Argument of type '{ e: number; f: number; }' is not assignable to parameter of type '{ c: { b: string; }; d: string; }'.
 !!! error TS2769:       Object literal may only specify known properties, and 'e' does not exist in type '{ c: { b: string; }; d: string; }'.
+!!! related TS2793 tests/cases/compiler/incompatibleTypes.ts:47:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     
     interface IMap {
      [key:string]:string;

--- a/tests/baselines/reference/optionalBindingParametersInOverloads1.errors.txt
+++ b/tests/baselines/reference/optionalBindingParametersInOverloads1.errors.txt
@@ -13,5 +13,7 @@ tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads1.
     foo([false, 0, ""]);
          ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'string'.
+!!! related TS2793 tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads1.ts:2:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
                    ~~
 !!! error TS2322: Type 'string' is not assignable to type 'boolean'.
+!!! related TS2793 tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads1.ts:2:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.

--- a/tests/baselines/reference/optionalBindingParametersInOverloads2.errors.txt
+++ b/tests/baselines/reference/optionalBindingParametersInOverloads2.errors.txt
@@ -14,6 +14,8 @@ tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads2.
           ~
 !!! error TS2322: Type 'boolean' is not assignable to type 'string'.
 !!! related TS6500 tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads2.ts:1:30: The expected type comes from property 'x' which is declared here on type '{ x: string; y: number; z: boolean; }'
+!!! related TS2793 tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads2.ts:2:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
                           ~
 !!! error TS2322: Type 'string' is not assignable to type 'boolean'.
 !!! related TS6500 tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads2.ts:1:52: The expected type comes from property 'z' which is declared here on type '{ x: string; y: number; z: boolean; }'
+!!! related TS2793 tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads2.ts:2:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.

--- a/tests/baselines/reference/overloadErrorMatchesImplementationElaboaration.errors.txt
+++ b/tests/baselines/reference/overloadErrorMatchesImplementationElaboaration.errors.txt
@@ -1,0 +1,15 @@
+tests/cases/compiler/overloadErrorMatchesImplementationElaboaration.ts(8,12): error TS2345: Argument of type 'number[]' is not assignable to parameter of type 'string'.
+
+
+==== tests/cases/compiler/overloadErrorMatchesImplementationElaboaration.ts (1 errors) ====
+    class EventAggregator
+    {
+        publish(event: string, data?: any): void;
+        publish<T>(event: T): void {}
+    }
+    
+    var ea: EventAggregator;
+    ea.publish([1,2,3]);
+               ~~~~~~~
+!!! error TS2345: Argument of type 'number[]' is not assignable to parameter of type 'string'.
+!!! related TS2793 tests/cases/compiler/overloadErrorMatchesImplementationElaboaration.ts:4:5: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.

--- a/tests/baselines/reference/overloadErrorMatchesImplementationElaboaration.js
+++ b/tests/baselines/reference/overloadErrorMatchesImplementationElaboaration.js
@@ -1,0 +1,19 @@
+//// [overloadErrorMatchesImplementationElaboaration.ts]
+class EventAggregator
+{
+    publish(event: string, data?: any): void;
+    publish<T>(event: T): void {}
+}
+
+var ea: EventAggregator;
+ea.publish([1,2,3]);
+
+//// [overloadErrorMatchesImplementationElaboaration.js]
+var EventAggregator = /** @class */ (function () {
+    function EventAggregator() {
+    }
+    EventAggregator.prototype.publish = function (event) { };
+    return EventAggregator;
+}());
+var ea;
+ea.publish([1, 2, 3]);

--- a/tests/baselines/reference/overloadErrorMatchesImplementationElaboaration.symbols
+++ b/tests/baselines/reference/overloadErrorMatchesImplementationElaboaration.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/overloadErrorMatchesImplementationElaboaration.ts ===
+class EventAggregator
+>EventAggregator : Symbol(EventAggregator, Decl(overloadErrorMatchesImplementationElaboaration.ts, 0, 0))
+{
+    publish(event: string, data?: any): void;
+>publish : Symbol(EventAggregator.publish, Decl(overloadErrorMatchesImplementationElaboaration.ts, 1, 1), Decl(overloadErrorMatchesImplementationElaboaration.ts, 2, 45))
+>event : Symbol(event, Decl(overloadErrorMatchesImplementationElaboaration.ts, 2, 12))
+>data : Symbol(data, Decl(overloadErrorMatchesImplementationElaboaration.ts, 2, 26))
+
+    publish<T>(event: T): void {}
+>publish : Symbol(EventAggregator.publish, Decl(overloadErrorMatchesImplementationElaboaration.ts, 1, 1), Decl(overloadErrorMatchesImplementationElaboaration.ts, 2, 45))
+>T : Symbol(T, Decl(overloadErrorMatchesImplementationElaboaration.ts, 3, 12))
+>event : Symbol(event, Decl(overloadErrorMatchesImplementationElaboaration.ts, 3, 15))
+>T : Symbol(T, Decl(overloadErrorMatchesImplementationElaboaration.ts, 3, 12))
+}
+
+var ea: EventAggregator;
+>ea : Symbol(ea, Decl(overloadErrorMatchesImplementationElaboaration.ts, 6, 3))
+>EventAggregator : Symbol(EventAggregator, Decl(overloadErrorMatchesImplementationElaboaration.ts, 0, 0))
+
+ea.publish([1,2,3]);
+>ea.publish : Symbol(EventAggregator.publish, Decl(overloadErrorMatchesImplementationElaboaration.ts, 1, 1), Decl(overloadErrorMatchesImplementationElaboaration.ts, 2, 45))
+>ea : Symbol(ea, Decl(overloadErrorMatchesImplementationElaboaration.ts, 6, 3))
+>publish : Symbol(EventAggregator.publish, Decl(overloadErrorMatchesImplementationElaboaration.ts, 1, 1), Decl(overloadErrorMatchesImplementationElaboaration.ts, 2, 45))
+

--- a/tests/baselines/reference/overloadErrorMatchesImplementationElaboaration.types
+++ b/tests/baselines/reference/overloadErrorMatchesImplementationElaboaration.types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/overloadErrorMatchesImplementationElaboaration.ts ===
+class EventAggregator
+>EventAggregator : EventAggregator
+{
+    publish(event: string, data?: any): void;
+>publish : (event: string, data?: any) => void
+>event : string
+>data : any
+
+    publish<T>(event: T): void {}
+>publish : (event: string, data?: any) => void
+>event : T
+}
+
+var ea: EventAggregator;
+>ea : EventAggregator
+
+ea.publish([1,2,3]);
+>ea.publish([1,2,3]) : void
+>ea.publish : (event: string, data?: any) => void
+>ea : EventAggregator
+>publish : (event: string, data?: any) => void
+>[1,2,3] : number[]
+>1 : 1
+>2 : 2
+>3 : 3
+

--- a/tests/baselines/reference/overloadOnConstNoAnyImplementation2.errors.txt
+++ b/tests/baselines/reference/overloadOnConstNoAnyImplementation2.errors.txt
@@ -36,6 +36,7 @@ tests/cases/compiler/overloadOnConstNoAnyImplementation2.ts(21,9): error TS2345:
 !!! error TS2345: Argument of type '(x: 'bye') => number' is not assignable to parameter of type '(x: "hi") => number'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2345:     Type '"hi"' is not assignable to type '"bye"'.
+!!! related TS2793 tests/cases/compiler/overloadOnConstNoAnyImplementation2.ts:7:5: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     c.x1(1, (x) => { return 1; } );
     
     c.x1(1, (x: number) => { return 1; } );

--- a/tests/baselines/reference/overloadOnConstNoStringImplementation2.errors.txt
+++ b/tests/baselines/reference/overloadOnConstNoStringImplementation2.errors.txt
@@ -29,9 +29,11 @@ tests/cases/compiler/overloadOnConstNoStringImplementation2.ts(20,9): error TS23
 !!! error TS2345: Argument of type '(x: 'bye') => number' is not assignable to parameter of type '(x: "hi") => number'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2345:     Type '"hi"' is not assignable to type '"bye"'.
+!!! related TS2793 tests/cases/compiler/overloadOnConstNoStringImplementation2.ts:7:5: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     c.x1(1, (x: string) => { return 1; } );
     c.x1(1, (x: number) => { return 1; } );
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: "hi") => number'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2345:     Type 'string' is not assignable to type 'number'.
+!!! related TS2793 tests/cases/compiler/overloadOnConstNoStringImplementation2.ts:7:5: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.

--- a/tests/baselines/reference/overloadResolutionTest1.errors.txt
+++ b/tests/baselines/reference/overloadResolutionTest1.errors.txt
@@ -31,6 +31,7 @@ tests/cases/compiler/overloadResolutionTest1.ts(24,15): error TS2769: No overloa
 !!! error TS2769:     Type 'string' is not assignable to type 'boolean'.
 !!! related TS6500 tests/cases/compiler/overloadResolutionTest1.ts:1:19: The expected type comes from property 'a' which is declared here on type '{ a: number; }'
 !!! related TS6500 tests/cases/compiler/overloadResolutionTest1.ts:2:19: The expected type comes from property 'a' which is declared here on type '{ a: boolean; }'
+!!! related TS2793 tests/cases/compiler/overloadResolutionTest1.ts:3:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var x1111 = foo([{a:null}]); // works - ambiguous call is resolved to be the first in the overload set so this returns a string
     
     
@@ -50,6 +51,7 @@ tests/cases/compiler/overloadResolutionTest1.ts(24,15): error TS2769: No overloa
 !!! error TS2769:     Type 'string' is not assignable to type 'boolean'.
 !!! related TS6500 tests/cases/compiler/overloadResolutionTest1.ts:12:20: The expected type comes from property 'a' which is declared here on type '{ a: number; }'
 !!! related TS6500 tests/cases/compiler/overloadResolutionTest1.ts:13:20: The expected type comes from property 'a' which is declared here on type '{ a: boolean; }'
+!!! related TS2793 tests/cases/compiler/overloadResolutionTest1.ts:14:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     
     
     function foo4(bar:{a:number;}):number;
@@ -64,3 +66,4 @@ tests/cases/compiler/overloadResolutionTest1.ts(24,15): error TS2769: No overloa
 !!! error TS2769:     Type 'boolean' is not assignable to type 'string'.
 !!! related TS6500 tests/cases/compiler/overloadResolutionTest1.ts:21:20: The expected type comes from property 'a' which is declared here on type '{ a: number; }'
 !!! related TS6500 tests/cases/compiler/overloadResolutionTest1.ts:22:20: The expected type comes from property 'a' which is declared here on type '{ a: string; }'
+!!! related TS2793 tests/cases/compiler/overloadResolutionTest1.ts:23:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.

--- a/tests/baselines/reference/overloadingOnConstants2.errors.txt
+++ b/tests/baselines/reference/overloadingOnConstants2.errors.txt
@@ -32,6 +32,7 @@ tests/cases/compiler/overloadingOnConstants2.ts(19,10): error TS2394: This overl
 !!! error TS2769:     Argument of type '"um"' is not assignable to parameter of type '"hi"'.
 !!! error TS2769:   Overload 2 of 2, '(x: "bye", items: string[]): E', gave the following error.
 !!! error TS2769:     Argument of type '"um"' is not assignable to parameter of type '"bye"'.
+!!! related TS2793 tests/cases/compiler/overloadingOnConstants2.ts:10:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     
     
     //function bar(x: "hi", items: string[]): D;

--- a/tests/baselines/reference/recursiveFunctionTypes.errors.txt
+++ b/tests/baselines/reference/recursiveFunctionTypes.errors.txt
@@ -79,6 +79,7 @@ tests/cases/compiler/recursiveFunctionTypes.ts(43,4): error TS2769: No overload 
     f6(""); // ok (function takes an any param)
        ~~
 !!! error TS2345: Argument of type 'string' is not assignable to parameter of type '{ (): typeof f6; (a: typeof f6): () => number; }'.
+!!! related TS2793 tests/cases/compiler/recursiveFunctionTypes.ts:31:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     f6(); // ok
     
     declare function f7(): typeof f7;

--- a/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution1.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution1.errors.txt
@@ -39,9 +39,11 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
 !!! error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 !!! error TS2345:   Property 'raw' is missing in type 'undefined[]' but required in type 'TemplateStringsArray'.
 !!! related TS2728 /.ts/lib.es5.d.ts:605:14: 'raw' is declared here.
+!!! related TS2793 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts:5:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var b = foo([], 1);          // string
                 ~~
 !!! error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
+!!! related TS2793 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts:5:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var c = foo([], 1, 2);       // boolean
                 ~~
 !!! error TS2769: No overload matches this call.
@@ -49,6 +51,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 !!! error TS2769:   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
+!!! related TS2793 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts:5:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var d = foo([], 1, true);    // boolean (with error)
                 ~~
 !!! error TS2769: No overload matches this call.
@@ -56,6 +59,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 !!! error TS2769:   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
+!!! related TS2793 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts:5:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var e = foo([], 1, "2");     // {}
                 ~~
 !!! error TS2769: No overload matches this call.
@@ -63,6 +67,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 !!! error TS2769:   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
+!!! related TS2793 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts:5:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var f = foo([], 1, 2, 3);    // any (with error)
                           ~
 !!! error TS2554: Expected 1-3 arguments, but got 4.
@@ -77,6 +82,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
 !!! error TS2769:     Argument of type 'boolean' is not assignable to parameter of type 'number'.
 !!! error TS2769:   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
 !!! error TS2769:     Argument of type 'boolean' is not assignable to parameter of type 'string'.
+!!! related TS2793 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts:5:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var y = foo `${1}${"2"}`;    // {}
     var z = foo `${1}${2}${3}`;  // any (with error)
                            ~

--- a/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution1_ES6.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution1_ES6.errors.txt
@@ -39,9 +39,11 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
 !!! error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 !!! error TS2345:   Property 'raw' is missing in type 'undefined[]' but required in type 'TemplateStringsArray'.
 !!! related TS2728 /.ts/lib.es5.d.ts:605:14: 'raw' is declared here.
+!!! related TS2793 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts:5:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var b = foo([], 1);          // string
                 ~~
 !!! error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
+!!! related TS2793 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts:5:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var c = foo([], 1, 2);       // boolean
                 ~~
 !!! error TS2769: No overload matches this call.
@@ -49,6 +51,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 !!! error TS2769:   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
+!!! related TS2793 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts:5:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var d = foo([], 1, true);    // boolean (with error)
                 ~~
 !!! error TS2769: No overload matches this call.
@@ -56,6 +59,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 !!! error TS2769:   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
+!!! related TS2793 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts:5:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var e = foo([], 1, "2");     // {}
                 ~~
 !!! error TS2769: No overload matches this call.
@@ -63,6 +67,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 !!! error TS2769:   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
+!!! related TS2793 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts:5:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var f = foo([], 1, 2, 3);    // any (with error)
                           ~
 !!! error TS2554: Expected 1-3 arguments, but got 4.
@@ -77,6 +82,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
 !!! error TS2769:     Argument of type 'boolean' is not assignable to parameter of type 'number'.
 !!! error TS2769:   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
 !!! error TS2769:     Argument of type 'boolean' is not assignable to parameter of type 'string'.
+!!! related TS2793 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts:5:10: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     var y = foo `${1}${"2"}`;    // {}
     var z = foo `${1}${2}${3}`;  // any (with error)
                            ~

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
@@ -91,6 +91,7 @@ tests/cases/conformance/jsx/file.tsx(56,12): error TS2769: No overload matches t
 !!! error TS2769:   Overload 3 of 3, '(hyphenProps: HyphenProps): Element', gave the following error.
 !!! error TS2769:     Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
 !!! error TS2769:       Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+!!! related TS2793 tests/cases/conformance/jsx/file.tsx:38:17: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     const b1 = <MainButton onClick={(e: any)=> {}} {...obj0}>Hello world</MainButton>;  // extra property;
     const b2 = <MainButton {...{to: "10000"}} {...obj2} />;  // extra property
     const b3 = <MainButton {...{to: "10000"}} {...{onClick: (k) => {}}} />;  // extra property

--- a/tests/cases/compiler/overloadErrorMatchesImplementationElaboaration.ts
+++ b/tests/cases/compiler/overloadErrorMatchesImplementationElaboaration.ts
@@ -1,0 +1,8 @@
+class EventAggregator
+{
+    publish(event: string, data?: any): void;
+    publish<T>(event: T): void {}
+}
+
+var ea: EventAggregator;
+ea.publish([1,2,3]);


### PR DESCRIPTION
Fixes #4797
