### PR TITLE
Fix transformation of nested return statements in "convert to async function" quick fix

### DIFF
--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -431,7 +431,7 @@ namespace ts.codefix {
                                 ) : factory.updateFunctionExpression(
                                     funcExpr,
                                     funcExpr.modifiers,
-                                    undefined,
+                                    funcExpr.asteriskToken,
                                     funcExpr.name,
                                     funcExpr.typeParameters,
                                     [],

--- a/src/testRunner/unittests/services/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/services/convertToAsyncFunction.ts
@@ -1510,5 +1510,30 @@ function [#|f|]() {
 }
 `);
 
+        _testConvertToAsyncFunction("convertToAsyncFunction_nestedReturn", `
+function [#|getTheNumber2|](): Promise<number> {
+    return Promise.resolve()
+        .then(() => {
+            if (true) {
+                return 1;
+            }
+        })
+        .then(function name(foo) {
+            while (true) {
+                return Promise.resolve(3);
+            }
+        })
+        .then(() => {
+            if (true) {
+                return Promise.resolve(123)
+            }
+        })
+        .then((bar) => {
+            if (true) {
+                return 2;
+            }
+        });
+    }
+`);
     });
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_nestedReturn.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_nestedReturn.ts
@@ -1,0 +1,49 @@
+// ==ORIGINAL==
+
+function /*[#|*/getTheNumber2/*|]*/(): Promise<number> {
+    return Promise.resolve()
+        .then(() => {
+            if (true) {
+                return 1;
+            }
+        })
+        .then(function name(foo) {
+            while (true) {
+                return Promise.resolve(3);
+            }
+        })
+        .then(() => {
+            if (true) {
+                return Promise.resolve(123)
+            }
+        })
+        .then((bar) => {
+            if (true) {
+                return 2;
+            }
+        });
+    }
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function getTheNumber2(): Promise<number> {
+    await Promise.resolve();
+    const foo = (() => {
+        if (true) {
+            return 1;
+        }
+    })();
+    await function name() {
+        while (true) {
+            return Promise.resolve(3);
+        }
+    } ();
+    const bar = await (() => {
+        if (true) {
+            return Promise.resolve(123);
+        }
+    })();
+    if (true) {
+        return 2;
+    }
+    }


### PR DESCRIPTION
Happy hacktoberfest! 🎃🥳

Fixes #40040.

Currently converting `return` statements that are not at the top level of `then` callback function results in a broken result.
With this PR, these kinds of functions are correctly converted using the IIFE pattern.

## Example

**Code Before "convert to async function"**

```ts
function getTheNumber2(): Promise<number> {
  return Promise.resolve()
    .then(() => {
        if (true) {
            return 1;
        }
    })
    .then(function name(foo) {
        while (true) {
            return Promise.resolve(3);
        }
    })
    .then(() => {
        if (true) {
            return Promise.resolve(123)
        }
    })
    .then((bar) => {
        if (true) {
            return 2;
        }
    });
}
```

**Current Behavior** (v4.1.0-dev.20201009)

```ts
async function getTheNumber2(): Promise<number> {
  await Promise.resolve();
if(true) {
return 1;
}
const foo=undefined;
while(true) {
return Promise.resolve(3);
}
if(true) {
return Promise.resolve(123);
}
const bar=undefined;
if(true) {
return 2;
}
}
```

**New Behavior**

```ts
async function getTheNumber2(): Promise<number> {
  await Promise.resolve();
  const foo = (() => {
    if (true) {
      return 1;
    }
  })();
  await function name() {
    while (true) {
      return Promise.resolve(3);
    }
  } ();
  const bar = await (() => {
    if (true) {
      return Promise.resolve(123);
    }
  })();
  if (true) {
    return 2;
  }
}
```