### PR TITLE
Remove errors for invalid escape sequences in tagged template literals

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1360,7 +1360,10 @@
         "category": "Error",
         "code": 1432
     },
-
+    "Octal escape sequences are not allowed in template strings.": {
+        "category": "Error",
+        "code": 1433
+    },
     "The types of '{0}' are incompatible between these types.": {
         "category": "Error",
         "code": 2200

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2633,7 +2633,6 @@ namespace ts {
 
         function parseTemplateExpression(isTaggedTemplate: boolean, containsInvalidEscape: boolean): TemplateExpression {
             const pos = getNodePos();
-            console.log({ isTaggedTemplate, containsInvalidEscape });
             return finishNode(
                 factory.createTemplateExpression(
                     parseTemplateHead(isTaggedTemplate, containsInvalidEscape),

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5239,7 +5239,7 @@ namespace ts {
                 tag,
                 typeArguments,
                 token() === SyntaxKind.NoSubstitutionTemplateLiteral ?
-                    (reScanTemplateHeadOrNoSubstitutionTemplate(true), parseLiteralNode() as NoSubstitutionTemplateLiteral) :
+                    (reScanTemplateHeadOrNoSubstitutionTemplate(/*isTaggedTemplate*/ true), parseLiteralNode() as NoSubstitutionTemplateLiteral) :
                     parseTemplateExpression(/*isTaggedTemplate*/ true, !!(scanner.getTokenFlags() & TokenFlags.ContainsInvalidEscape))
             );
             if (questionDotToken || tag.flags & NodeFlags.OptionalChain) {
@@ -5375,7 +5375,7 @@ namespace ts {
                     return parseLiteralNode();
                 case SyntaxKind.NoSubstitutionTemplateLiteral:
                     if (scanner.getTokenFlags() & TokenFlags.ContainsInvalidEscape) {
-                        reScanTemplateHeadOrNoSubstitutionTemplate(/* isTaggedTemplate */ false)
+                        reScanTemplateHeadOrNoSubstitutionTemplate(/* isTaggedTemplate */ false);
                     }
                     return parseLiteralNode();
                 case SyntaxKind.ThisKeyword:

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1208,7 +1208,7 @@ namespace ts {
                 }
                 if (ch === CharacterCodes.backslash && !jsxAttributeString) {
                     result += text.substring(start, pos);
-                    result += scanEscapeSequence(false, true);
+                    result += scanEscapeSequence(/* isTaggedTemplate */ false, /* shouldEmitInvalidEscapeError */ true);
                     start = pos;
                     continue;
                 }
@@ -1504,7 +1504,7 @@ namespace ts {
                     if (ch >= 0 && isIdentifierPart(ch, languageVersion)) {
                         pos += 3;
                         tokenFlags |= TokenFlags.ExtendedUnicodeEscape;
-                        result += scanExtendedUnicodeEscape(true);
+                        result += scanExtendedUnicodeEscape(/* shouldEmitInvalidEscapeError */ true);
                         start = pos;
                         continue;
                     }
@@ -1689,7 +1689,7 @@ namespace ts {
                         tokenValue = scanString();
                         return token = SyntaxKind.StringLiteral;
                     case CharacterCodes.backtick:
-                        return token = scanTemplateAndSetTokenValue(/* isTaggedTemplate */ false, false);
+                        return token = scanTemplateAndSetTokenValue(/* isTaggedTemplate */ false, /* shouldEmitInvalidEscapeError */ false);
                     case CharacterCodes.percent:
                         if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
                             return pos += 2, token = SyntaxKind.PercentEqualsToken;
@@ -2024,7 +2024,7 @@ namespace ts {
                         if (extendedCookedChar >= 0 && isIdentifierStart(extendedCookedChar, languageVersion)) {
                             pos += 3;
                             tokenFlags |= TokenFlags.ExtendedUnicodeEscape;
-                            tokenValue = scanExtendedUnicodeEscape(true) + scanIdentifierParts();
+                            tokenValue = scanExtendedUnicodeEscape(/* shouldEmitInvalidEscapeError */ true) + scanIdentifierParts();
                             return token = getIdentifierToken();
                         }
 
@@ -2232,12 +2232,12 @@ namespace ts {
         function reScanTemplateToken(isTaggedTemplate: boolean): SyntaxKind {
             Debug.assert(token === SyntaxKind.CloseBraceToken, "'reScanTemplateToken' should only be called on a '}'");
             pos = tokenPos;
-            return token = scanTemplateAndSetTokenValue(isTaggedTemplate, true);
+            return token = scanTemplateAndSetTokenValue(isTaggedTemplate, /* shouldEmitInvalidEscapeError */ true);
         }
 
         function reScanTemplateHeadOrNoSubstitutionTemplate(isTaggedTemplate?: boolean): SyntaxKind {
             pos = tokenPos;
-            return token = scanTemplateAndSetTokenValue(isTaggedTemplate || false, true);
+            return token = scanTemplateAndSetTokenValue(isTaggedTemplate || false, /* shouldEmitInvalidEscapeError */ true);
         }
 
         function reScanJsxToken(allowMultilineJsxText = true): JsxTokenSyntaxKind {
@@ -2445,7 +2445,7 @@ namespace ts {
                     if (extendedCookedChar >= 0 && isIdentifierStart(extendedCookedChar, languageVersion)) {
                         pos += 3;
                         tokenFlags |= TokenFlags.ExtendedUnicodeEscape;
-                        tokenValue = scanExtendedUnicodeEscape(true) + scanIdentifierParts();
+                        tokenValue = scanExtendedUnicodeEscape(/* shouldEmitInvalidEscapeError */ true) + scanIdentifierParts();
                         return token = getIdentifierToken();
                     }
 

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -36,7 +36,7 @@ namespace ts {
         reScanSlashToken(): SyntaxKind;
         reScanAsteriskEqualsToken(): SyntaxKind;
         reScanTemplateToken(isTaggedTemplate: boolean): SyntaxKind;
-        reScanTemplateHeadOrNoSubstitutionTemplate(isTaggedTemplate: boolean): SyntaxKind;
+        reScanTemplateHeadOrNoSubstitutionTemplate(isTaggedTemplate?: boolean): SyntaxKind;
         scanJsxIdentifier(): SyntaxKind;
         scanJsxAttributeValue(): SyntaxKind;
         reScanJsxAttributeValue(): SyntaxKind;
@@ -2235,9 +2235,9 @@ namespace ts {
             return token = scanTemplateAndSetTokenValue(isTaggedTemplate, true);
         }
 
-        function reScanTemplateHeadOrNoSubstitutionTemplate(isTaggedTemplate: boolean): SyntaxKind {
+        function reScanTemplateHeadOrNoSubstitutionTemplate(isTaggedTemplate?: boolean): SyntaxKind {
             pos = tokenPos;
-            return token = scanTemplateAndSetTokenValue(isTaggedTemplate, true);
+            return token = scanTemplateAndSetTokenValue(isTaggedTemplate || false, true);
         }
 
         function reScanJsxToken(allowMultilineJsxText = true): JsxTokenSyntaxKind {

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1312,6 +1312,9 @@ namespace ts {
                             pos++;
                             return text.substring(start, pos);
                         }
+                        if (shouldEmitInvalidEscapeError) {
+                            error(Diagnostics.Octal_escape_sequences_are_not_allowed_in_template_strings);
+                        }
                     }
                     return "\0";
                 case CharacterCodes.b:

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4011,7 +4011,7 @@ declare namespace ts {
         reScanSlashToken(): SyntaxKind;
         reScanAsteriskEqualsToken(): SyntaxKind;
         reScanTemplateToken(isTaggedTemplate: boolean): SyntaxKind;
-        reScanTemplateHeadOrNoSubstitutionTemplate(): SyntaxKind;
+        reScanTemplateHeadOrNoSubstitutionTemplate(isTaggedTemplate: boolean): SyntaxKind;
         scanJsxIdentifier(): SyntaxKind;
         scanJsxAttributeValue(): SyntaxKind;
         reScanJsxAttributeValue(): SyntaxKind;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4011,7 +4011,7 @@ declare namespace ts {
         reScanSlashToken(): SyntaxKind;
         reScanAsteriskEqualsToken(): SyntaxKind;
         reScanTemplateToken(isTaggedTemplate: boolean): SyntaxKind;
-        reScanTemplateHeadOrNoSubstitutionTemplate(isTaggedTemplate: boolean): SyntaxKind;
+        reScanTemplateHeadOrNoSubstitutionTemplate(isTaggedTemplate?: boolean): SyntaxKind;
         scanJsxIdentifier(): SyntaxKind;
         scanJsxAttributeValue(): SyntaxKind;
         reScanJsxAttributeValue(): SyntaxKind;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4011,7 +4011,7 @@ declare namespace ts {
         reScanSlashToken(): SyntaxKind;
         reScanAsteriskEqualsToken(): SyntaxKind;
         reScanTemplateToken(isTaggedTemplate: boolean): SyntaxKind;
-        reScanTemplateHeadOrNoSubstitutionTemplate(): SyntaxKind;
+        reScanTemplateHeadOrNoSubstitutionTemplate(isTaggedTemplate: boolean): SyntaxKind;
         scanJsxIdentifier(): SyntaxKind;
         scanJsxAttributeValue(): SyntaxKind;
         reScanJsxAttributeValue(): SyntaxKind;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4011,7 +4011,7 @@ declare namespace ts {
         reScanSlashToken(): SyntaxKind;
         reScanAsteriskEqualsToken(): SyntaxKind;
         reScanTemplateToken(isTaggedTemplate: boolean): SyntaxKind;
-        reScanTemplateHeadOrNoSubstitutionTemplate(isTaggedTemplate: boolean): SyntaxKind;
+        reScanTemplateHeadOrNoSubstitutionTemplate(isTaggedTemplate?: boolean): SyntaxKind;
         scanJsxIdentifier(): SyntaxKind;
         scanJsxAttributeValue(): SyntaxKind;
         reScanJsxAttributeValue(): SyntaxKind;

--- a/tests/baselines/reference/invalidTaggedTemplateEscapeSequences(target=es2015).errors.txt
+++ b/tests/baselines/reference/invalidTaggedTemplateEscapeSequences(target=es2015).errors.txt
@@ -1,13 +1,9 @@
-tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(7,18): error TS1125: Hexadecimal digit expected.
 tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(8,15): error TS1125: Hexadecimal digit expected.
 tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(8,33): error TS1125: Hexadecimal digit expected.
 tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(8,75): error TS1125: Hexadecimal digit expected.
-tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,18): error TS1125: Hexadecimal digit expected.
-tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,27): error TS1125: Hexadecimal digit expected.
-tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,51): error TS1125: Hexadecimal digit expected.
 
 
-==== tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts (7 errors) ====
+==== tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts (3 errors) ====
     function tag (str: any, ...args: any[]): any {
       return str
     }
@@ -15,8 +11,6 @@ tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,51): er
     const a = tag`123`
     const b = tag`123 ${100}`
     const x = tag`\u{hello} ${ 100 } \xtraordinary ${ 200 } wonderful ${ 300 } \uworld`;
-                     
-!!! error TS1125: Hexadecimal digit expected.
     const y = `\u{hello} ${ 100 } \xtraordinary ${ 200 } wonderful ${ 300 } \uworld`; // should error with NoSubstitutionTemplate
                   
 !!! error TS1125: Hexadecimal digit expected.
@@ -25,12 +19,6 @@ tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,51): er
                                                                               
 !!! error TS1125: Hexadecimal digit expected.
     const z = tag`\u{hello} \xtraordinary wonderful \uworld` // should work with Tagged NoSubstitutionTemplate
-                     
-!!! error TS1125: Hexadecimal digit expected.
-                              
-!!! error TS1125: Hexadecimal digit expected.
-                                                      
-!!! error TS1125: Hexadecimal digit expected.
     
     const a1 = tag`${ 100 }\0` // \0
     const a2 = tag`${ 100 }\00` // \\00

--- a/tests/baselines/reference/invalidTaggedTemplateEscapeSequences(target=es5).errors.txt
+++ b/tests/baselines/reference/invalidTaggedTemplateEscapeSequences(target=es5).errors.txt
@@ -1,13 +1,9 @@
-tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(7,18): error TS1125: Hexadecimal digit expected.
 tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(8,15): error TS1125: Hexadecimal digit expected.
 tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(8,33): error TS1125: Hexadecimal digit expected.
 tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(8,75): error TS1125: Hexadecimal digit expected.
-tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,18): error TS1125: Hexadecimal digit expected.
-tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,27): error TS1125: Hexadecimal digit expected.
-tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,51): error TS1125: Hexadecimal digit expected.
 
 
-==== tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts (7 errors) ====
+==== tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts (3 errors) ====
     function tag (str: any, ...args: any[]): any {
       return str
     }
@@ -15,8 +11,6 @@ tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,51): er
     const a = tag`123`
     const b = tag`123 ${100}`
     const x = tag`\u{hello} ${ 100 } \xtraordinary ${ 200 } wonderful ${ 300 } \uworld`;
-                     
-!!! error TS1125: Hexadecimal digit expected.
     const y = `\u{hello} ${ 100 } \xtraordinary ${ 200 } wonderful ${ 300 } \uworld`; // should error with NoSubstitutionTemplate
                   
 !!! error TS1125: Hexadecimal digit expected.
@@ -25,12 +19,6 @@ tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,51): er
                                                                               
 !!! error TS1125: Hexadecimal digit expected.
     const z = tag`\u{hello} \xtraordinary wonderful \uworld` // should work with Tagged NoSubstitutionTemplate
-                     
-!!! error TS1125: Hexadecimal digit expected.
-                              
-!!! error TS1125: Hexadecimal digit expected.
-                                                      
-!!! error TS1125: Hexadecimal digit expected.
     
     const a1 = tag`${ 100 }\0` // \0
     const a2 = tag`${ 100 }\00` // \\00

--- a/tests/baselines/reference/invalidTaggedTemplateEscapeSequences(target=esnext).errors.txt
+++ b/tests/baselines/reference/invalidTaggedTemplateEscapeSequences(target=esnext).errors.txt
@@ -1,13 +1,9 @@
-tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(7,18): error TS1125: Hexadecimal digit expected.
 tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(8,15): error TS1125: Hexadecimal digit expected.
 tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(8,33): error TS1125: Hexadecimal digit expected.
 tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(8,75): error TS1125: Hexadecimal digit expected.
-tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,18): error TS1125: Hexadecimal digit expected.
-tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,27): error TS1125: Hexadecimal digit expected.
-tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,51): error TS1125: Hexadecimal digit expected.
 
 
-==== tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts (7 errors) ====
+==== tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts (3 errors) ====
     function tag (str: any, ...args: any[]): any {
       return str
     }
@@ -15,8 +11,6 @@ tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,51): er
     const a = tag`123`
     const b = tag`123 ${100}`
     const x = tag`\u{hello} ${ 100 } \xtraordinary ${ 200 } wonderful ${ 300 } \uworld`;
-                     
-!!! error TS1125: Hexadecimal digit expected.
     const y = `\u{hello} ${ 100 } \xtraordinary ${ 200 } wonderful ${ 300 } \uworld`; // should error with NoSubstitutionTemplate
                   
 !!! error TS1125: Hexadecimal digit expected.
@@ -25,12 +19,6 @@ tests/cases/conformance/es2018/invalidTaggedTemplateEscapeSequences.ts(9,51): er
                                                                               
 !!! error TS1125: Hexadecimal digit expected.
     const z = tag`\u{hello} \xtraordinary wonderful \uworld` // should work with Tagged NoSubstitutionTemplate
-                     
-!!! error TS1125: Hexadecimal digit expected.
-                              
-!!! error TS1125: Hexadecimal digit expected.
-                                                      
-!!! error TS1125: Hexadecimal digit expected.
     
     const a1 = tag`${ 100 }\0` // \0
     const a2 = tag`${ 100 }\00` // \\00

--- a/tests/baselines/reference/templateLiteralInvalidEscape.errors.txt
+++ b/tests/baselines/reference/templateLiteralInvalidEscape.errors.txt
@@ -2,13 +2,15 @@ tests/cases/compiler/templateLiteralInvalidEscape.ts(11,4): error TS1125: Hexade
 tests/cases/compiler/templateLiteralInvalidEscape.ts(12,5): error TS1125: Hexadecimal digit expected.
 tests/cases/compiler/templateLiteralInvalidEscape.ts(13,6): error TS1125: Hexadecimal digit expected.
 tests/cases/compiler/templateLiteralInvalidEscape.ts(14,5): error TS1125: Hexadecimal digit expected.
+tests/cases/compiler/templateLiteralInvalidEscape.ts(15,4): error TS1433: Octal escape sequences are not allowed in template strings.
 tests/cases/compiler/templateLiteralInvalidEscape.ts(23,8): error TS1125: Hexadecimal digit expected.
 tests/cases/compiler/templateLiteralInvalidEscape.ts(24,9): error TS1125: Hexadecimal digit expected.
 tests/cases/compiler/templateLiteralInvalidEscape.ts(25,10): error TS1125: Hexadecimal digit expected.
 tests/cases/compiler/templateLiteralInvalidEscape.ts(26,9): error TS1125: Hexadecimal digit expected.
+tests/cases/compiler/templateLiteralInvalidEscape.ts(27,8): error TS1433: Octal escape sequences are not allowed in template strings.
 
 
-==== tests/cases/compiler/templateLiteralInvalidEscape.ts (8 errors) ====
+==== tests/cases/compiler/templateLiteralInvalidEscape.ts (10 errors) ====
     function raw(arr: TemplateStringsArray, ...args: unknown[]) {
       return arr.raw;
     }
@@ -32,6 +34,8 @@ tests/cases/compiler/templateLiteralInvalidEscape.ts(26,9): error TS1125: Hexade
         
 !!! error TS1125: Hexadecimal digit expected.
     `\0123`;
+       
+!!! error TS1433: Octal escape sequences are not allowed in template strings.
     
     raw`${0}\x`;
     raw`${0}\x0`;
@@ -52,4 +56,6 @@ tests/cases/compiler/templateLiteralInvalidEscape.ts(26,9): error TS1125: Hexade
             
 !!! error TS1125: Hexadecimal digit expected.
     `${0}\0123`;
+           
+!!! error TS1433: Octal escape sequences are not allowed in template strings.
     

--- a/tests/baselines/reference/templateLiteralInvalidEscape.errors.txt
+++ b/tests/baselines/reference/templateLiteralInvalidEscape.errors.txt
@@ -1,0 +1,55 @@
+tests/cases/compiler/templateLiteralInvalidEscape.ts(11,4): error TS1125: Hexadecimal digit expected.
+tests/cases/compiler/templateLiteralInvalidEscape.ts(12,5): error TS1125: Hexadecimal digit expected.
+tests/cases/compiler/templateLiteralInvalidEscape.ts(13,6): error TS1125: Hexadecimal digit expected.
+tests/cases/compiler/templateLiteralInvalidEscape.ts(14,5): error TS1125: Hexadecimal digit expected.
+tests/cases/compiler/templateLiteralInvalidEscape.ts(23,8): error TS1125: Hexadecimal digit expected.
+tests/cases/compiler/templateLiteralInvalidEscape.ts(24,9): error TS1125: Hexadecimal digit expected.
+tests/cases/compiler/templateLiteralInvalidEscape.ts(25,10): error TS1125: Hexadecimal digit expected.
+tests/cases/compiler/templateLiteralInvalidEscape.ts(26,9): error TS1125: Hexadecimal digit expected.
+
+
+==== tests/cases/compiler/templateLiteralInvalidEscape.ts (8 errors) ====
+    function raw(arr: TemplateStringsArray, ...args: unknown[]) {
+      return arr.raw;
+    }
+    
+    raw`\x`;
+    raw`\x0`;
+    raw`\u11`;
+    raw`\u{}`;
+    raw`\0123`;
+    
+    `\x`;
+       
+!!! error TS1125: Hexadecimal digit expected.
+    `\x0`;
+        
+!!! error TS1125: Hexadecimal digit expected.
+    `\u11`;
+         
+!!! error TS1125: Hexadecimal digit expected.
+    `\u{}`;
+        
+!!! error TS1125: Hexadecimal digit expected.
+    `\0123`;
+    
+    raw`${0}\x`;
+    raw`${0}\x0`;
+    raw`${0}\u11`;
+    raw`${0}\u{}`;
+    raw`${0}\0123`;
+    
+    `${0}\x`;
+           
+!!! error TS1125: Hexadecimal digit expected.
+    `${0}\x0`;
+            
+!!! error TS1125: Hexadecimal digit expected.
+    `${0}\u11`;
+             
+!!! error TS1125: Hexadecimal digit expected.
+    `${0}\u{}`;
+            
+!!! error TS1125: Hexadecimal digit expected.
+    `${0}\0123`;
+    

--- a/tests/baselines/reference/templateLiteralInvalidEscape.js
+++ b/tests/baselines/reference/templateLiteralInvalidEscape.js
@@ -1,0 +1,62 @@
+//// [templateLiteralInvalidEscape.ts]
+function raw(arr: TemplateStringsArray, ...args: unknown[]) {
+  return arr.raw;
+}
+
+raw`\x`;
+raw`\x0`;
+raw`\u11`;
+raw`\u{}`;
+raw`\0123`;
+
+`\x`;
+`\x0`;
+`\u11`;
+`\u{}`;
+`\0123`;
+
+raw`${0}\x`;
+raw`${0}\x0`;
+raw`${0}\u11`;
+raw`${0}\u{}`;
+raw`${0}\0123`;
+
+`${0}\x`;
+`${0}\x0`;
+`${0}\u11`;
+`${0}\u{}`;
+`${0}\0123`;
+
+
+//// [templateLiteralInvalidEscape.js]
+var __makeTemplateObject = (this && this.__makeTemplateObject) || function (cooked, raw) {
+    if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+    return cooked;
+};
+function raw(arr) {
+    var args = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        args[_i - 1] = arguments[_i];
+    }
+    return arr.raw;
+}
+raw(__makeTemplateObject([void 0], ["\\x"]));
+raw(__makeTemplateObject([void 0], ["\\x0"]));
+raw(__makeTemplateObject([void 0], ["\\u11"]));
+raw(__makeTemplateObject([void 0], ["\\u{}"]));
+raw(__makeTemplateObject([void 0], ["\\0123"]));
+"";
+"";
+"";
+"";
+"\x00123";
+raw(__makeTemplateObject(["", void 0], ["", "\\x"]), 0);
+raw(__makeTemplateObject(["", void 0], ["", "\\x0"]), 0);
+raw(__makeTemplateObject(["", void 0], ["", "\\u11"]), 0);
+raw(__makeTemplateObject(["", void 0], ["", "\\u{}"]), 0);
+raw(__makeTemplateObject(["", void 0], ["", "\\0123"]), 0);
+"" + 0;
+"" + 0;
+"" + 0;
+"" + 0;
+0 + "\x00123";

--- a/tests/baselines/reference/templateLiteralInvalidEscape.symbols
+++ b/tests/baselines/reference/templateLiteralInvalidEscape.symbols
@@ -1,0 +1,55 @@
+=== tests/cases/compiler/templateLiteralInvalidEscape.ts ===
+function raw(arr: TemplateStringsArray, ...args: unknown[]) {
+>raw : Symbol(raw, Decl(templateLiteralInvalidEscape.ts, 0, 0))
+>arr : Symbol(arr, Decl(templateLiteralInvalidEscape.ts, 0, 13))
+>TemplateStringsArray : Symbol(TemplateStringsArray, Decl(lib.es5.d.ts, --, --))
+>args : Symbol(args, Decl(templateLiteralInvalidEscape.ts, 0, 39))
+
+  return arr.raw;
+>arr.raw : Symbol(TemplateStringsArray.raw, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(templateLiteralInvalidEscape.ts, 0, 13))
+>raw : Symbol(TemplateStringsArray.raw, Decl(lib.es5.d.ts, --, --))
+}
+
+raw`\x`;
+>raw : Symbol(raw, Decl(templateLiteralInvalidEscape.ts, 0, 0))
+
+raw`\x0`;
+>raw : Symbol(raw, Decl(templateLiteralInvalidEscape.ts, 0, 0))
+
+raw`\u11`;
+>raw : Symbol(raw, Decl(templateLiteralInvalidEscape.ts, 0, 0))
+
+raw`\u{}`;
+>raw : Symbol(raw, Decl(templateLiteralInvalidEscape.ts, 0, 0))
+
+raw`\0123`;
+>raw : Symbol(raw, Decl(templateLiteralInvalidEscape.ts, 0, 0))
+
+`\x`;
+`\x0`;
+`\u11`;
+`\u{}`;
+`\0123`;
+
+raw`${0}\x`;
+>raw : Symbol(raw, Decl(templateLiteralInvalidEscape.ts, 0, 0))
+
+raw`${0}\x0`;
+>raw : Symbol(raw, Decl(templateLiteralInvalidEscape.ts, 0, 0))
+
+raw`${0}\u11`;
+>raw : Symbol(raw, Decl(templateLiteralInvalidEscape.ts, 0, 0))
+
+raw`${0}\u{}`;
+>raw : Symbol(raw, Decl(templateLiteralInvalidEscape.ts, 0, 0))
+
+raw`${0}\0123`;
+>raw : Symbol(raw, Decl(templateLiteralInvalidEscape.ts, 0, 0))
+
+`${0}\x`;
+`${0}\x0`;
+`${0}\u11`;
+`${0}\u{}`;
+`${0}\0123`;
+

--- a/tests/baselines/reference/templateLiteralInvalidEscape.types
+++ b/tests/baselines/reference/templateLiteralInvalidEscape.types
@@ -1,0 +1,102 @@
+=== tests/cases/compiler/templateLiteralInvalidEscape.ts ===
+function raw(arr: TemplateStringsArray, ...args: unknown[]) {
+>raw : (arr: TemplateStringsArray, ...args: unknown[]) => readonly string[]
+>arr : TemplateStringsArray
+>args : unknown[]
+
+  return arr.raw;
+>arr.raw : readonly string[]
+>arr : TemplateStringsArray
+>raw : readonly string[]
+}
+
+raw`\x`;
+>raw`\x` : readonly string[]
+>raw : (arr: TemplateStringsArray, ...args: unknown[]) => readonly string[]
+>`\x` : "\\x"
+
+raw`\x0`;
+>raw`\x0` : readonly string[]
+>raw : (arr: TemplateStringsArray, ...args: unknown[]) => readonly string[]
+>`\x0` : "\\x0"
+
+raw`\u11`;
+>raw`\u11` : readonly string[]
+>raw : (arr: TemplateStringsArray, ...args: unknown[]) => readonly string[]
+>`\u11` : "\\u11"
+
+raw`\u{}`;
+>raw`\u{}` : readonly string[]
+>raw : (arr: TemplateStringsArray, ...args: unknown[]) => readonly string[]
+>`\u{}` : "\\u{}"
+
+raw`\0123`;
+>raw`\0123` : readonly string[]
+>raw : (arr: TemplateStringsArray, ...args: unknown[]) => readonly string[]
+>`\0123` : "\\0123"
+
+`\x`;
+>`\x` : ""
+
+`\x0`;
+>`\x0` : ""
+
+`\u11`;
+>`\u11` : ""
+
+`\u{}`;
+>`\u{}` : ""
+
+`\0123`;
+>`\0123` : "\x00123"
+
+raw`${0}\x`;
+>raw`${0}\x` : readonly string[]
+>raw : (arr: TemplateStringsArray, ...args: unknown[]) => readonly string[]
+>`${0}\x` : string
+>0 : 0
+
+raw`${0}\x0`;
+>raw`${0}\x0` : readonly string[]
+>raw : (arr: TemplateStringsArray, ...args: unknown[]) => readonly string[]
+>`${0}\x0` : string
+>0 : 0
+
+raw`${0}\u11`;
+>raw`${0}\u11` : readonly string[]
+>raw : (arr: TemplateStringsArray, ...args: unknown[]) => readonly string[]
+>`${0}\u11` : string
+>0 : 0
+
+raw`${0}\u{}`;
+>raw`${0}\u{}` : readonly string[]
+>raw : (arr: TemplateStringsArray, ...args: unknown[]) => readonly string[]
+>`${0}\u{}` : string
+>0 : 0
+
+raw`${0}\0123`;
+>raw`${0}\0123` : readonly string[]
+>raw : (arr: TemplateStringsArray, ...args: unknown[]) => readonly string[]
+>`${0}\0123` : string
+>0 : 0
+
+`${0}\x`;
+>`${0}\x` : string
+>0 : 0
+
+`${0}\x0`;
+>`${0}\x0` : string
+>0 : 0
+
+`${0}\u11`;
+>`${0}\u11` : string
+>0 : 0
+
+`${0}\u{}`;
+>`${0}\u{}` : string
+>0 : 0
+
+`${0}\0123`;
+>`${0}\0123` : string
+>0 : 0
+

--- a/tests/cases/compiler/templateLiteralInvalidEscape.ts
+++ b/tests/cases/compiler/templateLiteralInvalidEscape.ts
@@ -1,0 +1,27 @@
+function raw(arr: TemplateStringsArray, ...args: unknown[]) {
+  return arr.raw;
+}
+
+raw`\x`;
+raw`\x0`;
+raw`\u11`;
+raw`\u{}`;
+raw`\0123`;
+
+`\x`;
+`\x0`;
+`\u11`;
+`\u{}`;
+`\0123`;
+
+raw`${0}\x`;
+raw`${0}\x0`;
+raw`${0}\u11`;
+raw`${0}\u{}`;
+raw`${0}\0123`;
+
+`${0}\x`;
+`${0}\x0`;
+`${0}\u11`;
+`${0}\u{}`;
+`${0}\0123`;


### PR DESCRIPTION
Happy hacktoberfest! 🎃🥳

Fixes #39715.
Also gives a partial fix to #396.

## Example

**Code**

```ts
String.raw`\x \012`;

`\x \012`;
```

**Current Behavior**

```
src/backslashx.ts:1:14 - error TS1125: Hexadecimal digit expected.

1 String.raw`\x \012`;
               

src/backslashx.ts:3:4 - error TS1125: Hexadecimal digit expected.

3 `\x \012`;
     


Found 2 errors.
```

**New Behavior**

```
src/backslashx.ts:3:4 - error TS1125: Hexadecimal digit expected.

3 `\x \012`;
     

src/backslashx.ts:3:7 - error TS1392: Octal escape sequences are not allowed in template strings.

3 `\x \012`;
        


Found 2 errors.
```

(Error disappeared from tagged template literal, and new error for octal escape sequence in untagged template literal)

## Implementation Detail

With this PR, invalid escape sequences do not emit errors when they are first scanned. Untagged template literals with invalid escape sequence in it are re-scanned to emit syntax errors.