### PR TITLE
Remove `undefined` from source type of renaming destructuring assignment with default

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -32569,6 +32569,10 @@ namespace ts {
             if (target.kind === SyntaxKind.BinaryExpression && (target as BinaryExpression).operatorToken.kind === SyntaxKind.EqualsToken) {
                 checkBinaryExpression(target as BinaryExpression, checkMode);
                 target = (target as BinaryExpression).left;
+                // A default value is specified, so remove undefined from the final type.
+                if (strictNullChecks) {
+                    sourceType = getTypeWithFacts(sourceType, TypeFacts.NEUndefined);
+                }
             }
             if (target.kind === SyntaxKind.ObjectLiteralExpression) {
                 return checkObjectLiteralAssignment(target as ObjectLiteralExpression, sourceType, rightIsThis);

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.errors.txt
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.errors.txt
@@ -29,6 +29,10 @@ tests/cases/compiler/destructuringAssignmentWithDefault2.ts(13,7): error TS2322:
           ~
 !!! error TS2322: Type 'undefined' is not assignable to type 'number'.
     
+    const { x: z1 } = a;
+    const { x: z2 = 0 } = a;
+    const { x: z3 = undefined } = a;
+    
     
     declare const r: Iterator<number>;
     let done: boolean;

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.errors.txt
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.errors.txt
@@ -1,0 +1,38 @@
+tests/cases/compiler/destructuringAssignmentWithDefault2.ts(11,4): error TS2322: Type 'undefined' is not assignable to type 'number'.
+tests/cases/compiler/destructuringAssignmentWithDefault2.ts(11,4): error TS2322: Type 'number | undefined' is not assignable to type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
+tests/cases/compiler/destructuringAssignmentWithDefault2.ts(12,7): error TS2322: Type 'undefined' is not assignable to type 'number'.
+tests/cases/compiler/destructuringAssignmentWithDefault2.ts(13,7): error TS2322: Type 'undefined' is not assignable to type 'number'.
+
+
+==== tests/cases/compiler/destructuringAssignmentWithDefault2.ts (4 errors) ====
+    const a: { x?: number; y?: number } = { };
+    
+    let x: number;
+    
+    // Should not error out
+    ({ x = 0 } = a);
+    ({ x: x = 0} = a);
+    ({ y: x = 0} = a);
+    
+    // Should be error
+    ({ x = undefined } = a);
+       ~
+!!! error TS2322: Type 'undefined' is not assignable to type 'number'.
+       ~
+!!! error TS2322: Type 'number | undefined' is not assignable to type 'number'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'number'.
+    ({ x: x = undefined } = a);
+          ~
+!!! error TS2322: Type 'undefined' is not assignable to type 'number'.
+    ({ y: x = undefined } = a);
+          ~
+!!! error TS2322: Type 'undefined' is not assignable to type 'number'.
+    
+    
+    declare const r: Iterator<number>;
+    let done: boolean;
+    let value;
+    
+    ({ done = false, value } = r.next());
+    ({ done: done = false, value } = r.next());

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.js
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.js
@@ -1,0 +1,18 @@
+//// [destructuringAssignmentWithDefault2.ts]
+const a: { x?: number; y?: number } = { };
+
+let x: number;
+
+({ x = 0 } = a);
+({ x: x = 0} = a);
+({ y: x = 0} = a);
+
+
+
+//// [destructuringAssignmentWithDefault2.js]
+var _a, _b, _c;
+var a = {};
+var x;
+(_a = a.x, x = _a === void 0 ? 0 : _a);
+(_b = a.x, x = _b === void 0 ? 0 : _b);
+(_c = a.y, x = _c === void 0 ? 0 : _c);

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.js
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.js
@@ -3,9 +3,15 @@ const a: { x?: number; y?: number } = { };
 
 let x: number;
 
+// Should not error out
 ({ x = 0 } = a);
 ({ x: x = 0} = a);
 ({ y: x = 0} = a);
+
+// Should be error
+({ x = undefined } = a);
+({ x: x = undefined } = a);
+({ y: x = undefined } = a);
 
 
 declare const r: Iterator<number>;
@@ -16,13 +22,18 @@ let value;
 ({ done: done = false, value } = r.next());
 
 //// [destructuringAssignmentWithDefault2.js]
-var _a, _b, _c, _d, _e, _f, _g;
+var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
 var a = {};
 var x;
+// Should not error out
 (_a = a.x, x = _a === void 0 ? 0 : _a);
 (_b = a.x, x = _b === void 0 ? 0 : _b);
 (_c = a.y, x = _c === void 0 ? 0 : _c);
+// Should be error
+(_d = a.x, x = _d === void 0 ? undefined : _d);
+(_e = a.x, x = _e === void 0 ? undefined : _e);
+(_f = a.y, x = _f === void 0 ? undefined : _f);
 var done;
 var value;
-(_d = r.next(), _e = _d.done, done = _e === void 0 ? false : _e, value = _d.value);
-(_f = r.next(), _g = _f.done, done = _g === void 0 ? false : _g, value = _f.value);
+(_g = r.next(), _h = _g.done, done = _h === void 0 ? false : _h, value = _g.value);
+(_j = r.next(), _k = _j.done, done = _k === void 0 ? false : _k, value = _j.value);

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.js
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.js
@@ -8,11 +8,21 @@ let x: number;
 ({ y: x = 0} = a);
 
 
+declare const r: Iterator<number>;
+let done: boolean;
+let value;
+
+({ done = false, value } = r.next());
+({ done: done = false, value } = r.next());
 
 //// [destructuringAssignmentWithDefault2.js]
-var _a, _b, _c;
+var _a, _b, _c, _d, _e, _f, _g;
 var a = {};
 var x;
 (_a = a.x, x = _a === void 0 ? 0 : _a);
 (_b = a.x, x = _b === void 0 ? 0 : _b);
 (_c = a.y, x = _c === void 0 ? 0 : _c);
+var done;
+var value;
+(_d = r.next(), _e = _d.done, done = _e === void 0 ? false : _e, value = _d.value);
+(_f = r.next(), _g = _f.done, done = _g === void 0 ? false : _g, value = _f.value);

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.js
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.js
@@ -13,6 +13,10 @@ let x: number;
 ({ x: x = undefined } = a);
 ({ y: x = undefined } = a);
 
+const { x: z1 } = a;
+const { x: z2 = 0 } = a;
+const { x: z3 = undefined } = a;
+
 
 declare const r: Iterator<number>;
 let done: boolean;
@@ -33,6 +37,9 @@ var x;
 (_d = a.x, x = _d === void 0 ? undefined : _d);
 (_e = a.x, x = _e === void 0 ? undefined : _e);
 (_f = a.y, x = _f === void 0 ? undefined : _f);
+var z1 = a.x;
+var _l = a.x, z2 = _l === void 0 ? 0 : _l;
+var _m = a.x, z3 = _m === void 0 ? undefined : _m;
 var done;
 var value;
 (_g = r.next(), _h = _g.done, done = _h === void 0 ? false : _h, value = _g.value);

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.symbols
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/destructuringAssignmentWithDefault2.ts ===
+const a: { x?: number; y?: number } = { };
+>a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 0, 10))
+>y : Symbol(y, Decl(destructuringAssignmentWithDefault2.ts, 0, 22))
+
+let x: number;
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 2, 3))
+
+({ x = 0 } = a);
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 4, 2))
+>a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
+
+({ x: x = 0} = a);
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 5, 2))
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 2, 3))
+>a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
+
+({ y: x = 0} = a);
+>y : Symbol(y, Decl(destructuringAssignmentWithDefault2.ts, 6, 2))
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 2, 3))
+>a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
+
+

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.symbols
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.symbols
@@ -22,3 +22,28 @@ let x: number;
 >a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
 
 
+declare const r: Iterator<number>;
+>r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 9, 13))
+>Iterator : Symbol(Iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+
+let done: boolean;
+>done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 10, 3))
+
+let value;
+>value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 11, 3))
+
+({ done = false, value } = r.next());
+>done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 13, 2))
+>value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 13, 16))
+>r.next : Symbol(Iterator.next, Decl(lib.es2015.iterable.d.ts, --, --))
+>r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 9, 13))
+>next : Symbol(Iterator.next, Decl(lib.es2015.iterable.d.ts, --, --))
+
+({ done: done = false, value } = r.next());
+>done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 14, 2))
+>done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 10, 3))
+>value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 14, 22))
+>r.next : Symbol(Iterator.next, Decl(lib.es2015.iterable.d.ts, --, --))
+>r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 9, 13))
+>next : Symbol(Iterator.next, Decl(lib.es2015.iterable.d.ts, --, --))
+

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.symbols
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.symbols
@@ -7,43 +7,62 @@ const a: { x?: number; y?: number } = { };
 let x: number;
 >x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 2, 3))
 
+// Should not error out
 ({ x = 0 } = a);
->x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 4, 2))
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 5, 2))
 >a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
 
 ({ x: x = 0} = a);
->x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 5, 2))
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 6, 2))
 >x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 2, 3))
 >a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
 
 ({ y: x = 0} = a);
->y : Symbol(y, Decl(destructuringAssignmentWithDefault2.ts, 6, 2))
+>y : Symbol(y, Decl(destructuringAssignmentWithDefault2.ts, 7, 2))
 >x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 2, 3))
+>a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
+
+// Should be error
+({ x = undefined } = a);
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 10, 2))
+>undefined : Symbol(undefined)
+>a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
+
+({ x: x = undefined } = a);
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 11, 2))
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 2, 3))
+>undefined : Symbol(undefined)
+>a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
+
+({ y: x = undefined } = a);
+>y : Symbol(y, Decl(destructuringAssignmentWithDefault2.ts, 12, 2))
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 2, 3))
+>undefined : Symbol(undefined)
 >a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
 
 
 declare const r: Iterator<number>;
->r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 9, 13))
+>r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 15, 13))
 >Iterator : Symbol(Iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
 let done: boolean;
->done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 10, 3))
+>done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 16, 3))
 
 let value;
->value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 11, 3))
+>value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 17, 3))
 
 ({ done = false, value } = r.next());
->done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 13, 2))
->value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 13, 16))
+>done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 19, 2))
+>value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 19, 16))
 >r.next : Symbol(Iterator.next, Decl(lib.es2015.iterable.d.ts, --, --))
->r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 9, 13))
+>r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 15, 13))
 >next : Symbol(Iterator.next, Decl(lib.es2015.iterable.d.ts, --, --))
 
 ({ done: done = false, value } = r.next());
->done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 14, 2))
->done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 10, 3))
->value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 14, 22))
+>done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 20, 2))
+>done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 16, 3))
+>value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 20, 22))
 >r.next : Symbol(Iterator.next, Decl(lib.es2015.iterable.d.ts, --, --))
->r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 9, 13))
+>r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 15, 13))
 >next : Symbol(Iterator.next, Decl(lib.es2015.iterable.d.ts, --, --))
 

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.symbols
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.symbols
@@ -40,29 +40,45 @@ let x: number;
 >undefined : Symbol(undefined)
 >a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
 
+const { x: z1 } = a;
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 0, 10))
+>z1 : Symbol(z1, Decl(destructuringAssignmentWithDefault2.ts, 14, 7))
+>a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
+
+const { x: z2 = 0 } = a;
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 0, 10))
+>z2 : Symbol(z2, Decl(destructuringAssignmentWithDefault2.ts, 15, 7))
+>a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
+
+const { x: z3 = undefined } = a;
+>x : Symbol(x, Decl(destructuringAssignmentWithDefault2.ts, 0, 10))
+>z3 : Symbol(z3, Decl(destructuringAssignmentWithDefault2.ts, 16, 7))
+>undefined : Symbol(undefined)
+>a : Symbol(a, Decl(destructuringAssignmentWithDefault2.ts, 0, 5))
+
 
 declare const r: Iterator<number>;
->r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 15, 13))
+>r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 19, 13))
 >Iterator : Symbol(Iterator, Decl(lib.es2015.iterable.d.ts, --, --))
 
 let done: boolean;
->done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 16, 3))
+>done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 20, 3))
 
 let value;
->value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 17, 3))
+>value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 21, 3))
 
 ({ done = false, value } = r.next());
->done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 19, 2))
->value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 19, 16))
+>done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 23, 2))
+>value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 23, 16))
 >r.next : Symbol(Iterator.next, Decl(lib.es2015.iterable.d.ts, --, --))
->r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 15, 13))
+>r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 19, 13))
 >next : Symbol(Iterator.next, Decl(lib.es2015.iterable.d.ts, --, --))
 
 ({ done: done = false, value } = r.next());
->done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 20, 2))
->done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 16, 3))
->value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 20, 22))
+>done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 24, 2))
+>done : Symbol(done, Decl(destructuringAssignmentWithDefault2.ts, 20, 3))
+>value : Symbol(value, Decl(destructuringAssignmentWithDefault2.ts, 24, 22))
 >r.next : Symbol(Iterator.next, Decl(lib.es2015.iterable.d.ts, --, --))
->r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 15, 13))
+>r : Symbol(r, Decl(destructuringAssignmentWithDefault2.ts, 19, 13))
 >next : Symbol(Iterator.next, Decl(lib.es2015.iterable.d.ts, --, --))
 

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.types
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.types
@@ -66,6 +66,23 @@ let x: number;
 >undefined : undefined
 >a : { x?: number | undefined; y?: number | undefined; }
 
+const { x: z1 } = a;
+>x : any
+>z1 : number | undefined
+>a : { x?: number | undefined; y?: number | undefined; }
+
+const { x: z2 = 0 } = a;
+>x : any
+>z2 : number
+>0 : 0
+>a : { x?: number | undefined; y?: number | undefined; }
+
+const { x: z3 = undefined } = a;
+>x : any
+>z3 : number | undefined
+>undefined : undefined
+>a : { x?: number | undefined; y?: number | undefined; }
+
 
 declare const r: Iterator<number>;
 >r : Iterator<number, any, undefined>

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.types
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.types
@@ -1,0 +1,39 @@
+=== tests/cases/compiler/destructuringAssignmentWithDefault2.ts ===
+const a: { x?: number; y?: number } = { };
+>a : { x?: number | undefined; y?: number | undefined; }
+>x : number | undefined
+>y : number | undefined
+>{ } : {}
+
+let x: number;
+>x : number
+
+({ x = 0 } = a);
+>({ x = 0 } = a) : { x?: number | undefined; y?: number | undefined; }
+>{ x = 0 } = a : { x?: number | undefined; y?: number | undefined; }
+>{ x = 0 } : { x?: number; }
+>x : number
+>0 : 0
+>a : { x?: number | undefined; y?: number | undefined; }
+
+({ x: x = 0} = a);
+>({ x: x = 0} = a) : { x?: number | undefined; y?: number | undefined; }
+>{ x: x = 0} = a : { x?: number | undefined; y?: number | undefined; }
+>{ x: x = 0} : { x?: number; }
+>x : number
+>x = 0 : 0
+>x : number
+>0 : 0
+>a : { x?: number | undefined; y?: number | undefined; }
+
+({ y: x = 0} = a);
+>({ y: x = 0} = a) : { x?: number | undefined; y?: number | undefined; }
+>{ y: x = 0} = a : { x?: number | undefined; y?: number | undefined; }
+>{ y: x = 0} : { y?: number; }
+>y : number
+>x = 0 : 0
+>x : number
+>0 : 0
+>a : { x?: number | undefined; y?: number | undefined; }
+
+

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.types
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.types
@@ -8,6 +8,7 @@ const a: { x?: number; y?: number } = { };
 let x: number;
 >x : number
 
+// Should not error out
 ({ x = 0 } = a);
 >({ x = 0 } = a) : { x?: number | undefined; y?: number | undefined; }
 >{ x = 0 } = a : { x?: number | undefined; y?: number | undefined; }
@@ -34,6 +35,35 @@ let x: number;
 >x = 0 : 0
 >x : number
 >0 : 0
+>a : { x?: number | undefined; y?: number | undefined; }
+
+// Should be error
+({ x = undefined } = a);
+>({ x = undefined } = a) : { x?: number | undefined; y?: number | undefined; }
+>{ x = undefined } = a : { x?: number | undefined; y?: number | undefined; }
+>{ x = undefined } : { x?: number; }
+>x : number
+>undefined : undefined
+>a : { x?: number | undefined; y?: number | undefined; }
+
+({ x: x = undefined } = a);
+>({ x: x = undefined } = a) : { x?: number | undefined; y?: number | undefined; }
+>{ x: x = undefined } = a : { x?: number | undefined; y?: number | undefined; }
+>{ x: x = undefined } : { x?: undefined; }
+>x : undefined
+>x = undefined : undefined
+>x : number
+>undefined : undefined
+>a : { x?: number | undefined; y?: number | undefined; }
+
+({ y: x = undefined } = a);
+>({ y: x = undefined } = a) : { x?: number | undefined; y?: number | undefined; }
+>{ y: x = undefined } = a : { x?: number | undefined; y?: number | undefined; }
+>{ y: x = undefined } : { y?: undefined; }
+>y : undefined
+>x = undefined : undefined
+>x : number
+>undefined : undefined
 >a : { x?: number | undefined; y?: number | undefined; }
 
 

--- a/tests/baselines/reference/destructuringAssignmentWithDefault2.types
+++ b/tests/baselines/reference/destructuringAssignmentWithDefault2.types
@@ -37,3 +37,38 @@ let x: number;
 >a : { x?: number | undefined; y?: number | undefined; }
 
 
+declare const r: Iterator<number>;
+>r : Iterator<number, any, undefined>
+
+let done: boolean;
+>done : boolean
+
+let value;
+>value : any
+
+({ done = false, value } = r.next());
+>({ done = false, value } = r.next()) : IteratorResult<number, any>
+>{ done = false, value } = r.next() : IteratorResult<number, any>
+>{ done = false, value } : { done?: boolean; value: any; }
+>done : boolean
+>false : false
+>value : any
+>r.next() : IteratorResult<number, any>
+>r.next : (...args: [] | [undefined]) => IteratorResult<number, any>
+>r : Iterator<number, any, undefined>
+>next : (...args: [] | [undefined]) => IteratorResult<number, any>
+
+({ done: done = false, value } = r.next());
+>({ done: done = false, value } = r.next()) : IteratorResult<number, any>
+>{ done: done = false, value } = r.next() : IteratorResult<number, any>
+>{ done: done = false, value } : { done?: boolean; value: any; }
+>done : boolean
+>done = false : false
+>done : boolean
+>false : false
+>value : any
+>r.next() : IteratorResult<number, any>
+>r.next : (...args: [] | [undefined]) => IteratorResult<number, any>
+>r : Iterator<number, any, undefined>
+>next : (...args: [] | [undefined]) => IteratorResult<number, any>
+

--- a/tests/cases/compiler/destructuringAssignmentWithDefault2.ts
+++ b/tests/cases/compiler/destructuringAssignmentWithDefault2.ts
@@ -14,6 +14,10 @@ let x: number;
 ({ x: x = undefined } = a);
 ({ y: x = undefined } = a);
 
+const { x: z1 } = a;
+const { x: z2 = 0 } = a;
+const { x: z3 = undefined } = a;
+
 
 declare const r: Iterator<number>;
 let done: boolean;

--- a/tests/cases/compiler/destructuringAssignmentWithDefault2.ts
+++ b/tests/cases/compiler/destructuringAssignmentWithDefault2.ts
@@ -1,3 +1,4 @@
+// @lib: es2015
 // @strictNullChecks: true
 const a: { x?: number; y?: number } = { };
 
@@ -7,3 +8,10 @@ let x: number;
 ({ x: x = 0} = a);
 ({ y: x = 0} = a);
 
+
+declare const r: Iterator<number>;
+let done: boolean;
+let value;
+
+({ done = false, value } = r.next());
+({ done: done = false, value } = r.next());

--- a/tests/cases/compiler/destructuringAssignmentWithDefault2.ts
+++ b/tests/cases/compiler/destructuringAssignmentWithDefault2.ts
@@ -1,0 +1,9 @@
+// @strictNullChecks: true
+const a: { x?: number; y?: number } = { };
+
+let x: number;
+
+({ x = 0 } = a);
+({ x: x = 0} = a);
+({ y: x = 0} = a);
+

--- a/tests/cases/compiler/destructuringAssignmentWithDefault2.ts
+++ b/tests/cases/compiler/destructuringAssignmentWithDefault2.ts
@@ -4,9 +4,15 @@ const a: { x?: number; y?: number } = { };
 
 let x: number;
 
+// Should not error out
 ({ x = 0 } = a);
 ({ x: x = 0} = a);
 ({ y: x = 0} = a);
+
+// Should be error
+({ x = undefined } = a);
+({ x: x = undefined } = a);
+({ y: x = undefined } = a);
 
 
 declare const r: Iterator<number>;


### PR DESCRIPTION
Happy hacktoberfest! 🎃🥳

Fixes #37693.

## Example

**Code**

```ts
const a: { x?: number; y?: number } = { };
let x: number;

({ x = 0 } = a);
({ x: x = 0} = a);
({ y: x = 0} = a);
```

**Current Behavior** (4.1.0-beta)

```
src/37693.ts:6:7 - error TS2322: Type 'number | undefined' is not assignable to type 'number'.
  Type 'undefined' is not assignable to type 'number'.

6 ({ x: x = 0} = a);
        ~

src/37693.ts:7:7 - error TS2322: Type 'number | undefined' is not assignable to type 'number'.
  Type 'undefined' is not assignable to type 'number'.

7 ({ y: x = 0} = a);
        ~


Found 2 errors.
```

**New Behavior**

(no errors)