### PR TITLE
Use the wildcard type for signature erasure

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14949,7 +14949,7 @@ namespace ts {
         }
 
         function createTypeEraser(sources: readonly TypeParameter[]): TypeMapper {
-            return createTypeMapper(sources, /*targets*/ undefined);
+            return createTypeMapper(sources, map(sources, () => wildcardType));
         }
 
         /**

--- a/tests/baselines/reference/complexRecursiveCollections.types
+++ b/tests/baselines/reference/complexRecursiveCollections.types
@@ -1137,7 +1137,7 @@ declare module Immutable {
 >Seq : typeof Seq
 
     function isSeq(maybeSeq: any): maybeSeq is Seq.Indexed<any> | Seq.Keyed<any, any>;
->isSeq : (maybeSeq: any) => maybeSeq is Indexed<any> | Keyed<any, any>
+>isSeq : (maybeSeq: any) => maybeSeq is Keyed<any, any> | Indexed<any>
 >maybeSeq : any
 >Seq : any
 >Seq : any

--- a/tests/baselines/reference/overloadAssignabilityChecksAllowGenericAssignment.js
+++ b/tests/baselines/reference/overloadAssignabilityChecksAllowGenericAssignment.js
@@ -1,0 +1,9 @@
+//// [overloadAssignabilityChecksAllowGenericAssignment.ts]
+declare function provide<T>(cb: (x: T) => void): void;
+declare function provide<T>(cb: (x: T[keyof T]) => void): void;
+
+declare function provider<T>(provide: (cb: (x: T) => void) => void): void;
+provider(provide);
+
+//// [overloadAssignabilityChecksAllowGenericAssignment.js]
+provider(provide);

--- a/tests/baselines/reference/overloadAssignabilityChecksAllowGenericAssignment.symbols
+++ b/tests/baselines/reference/overloadAssignabilityChecksAllowGenericAssignment.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/overloadAssignabilityChecksAllowGenericAssignment.ts ===
+declare function provide<T>(cb: (x: T) => void): void;
+>provide : Symbol(provide, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 0), Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 54))
+>T : Symbol(T, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 25))
+>cb : Symbol(cb, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 28))
+>x : Symbol(x, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 33))
+>T : Symbol(T, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 25))
+
+declare function provide<T>(cb: (x: T[keyof T]) => void): void;
+>provide : Symbol(provide, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 0), Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 54))
+>T : Symbol(T, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 1, 25))
+>cb : Symbol(cb, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 1, 28))
+>x : Symbol(x, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 1, 33))
+>T : Symbol(T, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 1, 25))
+>T : Symbol(T, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 1, 25))
+
+declare function provider<T>(provide: (cb: (x: T) => void) => void): void;
+>provider : Symbol(provider, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 1, 63))
+>T : Symbol(T, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 3, 26))
+>provide : Symbol(provide, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 3, 29))
+>cb : Symbol(cb, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 3, 39))
+>x : Symbol(x, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 3, 44))
+>T : Symbol(T, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 3, 26))
+
+provider(provide);
+>provider : Symbol(provider, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 1, 63))
+>provide : Symbol(provide, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 0), Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 54))
+

--- a/tests/baselines/reference/overloadAssignabilityChecksAllowGenericAssignment.types
+++ b/tests/baselines/reference/overloadAssignabilityChecksAllowGenericAssignment.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/overloadAssignabilityChecksAllowGenericAssignment.ts ===
+declare function provide<T>(cb: (x: T) => void): void;
+>provide : { <T>(cb: (x: T) => void): void; <T>(cb: (x: T[keyof T]) => void): void; }
+>cb : (x: T) => void
+>x : T
+
+declare function provide<T>(cb: (x: T[keyof T]) => void): void;
+>provide : { <T>(cb: (x: T) => void): void; <T>(cb: (x: T[keyof T]) => void): void; }
+>cb : (x: T[keyof T]) => void
+>x : T[keyof T]
+
+declare function provider<T>(provide: (cb: (x: T) => void) => void): void;
+>provider : <T>(provide: (cb: (x: T) => void) => void) => void
+>provide : (cb: (x: T) => void) => void
+>cb : (x: T) => void
+>x : T
+
+provider(provide);
+>provider(provide) : void
+>provider : <T>(provide: (cb: (x: T) => void) => void) => void
+>provide : { <T>(cb: (x: T) => void): void; <T>(cb: (x: T[keyof T]) => void): void; }
+

--- a/tests/baselines/reference/subtypingWithCallSignatures2.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures2.types
@@ -762,8 +762,8 @@ var r15arg1 = <T>(x: T) => <T[]>null
 >null : null
 
 var r15 = foo15(r15arg1); // any
->r15 : any
->foo15(r15arg1) : any
+>r15 : { (x: number): number[]; (x: string): string[]; }
+>foo15(r15arg1) : { (x: number): number[]; (x: string): string[]; }
 >foo15 : { (a: { (x: number): number[]; (x: string): string[]; }): { (x: number): number[]; (x: string): string[]; }; (a: any): any; }
 >r15arg1 : <T>(x: T) => T[]
 
@@ -789,8 +789,8 @@ var r17arg1 = <T>(x: (a: T) => T) => <T[]>null;
 >null : null
 
 var r17 = foo17(r17arg1); // any
->r17 : any
->foo17(r17arg1) : any
+>r17 : { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }
+>foo17(r17arg1) : { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }
 >foo17 : { (a: { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }): { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }; (a: any): any; }
 >r17arg1 : <T>(x: (a: T) => T) => T[]
 

--- a/tests/baselines/reference/subtypingWithCallSignatures3.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures3.types
@@ -457,8 +457,8 @@ module Errors {
 >null : null
 
     var r8 = foo16(r8arg); // any
->r8 : any
->foo16(r8arg) : any
+>r8 : { (x: { (a: number): number; (a?: number): number; }): number[]; (x: { (a: boolean): boolean; (a?: boolean): boolean; }): boolean[]; }
+>foo16(r8arg) : { (x: { (a: number): number; (a?: number): number; }): number[]; (x: { (a: boolean): boolean; (a?: boolean): boolean; }): boolean[]; }
 >foo16 : { (a2: { (x: { (a: number): number; (a?: number): number; }): number[]; (x: { (a: boolean): boolean; (a?: boolean): boolean; }): boolean[]; }): { (x: { (a: number): number; (a?: number): number; }): number[]; (x: { (a: boolean): boolean; (a?: boolean): boolean; }): boolean[]; }; (a2: any): any; }
 >r8arg : <T>(x: (a: T) => T) => T[]
 

--- a/tests/baselines/reference/subtypingWithConstructSignatures2.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures2.types
@@ -675,8 +675,8 @@ var r15arg1: new <T>(x: T) => T[];
 >x : T
 
 var r15 = foo15(r15arg1); // any
->r15 : any
->foo15(r15arg1) : any
+>r15 : { new (x: number): number[]; new (x: string): string[]; }
+>foo15(r15arg1) : { new (x: number): number[]; new (x: string): string[]; }
 >foo15 : { (a: { new (x: number): number[]; new (x: string): string[]; }): { new (x: number): number[]; new (x: string): string[]; }; (a: any): any; }
 >r15arg1 : new <T>(x: T) => T[]
 
@@ -696,8 +696,8 @@ var r17arg1: new <T>(x: (a: T) => T) => T[];
 >a : T
 
 var r17 = foo17(r17arg1); // any
->r17 : any
->foo17(r17arg1) : any
+>r17 : { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }
+>foo17(r17arg1) : { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }
 >foo17 : { (a: { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }): { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }; (a: any): any; }
 >r17arg1 : new <T>(x: (a: T) => T) => T[]
 

--- a/tests/baselines/reference/subtypingWithConstructSignatures3.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures3.types
@@ -406,8 +406,8 @@ module Errors {
 >a : T
 
     var r8 = foo16(r8arg); // any
->r8 : any
->foo16(r8arg) : any
+>r8 : { new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }
+>foo16(r8arg) : { new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }
 >foo16 : { (a2: { new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }): { new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }; (a2: any): any; }
 >r8arg : new <T>(x: new (a: T) => T) => T[]
 

--- a/tests/cases/compiler/overloadAssignabilityChecksAllowGenericAssignment.ts
+++ b/tests/cases/compiler/overloadAssignabilityChecksAllowGenericAssignment.ts
@@ -1,0 +1,5 @@
+declare function provide<T>(cb: (x: T) => void): void;
+declare function provide<T>(cb: (x: T[keyof T]) => void): void;
+
+declare function provider<T>(provide: (cb: (x: T) => void) => void): void;
+provider(provide);


### PR DESCRIPTION
Fixes #23352's first issue. We used `any` as a "type erasure placeholder" so that we could assume it would allow all assignability. It does, not, however, allow assignability to `never` (which is the cause of the issue). The `wildcardType` (an `any` variant) we introduced for inference awhile back _does_ admit assignability to `never`, and so fulfills the erasure duty better.
