### PR TITLE
Use minimal endings when generating declarations for js

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5479,7 +5479,7 @@ namespace ts {
                         specifierCompilerOptions,
                         contextFile,
                         moduleResolverHost,
-                        { importModuleSpecifierPreference: isBundle ? "non-relative" : "relative" },
+                        { importModuleSpecifierPreference: isBundle ? "non-relative" : "relative", importModuleSpecifierEnding: isBundle ? "minimal" : undefined },
                     ));
                     links.specifierCache ??= new Map();
                     links.specifierCache.set(contextFile.path, specifier);

--- a/tests/baselines/reference/declarationEmitOutFileBundlePaths.js
+++ b/tests/baselines/reference/declarationEmitOutFileBundlePaths.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/declarationEmitOutFileBundlePaths.ts] ////
+
+//// [versions.static.js]
+export default {
+    "@a/b": "1.0.0",
+    "@a/c": "1.2.3"
+};
+//// [index.js]
+import versions from './versions.static.js';
+
+export {
+    versions
+};
+
+
+
+//// [index.d.ts]
+declare module "mylib/versions.static" {
+    var _default: {
+        "@a/b": string;
+        "@a/c": string;
+    };
+    export default _default;
+}
+declare module "mylib" {
+    export { versions };
+    import versions from "mylib/versions.static";
+}

--- a/tests/baselines/reference/declarationEmitOutFileBundlePaths.symbols
+++ b/tests/baselines/reference/declarationEmitOutFileBundlePaths.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/js/versions.static.js ===
+export default {
+    "@a/b": "1.0.0",
+>"@a/b" : Symbol("@a/b", Decl(versions.static.js, 0, 16))
+
+    "@a/c": "1.2.3"
+>"@a/c" : Symbol("@a/c", Decl(versions.static.js, 1, 20))
+
+};
+=== tests/cases/compiler/js/index.js ===
+import versions from './versions.static.js';
+>versions : Symbol(versions, Decl(index.js, 0, 6))
+
+export {
+    versions
+>versions : Symbol(versions, Decl(index.js, 2, 8))
+
+};

--- a/tests/baselines/reference/declarationEmitOutFileBundlePaths.types
+++ b/tests/baselines/reference/declarationEmitOutFileBundlePaths.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/js/versions.static.js ===
+export default {
+>{    "@a/b": "1.0.0",    "@a/c": "1.2.3"} : { "@a/b": string; "@a/c": string; }
+
+    "@a/b": "1.0.0",
+>"@a/b" : string
+>"1.0.0" : "1.0.0"
+
+    "@a/c": "1.2.3"
+>"@a/c" : string
+>"1.2.3" : "1.2.3"
+
+};
+=== tests/cases/compiler/js/index.js ===
+import versions from './versions.static.js';
+>versions : { "@a/b": string; "@a/c": string; }
+
+export {
+    versions
+>versions : { "@a/b": string; "@a/c": string; }
+
+};

--- a/tests/cases/compiler/declarationEmitOutFileBundlePaths.ts
+++ b/tests/cases/compiler/declarationEmitOutFileBundlePaths.ts
@@ -1,0 +1,20 @@
+// @allowJs: true
+// @checkJs: true
+// @emitDeclarationOnly: true
+// @module: commonjs
+// @declaration: true
+// @strict: true
+// @esModuleInterop: true
+// @outFile: ./js/index.js
+// @bundledPackageName: mylib
+// @filename: js/versions.static.js
+export default {
+    "@a/b": "1.0.0",
+    "@a/c": "1.2.3"
+};
+// @filename: js/index.js
+import versions from './versions.static.js';
+
+export {
+    versions
+};


### PR DESCRIPTION
Fixes #34624


Fun fact! This was _mostly_ fixed with the addition of the `bundledPackageName` flag. All that was missing was passing in an option to our specifier generator for (bundled) js declaration emit. The declaration file we generate (when you add `"bundledPackageName": "mylib"`) now looks like
```ts
declare module "mylib/versions.static" {
    var _default: {
        "@a/b": string;
        "@a/c": string;
    };
    export default _default;
}
declare module "mylib" {
    export { versions };
    import versions from "mylib/versions.static";
}
```