### PR TITLE
fix(41078): Convert to ES6 Class Refactoring removes methods named with quoted properties

### DIFF
--- a/tests/cases/fourslash/convertFunctionToEs6Class10.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class10.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: foo.js
+////function Foo() {
+////    this.a = 0;
+////}
+////Foo["a b c"] = function () {
+////}
+
+verify.codeFix({
+    description: "Convert function to an ES2015 class",
+    newFileContent:
+`class Foo {
+    constructor() {
+        this.a = 0;
+    }
+    static "a b c"() {
+    }
+}
+`
+});

--- a/tests/cases/fourslash/convertFunctionToEs6Class11.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class11.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: foo.js
+////function Foo() {
+////    this.a = 0;
+////}
+////Foo[1] = function () {
+////}
+
+verify.codeFix({
+    description: "Convert function to an ES2015 class",
+    newFileContent:
+`class Foo {
+    constructor() {
+        this.a = 0;
+    }
+    static 1() {
+    }
+}
+`
+});

--- a/tests/cases/fourslash/convertFunctionToEs6Class12.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class12.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: foo.js
+////function Foo() {
+////    this.a = 0;
+////}
+////Foo[`a b c`] = function () {
+////}
+
+verify.codeFix({
+    description: "Convert function to an ES2015 class",
+    newFileContent:
+`class Foo {
+    constructor() {
+        this.a = 0;
+    }
+    static "a b c"() {
+    }
+}
+`
+});

--- a/tests/cases/fourslash/convertFunctionToEs6Class13.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class13.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: foo.js
+////function Foo() {
+////    this.a = 0;
+////}
+////Foo[`b`] = function () {
+////}
+
+verify.codeFix({
+    description: "Convert function to an ES2015 class",
+    newFileContent:
+`class Foo {
+    constructor() {
+        this.a = 0;
+    }
+    static b() {
+    }
+}
+`
+});

--- a/tests/cases/fourslash/convertFunctionToEs6Class4.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class4.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: foo.js
+////function Foo() {
+////    this.a = 0;
+////}
+////Foo.prototype["b"] = function () {
+////}
+
+verify.codeFix({
+    description: "Convert function to an ES2015 class",
+    newFileContent:
+`class Foo {
+    constructor() {
+        this.a = 0;
+    }
+    b() {
+    }
+}
+`
+});

--- a/tests/cases/fourslash/convertFunctionToEs6Class5.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class5.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: foo.js
+////function Foo() {
+////    this.a = 0;
+////}
+////Foo.prototype["a b c"] = function () {
+////}
+
+verify.codeFix({
+    description: "Convert function to an ES2015 class",
+    newFileContent:
+`class Foo {
+    constructor() {
+        this.a = 0;
+    }
+    "a b c"() {
+    }
+}
+`
+});

--- a/tests/cases/fourslash/convertFunctionToEs6Class6.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class6.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: foo.js
+////function Foo() {
+////    this.a = 0;
+////}
+////Foo.prototype[1] = function () {
+////}
+
+verify.codeFix({
+    description: "Convert function to an ES2015 class",
+    newFileContent:
+`class Foo {
+    constructor() {
+        this.a = 0;
+    }
+    1() {
+    }
+}
+`
+});

--- a/tests/cases/fourslash/convertFunctionToEs6Class7.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class7.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: foo.js
+////function Foo() {
+////    this.a = 0;
+////}
+////Foo.prototype[`a b c`] = function () {
+////}
+
+verify.codeFix({
+    description: "Convert function to an ES2015 class",
+    newFileContent:
+`class Foo {
+    constructor() {
+        this.a = 0;
+    }
+    "a b c"() {
+    }
+}
+`
+});

--- a/tests/cases/fourslash/convertFunctionToEs6Class8.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class8.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: foo.js
+////function Foo() {
+////    this.a = 0;
+////}
+////Foo.prototype[`b`] = function () {
+////}
+
+verify.codeFix({
+    description: "Convert function to an ES2015 class",
+    newFileContent:
+`class Foo {
+    constructor() {
+        this.a = 0;
+    }
+    b() {
+    }
+}
+`
+});

--- a/tests/cases/fourslash/convertFunctionToEs6Class9.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class9.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @allowNonTsExtensions: true
+// @Filename: foo.js
+////function Foo() {
+////    this.a = 0;
+////}
+////Foo["b"] = function () {
+////}
+
+verify.codeFix({
+    description: "Convert function to an ES2015 class",
+    newFileContent:
+`class Foo {
+    constructor() {
+        this.a = 0;
+    }
+    static b() {
+    }
+}
+`
+});


### PR DESCRIPTION
Fixes #41078