### PR TITLE
Narrow spreaded object types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15183,7 +15183,7 @@ namespace ts {
 
         /**
          * Since the source of spread types are object literals, which are not binary,
-         * this function should be called in a left folding style, with left = previous result of e
+         * this function should be called in a left folding style, with left = previous result of getSpreadType
          * and right = the new element to be spread.
          */
         function getSpreadType(left: Type, right: Type, symbol: Symbol | undefined, objectFlags: ObjectFlags, readonly: boolean): Type {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26190,7 +26190,8 @@ namespace ts {
                         hasSpreadAnyType = true;
                     }
                     if (isValidSpreadType(exprType)) {
-                        spread = getSpreadType(spread, exprType, attributes.symbol, objectFlags, /*readonly*/ false);
+                        const narrowedType = getFlowTypeOfAllSpreadableProperties(attributeDecl.expression, exprType);
+                        spread = getSpreadType(spread, narrowedType, attributes.symbol, objectFlags, /*readonly*/ false);
                         if (allAttributesTable) {
                             checkSpreadPropOverrides(exprType, allAttributesTable, attributeDecl);
                         }

--- a/tests/baselines/reference/narrowedJsxSpread.js
+++ b/tests/baselines/reference/narrowedJsxSpread.js
@@ -1,0 +1,31 @@
+//// [narrowedJsxSpread.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+import React from 'react';
+type Props = {
+  foo?: string
+}
+
+const Component = ({ foo }: Required<Props>) => <p>{foo}</p>;
+const Example = (props: Props) => (
+  <>
+    {props.foo && <Component {...props} />}
+  </>
+);
+
+
+
+//// [narrowedJsxSpread.jsx]
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+exports.__esModule = true;
+/// <reference path="react16.d.ts" />
+var react_1 = __importDefault(require("react"));
+var Component = function (_a) {
+    var foo = _a.foo;
+    return <p>{foo}</p>;
+};
+var Example = function (props) { return (<>
+    {props.foo && <Component {...props}/>}
+  </>); };

--- a/tests/baselines/reference/narrowedJsxSpread.symbols
+++ b/tests/baselines/reference/narrowedJsxSpread.symbols
@@ -15,9 +15,9 @@ const Component = ({ foo }: Required<Props>) => <p>{foo}</p>;
 >foo : Symbol(foo, Decl(narrowedJsxSpread.tsx, 6, 20))
 >Required : Symbol(Required, Decl(lib.es5.d.ts, --, --))
 >Props : Symbol(Props, Decl(narrowedJsxSpread.tsx, 1, 26))
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
 >foo : Symbol(foo, Decl(narrowedJsxSpread.tsx, 6, 20))
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
 
 const Example = (props: Props) => (
 >Example : Symbol(Example, Decl(narrowedJsxSpread.tsx, 7, 5))

--- a/tests/baselines/reference/narrowedJsxSpread.symbols
+++ b/tests/baselines/reference/narrowedJsxSpread.symbols
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/narrowedJsxSpread.tsx ===
+/// <reference path="react16.d.ts" />
+import React from 'react';
+>React : Symbol(React, Decl(narrowedJsxSpread.tsx, 1, 6))
+
+type Props = {
+>Props : Symbol(Props, Decl(narrowedJsxSpread.tsx, 1, 26))
+
+  foo?: string
+>foo : Symbol(foo, Decl(narrowedJsxSpread.tsx, 2, 14))
+}
+
+const Component = ({ foo }: Required<Props>) => <p>{foo}</p>;
+>Component : Symbol(Component, Decl(narrowedJsxSpread.tsx, 6, 5))
+>foo : Symbol(foo, Decl(narrowedJsxSpread.tsx, 6, 20))
+>Required : Symbol(Required, Decl(lib.es5.d.ts, --, --))
+>Props : Symbol(Props, Decl(narrowedJsxSpread.tsx, 1, 26))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>foo : Symbol(foo, Decl(narrowedJsxSpread.tsx, 6, 20))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+
+const Example = (props: Props) => (
+>Example : Symbol(Example, Decl(narrowedJsxSpread.tsx, 7, 5))
+>props : Symbol(props, Decl(narrowedJsxSpread.tsx, 7, 17))
+>Props : Symbol(Props, Decl(narrowedJsxSpread.tsx, 1, 26))
+
+  <>
+    {props.foo && <Component {...props} />}
+>props.foo : Symbol(foo, Decl(narrowedJsxSpread.tsx, 2, 14))
+>props : Symbol(props, Decl(narrowedJsxSpread.tsx, 7, 17))
+>foo : Symbol(foo, Decl(narrowedJsxSpread.tsx, 2, 14))
+>Component : Symbol(Component, Decl(narrowedJsxSpread.tsx, 6, 5))
+>props : Symbol(props, Decl(narrowedJsxSpread.tsx, 7, 17))
+
+  </>
+);
+
+

--- a/tests/baselines/reference/narrowedJsxSpread.types
+++ b/tests/baselines/reference/narrowedJsxSpread.types
@@ -1,0 +1,43 @@
+=== tests/cases/compiler/narrowedJsxSpread.tsx ===
+/// <reference path="react16.d.ts" />
+import React from 'react';
+>React : typeof React
+
+type Props = {
+>Props : Props
+
+  foo?: string
+>foo : string | undefined
+}
+
+const Component = ({ foo }: Required<Props>) => <p>{foo}</p>;
+>Component : ({ foo }: Required<Props>) => JSX.Element
+>({ foo }: Required<Props>) => <p>{foo}</p> : ({ foo }: Required<Props>) => JSX.Element
+>foo : string
+><p>{foo}</p> : JSX.Element
+>p : any
+>foo : string
+>p : any
+
+const Example = (props: Props) => (
+>Example : (props: Props) => JSX.Element
+>(props: Props) => (  <>    {props.foo && <Component {...props} />}  </>) : (props: Props) => JSX.Element
+>props : Props
+>(  <>    {props.foo && <Component {...props} />}  </>) : JSX.Element
+
+  <>
+><>    {props.foo && <Component {...props} />}  </> : JSX.Element
+
+    {props.foo && <Component {...props} />}
+>props.foo && <Component {...props} /> : "" | JSX.Element | undefined
+>props.foo : string | undefined
+>props : Props
+>foo : string | undefined
+><Component {...props} /> : JSX.Element
+>Component : ({ foo }: Required<Props>) => JSX.Element
+>props : Props
+
+  </>
+);
+
+

--- a/tests/baselines/reference/narrowedSpread.js
+++ b/tests/baselines/reference/narrowedSpread.js
@@ -1,0 +1,26 @@
+//// [narrowedSpread.ts]
+type Obj = { x: number };
+function go(obj: Obj) { }
+
+function fn(arg: { x?: number }) {
+    arg.x && go({ ...arg });
+}
+
+
+//// [narrowedSpread.js]
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+function go(obj) { }
+function fn(arg) {
+    arg.x && go(__assign({}, arg));
+}

--- a/tests/baselines/reference/narrowedSpread.js
+++ b/tests/baselines/reference/narrowedSpread.js
@@ -1,10 +1,33 @@
 //// [narrowedSpread.ts]
-type Obj = { x: number };
-function go(obj: Obj) { }
-
-function fn(arg: { x?: number }) {
-    arg.x && go({ ...arg });
+function useX(obj: { x: number }) { }
+function fn1(arg: { x?: number }) {
+    arg.x && useX({ ...arg });
 }
+
+function useXYZ(obj: { w: number; x: number; y: number; z: number }) { }
+function fn2(arg: { x?: number; y: number | null; z: string | number }) {
+    if (arg.x && arg.y !== null) {
+        if (typeof arg.z === "number") {
+            useXYZ({ ...arg, w: 100 });
+        }
+    }
+} 
+
+type None = { type: "none" };
+type Some<T> = { type: "some"; value: T };
+type Option<T> = None | Some<T>;
+function useSome<T>(obj: { opt: Some<T> }) { }
+
+function fn3<T>(arg: { opt: Option<T> }) {
+    if (arg.opt.type === "some") {
+        useSome({ ...arg });
+    }
+}
+
+
+
+
+
 
 
 //// [narrowedSpread.js]
@@ -20,7 +43,21 @@ var __assign = (this && this.__assign) || function () {
     };
     return __assign.apply(this, arguments);
 };
-function go(obj) { }
-function fn(arg) {
-    arg.x && go(__assign({}, arg));
+function useX(obj) { }
+function fn1(arg) {
+    arg.x && useX(__assign({}, arg));
+}
+function useXYZ(obj) { }
+function fn2(arg) {
+    if (arg.x && arg.y !== null) {
+        if (typeof arg.z === "number") {
+            useXYZ(__assign(__assign({}, arg), { w: 100 }));
+        }
+    }
+}
+function useSome(obj) { }
+function fn3(arg) {
+    if (arg.opt.type === "some") {
+        useSome(__assign({}, arg));
+    }
 }

--- a/tests/baselines/reference/narrowedSpread.symbols
+++ b/tests/baselines/reference/narrowedSpread.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/narrowedSpread.ts ===
+type Obj = { x: number };
+>Obj : Symbol(Obj, Decl(narrowedSpread.ts, 0, 0))
+>x : Symbol(x, Decl(narrowedSpread.ts, 0, 12))
+
+function go(obj: Obj) { }
+>go : Symbol(go, Decl(narrowedSpread.ts, 0, 25))
+>obj : Symbol(obj, Decl(narrowedSpread.ts, 1, 12))
+>Obj : Symbol(Obj, Decl(narrowedSpread.ts, 0, 0))
+
+function fn(arg: { x?: number }) {
+>fn : Symbol(fn, Decl(narrowedSpread.ts, 1, 25))
+>arg : Symbol(arg, Decl(narrowedSpread.ts, 3, 12))
+>x : Symbol(x, Decl(narrowedSpread.ts, 3, 18))
+
+    arg.x && go({ ...arg });
+>arg.x : Symbol(x, Decl(narrowedSpread.ts, 3, 18))
+>arg : Symbol(arg, Decl(narrowedSpread.ts, 3, 12))
+>x : Symbol(x, Decl(narrowedSpread.ts, 3, 18))
+>go : Symbol(go, Decl(narrowedSpread.ts, 0, 25))
+>arg : Symbol(arg, Decl(narrowedSpread.ts, 3, 12))
+}
+

--- a/tests/baselines/reference/narrowedSpread.symbols
+++ b/tests/baselines/reference/narrowedSpread.symbols
@@ -1,23 +1,107 @@
 === tests/cases/compiler/narrowedSpread.ts ===
-type Obj = { x: number };
->Obj : Symbol(Obj, Decl(narrowedSpread.ts, 0, 0))
->x : Symbol(x, Decl(narrowedSpread.ts, 0, 12))
+function useX(obj: { x: number }) { }
+>useX : Symbol(useX, Decl(narrowedSpread.ts, 0, 0))
+>obj : Symbol(obj, Decl(narrowedSpread.ts, 0, 14))
+>x : Symbol(x, Decl(narrowedSpread.ts, 0, 20))
 
-function go(obj: Obj) { }
->go : Symbol(go, Decl(narrowedSpread.ts, 0, 25))
->obj : Symbol(obj, Decl(narrowedSpread.ts, 1, 12))
->Obj : Symbol(Obj, Decl(narrowedSpread.ts, 0, 0))
+function fn1(arg: { x?: number }) {
+>fn1 : Symbol(fn1, Decl(narrowedSpread.ts, 0, 37))
+>arg : Symbol(arg, Decl(narrowedSpread.ts, 1, 13))
+>x : Symbol(x, Decl(narrowedSpread.ts, 1, 19))
 
-function fn(arg: { x?: number }) {
->fn : Symbol(fn, Decl(narrowedSpread.ts, 1, 25))
->arg : Symbol(arg, Decl(narrowedSpread.ts, 3, 12))
->x : Symbol(x, Decl(narrowedSpread.ts, 3, 18))
-
-    arg.x && go({ ...arg });
->arg.x : Symbol(x, Decl(narrowedSpread.ts, 3, 18))
->arg : Symbol(arg, Decl(narrowedSpread.ts, 3, 12))
->x : Symbol(x, Decl(narrowedSpread.ts, 3, 18))
->go : Symbol(go, Decl(narrowedSpread.ts, 0, 25))
->arg : Symbol(arg, Decl(narrowedSpread.ts, 3, 12))
+    arg.x && useX({ ...arg });
+>arg.x : Symbol(x, Decl(narrowedSpread.ts, 1, 19))
+>arg : Symbol(arg, Decl(narrowedSpread.ts, 1, 13))
+>x : Symbol(x, Decl(narrowedSpread.ts, 1, 19))
+>useX : Symbol(useX, Decl(narrowedSpread.ts, 0, 0))
+>arg : Symbol(arg, Decl(narrowedSpread.ts, 1, 13))
 }
+
+function useXYZ(obj: { w: number; x: number; y: number; z: number }) { }
+>useXYZ : Symbol(useXYZ, Decl(narrowedSpread.ts, 3, 1))
+>obj : Symbol(obj, Decl(narrowedSpread.ts, 5, 16))
+>w : Symbol(w, Decl(narrowedSpread.ts, 5, 22))
+>x : Symbol(x, Decl(narrowedSpread.ts, 5, 33))
+>y : Symbol(y, Decl(narrowedSpread.ts, 5, 44))
+>z : Symbol(z, Decl(narrowedSpread.ts, 5, 55))
+
+function fn2(arg: { x?: number; y: number | null; z: string | number }) {
+>fn2 : Symbol(fn2, Decl(narrowedSpread.ts, 5, 72))
+>arg : Symbol(arg, Decl(narrowedSpread.ts, 6, 13))
+>x : Symbol(x, Decl(narrowedSpread.ts, 6, 19))
+>y : Symbol(y, Decl(narrowedSpread.ts, 6, 31))
+>z : Symbol(z, Decl(narrowedSpread.ts, 6, 49))
+
+    if (arg.x && arg.y !== null) {
+>arg.x : Symbol(x, Decl(narrowedSpread.ts, 6, 19))
+>arg : Symbol(arg, Decl(narrowedSpread.ts, 6, 13))
+>x : Symbol(x, Decl(narrowedSpread.ts, 6, 19))
+>arg.y : Symbol(y, Decl(narrowedSpread.ts, 6, 31))
+>arg : Symbol(arg, Decl(narrowedSpread.ts, 6, 13))
+>y : Symbol(y, Decl(narrowedSpread.ts, 6, 31))
+
+        if (typeof arg.z === "number") {
+>arg.z : Symbol(z, Decl(narrowedSpread.ts, 6, 49))
+>arg : Symbol(arg, Decl(narrowedSpread.ts, 6, 13))
+>z : Symbol(z, Decl(narrowedSpread.ts, 6, 49))
+
+            useXYZ({ ...arg, w: 100 });
+>useXYZ : Symbol(useXYZ, Decl(narrowedSpread.ts, 3, 1))
+>arg : Symbol(arg, Decl(narrowedSpread.ts, 6, 13))
+>w : Symbol(w, Decl(narrowedSpread.ts, 9, 28))
+        }
+    }
+} 
+
+type None = { type: "none" };
+>None : Symbol(None, Decl(narrowedSpread.ts, 12, 1))
+>type : Symbol(type, Decl(narrowedSpread.ts, 14, 13))
+
+type Some<T> = { type: "some"; value: T };
+>Some : Symbol(Some, Decl(narrowedSpread.ts, 14, 29))
+>T : Symbol(T, Decl(narrowedSpread.ts, 15, 10))
+>type : Symbol(type, Decl(narrowedSpread.ts, 15, 16))
+>value : Symbol(value, Decl(narrowedSpread.ts, 15, 30))
+>T : Symbol(T, Decl(narrowedSpread.ts, 15, 10))
+
+type Option<T> = None | Some<T>;
+>Option : Symbol(Option, Decl(lib.dom.d.ts, --, --), Decl(narrowedSpread.ts, 15, 42))
+>T : Symbol(T, Decl(narrowedSpread.ts, 16, 12))
+>None : Symbol(None, Decl(narrowedSpread.ts, 12, 1))
+>Some : Symbol(Some, Decl(narrowedSpread.ts, 14, 29))
+>T : Symbol(T, Decl(narrowedSpread.ts, 16, 12))
+
+function useSome<T>(obj: { opt: Some<T> }) { }
+>useSome : Symbol(useSome, Decl(narrowedSpread.ts, 16, 32))
+>T : Symbol(T, Decl(narrowedSpread.ts, 17, 17))
+>obj : Symbol(obj, Decl(narrowedSpread.ts, 17, 20))
+>opt : Symbol(opt, Decl(narrowedSpread.ts, 17, 26))
+>Some : Symbol(Some, Decl(narrowedSpread.ts, 14, 29))
+>T : Symbol(T, Decl(narrowedSpread.ts, 17, 17))
+
+function fn3<T>(arg: { opt: Option<T> }) {
+>fn3 : Symbol(fn3, Decl(narrowedSpread.ts, 17, 46))
+>T : Symbol(T, Decl(narrowedSpread.ts, 19, 13))
+>arg : Symbol(arg, Decl(narrowedSpread.ts, 19, 16))
+>opt : Symbol(opt, Decl(narrowedSpread.ts, 19, 22))
+>Option : Symbol(Option, Decl(lib.dom.d.ts, --, --), Decl(narrowedSpread.ts, 15, 42))
+>T : Symbol(T, Decl(narrowedSpread.ts, 19, 13))
+
+    if (arg.opt.type === "some") {
+>arg.opt.type : Symbol(type, Decl(narrowedSpread.ts, 14, 13), Decl(narrowedSpread.ts, 15, 16))
+>arg.opt : Symbol(opt, Decl(narrowedSpread.ts, 19, 22))
+>arg : Symbol(arg, Decl(narrowedSpread.ts, 19, 16))
+>opt : Symbol(opt, Decl(narrowedSpread.ts, 19, 22))
+>type : Symbol(type, Decl(narrowedSpread.ts, 14, 13), Decl(narrowedSpread.ts, 15, 16))
+
+        useSome({ ...arg });
+>useSome : Symbol(useSome, Decl(narrowedSpread.ts, 16, 32))
+>arg : Symbol(arg, Decl(narrowedSpread.ts, 19, 16))
+    }
+}
+
+
+
+
+
 

--- a/tests/baselines/reference/narrowedSpread.types
+++ b/tests/baselines/reference/narrowedSpread.types
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/narrowedSpread.ts ===
+type Obj = { x: number };
+>Obj : Obj
+>x : number
+
+function go(obj: Obj) { }
+>go : (obj: Obj) => void
+>obj : Obj
+
+function fn(arg: { x?: number }) {
+>fn : (arg: {    x?: number;}) => void
+>arg : { x?: number | undefined; }
+>x : number | undefined
+
+    arg.x && go({ ...arg });
+>arg.x && go({ ...arg }) : void | 0 | undefined
+>arg.x : number | undefined
+>arg : { x?: number | undefined; }
+>x : number | undefined
+>go({ ...arg }) : void
+>go : (obj: Obj) => void
+>{ ...arg } : { x: number; }
+>arg : { x?: number | undefined; }
+}
+

--- a/tests/baselines/reference/narrowedSpread.types
+++ b/tests/baselines/reference/narrowedSpread.types
@@ -1,25 +1,112 @@
 === tests/cases/compiler/narrowedSpread.ts ===
-type Obj = { x: number };
->Obj : Obj
+function useX(obj: { x: number }) { }
+>useX : (obj: {    x: number;}) => void
+>obj : { x: number; }
 >x : number
 
-function go(obj: Obj) { }
->go : (obj: Obj) => void
->obj : Obj
-
-function fn(arg: { x?: number }) {
->fn : (arg: {    x?: number;}) => void
+function fn1(arg: { x?: number }) {
+>fn1 : (arg: {    x?: number;}) => void
 >arg : { x?: number | undefined; }
 >x : number | undefined
 
-    arg.x && go({ ...arg });
->arg.x && go({ ...arg }) : void | 0 | undefined
+    arg.x && useX({ ...arg });
+>arg.x && useX({ ...arg }) : void | 0 | undefined
 >arg.x : number | undefined
 >arg : { x?: number | undefined; }
 >x : number | undefined
->go({ ...arg }) : void
->go : (obj: Obj) => void
+>useX({ ...arg }) : void
+>useX : (obj: { x: number; }) => void
 >{ ...arg } : { x: number; }
 >arg : { x?: number | undefined; }
 }
+
+function useXYZ(obj: { w: number; x: number; y: number; z: number }) { }
+>useXYZ : (obj: {    w: number;    x: number;    y: number;    z: number;}) => void
+>obj : { w: number; x: number; y: number; z: number; }
+>w : number
+>x : number
+>y : number
+>z : number
+
+function fn2(arg: { x?: number; y: number | null; z: string | number }) {
+>fn2 : (arg: {    x?: number;    y: number | null;    z: string | number;}) => void
+>arg : { x?: number | undefined; y: number | null; z: string | number; }
+>x : number | undefined
+>y : number | null
+>null : null
+>z : string | number
+
+    if (arg.x && arg.y !== null) {
+>arg.x && arg.y !== null : boolean | 0 | undefined
+>arg.x : number | undefined
+>arg : { x?: number | undefined; y: number | null; z: string | number; }
+>x : number | undefined
+>arg.y !== null : boolean
+>arg.y : number | null
+>arg : { x?: number | undefined; y: number | null; z: string | number; }
+>y : number | null
+>null : null
+
+        if (typeof arg.z === "number") {
+>typeof arg.z === "number" : boolean
+>typeof arg.z : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>arg.z : string | number
+>arg : { x?: number | undefined; y: number | null; z: string | number; }
+>z : string | number
+>"number" : "number"
+
+            useXYZ({ ...arg, w: 100 });
+>useXYZ({ ...arg, w: 100 }) : void
+>useXYZ : (obj: { w: number; x: number; y: number; z: number; }) => void
+>{ ...arg, w: 100 } : { w: number; x: number; y: number; z: number; }
+>arg : { x?: number | undefined; y: number | null; z: string | number; }
+>w : number
+>100 : 100
+        }
+    }
+} 
+
+type None = { type: "none" };
+>None : None
+>type : "none"
+
+type Some<T> = { type: "some"; value: T };
+>Some : Some<T>
+>type : "some"
+>value : T
+
+type Option<T> = None | Some<T>;
+>Option : Option<T>
+
+function useSome<T>(obj: { opt: Some<T> }) { }
+>useSome : <T>(obj: {    opt: Some<T>;}) => void
+>obj : { opt: Some<T>; }
+>opt : Some<T>
+
+function fn3<T>(arg: { opt: Option<T> }) {
+>fn3 : <T>(arg: {    opt: Option<T>;}) => void
+>arg : { opt: Option<T>; }
+>opt : Option<T>
+
+    if (arg.opt.type === "some") {
+>arg.opt.type === "some" : boolean
+>arg.opt.type : "none" | "some"
+>arg.opt : Option<T>
+>arg : { opt: Option<T>; }
+>opt : Option<T>
+>type : "none" | "some"
+>"some" : "some"
+
+        useSome({ ...arg });
+>useSome({ ...arg }) : void
+>useSome : <T>(obj: { opt: Some<T>; }) => void
+>{ ...arg } : { opt: Some<T>; }
+>arg : { opt: Option<T>; }
+    }
+}
+
+
+
+
+
 

--- a/tests/cases/compiler/narrowedJsxSpread.tsx
+++ b/tests/cases/compiler/narrowedJsxSpread.tsx
@@ -1,0 +1,16 @@
+// @jsx: preserve
+// @esModuleInterop: true
+// @strict: true
+/// <reference path="/.lib/react16.d.ts" />
+import React from 'react';
+type Props = {
+  foo?: string
+}
+
+const Component = ({ foo }: Required<Props>) => <p>{foo}</p>;
+const Example = (props: Props) => (
+  <>
+    {props.foo && <Component {...props} />}
+  </>
+);
+

--- a/tests/cases/compiler/narrowedSpread.ts
+++ b/tests/cases/compiler/narrowedSpread.ts
@@ -1,7 +1,30 @@
 // @strict: true
-type Obj = { x: number };
-function go(obj: Obj) { }
-
-function fn(arg: { x?: number }) {
-    arg.x && go({ ...arg });
+function useX(obj: { x: number }) { }
+function fn1(arg: { x?: number }) {
+    arg.x && useX({ ...arg });
 }
+
+function useXYZ(obj: { w: number; x: number; y: number; z: number }) { }
+function fn2(arg: { x?: number; y: number | null; z: string | number }) {
+    if (arg.x && arg.y !== null) {
+        if (typeof arg.z === "number") {
+            useXYZ({ ...arg, w: 100 });
+        }
+    }
+} 
+
+type None = { type: "none" };
+type Some<T> = { type: "some"; value: T };
+type Option<T> = None | Some<T>;
+function useSome<T>(obj: { opt: Some<T> }) { }
+
+function fn3<T>(arg: { opt: Option<T> }) {
+    if (arg.opt.type === "some") {
+        useSome({ ...arg });
+    }
+}
+
+
+
+
+

--- a/tests/cases/compiler/narrowedSpread.ts
+++ b/tests/cases/compiler/narrowedSpread.ts
@@ -1,0 +1,7 @@
+// @strict: true
+type Obj = { x: number };
+function go(obj: Obj) { }
+
+function fn(arg: { x?: number }) {
+    arg.x && go({ ...arg });
+}


### PR DESCRIPTION
Happy hacktoberfest! 🎃🥳 

Fixes #36702.

I think this has non-negligible negative performance impact though, because it basically invokes control flow analysis to all properties once an object is spread. How do you think?

## Example

```ts
type Obj = { x: number };
function go(obj: Obj) { }

function fn(arg: { x?: number }) {
    // should be ok
    arg.x && go({ ...arg });
}
```

**Current Behavior** (TS 4.1 beta)

```
src/36702.ts:6:17 - error TS2345: Argument of type '{ x?: number | undefined; }' is not assignable to parameter of type 'Obj'.
  Types of property 'x' are incompatible.
    Type 'number | undefined' is not assignable to type 'number'.
      Type 'undefined' is not assignable to type 'number'.

6     arg.x && go({ ...arg });
                  ~~~~~~~~~~


Found 1 error.
```

**New Behavior**

(no errors)