### PR TITLE
Separate delete-all-imports from other delete-all

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -5955,6 +5955,10 @@
         "category": "Message",
         "code": 95144
     },
+    "Delete all unused imports": {
+        "category": "Message",
+        "code": 95145
+    },
 
     "No value exists in scope for the shorthand property '{0}'. Either declare one or provide an initializer.": {
         "category": "Error",

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_all_delete_import.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_all_delete_import.ts
@@ -58,18 +58,17 @@
 ////export type Length<T> = T extends ArrayLike<infer U> ? number : never; // Not affected, can't delete
 
 verify.codeFixAll({
-    fixId: "unusedIdentifier_delete",
-    fixAllDescription: ts.Diagnostics.Delete_all_unused_declarations.message,
+    fixId: "unusedIdentifier_deleteImports",
+    fixAllDescription: ts.Diagnostics.Delete_all_unused_imports.message,
     newFileContent:
-`import d from "foo";
-import d2, { used1 } from "foo";
-import { x } from "foo";
-import { x2, used2 } from "foo";
+`import { used1 } from "foo";
+import { used2 } from "foo";
 used1; used2;
 
-function f() {
+function f(a, b) {
+    const x = 0;
 }
-function g(a) { return a; }
+function g(a, b, c) { return a; }
 f; g;
 
 interface I {
@@ -78,36 +77,39 @@ interface I {
 
 class C implements I {
     m(x: number): void {} // Does not remove 'x', which is inherited
-    n(): void {}
+    n(x: number): void {}
+    private ["o"](): void {}
 }
 C;
 
 declare function takesCb(cb: (x: number, y: string) => void): void;
-takesCb(() => {});
-takesCb((x) => { x; });
+takesCb((x, y) => {});
+takesCb((x, y) => { x; });
 takesCb((x, y) => { y; });
 
-function fn1(): void {}
+function fn1(x: number, y: string): void {}
 takesCb(fn1);
 
-function fn2(x: number): void { x; }
+function fn2(x: number, y: string): void { x; }
 takesCb(fn2);
 
 function fn3(x: number, y: string): void { y; }
 takesCb(fn3);
 
-() => {
+x => {
+    const y = 0;
 };
 
 {
+    let a, b;
 }
-for (; ;) {}
-for (const {} of []) {}
-for (const {} in {}) {}
+for (let i = 0, j = 0; ;) {}
+for (const x of []) {}
+for (const y in {}) {}
 
-export type First<T> = T;
-export interface ISecond<U> { u: U; }
-export const cls = class<U> { u: U; };
-export class Ctu {}
+export type First<T, U> = T;
+export interface ISecond<T, U> { u: U; }
+export const cls = class<T, U> { u: U; };
+export class Ctu<T, U> {}
 export type Length<T> = T extends ArrayLike<infer U> ? number : never; // Not affected, can't delete`,
 });


### PR DESCRIPTION
This fixes the first part of #32196: Now, when the token is an import the codefix will offer "delete all unused imports" instead of "delete all unused declarations". This now only deletes imports. The opposite applies to other declarations.
