### PR TITLE
Optimizes project loading in few scenarios

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3800,7 +3800,7 @@ namespace ts {
         getResolvedProjectReferences(): readonly (ResolvedProjectReference | undefined)[] | undefined;
         /*@internal*/ getProjectReferenceRedirect(fileName: string): string | undefined;
         /*@internal*/ getResolvedProjectReferenceToRedirect(fileName: string): ResolvedProjectReference | undefined;
-        /*@internal*/ forEachResolvedProjectReference<T>(cb: (resolvedProjectReference: ResolvedProjectReference | undefined, resolvedProjectReferencePath: Path) => T | undefined): T | undefined;
+        /*@internal*/ forEachResolvedProjectReference<T>(cb: (resolvedProjectReference: ResolvedProjectReference) => T | undefined): T | undefined;
         /*@internal*/ getResolvedProjectReferenceByPath(projectReferencePath: Path): ResolvedProjectReference | undefined;
         /*@internal*/ isSourceOfProjectReferenceRedirect(fileName: string): boolean;
         /*@internal*/ getProgramBuildInfo?(): ProgramBuildInfo | undefined;
@@ -6330,7 +6330,7 @@ namespace ts {
     /*@internal*/
     export interface ResolvedProjectReferenceCallbacks {
         getSourceOfProjectReferenceRedirect(fileName: string): SourceOfProjectReferenceRedirect | undefined;
-        forEachResolvedProjectReference<T>(cb: (resolvedProjectReference: ResolvedProjectReference | undefined, resolvedProjectReferencePath: Path) => T | undefined): T | undefined;
+        forEachResolvedProjectReference<T>(cb: (resolvedProjectReference: ResolvedProjectReference) => T | undefined): T | undefined;
     }
 
     /* @internal */

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -749,11 +749,8 @@ namespace ts.server {
                 for (const f of this.program.getSourceFiles()) {
                     this.detachScriptInfoIfNotRoot(f.fileName);
                 }
-                this.program.forEachResolvedProjectReference(ref => {
-                    if (ref) {
-                        this.detachScriptInfoFromProject(ref.sourceFile.fileName);
-                    }
-                });
+                this.program.forEachResolvedProjectReference(ref =>
+                    this.detachScriptInfoFromProject(ref.sourceFile.fileName));
             }
 
             // Release external files
@@ -1098,8 +1095,8 @@ namespace ts.server {
                         }
                     }
 
-                    oldProgram.forEachResolvedProjectReference((resolvedProjectReference, resolvedProjectReferencePath) => {
-                        if (resolvedProjectReference && !this.program!.getResolvedProjectReferenceByPath(resolvedProjectReferencePath)) {
+                    oldProgram.forEachResolvedProjectReference(resolvedProjectReference => {
+                        if (!this.program!.getResolvedProjectReferenceByPath(resolvedProjectReference.sourceFile.path)) {
                             this.detachScriptInfoFromProject(resolvedProjectReference.sourceFile.fileName);
                         }
                     });
@@ -2189,6 +2186,13 @@ namespace ts.server {
         getResolvedProjectReferenceToRedirect(fileName: string): ResolvedProjectReference | undefined {
             const program = this.getCurrentProgram();
             return program && program.getResolvedProjectReferenceToRedirect(fileName);
+        }
+
+        /*@internal*/
+        forEachResolvedProjectReference<T>(
+            cb: (resolvedProjectReference: ResolvedProjectReference) => T | undefined
+        ): T | undefined {
+            return this.getCurrentProgram()?.forEachResolvedProjectReference(cb);
         }
 
         /*@internal*/

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2303,6 +2303,7 @@ namespace ts.server {
         getDefaultChildProjectFromProjectWithReferences(info: ScriptInfo) {
             return forEachResolvedProjectReferenceProject(
                 this,
+                info.path,
                 child => projectContainsInfoDirectly(child, info) ?
                     child :
                     undefined,
@@ -2340,6 +2341,7 @@ namespace ts.server {
                     return this.containsScriptInfo(info) ||
                         !!forEachResolvedProjectReferenceProject(
                             this,
+                            info.path,
                             child => child.containsScriptInfo(info),
                             ProjectReferenceProjectLoadKind.Find
                         );

--- a/src/testRunner/unittests/tsserver/projectReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectReferences.ts
@@ -2645,5 +2645,75 @@ bar;`
                 verifyAutoImport(/*built*/ true, /*disableSourceOfProjectReferenceRedirect*/ true);
             });
         });
+
+        it("when files from two projects are open and one project references", () => {
+            function getPackageAndFile(packageName: string, references?: string[], optionsToExtend?: CompilerOptions): [file: File, config: File] {
+                const file: File = {
+                    path: `${tscWatch.projectRoot}/${packageName}/src/file1.ts`,
+                    content: `export const ${packageName}Const = 10;`
+                };
+                const config: File = {
+                    path: `${tscWatch.projectRoot}/${packageName}/tsconfig.json`,
+                    content: JSON.stringify({
+                        compilerOptions: { composite: true, ...optionsToExtend || {} },
+                        references: references?.map(path => ({ path: `../${path}` }))
+                    })
+                };
+                return [file, config];
+            }
+            const [mainFile, mainConfig] = getPackageAndFile("main", ["core", "indirect", "noCoreRef1", "indirectDisabledChildLoad1", "indirectDisabledChildLoad2", "refToCoreRef3", "indirectNoCoreRef"]);
+            const [coreFile, coreConfig] = getPackageAndFile("core");
+            const [noCoreRef1File, noCoreRef1Config] = getPackageAndFile("noCoreRef1");
+            const [indirectFile, indirectConfig] = getPackageAndFile("indirect", ["coreRef1"]);
+            const [coreRef1File, coreRef1Config] = getPackageAndFile("coreRef1", ["core"]);
+            const [indirectDisabledChildLoad1File, indirectDisabledChildLoad1Config] = getPackageAndFile("indirectDisabledChildLoad1", ["coreRef2"], { disableReferencedProjectLoad: true });
+            const [coreRef2File, coreRef2Config] = getPackageAndFile("coreRef2", ["core"]);
+            const [indirectDisabledChildLoad2File, indirectDisabledChildLoad2Config] = getPackageAndFile("indirectDisabledChildLoad2", ["coreRef3"], { disableReferencedProjectLoad: true });
+            const [coreRef3File, coreRef3Config] = getPackageAndFile("coreRef3", ["core"]);
+            const [refToCoreRef3File, refToCoreRef3Config] = getPackageAndFile("refToCoreRef3", ["coreRef3"]);
+            const [indirectNoCoreRefFile, indirectNoCoreRefConfig] = getPackageAndFile("indirectNoCoreRef", ["noCoreRef2"]);
+            const [noCoreRef2File, noCoreRef2Config] = getPackageAndFile("noCoreRef2");
+
+            const host = createServerHost([
+                libFile, mainFile, mainConfig, coreFile, coreConfig, noCoreRef1File, noCoreRef1Config,
+                indirectFile, indirectConfig, coreRef1File, coreRef1Config,
+                indirectDisabledChildLoad1File, indirectDisabledChildLoad1Config, coreRef2File, coreRef2Config,
+                indirectDisabledChildLoad2File, indirectDisabledChildLoad2Config, coreRef3File, coreRef3Config,
+                refToCoreRef3File, refToCoreRef3Config,
+                indirectNoCoreRefFile, indirectNoCoreRefConfig, noCoreRef2File, noCoreRef2Config
+            ], { useCaseSensitiveFileNames: true });
+            const session = createSession(host);
+            const service = session.getProjectService();
+            openFilesForSession([mainFile, coreFile], session);
+
+            verifyProject(mainConfig);
+            verifyProject(coreConfig);
+
+            // Find all refs in coreFile
+            session.executeCommandSeq<protocol.ReferencesRequest>({
+                command: protocol.CommandTypes.References,
+                arguments: protocolFileLocationFromSubstring(coreFile, `coreConst`)
+            });
+            verifyProject(mainConfig);
+            verifyProject(coreConfig);
+            verifyProject(noCoreRef1Config); // Should not be loaded
+            verifyProject(indirectConfig);
+            verifyProject(coreRef1Config);
+            verifyProject(indirectDisabledChildLoad1Config);
+            verifyNoProject(coreRef2Config); // Should not be loaded
+            verifyProject(indirectDisabledChildLoad2Config);
+            verifyProject(coreRef3Config);
+            verifyProject(refToCoreRef3Config);
+            verifyProject(indirectNoCoreRefConfig); // Should not be loaded
+            verifyProject(noCoreRef2Config); // Should not be loaded
+
+            function verifyProject(config: File) {
+                assert.isDefined(service.configuredProjects.get(config.path), `Expected to find ${config.path}`);
+            }
+
+            function verifyNoProject(config: File) {
+                assert.isUndefined(service.configuredProjects.get(config.path), `Expected to not find ${config.path}`);
+            }
+        });
     });
 }

--- a/src/testRunner/unittests/tsserver/projectReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectReferences.ts
@@ -2189,19 +2189,14 @@ export function bar() {}`
                 verifySolutionScenario({
                     configRefs: ["./tsconfig-indirect1.json", "./tsconfig-indirect2.json"],
                     additionalFiles: [tsconfigIndirect, indirect, tsconfigIndirect2, indirect2],
-                    additionalProjects: [{
-                        projectName: tsconfigIndirect.path,
-                        files: [tsconfigIndirect.path, main.path, helper.path, indirect.path, libFile.path]
-                    }],
+                    additionalProjects: emptyArray,
                     expectedOpenEvents: [
                         ...expectedSolutionLoadAndTelemetry(),
-                        ...expectedProjectReferenceLoadAndTelemetry(tsconfigIndirect.path),
                         ...expectedProjectReferenceLoadAndTelemetry(tsconfigSrcPath),
                         configFileDiagEvent(main.path, tsconfigSrcPath, [])
                     ],
                     expectedReloadEvents: [
                         ...expectedReloadEvent(tsconfigPath),
-                        ...expectedReloadEvent(tsconfigIndirect.path),
                         ...expectedReloadEvent(tsconfigSrcPath),
                     ],
                     expectedReferences: {
@@ -2217,8 +2212,8 @@ export function bar() {}`
                         refs: [
                             ...expectedIndirectRefs(fileResolvingToMainDts),
                             ...refs,
-                            ...expectedIndirectRefs(indirect2),
                             ...expectedIndirectRefs(indirect),
+                            ...expectedIndirectRefs(indirect2),
                         ],
                         symbolDisplayString: "(alias) const foo: 1\nimport foo",
                     }
@@ -2296,8 +2291,6 @@ export function bar() {}`
                 const expectedProjectsOnOpen: VerifyProjects = {
                     configuredProjects: [
                         { projectName: tsconfigPath, files: [tsconfigPath] },
-                        { projectName: tsconfigIndirect.path, files: [tsconfigIndirect.path, main.path, helper.path, indirect.path, libFile.path] },
-                        { projectName: tsconfigIndirect2.path, files: [tsconfigIndirect2.path, main.path, helper.path, indirect2.path, libFile.path] },
                         { projectName: tsconfigSrcPath, files: [tsconfigSrcPath, main.path, helper.path, libFile.path] },
                     ],
                     inferredProjects: emptyArray
@@ -2307,8 +2300,6 @@ export function bar() {}`
                     additionalFiles: [tsconfigIndirect, indirect, tsconfigIndirect2, indirect2],
                     expectedOpenEvents: [
                         ...expectedSolutionLoadAndTelemetry(),
-                        ...expectedProjectReferenceLoadAndTelemetry(tsconfigIndirect.path),
-                        ...expectedProjectReferenceLoadAndTelemetry(tsconfigIndirect2.path),
                         ...expectedProjectReferenceLoadAndTelemetry(tsconfigSrcPath),
                         configFileDiagEvent(main.path, tsconfigSrcPath, [])
                     ],
@@ -2317,9 +2308,7 @@ export function bar() {}`
                     expectedProjectsOnOpen,
                     expectedReloadEvents: [
                         ...expectedReloadEvent(tsconfigPath),
-                        ...expectedReloadEvent(tsconfigIndirect.path),
                         ...expectedReloadEvent(tsconfigSrcPath),
-                        ...expectedReloadEvent(tsconfigIndirect2.path),
                     ]
                 });
             });
@@ -2387,19 +2376,14 @@ bar;`
                         solutionProject: [tsconfigPath, indirect.path, ownMain.path, main.path, libFile.path, helper.path],
                         configRefs: ["./tsconfig-indirect1.json", "./tsconfig-indirect2.json"],
                         additionalFiles: [tsconfigIndirect, indirect, tsconfigIndirect2, indirect2, ownMain],
-                        additionalProjects: [{
-                            projectName: tsconfigIndirect.path,
-                            files: [tsconfigIndirect.path, main.path, helper.path, indirect.path, libFile.path]
-                        }],
+                        additionalProjects: emptyArray,
                         expectedOpenEvents: [
                             ...expectedSolutionLoadAndTelemetry(),
-                            ...expectedProjectReferenceLoadAndTelemetry(tsconfigIndirect.path),
                             ...expectedProjectReferenceLoadAndTelemetry(tsconfigSrcPath),
                             configFileDiagEvent(main.path, tsconfigSrcPath, [])
                         ],
                         expectedReloadEvents: [
                             ...expectedReloadEvent(tsconfigPath),
-                            ...expectedReloadEvent(tsconfigIndirect.path),
                             ...expectedReloadEvent(tsconfigSrcPath),
                         ],
                         expectedReferences: {
@@ -2415,8 +2399,8 @@ bar;`
                             refs: [
                                 ...expectedIndirectRefs(fileResolvingToMainDts),
                                 ...refs,
-                                ...expectedIndirectRefs(indirect2),
                                 ...expectedIndirectRefs(indirect),
+                                ...expectedIndirectRefs(indirect2),
                             ],
                             symbolDisplayString: "(alias) const foo: 1\nimport foo",
                         }
@@ -2502,8 +2486,6 @@ bar;`
                     const expectedProjectsOnOpen: VerifyProjects = {
                         configuredProjects: [
                             { projectName: tsconfigPath, files: [tsconfigPath, indirect.path, ownMain.path, main.path, libFile.path, helper.path] },
-                            { projectName: tsconfigIndirect.path, files: [tsconfigIndirect.path, main.path, helper.path, indirect.path, libFile.path] },
-                            { projectName: tsconfigIndirect2.path, files: [tsconfigIndirect2.path, main.path, helper.path, indirect2.path, libFile.path] },
                             { projectName: tsconfigSrcPath, files: [tsconfigSrcPath, main.path, helper.path, libFile.path] },
                         ],
                         inferredProjects: emptyArray
@@ -2518,8 +2500,6 @@ bar;`
                         additionalFiles: [tsconfigIndirect, indirect, tsconfigIndirect2, indirect2, ownMain],
                         expectedOpenEvents: [
                             ...expectedSolutionLoadAndTelemetry(),
-                            ...expectedProjectReferenceLoadAndTelemetry(tsconfigIndirect.path),
-                            ...expectedProjectReferenceLoadAndTelemetry(tsconfigIndirect2.path),
                             ...expectedProjectReferenceLoadAndTelemetry(tsconfigSrcPath),
                             configFileDiagEvent(main.path, tsconfigSrcPath, [])
                         ],
@@ -2528,9 +2508,7 @@ bar;`
                         expectedProjectsOnOpen,
                         expectedReloadEvents: [
                             ...expectedReloadEvent(tsconfigPath),
-                            ...expectedReloadEvent(tsconfigIndirect.path),
                             ...expectedReloadEvent(tsconfigSrcPath),
-                            ...expectedReloadEvent(tsconfigIndirect2.path),
                         ]
                     });
                 });

--- a/src/testRunner/unittests/tsserver/projectReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectReferences.ts
@@ -2696,7 +2696,7 @@ bar;`
             });
             verifyProject(mainConfig);
             verifyProject(coreConfig);
-            verifyProject(noCoreRef1Config); // Should not be loaded
+            verifyNoProject(noCoreRef1Config); // Should not be loaded
             verifyProject(indirectConfig);
             verifyProject(coreRef1Config);
             verifyProject(indirectDisabledChildLoad1Config);
@@ -2704,8 +2704,8 @@ bar;`
             verifyProject(indirectDisabledChildLoad2Config);
             verifyProject(coreRef3Config);
             verifyProject(refToCoreRef3Config);
-            verifyProject(indirectNoCoreRefConfig); // Should not be loaded
-            verifyProject(noCoreRef2Config); // Should not be loaded
+            verifyNoProject(indirectNoCoreRefConfig); // Should not be loaded
+            verifyNoProject(noCoreRef2Config); // Should not be loaded
 
             function verifyProject(config: File) {
                 assert.isDefined(service.configuredProjects.get(config.path), `Expected to find ${config.path}`);


### PR DESCRIPTION
Main changes are in 2a920f2 and 421ea3b

- 2a920f2: When we try to load ancestor tree for finding all references or other such multi project operations, earlier we would load all child projects if project referenced the project in which we are searching. That is say if we are looking for something in `src\compiler` it would load whole tree set by `src/tsconfig` which is a solution file. But we dont need to load all children, we need to load only those that reference compiler directly or indirectly. In our case that might be all cases but in big mono repo like scenarios thats not true, so this only loads the projects that truly could reference compiler.

- 421ea3b When opening project or any other operation that involves finding default project for a file, earlier we would load project tree one by one. So if the default project is referenced indirectly, first that indirect project will be loaded only to find that it does not contain default project. Now, we just query what's the projectReference the file redirects to and try operation on that first so this avoids having to load these indirect projects in file open or reload like scenarios. So give this in our source code scenario if `src\tsconfig.json` did not refererence `src\compiler` then opening in file in `compiler` would first load `services` project and then `src\compiler` before this change. Now it will directly. For purpose of this understanding you also have to assume that tsconfig in compiler is not named tsconfig but something else which is when solution is found instead of default project. 
