### PR TITLE
Fix show deprecated suggestion for alias

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -447,7 +447,7 @@ namespace ts.Completions {
         return {
             name,
             kind: SymbolDisplay.getSymbolKind(typeChecker, symbol, location!), // TODO: GH#18217
-            kindModifiers: SymbolDisplay.getSymbolModifiers(symbol),
+            kindModifiers: SymbolDisplay.getSymbolModifiers(typeChecker, symbol),
             sortText,
             source: getSourceFromOrigin(origin),
             hasAction: origin && originIsExport(origin) || undefined,
@@ -697,7 +697,7 @@ namespace ts.Completions {
             checker.runWithCancellationToken(cancellationToken, checker =>
                 SymbolDisplay.getSymbolDisplayPartsDocumentationAndSymbolKind(checker, symbol, sourceFile, location, location, SemanticMeaning.All)
             );
-        return createCompletionDetails(symbol.name, SymbolDisplay.getSymbolModifiers(symbol), symbolKind, displayParts, documentation, tags, codeActions, sourceDisplay);
+        return createCompletionDetails(symbol.name, SymbolDisplay.getSymbolModifiers(checker, symbol), symbolKind, displayParts, documentation, tags, codeActions, sourceDisplay);
     }
 
     export function createCompletionDetails(name: string, kindModifiers: string, kind: ScriptElementKind, displayParts: SymbolDisplayPart[], documentation?: SymbolDisplayPart[], tags?: JSDocTagInfo[], codeActions?: CodeAction[], source?: SymbolDisplayPart[]): CompletionEntryDetails {

--- a/src/services/rename.ts
+++ b/src/services/rename.ts
@@ -44,7 +44,7 @@ namespace ts.Rename {
             : undefined;
         const displayName = specifierName || typeChecker.symbolToString(symbol);
         const fullDisplayName = specifierName || typeChecker.getFullyQualifiedName(symbol);
-        return getRenameInfoSuccess(displayName, fullDisplayName, kind, SymbolDisplay.getSymbolModifiers(symbol), node, sourceFile);
+        return getRenameInfoSuccess(displayName, fullDisplayName, kind, SymbolDisplay.getSymbolModifiers(typeChecker,symbol), node, sourceFile);
     }
 
     function getRenameInfoForModule(node: StringLiteralLike, sourceFile: SourceFile, moduleSymbol: Symbol): RenameInfo | undefined {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1598,7 +1598,7 @@ namespace ts {
             );
             return {
                 kind: symbolKind,
-                kindModifiers: SymbolDisplay.getSymbolModifiers(symbol),
+                kindModifiers: SymbolDisplay.getSymbolModifiers(typeChecker, symbol),
                 textSpan: createTextSpanFromNode(nodeForQuickInfo, sourceFile),
                 displayParts,
                 documentation,

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -102,15 +102,26 @@ namespace ts.SymbolDisplay {
         return ScriptElementKind.unknown;
     }
 
-    export function getSymbolModifiers(symbol: Symbol): string {
-        const nodeModifiers = symbol && symbol.declarations && symbol.declarations.length > 0
-            ? getNodeModifiers(symbol.declarations[0])
-            : ScriptElementKindModifier.none;
+    export function getSymbolModifiers(typeChecker: TypeChecker, symbol: Symbol): string {
+        if (!symbol) {
+            return ScriptElementKindModifier.none;
+        }
 
-        const symbolModifiers = symbol && symbol.flags & SymbolFlags.Optional ?
-            ScriptElementKindModifier.optionalModifier
-            : ScriptElementKindModifier.none;
-        return nodeModifiers && symbolModifiers ? nodeModifiers + "," + symbolModifiers : nodeModifiers || symbolModifiers;
+        const modifiers: string[] = [];
+        if (symbol.declarations && symbol.declarations.length > 0) {
+            modifiers.push(getNodeModifiers(symbol.declarations[0]));
+        }
+        if (symbol.flags & SymbolFlags.Alias) {
+            const resolvedSymbol = typeChecker.getAliasedSymbol(symbol);
+            if (resolvedSymbol !== symbol && resolvedSymbol.declarations && resolvedSymbol.declarations.length > 0) {
+                modifiers.push(getNodeModifiers(resolvedSymbol.declarations[0]));
+            }
+        }
+        if (symbol.flags & SymbolFlags.Optional) {
+            modifiers.push(ScriptElementKindModifier.optionalModifier);
+        }
+
+        return modifiers.filter(s => !!s).join(",");
     }
 
     interface SymbolDisplayPartsDocumentationAndSymbolKind {

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -109,19 +109,25 @@ namespace ts.SymbolDisplay {
 
         const modifiers: string[] = [];
         if (symbol.declarations && symbol.declarations.length > 0) {
-            modifiers.push(getNodeModifiers(symbol.declarations[0]));
+            const kindModifiers = getNodeModifiers(symbol.declarations[0]);
+            if (kindModifiers !== ScriptElementKindModifier.none) {
+                modifiers.push(kindModifiers);
+            }
         }
         if (symbol.flags & SymbolFlags.Alias) {
             const resolvedSymbol = typeChecker.getAliasedSymbol(symbol);
             if (resolvedSymbol !== symbol && resolvedSymbol.declarations && resolvedSymbol.declarations.length > 0) {
-                modifiers.push(getNodeModifiers(resolvedSymbol.declarations[0]));
+                const kindModifiers = getNodeModifiers(resolvedSymbol.declarations[0]);
+                if (kindModifiers !== ScriptElementKindModifier.none) {
+                    modifiers.push(kindModifiers);
+                }
             }
         }
         if (symbol.flags & SymbolFlags.Optional) {
             modifiers.push(ScriptElementKindModifier.optionalModifier);
         }
 
-        return modifiers.filter(s => !!s).join(",");
+        return modifiers.length > 0 ? modifiers.join(",") : ScriptElementKindModifier.none;
     }
 
     interface SymbolDisplayPartsDocumentationAndSymbolKind {

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -107,11 +107,11 @@ namespace ts.SymbolDisplay {
             return ScriptElementKindModifier.none;
         }
 
-        const modifiers: string[] = [];
+        const modifiers = new Set<string>();
         if (symbol.declarations && symbol.declarations.length > 0) {
             const kindModifiers = getNodeModifiers(symbol.declarations[0]);
             if (kindModifiers !== ScriptElementKindModifier.none) {
-                modifiers.push(kindModifiers);
+                kindModifiers.split(",").forEach(m => modifiers.add(m));
             }
         }
         if (symbol.flags & SymbolFlags.Alias) {
@@ -119,15 +119,15 @@ namespace ts.SymbolDisplay {
             if (resolvedSymbol !== symbol && resolvedSymbol.declarations && resolvedSymbol.declarations.length > 0) {
                 const kindModifiers = getNodeModifiers(resolvedSymbol.declarations[0]);
                 if (kindModifiers !== ScriptElementKindModifier.none) {
-                    modifiers.push(kindModifiers);
+                    kindModifiers.split(",").forEach(m => modifiers.add(m));
                 }
             }
         }
         if (symbol.flags & SymbolFlags.Optional) {
-            modifiers.push(ScriptElementKindModifier.optionalModifier);
+            modifiers.add(ScriptElementKindModifier.optionalModifier);
         }
 
-        return modifiers.length > 0 ? modifiers.join(",") : ScriptElementKindModifier.none;
+        return modifiers.size > 0 ? arrayFrom(modifiers.values()).join(",") : ScriptElementKindModifier.none;
     }
 
     interface SymbolDisplayPartsDocumentationAndSymbolKind {

--- a/tests/baselines/reference/quickInfoDisplayPartsInternalModuleAlias.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsInternalModuleAlias.baseline
@@ -516,7 +516,7 @@
     },
     "quickInfo": {
       "kind": "alias",
-      "kindModifiers": "export,export",
+      "kindModifiers": "export",
       "textSpan": {
         "start": 194,
         "length": 2
@@ -617,7 +617,7 @@
     },
     "quickInfo": {
       "kind": "alias",
-      "kindModifiers": "export,export",
+      "kindModifiers": "export",
       "textSpan": {
         "start": 213,
         "length": 2

--- a/tests/baselines/reference/quickInfoDisplayPartsInternalModuleAlias.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsInternalModuleAlias.baseline
@@ -160,7 +160,7 @@
     },
     "quickInfo": {
       "kind": "alias",
-      "kindModifiers": "",
+      "kindModifiers": "export",
       "textSpan": {
         "start": 104,
         "length": 2
@@ -245,7 +245,7 @@
     },
     "quickInfo": {
       "kind": "alias",
-      "kindModifiers": "",
+      "kindModifiers": "export",
       "textSpan": {
         "start": 123,
         "length": 2
@@ -516,7 +516,7 @@
     },
     "quickInfo": {
       "kind": "alias",
-      "kindModifiers": "export",
+      "kindModifiers": "export,export",
       "textSpan": {
         "start": 194,
         "length": 2
@@ -617,7 +617,7 @@
     },
     "quickInfo": {
       "kind": "alias",
-      "kindModifiers": "export",
+      "kindModifiers": "export,export",
       "textSpan": {
         "start": 213,
         "length": 2

--- a/tests/cases/fourslash/completionsExportImport.ts
+++ b/tests/cases/fourslash/completionsExportImport.ts
@@ -11,7 +11,7 @@
 verify.completions({
     marker: "",
     exact: [
-        { name: "foo", kind: "alias", kindModifiers: "export", text: "(alias) const foo: number\nimport foo = N.foo" },
+        { name: "foo", kind: "alias", kindModifiers: "export,declare", text: "(alias) const foo: number\nimport foo = N.foo" },
         ...completion.globalsPlus([{ name: "N", kind: "module", kindModifiers: "declare", text: "namespace N" }]),
     ],
 });

--- a/tests/cases/fourslash/completionsImport_named_didNotExistBefore.ts
+++ b/tests/cases/fourslash/completionsImport_named_didNotExistBefore.ts
@@ -16,7 +16,8 @@ verify.completions({
         {
             name: "Test2",
             text: "(alias) function Test2(): void\nimport Test2",
-            kind: "alias"
+            kind: "alias",
+            kindModifiers: "export"
         },
         completion.globalThisEntry,
         completion.undefinedVarEntry,

--- a/tests/cases/fourslash/completionsImport_reExportDefault.ts
+++ b/tests/cases/fourslash/completionsImport_reExportDefault.ts
@@ -34,6 +34,7 @@ verify.completions({
             sourceDisplay: "./a",
             text: "(alias) function foo(): void\nexport foo",
             kind: "alias",
+            kindModifiers: "export",
             hasAction: true,
             sortText: completion.SortText.AutoImportSuggestions
         },

--- a/tests/cases/fourslash/completionsWithDeprecatedTag.ts
+++ b/tests/cases/fourslash/completionsWithDeprecatedTag.ts
@@ -1,6 +1,13 @@
 /// <reference path="fourslash.ts" />
 // @strict: true
 
+// @filename: /foobar.ts
+//// /** @deprecated */
+//// export function foobar() {}
+
+// @filename: /foo.ts
+//// import { foobar/*4*/ } from "./foobar";
+////
 //// /** @deprecated */
 //// interface Foo {
 ////     /** @deprecated */
@@ -12,6 +19,8 @@
 //// declare const foooo: Fo/*1*/;
 //// foo.ba/*2*/;
 //// foo.pro/*3*/;
+////
+//// fooba/*5*/;
 
 verify.completions({
     marker: "1",
@@ -28,5 +37,15 @@ verify.completions({
     includes: [
       { name: "prop", kind: "property", kindModifiers: "deprecated" }
     ]
-});
-
+}, {
+    marker: "4",
+    includes: [
+      { name: "foobar", kind: "function", kindModifiers: "export,deprecated" }
+    ]
+}, {
+    marker: "5",
+    includes: [
+      { name: "foobar", kind: "alias", kindModifiers: "export,deprecated" }
+    ]
+}
+);

--- a/tests/cases/fourslash/quickInfoAlias.ts
+++ b/tests/cases/fourslash/quickInfoAlias.ts
@@ -28,7 +28,7 @@
 goTo.eachMarker((_, index) => {
     verify.verifyQuickInfoDisplayParts(
         "alias",
-        "",
+        "export",
         { start: index === 0 ? 25 : 117, length: 1 },
         [
             { text:"(",kind:"punctuation" },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #40588

I'm marking this as a draft as I'm not sure if the `kindModifiers` for the alias `"export,deprecated"` should contain the `export` modifier.
Let me know if this is correct or not as there are a few other fourslash test that are failing due to this change, so not sure if I should update them or not