### PR TITLE
fix(39022): If exported variable is renamed, tsc will generate code with a syntax error

### DIFF
--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -1874,9 +1874,8 @@ namespace ts {
                     for (const exportName of exportedNames) {
                         // Mark the node to prevent triggering this rule again.
                         noSubstitution[getNodeId(expression)] = true;
-                        expression = createExportExpression(exportName, expression);
+                        expression = factory.createParenthesizedExpression(createExportExpression(exportName, expression));
                     }
-
                     return expression;
                 }
             }

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.js
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.js
@@ -32,6 +32,6 @@ exports.buzz = buzz;
 exports.buzz = buzz += 3;
 var bizz = 8;
 exports.bizz = bizz;
-exports.bizz = bizz += 1; // compiles to exports.bizz = bizz += 1
-exports.bizz = bizz -= 1; // similarly
-exports.bizz = ++bizz; // compiles to exports.bizz = ++bizz
+(exports.bizz = bizz += 1); // compiles to exports.bizz = bizz += 1
+(exports.bizz = bizz -= 1); // similarly
+(exports.bizz = ++bizz); // compiles to exports.bizz = ++bizz

--- a/tests/baselines/reference/moduleExportsUnaryExpression.js
+++ b/tests/baselines/reference/moduleExportsUnaryExpression.js
@@ -1,0 +1,39 @@
+//// [moduleExportsUnaryExpression.ts]
+let x = 1;
+
+export function foo(y: number) {
+    if (y <= x++) return y <= x++;
+    if (y <= x--) return y <= x--;
+    if (y <= ++x) return y <= ++x;
+    if (y <= --x) return y <= --x;
+
+    x++;
+    x--;
+    ++x;
+    --x;
+}
+
+export { x };
+
+
+//// [moduleExportsUnaryExpression.js]
+"use strict";
+exports.__esModule = true;
+exports.x = exports.foo = void 0;
+var x = 1;
+exports.x = x;
+function foo(y) {
+    if (y <= (exports.x = x += 1))
+        return y <= (exports.x = x += 1);
+    if (y <= (exports.x = x -= 1))
+        return y <= (exports.x = x -= 1);
+    if (y <= (exports.x = ++x))
+        return y <= (exports.x = ++x);
+    if (y <= (exports.x = --x))
+        return y <= (exports.x = --x);
+    (exports.x = x += 1);
+    (exports.x = x -= 1);
+    (exports.x = ++x);
+    (exports.x = --x);
+}
+exports.foo = foo;

--- a/tests/baselines/reference/moduleExportsUnaryExpression.symbols
+++ b/tests/baselines/reference/moduleExportsUnaryExpression.symbols
@@ -1,0 +1,48 @@
+=== tests/cases/compiler/moduleExportsUnaryExpression.ts ===
+let x = 1;
+>x : Symbol(x, Decl(moduleExportsUnaryExpression.ts, 0, 3))
+
+export function foo(y: number) {
+>foo : Symbol(foo, Decl(moduleExportsUnaryExpression.ts, 0, 10))
+>y : Symbol(y, Decl(moduleExportsUnaryExpression.ts, 2, 20))
+
+    if (y <= x++) return y <= x++;
+>y : Symbol(y, Decl(moduleExportsUnaryExpression.ts, 2, 20))
+>x : Symbol(x, Decl(moduleExportsUnaryExpression.ts, 0, 3))
+>y : Symbol(y, Decl(moduleExportsUnaryExpression.ts, 2, 20))
+>x : Symbol(x, Decl(moduleExportsUnaryExpression.ts, 0, 3))
+
+    if (y <= x--) return y <= x--;
+>y : Symbol(y, Decl(moduleExportsUnaryExpression.ts, 2, 20))
+>x : Symbol(x, Decl(moduleExportsUnaryExpression.ts, 0, 3))
+>y : Symbol(y, Decl(moduleExportsUnaryExpression.ts, 2, 20))
+>x : Symbol(x, Decl(moduleExportsUnaryExpression.ts, 0, 3))
+
+    if (y <= ++x) return y <= ++x;
+>y : Symbol(y, Decl(moduleExportsUnaryExpression.ts, 2, 20))
+>x : Symbol(x, Decl(moduleExportsUnaryExpression.ts, 0, 3))
+>y : Symbol(y, Decl(moduleExportsUnaryExpression.ts, 2, 20))
+>x : Symbol(x, Decl(moduleExportsUnaryExpression.ts, 0, 3))
+
+    if (y <= --x) return y <= --x;
+>y : Symbol(y, Decl(moduleExportsUnaryExpression.ts, 2, 20))
+>x : Symbol(x, Decl(moduleExportsUnaryExpression.ts, 0, 3))
+>y : Symbol(y, Decl(moduleExportsUnaryExpression.ts, 2, 20))
+>x : Symbol(x, Decl(moduleExportsUnaryExpression.ts, 0, 3))
+
+    x++;
+>x : Symbol(x, Decl(moduleExportsUnaryExpression.ts, 0, 3))
+
+    x--;
+>x : Symbol(x, Decl(moduleExportsUnaryExpression.ts, 0, 3))
+
+    ++x;
+>x : Symbol(x, Decl(moduleExportsUnaryExpression.ts, 0, 3))
+
+    --x;
+>x : Symbol(x, Decl(moduleExportsUnaryExpression.ts, 0, 3))
+}
+
+export { x };
+>x : Symbol(x, Decl(moduleExportsUnaryExpression.ts, 14, 8))
+

--- a/tests/baselines/reference/moduleExportsUnaryExpression.types
+++ b/tests/baselines/reference/moduleExportsUnaryExpression.types
@@ -1,0 +1,69 @@
+=== tests/cases/compiler/moduleExportsUnaryExpression.ts ===
+let x = 1;
+>x : number
+>1 : 1
+
+export function foo(y: number) {
+>foo : (y: number) => boolean
+>y : number
+
+    if (y <= x++) return y <= x++;
+>y <= x++ : boolean
+>y : number
+>x++ : number
+>x : number
+>y <= x++ : boolean
+>y : number
+>x++ : number
+>x : number
+
+    if (y <= x--) return y <= x--;
+>y <= x-- : boolean
+>y : number
+>x-- : number
+>x : number
+>y <= x-- : boolean
+>y : number
+>x-- : number
+>x : number
+
+    if (y <= ++x) return y <= ++x;
+>y <= ++x : boolean
+>y : number
+>++x : number
+>x : number
+>y <= ++x : boolean
+>y : number
+>++x : number
+>x : number
+
+    if (y <= --x) return y <= --x;
+>y <= --x : boolean
+>y : number
+>--x : number
+>x : number
+>y <= --x : boolean
+>y : number
+>--x : number
+>x : number
+
+    x++;
+>x++ : number
+>x : number
+
+    x--;
+>x-- : number
+>x : number
+
+    ++x;
+>++x : number
+>x : number
+
+    --x;
+>--x : number
+>x : number
+}
+
+export { x };
+>x : number
+

--- a/tests/cases/compiler/moduleExportsUnaryExpression.ts
+++ b/tests/cases/compiler/moduleExportsUnaryExpression.ts
@@ -1,0 +1,16 @@
+// @module: commonjs
+let x = 1;
+
+export function foo(y: number) {
+    if (y <= x++) return y <= x++;
+    if (y <= x--) return y <= x--;
+    if (y <= ++x) return y <= ++x;
+    if (y <= --x) return y <= --x;
+
+    x++;
+    x--;
+    ++x;
+    --x;
+}
+
+export { x };


### PR DESCRIPTION
Fixes #39022