### PR TITLE
Use stricter types for tracing event arguments

### DIFF
--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -18,7 +18,7 @@ namespace ts.tracing {
     const legend: TraceRecord[] = [];
 
     // The actual constraint is that JSON.stringify be able to serialize it without throwing.
-    type Args = {
+    interface Args {
         [key: string]: string | number | boolean | null | undefined | Args | readonly (string | number | boolean | null | undefined | Args)[];
     };
 


### PR DESCRIPTION
In local development, I've routinely passed the wrong local and ended up having JSON.stringify throw.