### PR TITLE
Fix dependency order and observer registration

### DIFF
--- a/src/compiler/performanceCore.ts
+++ b/src/compiler/performanceCore.ts
@@ -71,7 +71,7 @@ namespace ts {
                     // optional `start` and `end` arguments for `performance.measure`.
                     // See https://github.com/nodejs/node/pull/32651 for more information.
                     const version = new Version(process.versions.node);
-                    const range = new VersionRange("<12 || 13 <13.13");
+                    const range = new VersionRange("<12.16.3 || 13 <13.13");
                     if (range.test(version)) {
                         return {
                             performance: {
@@ -84,7 +84,7 @@ namespace ts {
                                         performance.mark(end);
                                     }
                                     performance.measure(name, start, end);
-                                    if (end = "__performance.measure-fix__") {
+                                    if (end === "__performance.measure-fix__") {
                                         performance.clearMarks("__performance.measure-fix__");
                                     }
                                 }

--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -13,10 +13,10 @@
         "corePublic.ts",
         "core.ts",
         "debug.ts",
+        "semver.ts",
         "performanceCore.ts",
         "performance.ts",
         "perfLogger.ts",
-        "semver.ts",
         "tracing.ts",
 
         "types.ts",


### PR DESCRIPTION
Fixes a dependency ordering issue in #40593 and correctly handles that PerformanceObserver's callback is called each time a mark or measure is recorded, not just once.

These issues were detected when running perf tests on another PR.