### PR TITLE
Fix visibility lookup for cjs require aliases

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4164,6 +4164,14 @@ namespace ts {
                         && isDeclarationVisible(declaration.parent)) {
                         return addVisibleAlias(declaration, declaration);
                     }
+                    else if (isBindingElement(declaration) && isInJSFile(declaration) && declaration.parent?.parent // exported import-like top-level JS require statement
+                        && isVariableDeclaration(declaration.parent.parent)
+                        && declaration.parent.parent.parent?.parent && isVariableStatement(declaration.parent.parent.parent.parent)
+                        && !hasSyntacticModifier(declaration.parent.parent.parent.parent, ModifierFlags.Export)
+                        && declaration.parent.parent.parent.parent.parent // check if the thing containing the variable statement is visible (ie, the file)
+                        && isDeclarationVisible(declaration.parent.parent.parent.parent.parent)) {
+                        return addVisibleAlias(declaration, declaration.parent.parent.parent.parent);
+                    }
 
                     // Declaration is not visible
                     return false;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4164,7 +4164,7 @@ namespace ts {
                         && isDeclarationVisible(declaration.parent)) {
                         return addVisibleAlias(declaration, declaration);
                     }
-                    else if (isBindingElement(declaration) && isInJSFile(declaration) && declaration.parent?.parent // exported import-like top-level JS require statement
+                    else if (symbol.flags & SymbolFlags.Alias && isBindingElement(declaration) && isInJSFile(declaration) && declaration.parent?.parent // exported import-like top-level JS require statement
                         && isVariableDeclaration(declaration.parent.parent)
                         && declaration.parent.parent.parent?.parent && isVariableStatement(declaration.parent.parent.parent.parent)
                         && !hasSyntacticModifier(declaration.parent.parent.parent.parent, ModifierFlags.Export)

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.js
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.js
@@ -94,14 +94,6 @@ export const testFnTypes: {
     [x: string]: any;
 };
 export namespace testFnTypes {
-    type input = boolean | Function | {
-        /**
-         * - Prop 1.
-         */
-        prop1: string | RegExp | (string | RegExp)[];
-        /**
-         * - Prop 2.
-         */
-        prop2: string;
-    };
+    type input = boolean | Function | myTypes.typeB;
 }
+import { myTypes } from "./file.js";

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.types
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.types
@@ -27,12 +27,12 @@ const testFnTypes = {
  */
 function testFn(input) {
 >testFn : (input: testFnTypes.input) => number | null
->input : boolean | Function | { prop1: string | RegExp | (string | RegExp)[]; prop2: string; }
+>input : boolean | Function | myTypes.typeB
 
     if (typeof input === 'number') {
 >typeof input === 'number' : boolean
 >typeof input : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
->input : boolean | Function | { prop1: string | RegExp | (string | RegExp)[]; prop2: string; }
+>input : boolean | Function | myTypes.typeB
 >'number' : "number"
 
         return 2 * input;


### PR DESCRIPTION
Fixes the easier half of #41250 (painting the visibility of `const {Item} = require("...")` statements), which is otherwise still broken with this change. You can see how this change positively affects an existing baseline.