### PR TITLE
feat(12365): Add formatter option "insertSpaceAfterTypeAnnotation"

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -3206,7 +3206,7 @@ namespace ts.server.protocol {
         placeOpenBraceOnNewLineForFunctions?: boolean;
         placeOpenBraceOnNewLineForControlBlocks?: boolean;
         insertSpaceBeforeTypeAnnotation?: boolean;
-        insertSpaceAftertypeAnnotation?: boolean;
+        insertSpaceAfterTypeAnnotation?: boolean;
         semicolons?: SemicolonPreference;
     }
 

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -3206,6 +3206,7 @@ namespace ts.server.protocol {
         placeOpenBraceOnNewLineForFunctions?: boolean;
         placeOpenBraceOnNewLineForControlBlocks?: boolean;
         insertSpaceBeforeTypeAnnotation?: boolean;
+        insertSpaceAftertypeAnnotation?: boolean;
         semicolons?: SemicolonPreference;
     }
 

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -300,8 +300,8 @@ namespace ts.formatting {
             rule("NoSpaceBeforeBinaryOperator", anyToken, binaryOperators, [isOptionDisabledOrUndefined("insertSpaceBeforeAndAfterBinaryOperators"), isNonJsxSameLineTokenContext, isBinaryOpContext], RuleAction.DeleteSpace),
             rule("NoSpaceAfterBinaryOperator", binaryOperators, anyToken, [isOptionDisabledOrUndefined("insertSpaceBeforeAndAfterBinaryOperators"), isNonJsxSameLineTokenContext, isBinaryOpContext], RuleAction.DeleteSpace),
 
-            rule("SpaceBeforeOpenParenInFuncDecl", anyToken, SyntaxKind.OpenParenToken, [isOptionEnabled("insertSpaceBeforeFunctionParenthesis"), isNonJsxSameLineTokenContext, isFunctionDeclContext], RuleAction.InsertSpace),
-            rule("NoSpaceBeforeOpenParenInFuncDecl", anyToken, SyntaxKind.OpenParenToken, [isOptionDisabledOrUndefined("insertSpaceBeforeFunctionParenthesis"), isNonJsxSameLineTokenContext, isFunctionDeclContext], RuleAction.DeleteSpace),
+            rule("SpaceBeforeOpenParenInFuncDecl", [SyntaxKind.Identifier, SyntaxKind.GreaterThanToken], SyntaxKind.OpenParenToken, [isOptionEnabled("insertSpaceBeforeFunctionParenthesis"), isNonJsxSameLineTokenContext, isFunctionDeclContext], RuleAction.InsertSpace),
+            rule("NoSpaceBeforeOpenParenInFuncDecl", [SyntaxKind.Identifier, SyntaxKind.GreaterThanToken], SyntaxKind.OpenParenToken, [isOptionDisabledOrUndefined("insertSpaceBeforeFunctionParenthesis"), isNonJsxSameLineTokenContext, isFunctionDeclContext], RuleAction.DeleteSpace),
 
             // Open Brace braces after control block
             rule("NewLineBeforeOpenBraceInControl", controlOpenBraceLeftTokenRange, SyntaxKind.OpenBraceToken, [isOptionEnabled("placeOpenBraceOnNewLineForControlBlocks"), isControlDeclContext, isBeforeMultilineBlockContext], RuleAction.InsertNewLine, RuleFlags.CanDeleteNewLines),

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -51,7 +51,7 @@ namespace ts.formatting {
             rule("IgnoreAfterLineComment", SyntaxKind.SingleLineCommentTrivia, anyToken, anyContext, RuleAction.StopProcessingSpaceActions),
 
             rule("NotSpaceBeforeColon", anyToken, SyntaxKind.ColonToken, [isNonJsxSameLineTokenContext, isNotBinaryOpContext, isNotTypeAnnotationContext], RuleAction.DeleteSpace),
-            rule("SpaceAfterColon", SyntaxKind.ColonToken, anyToken, [isNonJsxSameLineTokenContext, isNotBinaryOpContext], RuleAction.InsertSpace),
+            rule("SpaceAfterColon", SyntaxKind.ColonToken, anyToken, [isNonJsxSameLineTokenContext, isNotBinaryOpContext, isNotTypeAnnotationContext], RuleAction.InsertSpace),
             rule("NoSpaceBeforeQuestionMark", anyToken, SyntaxKind.QuestionToken, [isNonJsxSameLineTokenContext, isNotBinaryOpContext, isNotTypeAnnotationContext], RuleAction.DeleteSpace),
             // insert space after '?' only when it is used in conditional operator
             rule("SpaceAfterQuestionMarkInConditionalOperator", SyntaxKind.QuestionToken, anyToken, [isNonJsxSameLineTokenContext, isConditionalOperatorContext], RuleAction.InsertSpace),
@@ -317,6 +317,9 @@ namespace ts.formatting {
 
             rule("SpaceBeforeTypeAnnotation", anyToken, [SyntaxKind.QuestionToken, SyntaxKind.ColonToken], [isOptionEnabled("insertSpaceBeforeTypeAnnotation"), isNonJsxSameLineTokenContext, isTypeAnnotationContext], RuleAction.InsertSpace),
             rule("NoSpaceBeforeTypeAnnotation", anyToken, [SyntaxKind.QuestionToken, SyntaxKind.ColonToken], [isOptionDisabledOrUndefined("insertSpaceBeforeTypeAnnotation"), isNonJsxSameLineTokenContext, isTypeAnnotationContext], RuleAction.DeleteSpace),
+
+            rule("SpaceAfterTypeAnnotation", SyntaxKind.ColonToken, anyToken, [isOptionEnabledOrUndefined("insertSpaceAfterTypeAnnotation"), isNonJsxSameLineTokenContext, isTypeAnnotationContext], RuleAction.InsertSpace),
+            rule("NoSpaceAfterTypeAnnotation", SyntaxKind.ColonToken, anyToken, [isOptionDisabled("insertSpaceAfterTypeAnnotation"), isNonJsxSameLineTokenContext, isTypeAnnotationContext], RuleAction.DeleteSpace),
 
             rule("NoOptionalSemicolon", SyntaxKind.SemicolonToken, anyTokenIncludingEOF, [optionEquals("semicolons", SemicolonPreference.Remove), isSemicolonDeletionContext], RuleAction.DeleteToken),
             rule("OptionalSemicolon", anyToken, anyTokenIncludingEOF, [optionEquals("semicolons", SemicolonPreference.Insert), isSemicolonInsertionContext], RuleAction.InsertTrailingSemicolon),

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -943,6 +943,7 @@ namespace ts {
         readonly placeOpenBraceOnNewLineForFunctions?: boolean;
         readonly placeOpenBraceOnNewLineForControlBlocks?: boolean;
         readonly insertSpaceBeforeTypeAnnotation?: boolean;
+        readonly insertSpaceAfterTypeAnnotation?: boolean;
         readonly indentMultiLineObjectLiteralBeginningOnBlankLine?: boolean;
         readonly semicolons?: SemicolonPreference;
     }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -5925,6 +5925,7 @@ declare namespace ts {
         readonly placeOpenBraceOnNewLineForFunctions?: boolean;
         readonly placeOpenBraceOnNewLineForControlBlocks?: boolean;
         readonly insertSpaceBeforeTypeAnnotation?: boolean;
+        readonly insertSpaceAfterTypeAnnotation?: boolean;
         readonly indentMultiLineObjectLiteralBeginningOnBlankLine?: boolean;
         readonly semicolons?: SemicolonPreference;
     }
@@ -8977,6 +8978,7 @@ declare namespace ts.server.protocol {
         placeOpenBraceOnNewLineForFunctions?: boolean;
         placeOpenBraceOnNewLineForControlBlocks?: boolean;
         insertSpaceBeforeTypeAnnotation?: boolean;
+        insertSpaceAfterTypeAnnotation?: boolean;
         semicolons?: SemicolonPreference;
     }
     interface UserPreferences {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -5925,6 +5925,7 @@ declare namespace ts {
         readonly placeOpenBraceOnNewLineForFunctions?: boolean;
         readonly placeOpenBraceOnNewLineForControlBlocks?: boolean;
         readonly insertSpaceBeforeTypeAnnotation?: boolean;
+        readonly insertSpaceAfterTypeAnnotation?: boolean;
         readonly indentMultiLineObjectLiteralBeginningOnBlankLine?: boolean;
         readonly semicolons?: SemicolonPreference;
     }

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -161,6 +161,7 @@ declare namespace FourSlashInterface {
         readonly placeOpenBraceOnNewLineForFunctions?: boolean;
         readonly placeOpenBraceOnNewLineForControlBlocks?: boolean;
         readonly insertSpaceBeforeTypeAnnotation?: boolean;
+        readonly insertSpaceAfterTypeAnnotation?: boolean;
         readonly indentMultiLineObjectLiteralBeginningOnBlankLine?: boolean;
         readonly semicolons?: ts.SemicolonPreference;
     }

--- a/tests/cases/fourslash/spaceAfterTypeAnnotation.ts
+++ b/tests/cases/fourslash/spaceAfterTypeAnnotation.ts
@@ -1,0 +1,61 @@
+/// <reference path="fourslash.ts" />
+
+////
+//// interface Person {
+////     name:string;
+////     age: number;
+//// }
+//// let person: Person = {
+////     name:"Obi-Wan Kenobi",
+////     age: 38
+//// };
+//// let ground:object = { type:"high" };
+//// function greet(from: typeof person, message:"hello there"):void { }
+//// let landing:(type: string) => string = function (type:"another"):"sad" | "happy" {
+////     return "happy"; 
+//// };
+////
+
+// 1. Variable, field, parameter and return types should all be affected.
+// 2. Make sure colons in object literals aren't affected.
+// 3. Check one-liner object literals on the same line as type annotations as well, just in case.
+
+//format.setOption("insertSpaceAfterTypeAnnotation", true); // true should be the default option.
+format.document();
+verify.currentFileContentIs(
+`
+interface Person {
+    name: string;
+    age: number;
+}
+let person: Person = {
+    name: "Obi-Wan Kenobi",
+    age: 38
+};
+let ground: object = { type: "high" };
+function greet(from: typeof person, message: "hello there"): void { }
+let landing: (type: string) => string = function(type: "another"): "sad" | "happy" {
+    return "happy";
+};
+`
+);
+
+format.setOption("insertSpaceAfterTypeAnnotation", false);
+format.document();
+verify.currentFileContentIs(
+`
+interface Person {
+    name:string;
+    age:number;
+}
+let person:Person = {
+    name: "Obi-Wan Kenobi",
+    age: 38
+};
+let ground:object = { type: "high" };
+function greet(from:typeof person, message:"hello there"):void { }
+let landing:(type:string) => string = function(type:"another"):"sad" | "happy" {
+    return "happy";
+};
+`
+);

--- a/tests/cases/fourslash/spaceBeforeOpenParenInFuncDecl.ts
+++ b/tests/cases/fourslash/spaceBeforeOpenParenInFuncDecl.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+//// /*1*/function f () : void { }
+//// /*2*/function f<A>   () : void { }
+//// /*3*/function f<A extends B<A>>   ()  :void { }
+//// /*4*/function f<A extends C<B<A>>>     ()  :   void { }
+
+format.document();
+
+goTo.marker("1");
+verify.currentLineContentIs("function f(): void { }");
+
+goTo.marker("2");
+verify.currentLineContentIs("function f<A>(): void { }");
+
+goTo.marker("3");
+verify.currentLineContentIs("function f<A extends B<A>>(): void { }");
+
+goTo.marker("4");
+verify.currentLineContentIs("function f<A extends C<B<A>>>(): void { }");


### PR DESCRIPTION
Adds an option to insert/remove space after the type annotation colon:
```ts
// true or undefined
let obj: { a: string, b: number } = { a: "a", b: 1 };

// false
let obj:{ a:string, b:number } = { a: "a", b: 1 };
```

First contribution, so I'm definitely not familiar with the codebase.
There can be places I missed that I have to change as well to add the new formatter option.

Fixes #12365
