### PR TITLE
fix(41227): Cryptic error message when assigning to a key also present on the construtor, but forggetting to declare it in the calss body

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13861,7 +13861,8 @@ namespace ts {
                     }
                     else if (noImplicitAny && !compilerOptions.suppressImplicitAnyIndexErrors && !suppressNoImplicitAnyError) {
                         if (propName !== undefined && typeHasStaticProperty(propName, objectType)) {
-                            error(accessExpression, Diagnostics.Property_0_is_a_static_member_of_type_1, propName as string, typeToString(objectType));
+                            const typeName = typeToString(objectType);
+                            error(accessExpression, Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_mean_to_access_the_static_member_2_instead, propName as string, typeName, typeName + "[" + getTextOfNode(accessExpression.argumentExpression) + "]");
                         }
                         else if (getIndexTypeOfType(objectType, IndexKind.Number)) {
                             error(accessExpression.argumentExpression, Diagnostics.Element_implicitly_has_an_any_type_because_index_expression_is_not_of_type_number);
@@ -25940,7 +25941,9 @@ namespace ts {
                 }
             }
             if (typeHasStaticProperty(propNode.escapedText, containingType)) {
-                errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_is_a_static_member_of_type_1, declarationNameToString(propNode), typeToString(containingType));
+                const propName = declarationNameToString(propNode);
+                const typeName = typeToString(containingType);
+                errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_mean_to_access_the_static_member_2_instead, propName, typeName, typeName + "." + propName);
             }
             else {
                 const promisedType = getPromisedTypeOfPromise(containingType);

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2293,7 +2293,7 @@
         "category": "Error",
         "code": 2575
     },
-    "Property '{0}' is a static member of type '{1}'.": {
+    "Property '{0}' does not exist on type '{1}'. Did you mean to access the static member '{2}' instead?": {
         "category": "Error",
         "code": 2576
     },

--- a/tests/baselines/reference/classImplementsClass6.errors.txt
+++ b/tests/baselines/reference/classImplementsClass6.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/classImplementsClass6.ts(20,3): error TS2339: Property 'bar' does not exist on type 'C'.
-tests/cases/compiler/classImplementsClass6.ts(21,4): error TS2576: Property 'bar' is a static member of type 'C2'.
+tests/cases/compiler/classImplementsClass6.ts(21,4): error TS2576: Property 'bar' does not exist on type 'C2'. Did you mean to access the static member 'C2.bar' instead?
 
 
 ==== tests/cases/compiler/classImplementsClass6.ts (2 errors) ====
@@ -27,4 +27,4 @@ tests/cases/compiler/classImplementsClass6.ts(21,4): error TS2576: Property 'bar
 !!! error TS2339: Property 'bar' does not exist on type 'C'.
     c2.bar(); // should error
        ~~~
-!!! error TS2576: Property 'bar' is a static member of type 'C2'.
+!!! error TS2576: Property 'bar' does not exist on type 'C2'. Did you mean to access the static member 'C2.bar' instead?

--- a/tests/baselines/reference/classSideInheritance1.errors.txt
+++ b/tests/baselines/reference/classSideInheritance1.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/classSideInheritance1.ts(12,3): error TS2576: Property 'bar' is a static member of type 'A'.
-tests/cases/compiler/classSideInheritance1.ts(13,3): error TS2576: Property 'bar' is a static member of type 'C2'.
+tests/cases/compiler/classSideInheritance1.ts(12,3): error TS2576: Property 'bar' does not exist on type 'A'. Did you mean to access the static member 'A.bar' instead?
+tests/cases/compiler/classSideInheritance1.ts(13,3): error TS2576: Property 'bar' does not exist on type 'C2'. Did you mean to access the static member 'C2.bar' instead?
 
 
 ==== tests/cases/compiler/classSideInheritance1.ts (2 errors) ====
@@ -16,9 +16,9 @@ tests/cases/compiler/classSideInheritance1.ts(13,3): error TS2576: Property 'bar
     var c: C2;
     a.bar(); // static off an instance - should be an error
       ~~~
-!!! error TS2576: Property 'bar' is a static member of type 'A'.
+!!! error TS2576: Property 'bar' does not exist on type 'A'. Did you mean to access the static member 'A.bar' instead?
     c.bar(); // static off an instance - should be an error
       ~~~
-!!! error TS2576: Property 'bar' is a static member of type 'C2'.
+!!! error TS2576: Property 'bar' does not exist on type 'C2'. Did you mean to access the static member 'C2.bar' instead?
     A.bar(); // valid
     C2.bar(); // valid

--- a/tests/baselines/reference/classStaticPropertyAccess.errors.txt
+++ b/tests/baselines/reference/classStaticPropertyAccess.errors.txt
@@ -1,11 +1,13 @@
-tests/cases/compiler/classStaticPropertyAccess.ts(9,1): error TS2576: Property 'y' is a static member of type 'A'.
-tests/cases/compiler/classStaticPropertyAccess.ts(10,3): error TS2576: Property 'y' is a static member of type 'A'.
-tests/cases/compiler/classStaticPropertyAccess.ts(11,3): error TS2341: Property '_b' is private and only accessible within class 'A'.
-tests/cases/compiler/classStaticPropertyAccess.ts(12,3): error TS2339: Property 'a' does not exist on type 'typeof A'.
+tests/cases/compiler/classStaticPropertyAccess.ts(10,1): error TS2576: Property '"' does not exist on type 'A'. Did you mean to access the static member 'A["\""]' instead?
+tests/cases/compiler/classStaticPropertyAccess.ts(11,1): error TS2576: Property 'y' does not exist on type 'A'. Did you mean to access the static member 'A['y']' instead?
+tests/cases/compiler/classStaticPropertyAccess.ts(12,3): error TS2576: Property 'y' does not exist on type 'A'. Did you mean to access the static member 'A.y' instead?
+tests/cases/compiler/classStaticPropertyAccess.ts(13,3): error TS2341: Property '_b' is private and only accessible within class 'A'.
+tests/cases/compiler/classStaticPropertyAccess.ts(14,3): error TS2339: Property 'a' does not exist on type 'typeof A'.
 
 
-==== tests/cases/compiler/classStaticPropertyAccess.ts (4 errors) ====
+==== tests/cases/compiler/classStaticPropertyAccess.ts (5 errors) ====
     class A {
+        public static "\""() {}
         public static x: number = 1;
         public static y: number = 1;
         private static _b: number = 2;
@@ -13,13 +15,16 @@ tests/cases/compiler/classStaticPropertyAccess.ts(12,3): error TS2339: Property 
     
     const a = new A();
     
-    a['y'] // Error
+    a["\""] // Error
+    ~~~~~~~
+!!! error TS2576: Property '"' does not exist on type 'A'. Did you mean to access the static member 'A["\""]' instead?
+    a['y']  // Error
     ~~~~~~
-!!! error TS2576: Property 'y' is a static member of type 'A'.
-    a.y    // Error
+!!! error TS2576: Property 'y' does not exist on type 'A'. Did you mean to access the static member 'A['y']' instead?
+    a.y     // Error
       ~
-!!! error TS2576: Property 'y' is a static member of type 'A'.
-    A._b   // Error
+!!! error TS2576: Property 'y' does not exist on type 'A'. Did you mean to access the static member 'A.y' instead?
+    A._b    // Error
       ~~
 !!! error TS2341: Property '_b' is private and only accessible within class 'A'.
     A.a

--- a/tests/baselines/reference/classStaticPropertyAccess.js
+++ b/tests/baselines/reference/classStaticPropertyAccess.js
@@ -1,5 +1,6 @@
 //// [classStaticPropertyAccess.ts]
 class A {
+    public static "\""() {}
     public static x: number = 1;
     public static y: number = 1;
     private static _b: number = 2;
@@ -7,9 +8,10 @@ class A {
 
 const a = new A();
 
-a['y'] // Error
-a.y    // Error
-A._b   // Error
+a["\""] // Error
+a['y']  // Error
+a.y     // Error
+A._b    // Error
 A.a
 
 
@@ -18,12 +20,14 @@ A.a
 var A = /** @class */ (function () {
     function A() {
     }
+    A["\""] = function () { };
     A.x = 1;
     A.y = 1;
     A._b = 2;
     return A;
 }());
 var a = new A();
+a["\""]; // Error
 a['y']; // Error
 a.y; // Error
 A._b; // Error

--- a/tests/baselines/reference/classStaticPropertyAccess.symbols
+++ b/tests/baselines/reference/classStaticPropertyAccess.symbols
@@ -2,30 +2,36 @@
 class A {
 >A : Symbol(A, Decl(classStaticPropertyAccess.ts, 0, 0))
 
+    public static "\""() {}
+>"\"" : Symbol(A["\""], Decl(classStaticPropertyAccess.ts, 0, 9))
+
     public static x: number = 1;
->x : Symbol(A.x, Decl(classStaticPropertyAccess.ts, 0, 9))
+>x : Symbol(A.x, Decl(classStaticPropertyAccess.ts, 1, 27))
 
     public static y: number = 1;
->y : Symbol(A.y, Decl(classStaticPropertyAccess.ts, 1, 32))
+>y : Symbol(A.y, Decl(classStaticPropertyAccess.ts, 2, 32))
 
     private static _b: number = 2;
->_b : Symbol(A._b, Decl(classStaticPropertyAccess.ts, 2, 32))
+>_b : Symbol(A._b, Decl(classStaticPropertyAccess.ts, 3, 32))
 }
 
 const a = new A();
->a : Symbol(a, Decl(classStaticPropertyAccess.ts, 6, 5))
+>a : Symbol(a, Decl(classStaticPropertyAccess.ts, 7, 5))
 >A : Symbol(A, Decl(classStaticPropertyAccess.ts, 0, 0))
 
-a['y'] // Error
->a : Symbol(a, Decl(classStaticPropertyAccess.ts, 6, 5))
+a["\""] // Error
+>a : Symbol(a, Decl(classStaticPropertyAccess.ts, 7, 5))
 
-a.y    // Error
->a : Symbol(a, Decl(classStaticPropertyAccess.ts, 6, 5))
+a['y']  // Error
+>a : Symbol(a, Decl(classStaticPropertyAccess.ts, 7, 5))
 
-A._b   // Error
->A._b : Symbol(A._b, Decl(classStaticPropertyAccess.ts, 2, 32))
+a.y     // Error
+>a : Symbol(a, Decl(classStaticPropertyAccess.ts, 7, 5))
+
+A._b    // Error
+>A._b : Symbol(A._b, Decl(classStaticPropertyAccess.ts, 3, 32))
 >A : Symbol(A, Decl(classStaticPropertyAccess.ts, 0, 0))
->_b : Symbol(A._b, Decl(classStaticPropertyAccess.ts, 2, 32))
+>_b : Symbol(A._b, Decl(classStaticPropertyAccess.ts, 3, 32))
 
 A.a
 >A : Symbol(A, Decl(classStaticPropertyAccess.ts, 0, 0))

--- a/tests/baselines/reference/classStaticPropertyAccess.types
+++ b/tests/baselines/reference/classStaticPropertyAccess.types
@@ -2,6 +2,9 @@
 class A {
 >A : A
 
+    public static "\""() {}
+>"\"" : () => void
+
     public static x: number = 1;
 >x : number
 >1 : 1
@@ -20,17 +23,22 @@ const a = new A();
 >new A() : A
 >A : typeof A
 
-a['y'] // Error
+a["\""] // Error
+>a["\""] : any
+>a : A
+>"\"" : "\""
+
+a['y']  // Error
 >a['y'] : any
 >a : A
 >'y' : "y"
 
-a.y    // Error
+a.y     // Error
 >a.y : any
 >a : A
 >y : any
 
-A._b   // Error
+A._b    // Error
 >A._b : number
 >A : typeof A
 >_b : number

--- a/tests/baselines/reference/cloduleTest2.errors.txt
+++ b/tests/baselines/reference/cloduleTest2.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/compiler/cloduleTest2.ts(4,13): error TS2554: Expected 1 arguments, but got 0.
 tests/cases/compiler/cloduleTest2.ts(10,13): error TS2554: Expected 1 arguments, but got 0.
-tests/cases/compiler/cloduleTest2.ts(18,7): error TS2576: Property 'bar' is a static member of type 'm3d'.
+tests/cases/compiler/cloduleTest2.ts(18,7): error TS2576: Property 'bar' does not exist on type 'm3d'. Did you mean to access the static member 'm3d.bar' instead?
 tests/cases/compiler/cloduleTest2.ts(19,7): error TS2339: Property 'y' does not exist on type 'm3d'.
-tests/cases/compiler/cloduleTest2.ts(27,7): error TS2576: Property 'bar' is a static member of type 'm3d'.
+tests/cases/compiler/cloduleTest2.ts(27,7): error TS2576: Property 'bar' does not exist on type 'm3d'. Did you mean to access the static member 'm3d.bar' instead?
 tests/cases/compiler/cloduleTest2.ts(28,7): error TS2339: Property 'y' does not exist on type 'm3d'.
 tests/cases/compiler/cloduleTest2.ts(33,9): error TS2554: Expected 1 arguments, but got 0.
 tests/cases/compiler/cloduleTest2.ts(36,10): error TS2554: Expected 1 arguments, but got 0.
@@ -34,7 +34,7 @@ tests/cases/compiler/cloduleTest2.ts(36,10): error TS2554: Expected 1 arguments,
         r.foo();
         r.bar(); // error
           ~~~
-!!! error TS2576: Property 'bar' is a static member of type 'm3d'.
+!!! error TS2576: Property 'bar' does not exist on type 'm3d'. Did you mean to access the static member 'm3d.bar' instead?
         r.y; // error
           ~
 !!! error TS2339: Property 'y' does not exist on type 'm3d'.
@@ -47,7 +47,7 @@ tests/cases/compiler/cloduleTest2.ts(36,10): error TS2554: Expected 1 arguments,
         r.foo();
         r.bar(); // error
           ~~~
-!!! error TS2576: Property 'bar' is a static member of type 'm3d'.
+!!! error TS2576: Property 'bar' does not exist on type 'm3d'. Did you mean to access the static member 'm3d.bar' instead?
         r.y; // error
           ~
 !!! error TS2339: Property 'y' does not exist on type 'm3d'.

--- a/tests/baselines/reference/staticMemberExportAccess.errors.txt
+++ b/tests/baselines/reference/staticMemberExportAccess.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/staticMemberExportAccess.ts(14,39): error TS2351: This expression is not constructable.
   Type 'Sammy' has no construct signatures.
-tests/cases/compiler/staticMemberExportAccess.ts(17,18): error TS2576: Property 'bar' is a static member of type 'Sammy'.
+tests/cases/compiler/staticMemberExportAccess.ts(17,18): error TS2576: Property 'bar' does not exist on type 'Sammy'. Did you mean to access the static member 'Sammy.bar' instead?
 tests/cases/compiler/staticMemberExportAccess.ts(18,18): error TS2339: Property 'x' does not exist on type 'Sammy'.
 
 
@@ -26,7 +26,7 @@ tests/cases/compiler/staticMemberExportAccess.ts(18,18): error TS2339: Property 
     var r2 = $.sammy.foo();
     var r3 = $.sammy.bar(); // error
                      ~~~
-!!! error TS2576: Property 'bar' is a static member of type 'Sammy'.
+!!! error TS2576: Property 'bar' does not exist on type 'Sammy'. Did you mean to access the static member 'Sammy.bar' instead?
     var r4 = $.sammy.x; // error
                      ~
 !!! error TS2339: Property 'x' does not exist on type 'Sammy'.

--- a/tests/baselines/reference/staticOffOfInstance1.errors.txt
+++ b/tests/baselines/reference/staticOffOfInstance1.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/staticOffOfInstance1.ts(3,10): error TS2576: Property 'Foo' is a static member of type 'List'.
+tests/cases/compiler/staticOffOfInstance1.ts(3,10): error TS2576: Property 'Foo' does not exist on type 'List'. Did you mean to access the static member 'List.Foo' instead?
 
 
 ==== tests/cases/compiler/staticOffOfInstance1.ts (1 errors) ====
@@ -6,7 +6,7 @@ tests/cases/compiler/staticOffOfInstance1.ts(3,10): error TS2576: Property 'Foo'
       public Blah() {
         this.Foo();
              ~~~
-!!! error TS2576: Property 'Foo' is a static member of type 'List'.
+!!! error TS2576: Property 'Foo' does not exist on type 'List'. Did you mean to access the static member 'List.Foo' instead?
       }
       public static Foo() {}
     }

--- a/tests/baselines/reference/staticOffOfInstance2.errors.txt
+++ b/tests/baselines/reference/staticOffOfInstance2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/staticOffOfInstance2.ts(3,14): error TS2576: Property 'Foo' is a static member of type 'List<T>'.
+tests/cases/compiler/staticOffOfInstance2.ts(3,14): error TS2576: Property 'Foo' does not exist on type 'List<T>'. Did you mean to access the static member 'List<T>.Foo' instead?
 
 
 ==== tests/cases/compiler/staticOffOfInstance2.ts (1 errors) ====
@@ -6,7 +6,7 @@ tests/cases/compiler/staticOffOfInstance2.ts(3,14): error TS2576: Property 'Foo'
         public Blah() {
             this.Foo(); // no error
                  ~~~
-!!! error TS2576: Property 'Foo' is a static member of type 'List<T>'.
+!!! error TS2576: Property 'Foo' does not exist on type 'List<T>'. Did you mean to access the static member 'List<T>.Foo' instead?
             List.Foo();
         }
         public static Foo() { }

--- a/tests/baselines/reference/staticPropertyNotInClassType.errors.txt
+++ b/tests/baselines/reference/staticPropertyNotInClassType.errors.txt
@@ -1,14 +1,14 @@
 tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(4,20): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(5,20): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(16,16): error TS2576: Property 'foo' is a static member of type 'C'.
+tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(16,16): error TS2576: Property 'foo' does not exist on type 'C'. Did you mean to access the static member 'C.foo' instead?
 tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(17,16): error TS2339: Property 'bar' does not exist on type 'C'.
-tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(18,16): error TS2576: Property 'x' is a static member of type 'C'.
+tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(18,16): error TS2576: Property 'x' does not exist on type 'C'. Did you mean to access the static member 'C.x' instead?
 tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(24,20): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(25,20): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(27,21): error TS2302: Static members cannot reference class type parameters.
-tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(36,16): error TS2576: Property 'foo' is a static member of type 'C<number, string>'.
+tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(36,16): error TS2576: Property 'foo' does not exist on type 'C<number, string>'. Did you mean to access the static member 'C<number, string>.foo' instead?
 tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(37,16): error TS2339: Property 'bar' does not exist on type 'C<number, string>'.
-tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(38,16): error TS2576: Property 'x' is a static member of type 'C<number, string>'.
+tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts(38,16): error TS2576: Property 'x' does not exist on type 'C<number, string>'. Did you mean to access the static member 'C<number, string>.x' instead?
 
 
 ==== tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts (11 errors) ====
@@ -33,13 +33,13 @@ tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.
         var r = c.fn();
         var r4 = c.foo; // error
                    ~~~
-!!! error TS2576: Property 'foo' is a static member of type 'C'.
+!!! error TS2576: Property 'foo' does not exist on type 'C'. Did you mean to access the static member 'C.foo' instead?
         var r5 = c.bar; // error
                    ~~~
 !!! error TS2339: Property 'bar' does not exist on type 'C'.
         var r6 = c.x; // error
                    ~
-!!! error TS2576: Property 'x' is a static member of type 'C'.
+!!! error TS2576: Property 'x' does not exist on type 'C'. Did you mean to access the static member 'C.x' instead?
     }
     
     module Generic {
@@ -65,11 +65,11 @@ tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.
         var r = c.fn();
         var r4 = c.foo; // error
                    ~~~
-!!! error TS2576: Property 'foo' is a static member of type 'C<number, string>'.
+!!! error TS2576: Property 'foo' does not exist on type 'C<number, string>'. Did you mean to access the static member 'C<number, string>.foo' instead?
         var r5 = c.bar; // error
                    ~~~
 !!! error TS2339: Property 'bar' does not exist on type 'C<number, string>'.
         var r6 = c.x; // error
                    ~
-!!! error TS2576: Property 'x' is a static member of type 'C<number, string>'.
+!!! error TS2576: Property 'x' does not exist on type 'C<number, string>'. Did you mean to access the static member 'C<number, string>.x' instead?
     }

--- a/tests/baselines/reference/staticVisibility2.errors.txt
+++ b/tests/baselines/reference/staticVisibility2.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/staticVisibility2.ts(2,12): error TS7008: Member 'sideLength' implicitly has an 'any' type.
-tests/cases/compiler/staticVisibility2.ts(4,14): error TS2576: Property 'sideLength' is a static member of type 'Square'.
+tests/cases/compiler/staticVisibility2.ts(4,14): error TS2576: Property 'sideLength' does not exist on type 'Square'. Did you mean to access the static member 'Square.sideLength' instead?
 
 
 ==== tests/cases/compiler/staticVisibility2.ts (2 errors) ====
@@ -10,6 +10,6 @@ tests/cases/compiler/staticVisibility2.ts(4,14): error TS2576: Property 'sideLen
         constructor(sideLength: number) {
             this.sideLength = sideLength;
                  ~~~~~~~~~~
-!!! error TS2576: Property 'sideLength' is a static member of type 'Square'.
+!!! error TS2576: Property 'sideLength' does not exist on type 'Square'. Did you mean to access the static member 'Square.sideLength' instead?
         }
     }

--- a/tests/baselines/reference/superAccess.errors.txt
+++ b/tests/baselines/reference/superAccess.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/superAccess.ts(9,24): error TS2576: Property 'S1' is a static member of type 'MyBase'.
+tests/cases/compiler/superAccess.ts(9,24): error TS2576: Property 'S1' does not exist on type 'MyBase'. Did you mean to access the static member 'MyBase.S1' instead?
 tests/cases/compiler/superAccess.ts(10,24): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
 tests/cases/compiler/superAccess.ts(11,24): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
 
@@ -14,7 +14,7 @@ tests/cases/compiler/superAccess.ts(11,24): error TS2340: Only public and protec
         foo() {
             var l3 = super.S1;    // Expected => Error: Only public instance methods of the base class are accessible via the 'super' keyword
                            ~~
-!!! error TS2576: Property 'S1' is a static member of type 'MyBase'.
+!!! error TS2576: Property 'S1' does not exist on type 'MyBase'. Did you mean to access the static member 'MyBase.S1' instead?
             var l4 = super.S2;    // Expected => Error: Only public instance methods of the base class are accessible via the 'super' keyword
                            ~~
 !!! error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.

--- a/tests/baselines/reference/superAccess2.errors.txt
+++ b/tests/baselines/reference/superAccess2.errors.txt
@@ -9,7 +9,7 @@ tests/cases/compiler/superAccess2.ts(11,40): error TS17011: 'super' must be call
 tests/cases/compiler/superAccess2.ts(11,45): error TS1034: 'super' must be followed by an argument list or member access.
 tests/cases/compiler/superAccess2.ts(11,64): error TS1034: 'super' must be followed by an argument list or member access.
 tests/cases/compiler/superAccess2.ts(15,19): error TS1034: 'super' must be followed by an argument list or member access.
-tests/cases/compiler/superAccess2.ts(17,15): error TS2576: Property 'y' is a static member of type 'P'.
+tests/cases/compiler/superAccess2.ts(17,15): error TS2576: Property 'y' does not exist on type 'P'. Did you mean to access the static member 'P.y' instead?
 tests/cases/compiler/superAccess2.ts(20,26): error TS1034: 'super' must be followed by an argument list or member access.
 tests/cases/compiler/superAccess2.ts(21,15): error TS2339: Property 'x' does not exist on type 'typeof P'.
 
@@ -55,7 +55,7 @@ tests/cases/compiler/superAccess2.ts(21,15): error TS2339: Property 'x' does not
             super.x();
             super.y(); // error
                   ~
-!!! error TS2576: Property 'y' is a static member of type 'P'.
+!!! error TS2576: Property 'y' does not exist on type 'P'. Did you mean to access the static member 'P.y' instead?
         }
     
         static bar(zz = super) {

--- a/tests/baselines/reference/superPropertyAccess2.errors.txt
+++ b/tests/baselines/reference/superPropertyAccess2.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/superPropertyAccess2.ts(3,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/superPropertyAccess2.ts(13,15): error TS2339: Property 'x' does not exist on type 'typeof C'.
-tests/cases/compiler/superPropertyAccess2.ts(18,15): error TS2576: Property 'bar' is a static member of type 'C'.
+tests/cases/compiler/superPropertyAccess2.ts(18,15): error TS2576: Property 'bar' does not exist on type 'C'. Did you mean to access the static member 'C.bar' instead?
 tests/cases/compiler/superPropertyAccess2.ts(19,15): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
 tests/cases/compiler/superPropertyAccess2.ts(22,23): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/superPropertyAccess2.ts(24,15): error TS2339: Property 'x' does not exist on type 'typeof C'.
@@ -30,7 +30,7 @@ tests/cases/compiler/superPropertyAccess2.ts(24,15): error TS2339: Property 'x' 
             super();
             super.bar(); // error
                   ~~~
-!!! error TS2576: Property 'bar' is a static member of type 'C'.
+!!! error TS2576: Property 'bar' does not exist on type 'C'. Did you mean to access the static member 'C.bar' instead?
             super.x;  // error
                   ~
 !!! error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.

--- a/tests/baselines/reference/thisInOuterClassBody.errors.txt
+++ b/tests/baselines/reference/thisInOuterClassBody.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/thisInOuterClassBody.ts(5,16): error TS2334: 'this' cannot be referenced in a static property initializer.
-tests/cases/compiler/thisInOuterClassBody.ts(12,22): error TS2576: Property 'y' is a static member of type 'Foo'.
+tests/cases/compiler/thisInOuterClassBody.ts(12,22): error TS2576: Property 'y' does not exist on type 'Foo'. Did you mean to access the static member 'Foo.y' instead?
 tests/cases/compiler/thisInOuterClassBody.ts(18,22): error TS2339: Property 'x' does not exist on type 'typeof Foo'.
 
 
@@ -19,7 +19,7 @@ tests/cases/compiler/thisInOuterClassBody.ts(18,22): error TS2339: Property 'x' 
             var f = () => this.x; // 'this' should be type 'Foo' as well
             var p = this.y;
                          ~
-!!! error TS2576: Property 'y' is a static member of type 'Foo'.
+!!! error TS2576: Property 'y' does not exist on type 'Foo'. Did you mean to access the static member 'Foo.y' instead?
             return this;
         }
     

--- a/tests/baselines/reference/typeofClass.errors.txt
+++ b/tests/baselines/reference/typeofClass.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/typeofClass.ts(8,4): error TS2576: Property 'bar' is a static member of type 'K'.
+tests/cases/compiler/typeofClass.ts(8,4): error TS2576: Property 'bar' does not exist on type 'K'. Did you mean to access the static member 'K.bar' instead?
 tests/cases/compiler/typeofClass.ts(10,4): error TS2339: Property 'foo' does not exist on type 'typeof K'.
 
 
@@ -12,7 +12,7 @@ tests/cases/compiler/typeofClass.ts(10,4): error TS2339: Property 'foo' does not
     k1.foo;
     k1.bar;
        ~~~
-!!! error TS2576: Property 'bar' is a static member of type 'K'.
+!!! error TS2576: Property 'bar' does not exist on type 'K'. Did you mean to access the static member 'K.bar' instead?
     var k2: typeof K;
     k2.foo;
        ~~~

--- a/tests/cases/compiler/classStaticPropertyAccess.ts
+++ b/tests/cases/compiler/classStaticPropertyAccess.ts
@@ -2,6 +2,7 @@
 // @target: ES5
 
 class A {
+    public static "\""() {}
     public static x: number = 1;
     public static y: number = 1;
     private static _b: number = 2;
@@ -9,7 +10,8 @@ class A {
 
 const a = new A();
 
-a['y'] // Error
-a.y    // Error
-A._b   // Error
+a["\""] // Error
+a['y']  // Error
+a.y     // Error
+A._b    // Error
 A.a


### PR DESCRIPTION
Fixes #41227