### PR TITLE
Remove string literals from unions with matching template literals

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13100,6 +13100,20 @@ namespace ts {
             }
         }
 
+        function removeStringLiteralsMatchedByTemplateLiterals(types: Type[]) {
+            const templates = filter(types, isPatternLiteralType);
+            if (templates.length) {
+                let i = types.length;
+                while (i > 0) {
+                    i--;
+                    const t = types[i];
+                    if (t.flags & TypeFlags.StringLiteral && some(templates, template => isTypeSubtypeOf(t, template))) {
+                        orderedRemoveItemAt(types, i);
+                    }
+                }
+            }
+        }
+
         // We sort and deduplicate the constituent types based on object identity. If the subtypeReduction
         // flag is specified we also reduce the constituent type set to only include types that aren't subtypes
         // of other types. Subtype reduction is expensive for large union types and is possible only when union
@@ -13124,6 +13138,9 @@ namespace ts {
                     case UnionReduction.Literal:
                         if (includes & (TypeFlags.Literal | TypeFlags.UniqueESSymbol)) {
                             removeRedundantLiteralTypes(typeSet, includes);
+                        }
+                        if (includes & TypeFlags.StringLiteral && includes & TypeFlags.TemplateLiteral) {
+                            removeStringLiteralsMatchedByTemplateLiterals(typeSet);
                         }
                         break;
                     case UnionReduction.Subtype:

--- a/tests/baselines/reference/templateLiteralTypesPatterns.errors.txt
+++ b/tests/baselines/reference/templateLiteralTypesPatterns.errors.txt
@@ -339,3 +339,12 @@ tests/cases/conformance/types/literal/templateLiteralTypesPatterns.ts(160,7): er
     var aa: '0';
     var aa: '0' & `${number}`;
     
+    // Remove string literals from unions with matching template literals
+    
+    let t1: `foo${string}` | 'foo1' | '1foo';  // `foo${string}` | '1foo'
+    let t2: `foo1` | '1foo' | 'foofoo' | `foo${string}` | 'foox' | 'xfoo';  // `foo${string}` | '1foo' | 'xfoo'
+    let t3: `foo1` | '1foo' | 'foofoo' | `foo${string}` | 'foox' | 'xfoo' | `${number}foo`;  // `foo${string}` | xfoo' | `${number}foo`
+    
+    var bb: `${number}`;
+    var bb: `${number}` | '0';
+    

--- a/tests/baselines/reference/templateLiteralTypesPatterns.js
+++ b/tests/baselines/reference/templateLiteralTypesPatterns.js
@@ -166,6 +166,15 @@ const exampleGood: B = "1 2"; // ok
 var aa: '0';
 var aa: '0' & `${number}`;
 
+// Remove string literals from unions with matching template literals
+
+let t1: `foo${string}` | 'foo1' | '1foo';  // `foo${string}` | '1foo'
+let t2: `foo1` | '1foo' | 'foofoo' | `foo${string}` | 'foox' | 'xfoo';  // `foo${string}` | '1foo' | 'xfoo'
+let t3: `foo1` | '1foo' | 'foofoo' | `foo${string}` | 'foox' | 'xfoo' | `${number}foo`;  // `foo${string}` | xfoo' | `${number}foo`
+
+var bb: `${number}`;
+var bb: `${number}` | '0';
+
 
 //// [templateLiteralTypesPatterns.js]
 "use strict";
@@ -289,3 +298,9 @@ var exampleGood = "1 2"; // ok
 // Repro from #41161
 var aa;
 var aa;
+// Remove string literals from unions with matching template literals
+var t1; // `foo${string}` | '1foo'
+var t2; // `foo${string}` | '1foo' | 'xfoo'
+var t3; // `foo${string}` | xfoo' | `${number}foo`
+var bb;
+var bb;

--- a/tests/baselines/reference/templateLiteralTypesPatterns.symbols
+++ b/tests/baselines/reference/templateLiteralTypesPatterns.symbols
@@ -401,3 +401,20 @@ var aa: '0';
 var aa: '0' & `${number}`;
 >aa : Symbol(aa, Decl(templateLiteralTypesPatterns.ts, 164, 3), Decl(templateLiteralTypesPatterns.ts, 165, 3))
 
+// Remove string literals from unions with matching template literals
+
+let t1: `foo${string}` | 'foo1' | '1foo';  // `foo${string}` | '1foo'
+>t1 : Symbol(t1, Decl(templateLiteralTypesPatterns.ts, 169, 3))
+
+let t2: `foo1` | '1foo' | 'foofoo' | `foo${string}` | 'foox' | 'xfoo';  // `foo${string}` | '1foo' | 'xfoo'
+>t2 : Symbol(t2, Decl(templateLiteralTypesPatterns.ts, 170, 3))
+
+let t3: `foo1` | '1foo' | 'foofoo' | `foo${string}` | 'foox' | 'xfoo' | `${number}foo`;  // `foo${string}` | xfoo' | `${number}foo`
+>t3 : Symbol(t3, Decl(templateLiteralTypesPatterns.ts, 171, 3))
+
+var bb: `${number}`;
+>bb : Symbol(bb, Decl(templateLiteralTypesPatterns.ts, 173, 3), Decl(templateLiteralTypesPatterns.ts, 174, 3))
+
+var bb: `${number}` | '0';
+>bb : Symbol(bb, Decl(templateLiteralTypesPatterns.ts, 173, 3), Decl(templateLiteralTypesPatterns.ts, 174, 3))
+

--- a/tests/baselines/reference/templateLiteralTypesPatterns.types
+++ b/tests/baselines/reference/templateLiteralTypesPatterns.types
@@ -560,3 +560,20 @@ var aa: '0';
 var aa: '0' & `${number}`;
 >aa : "0"
 
+// Remove string literals from unions with matching template literals
+
+let t1: `foo${string}` | 'foo1' | '1foo';  // `foo${string}` | '1foo'
+>t1 : `foo${string}` | "1foo"
+
+let t2: `foo1` | '1foo' | 'foofoo' | `foo${string}` | 'foox' | 'xfoo';  // `foo${string}` | '1foo' | 'xfoo'
+>t2 : `foo${string}` | "1foo" | "xfoo"
+
+let t3: `foo1` | '1foo' | 'foofoo' | `foo${string}` | 'foox' | 'xfoo' | `${number}foo`;  // `foo${string}` | xfoo' | `${number}foo`
+>t3 : `foo${string}` | "xfoo" | `${number}foo`
+
+var bb: `${number}`;
+>bb : `${number}`
+
+var bb: `${number}` | '0';
+>bb : `${number}`
+

--- a/tests/cases/conformance/types/literal/templateLiteralTypesPatterns.ts
+++ b/tests/cases/conformance/types/literal/templateLiteralTypesPatterns.ts
@@ -165,3 +165,12 @@ const exampleGood: B = "1 2"; // ok
 
 var aa: '0';
 var aa: '0' & `${number}`;
+
+// Remove string literals from unions with matching template literals
+
+let t1: `foo${string}` | 'foo1' | '1foo';  // `foo${string}` | '1foo'
+let t2: `foo1` | '1foo' | 'foofoo' | `foo${string}` | 'foox' | 'xfoo';  // `foo${string}` | '1foo' | 'xfoo'
+let t3: `foo1` | '1foo' | 'foofoo' | `foo${string}` | 'foox' | 'xfoo' | `${number}foo`;  // `foo${string}` | xfoo' | `${number}foo`
+
+var bb: `${number}`;
+var bb: `${number}` | '0';


### PR DESCRIPTION
We currently remove template literals from intersections containing matching string literals. For example `` `foo${string}` & 'foox'`` is  reduced to just `'foox'`. We also need to perform the complementary reduction for union types, i.e. `` `foo${string}` | 'foox'`` should reduce to just `` `foo${string}` ``. This PR adds that functionality.

The following now produces no errors:

```ts
var x: '0';
var x: '0' & `${number}`;

var y: `${number}`;
var y: `${number}` | '0';  // Ok, previously was error
```

See also #40598.