### PR TITLE
Bind `module.export = {Thing}` with alias symbols

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2833,12 +2833,21 @@ namespace ts {
                 return;
             }
 
+            if (isObjectLiteralExpression(assignedExpression) && every(assignedExpression.properties, isShorthandPropertyAssignment)) {
+                forEach(assignedExpression.properties, bindExportAssignedObjectMemberAlias);
+                return;
+            }
+
             // 'module.exports = expr' assignment
             const flags = exportAssignmentIsAlias(node)
                 ? SymbolFlags.Alias // An export= with an EntityNameExpression or a ClassExpression exports all meanings of that identifier or class
                 : SymbolFlags.Property | SymbolFlags.ExportValue | SymbolFlags.ValueModule;
             const symbol = declareSymbol(file.symbol.exports!, file.symbol, node, flags | SymbolFlags.Assignment, SymbolFlags.None);
             setValueDeclaration(symbol, node);
+        }
+
+        function bindExportAssignedObjectMemberAlias(node: ShorthandPropertyAssignment) {
+            declareSymbol(file.symbol.exports!, file.symbol, node, SymbolFlags.Alias | SymbolFlags.Assignment, SymbolFlags.None);
         }
 
         function bindThisPropertyAssignment(node: BindablePropertyAssignmentExpression | PropertyAccessExpression | LiteralLikeElementAccessExpression) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6807,21 +6807,17 @@ namespace ts {
                                 ), ModifierFlags.None);
                                 break;
                             }
-                            // At present, the below case should be entirely unhit, as, generally speaking, the below case is *usually* bound
-                            // such that the `BinaryExpression` is the declaration rather than the specific, nested binding element
-                            // (because we don't seek to emit an alias in these forms yet). As such, the `BinaryExpression` switch case
-                            // will be what actually handles this form. _However_, in anticipation of binding the below with proper
-                            // alias symbols, I'm _pretty comfortable_ including the case here, even though it is not yet live.
+                            // We don't know how to serialize this (nested?) binding element
+                            Debug.failBadSyntaxKind(node.parent?.parent || node, "Unhandled binding element grandparent kind in declaration serialization");
+                            break;
+                        case SyntaxKind.ShorthandPropertyAssignment:
                             if (node.parent?.parent?.kind === SyntaxKind.BinaryExpression) {
                                 // module.exports = { SomeClass }
                                 serializeExportSpecifier(
                                     unescapeLeadingUnderscores(symbol.escapedName),
                                     targetName
                                 );
-                                break;
                             }
-                            // We don't know how to serialize this (nested?) binding element
-                            Debug.failBadSyntaxKind(node.parent?.parent || node, "Unhandled binding element grandparent kind in declaration serialization");
                             break;
                         case SyntaxKind.VariableDeclaration:
                             // commonjs require: const x = require('y')

--- a/tests/baselines/reference/findAllRefsCommonJsRequire3.baseline.jsonc
+++ b/tests/baselines/reference/findAllRefsCommonJsRequire3.baseline.jsonc
@@ -13,7 +13,7 @@
       "containerName": "",
       "fileName": "/b.js",
       "kind": "alias",
-      "name": "(alias) (property) f: () => void\nimport f",
+      "name": "(alias) function f(): void\nimport f",
       "textSpan": {
         "start": 8,
         "length": 1
@@ -36,16 +36,8 @@
           "kind": "space"
         },
         {
-          "text": "(",
-          "kind": "punctuation"
-        },
-        {
-          "text": "property",
-          "kind": "text"
-        },
-        {
-          "text": ")",
-          "kind": "punctuation"
+          "text": "function",
+          "kind": "keyword"
         },
         {
           "text": " ",
@@ -56,14 +48,6 @@
           "kind": "aliasName"
         },
         {
-          "text": ":",
-          "kind": "punctuation"
-        },
-        {
-          "text": " ",
-          "kind": "space"
-        },
-        {
           "text": "(",
           "kind": "punctuation"
         },
@@ -72,11 +56,7 @@
           "kind": "punctuation"
         },
         {
-          "text": " ",
-          "kind": "space"
-        },
-        {
-          "text": "=>",
+          "text": ":",
           "kind": "punctuation"
         },
         {

--- a/tests/baselines/reference/jsDeclarationsCommonjsRelativePath.js
+++ b/tests/baselines/reference/jsDeclarationsCommonjsRelativePath.js
@@ -17,6 +17,6 @@ module.exports = { Thing }
 export class Thing {
 }
 //// [reexport.d.ts]
+export { Thing };
 import Thing_1 = require("./thing");
 import Thing = Thing_1.Thing;
-export { Thing };

--- a/tests/baselines/reference/jsDeclarationsCommonjsRelativePath.symbols
+++ b/tests/baselines/reference/jsDeclarationsCommonjsRelativePath.symbols
@@ -9,8 +9,8 @@ const Thing = require('./thing').Thing
 
 module.exports = { Thing }
 >module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/reexport", Decl(reexport.js, 0, 0))
->module : Symbol(export=, Decl(reexport.js, 1, 38))
->exports : Symbol(export=, Decl(reexport.js, 1, 38))
+>module : Symbol(module, Decl(reexport.js, 1, 38))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/reexport", Decl(reexport.js, 0, 0))
 >Thing : Symbol(Thing, Decl(reexport.js, 2, 18))
 
 === tests/cases/conformance/jsdoc/declarations/thing.js ===
@@ -20,7 +20,7 @@ class Thing {}
 
 module.exports = { Thing }
 >module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/thing", Decl(thing.js, 0, 0))
->module : Symbol(export=, Decl(thing.js, 1, 14))
->exports : Symbol(export=, Decl(thing.js, 1, 14))
+>module : Symbol(module, Decl(thing.js, 1, 14))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/thing", Decl(thing.js, 0, 0))
 >Thing : Symbol(Thing, Decl(thing.js, 2, 18))
 

--- a/tests/baselines/reference/jsDeclarationsCommonjsRelativePath.types
+++ b/tests/baselines/reference/jsDeclarationsCommonjsRelativePath.types
@@ -5,16 +5,16 @@
 const Thing = require('./thing').Thing
 >Thing : typeof Thing
 >require('./thing').Thing : typeof Thing
->require('./thing') : { Thing: typeof Thing; }
+>require('./thing') : typeof import("tests/cases/conformance/jsdoc/declarations/thing")
 >require : any
 >'./thing' : "./thing"
 >Thing : typeof Thing
 
 module.exports = { Thing }
->module.exports = { Thing } : { Thing: typeof Thing; }
->module.exports : { Thing: typeof Thing; }
->module : { "\"tests/cases/conformance/jsdoc/declarations/reexport\"": { Thing: typeof Thing; }; }
->exports : { Thing: typeof Thing; }
+>module.exports = { Thing } : typeof import("tests/cases/conformance/jsdoc/declarations/reexport")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/reexport")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/reexport\"": typeof import("tests/cases/conformance/jsdoc/declarations/reexport"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/reexport")
 >{ Thing } : { Thing: typeof Thing; }
 >Thing : typeof Thing
 
@@ -26,10 +26,10 @@ class Thing {}
 >Thing : Thing
 
 module.exports = { Thing }
->module.exports = { Thing } : { Thing: typeof Thing; }
->module.exports : { Thing: typeof Thing; }
->module : { "\"tests/cases/conformance/jsdoc/declarations/thing\"": { Thing: typeof Thing; }; }
->exports : { Thing: typeof Thing; }
+>module.exports = { Thing } : typeof import("tests/cases/conformance/jsdoc/declarations/thing")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/thing")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/thing\"": typeof import("tests/cases/conformance/jsdoc/declarations/thing"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/thing")
 >{ Thing } : { Thing: typeof Thing; }
 >Thing : typeof Thing
 

--- a/tests/baselines/reference/jsDeclarationsDocCommentsOnConsts.symbols
+++ b/tests/baselines/reference/jsDeclarationsDocCommentsOnConsts.symbols
@@ -20,8 +20,8 @@ function b() {
 
 module.exports = {x, b}
 >module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/index1", Decl(index1.js, 0, 0))
->module : Symbol(export=, Decl(index1.js, 12, 1))
->exports : Symbol(export=, Decl(index1.js, 12, 1))
+>module : Symbol(module, Decl(index1.js, 12, 1))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/index1", Decl(index1.js, 0, 0))
 >x : Symbol(x, Decl(index1.js, 14, 18))
 >b : Symbol(b, Decl(index1.js, 14, 20))
 

--- a/tests/baselines/reference/jsDeclarationsDocCommentsOnConsts.types
+++ b/tests/baselines/reference/jsDeclarationsDocCommentsOnConsts.types
@@ -23,10 +23,10 @@ function b() {
 }
 
 module.exports = {x, b}
->module.exports = {x, b} : { x: (a: any) => string; b: () => number; }
->module.exports : { x: (a: any) => string; b: () => number; }
->module : { "\"tests/cases/conformance/jsdoc/declarations/index1\"": { x: (a: any) => string; b: () => number; }; }
->exports : { x: (a: any) => string; b: () => number; }
+>module.exports = {x, b} : typeof import("tests/cases/conformance/jsdoc/declarations/index1")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/index1")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/index1\"": typeof import("tests/cases/conformance/jsdoc/declarations/index1"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/index1")
 >{x, b} : { x: (a: any) => string; b: () => number; }
 >x : (a: any) => string
 >b : () => number

--- a/tests/baselines/reference/jsDeclarationsExportForms.js
+++ b/tests/baselines/reference/jsDeclarationsExportForms.js
@@ -176,8 +176,8 @@ import * as ns from "./cls";
 export { ns as classContainer };
 import * as ns from "./cls";
 //// [cjs.d.ts]
-import ns = require("./cls");
 export { ns };
+import ns = require("./cls");
 //// [cjs2.d.ts]
 export = ns;
 import ns = require("./cls");

--- a/tests/baselines/reference/jsDeclarationsExportForms.symbols
+++ b/tests/baselines/reference/jsDeclarationsExportForms.symbols
@@ -50,8 +50,8 @@ const ns = require("./cls");
 
 module.exports = { ns };
 >module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/cjs", Decl(cjs.js, 0, 0))
->module : Symbol(export=, Decl(cjs.js, 0, 28))
->exports : Symbol(export=, Decl(cjs.js, 0, 28))
+>module : Symbol(module, Decl(cjs.js, 0, 28))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/cjs", Decl(cjs.js, 0, 0))
 >ns : Symbol(ns, Decl(cjs.js, 1, 18))
 
 === tests/cases/conformance/jsdoc/declarations/cjs2.js ===

--- a/tests/baselines/reference/jsDeclarationsExportForms.types
+++ b/tests/baselines/reference/jsDeclarationsExportForms.types
@@ -50,10 +50,10 @@ const ns = require("./cls");
 >"./cls" : "./cls"
 
 module.exports = { ns };
->module.exports = { ns } : { ns: typeof ns; }
->module.exports : { ns: typeof ns; }
->module : { "\"tests/cases/conformance/jsdoc/declarations/cjs\"": { ns: typeof ns; }; }
->exports : { ns: typeof ns; }
+>module.exports = { ns } : typeof import("tests/cases/conformance/jsdoc/declarations/cjs")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/cjs")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/cjs\"": typeof import("tests/cases/conformance/jsdoc/declarations/cjs"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/cjs")
 >{ ns } : { ns: typeof ns; }
 >ns : typeof ns
 

--- a/tests/baselines/reference/jsDeclarationsExportedClassAliases.js
+++ b/tests/baselines/reference/jsDeclarationsExportedClassAliases.js
@@ -56,5 +56,5 @@ export class FancyError extends Error {
     constructor(status: any);
 }
 //// [index.d.ts]
-import errors = require("./errors");
 export { errors };
+import errors = require("./errors");

--- a/tests/baselines/reference/jsDeclarationsExportedClassAliases.symbols
+++ b/tests/baselines/reference/jsDeclarationsExportedClassAliases.symbols
@@ -3,12 +3,12 @@
 const errors = require("./errors");
 >errors : Symbol(errors, Decl(index.js, 1, 5))
 >require : Symbol(require)
->"./errors" : Symbol("tests/cases/conformance/jsdoc/declarations/utils/errors", Decl(errors.js, 0, 0))
+>"./errors" : Symbol(errors, Decl(errors.js, 0, 0))
 
 module.exports = {
 >module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/utils/index", Decl(index.js, 0, 0))
->module : Symbol(export=, Decl(index.js, 1, 35))
->exports : Symbol(export=, Decl(index.js, 1, 35))
+>module : Symbol(module, Decl(index.js, 1, 35))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/utils/index", Decl(index.js, 0, 0))
 
     errors
 >errors : Symbol(errors, Decl(index.js, 3, 18))
@@ -30,8 +30,8 @@ class FancyError extends Error {
 
 module.exports = {
 >module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/utils/errors", Decl(errors.js, 0, 0))
->module : Symbol(export=, Decl(errors.js, 4, 1))
->exports : Symbol(export=, Decl(errors.js, 4, 1))
+>module : Symbol(module, Decl(errors.js, 4, 1))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/utils/errors", Decl(errors.js, 0, 0))
 
     FancyError
 >FancyError : Symbol(FancyError, Decl(errors.js, 6, 18))

--- a/tests/baselines/reference/jsDeclarationsExportedClassAliases.types
+++ b/tests/baselines/reference/jsDeclarationsExportedClassAliases.types
@@ -1,20 +1,20 @@
 === tests/cases/conformance/jsdoc/declarations/utils/index.js ===
 // issue arises here on compilation
 const errors = require("./errors");
->errors : { FancyError: typeof FancyError; }
->require("./errors") : { FancyError: typeof FancyError; }
+>errors : typeof errors
+>require("./errors") : typeof errors
 >require : any
 >"./errors" : "./errors"
 
 module.exports = {
->module.exports = {    errors} : { errors: { FancyError: typeof FancyError; }; }
->module.exports : { errors: { FancyError: typeof FancyError; }; }
->module : { "\"tests/cases/conformance/jsdoc/declarations/utils/index\"": { errors: { FancyError: typeof FancyError; }; }; }
->exports : { errors: { FancyError: typeof FancyError; }; }
->{    errors} : { errors: { FancyError: typeof FancyError; }; }
+>module.exports = {    errors} : typeof import("tests/cases/conformance/jsdoc/declarations/utils/index")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/utils/index")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/utils/index\"": typeof import("tests/cases/conformance/jsdoc/declarations/utils/index"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/utils/index")
+>{    errors} : { errors: typeof errors; }
 
     errors
->errors : { FancyError: typeof FancyError; }
+>errors : typeof errors
 
 };
 === tests/cases/conformance/jsdoc/declarations/utils/errors.js ===
@@ -34,10 +34,10 @@ class FancyError extends Error {
 }
 
 module.exports = {
->module.exports = {    FancyError} : { FancyError: typeof FancyError; }
->module.exports : { FancyError: typeof FancyError; }
->module : { "\"tests/cases/conformance/jsdoc/declarations/utils/errors\"": { FancyError: typeof FancyError; }; }
->exports : { FancyError: typeof FancyError; }
+>module.exports = {    FancyError} : typeof import("tests/cases/conformance/jsdoc/declarations/utils/errors")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/utils/errors")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/utils/errors\"": typeof import("tests/cases/conformance/jsdoc/declarations/utils/errors"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/utils/errors")
 >{    FancyError} : { FancyError: typeof FancyError; }
 
     FancyError

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.symbols
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.symbols
@@ -40,8 +40,8 @@ function testFn(input) {
 
 module.exports = {testFn, testFnTypes};
 >module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/file2", Decl(file2.js, 0, 0))
->module : Symbol(export=, Decl(file2.js, 25, 1))
->exports : Symbol(export=, Decl(file2.js, 25, 1))
+>module : Symbol(module, Decl(file2.js, 25, 1))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/file2", Decl(file2.js, 0, 0))
 >testFn : Symbol(testFn, Decl(file2.js, 27, 18))
 >testFnTypes : Symbol(testFnTypes, Decl(file2.js, 27, 25))
 

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.types
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.types
@@ -47,10 +47,10 @@ function testFn(input) {
 }
 
 module.exports = {testFn, testFnTypes};
->module.exports = {testFn, testFnTypes} : { testFn: (input: testFnTypes.input) => number; testFnTypes: { [x: string]: any; }; }
->module.exports : { testFn: (input: testFnTypes.input) => number; testFnTypes: { [x: string]: any; }; }
->module : { "\"tests/cases/conformance/jsdoc/declarations/file2\"": { testFn: (input: testFnTypes.input) => number; testFnTypes: { [x: string]: any; }; }; }
->exports : { testFn: (input: testFnTypes.input) => number; testFnTypes: { [x: string]: any; }; }
+>module.exports = {testFn, testFnTypes} : typeof import("tests/cases/conformance/jsdoc/declarations/file2")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/file2")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/file2\"": typeof import("tests/cases/conformance/jsdoc/declarations/file2"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/file2")
 >{testFn, testFnTypes} : { testFn: (input: testFnTypes.input) => number; testFnTypes: { [x: string]: any; }; }
 >testFn : (input: testFnTypes.input) => number
 >testFnTypes : { [x: string]: any; }

--- a/tests/baselines/reference/jsDeclarationsReexportedCjsAlias.symbols
+++ b/tests/baselines/reference/jsDeclarationsReexportedCjsAlias.symbols
@@ -8,8 +8,8 @@ const { SomeClass, SomeClass: Another } = require('./lib');
 
 module.exports = {
 >module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/main", Decl(main.js, 0, 0))
->module : Symbol(export=, Decl(main.js, 0, 59))
->exports : Symbol(export=, Decl(main.js, 0, 59))
+>module : Symbol(module, Decl(main.js, 0, 59))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/main", Decl(main.js, 0, 0))
 
     SomeClass,
 >SomeClass : Symbol(SomeClass, Decl(main.js, 2, 18))
@@ -42,8 +42,8 @@ class SomeClass {
 
 module.exports = {
 >module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/lib", Decl(lib.js, 0, 0))
->module : Symbol(export=, Decl(lib.js, 11, 1))
->exports : Symbol(export=, Decl(lib.js, 11, 1))
+>module : Symbol(module, Decl(lib.js, 11, 1))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/lib", Decl(lib.js, 0, 0))
 
     bar,
 >bar : Symbol(bar, Decl(lib.js, 13, 18))

--- a/tests/baselines/reference/jsDeclarationsReexportedCjsAlias.types
+++ b/tests/baselines/reference/jsDeclarationsReexportedCjsAlias.types
@@ -3,15 +3,15 @@ const { SomeClass, SomeClass: Another } = require('./lib');
 >SomeClass : typeof SomeClass
 >SomeClass : any
 >Another : typeof SomeClass
->require('./lib') : { bar: (a: string) => string; SomeClass: typeof SomeClass; }
+>require('./lib') : typeof import("tests/cases/conformance/jsdoc/declarations/lib")
 >require : any
 >'./lib' : "./lib"
 
 module.exports = {
->module.exports = {    SomeClass,    Another} : { SomeClass: typeof SomeClass; Another: typeof SomeClass; }
->module.exports : { SomeClass: typeof SomeClass; Another: typeof SomeClass; }
->module : { "\"tests/cases/conformance/jsdoc/declarations/main\"": { SomeClass: typeof SomeClass; Another: typeof SomeClass; }; }
->exports : { SomeClass: typeof SomeClass; Another: typeof SomeClass; }
+>module.exports = {    SomeClass,    Another} : typeof import("tests/cases/conformance/jsdoc/declarations/main")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/main")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/main\"": typeof import("tests/cases/conformance/jsdoc/declarations/main"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/main")
 >{    SomeClass,    Another} : { SomeClass: typeof SomeClass; Another: typeof SomeClass; }
 
     SomeClass,
@@ -46,10 +46,10 @@ class SomeClass {
 }
 
 module.exports = {
->module.exports = {    bar,    SomeClass} : { bar: (a: string) => string; SomeClass: typeof SomeClass; }
->module.exports : { bar: (a: string) => string; SomeClass: typeof SomeClass; }
->module : { "\"tests/cases/conformance/jsdoc/declarations/lib\"": { bar: (a: string) => string; SomeClass: typeof SomeClass; }; }
->exports : { bar: (a: string) => string; SomeClass: typeof SomeClass; }
+>module.exports = {    bar,    SomeClass} : typeof import("tests/cases/conformance/jsdoc/declarations/lib")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/lib")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/lib\"": typeof import("tests/cases/conformance/jsdoc/declarations/lib"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/lib")
 >{    bar,    SomeClass} : { bar: (a: string) => string; SomeClass: typeof SomeClass; }
 
     bar,

--- a/tests/baselines/reference/jsDeclarationsReferenceToClassInstanceCrossFile.js
+++ b/tests/baselines/reference/jsDeclarationsReferenceToClassInstanceCrossFile.js
@@ -1,0 +1,63 @@
+//// [tests/cases/conformance/jsdoc/declarations/jsDeclarationsReferenceToClassInstanceCrossFile.ts] ////
+
+//// [rectangle.js]
+class Rectangle {
+    constructor() {
+        console.log("I'm a rectangle!");
+    }
+}
+
+module.exports = { Rectangle };
+//// [index.js]
+const {Rectangle} = require('./rectangle');
+
+class Render {
+    constructor() {
+        /**
+         * Object list
+         * @type {Rectangle[]}
+         */
+        this.objects = [];
+    }
+    /**
+     * Adds a rectangle
+     * 
+     * @returns {Rectangle} the rect
+     */
+    addRectangle() {
+        const obj = new Rectangle();
+        this.objects.push(obj);
+        return obj;
+    }
+}
+
+module.exports = { Render };
+//// [test.js]
+const {Render} = require("./index");
+let render = new Render();
+
+render.addRectangle();
+console.log("Objects", render.objects);
+
+
+
+//// [rectangle.d.ts]
+export class Rectangle {
+}
+//// [index.d.ts]
+export class Render {
+    /**
+     * Object list
+     * @type {Rectangle[]}
+     */
+    objects: Rectangle[];
+    /**
+     * Adds a rectangle
+     *
+     * @returns {Rectangle} the rect
+     */
+    addRectangle(): Rectangle;
+}
+import { Rectangle } from "./rectangle";
+//// [test.d.ts]
+export {};

--- a/tests/baselines/reference/jsDeclarationsReferenceToClassInstanceCrossFile.symbols
+++ b/tests/baselines/reference/jsDeclarationsReferenceToClassInstanceCrossFile.symbols
@@ -1,0 +1,91 @@
+=== tests/cases/conformance/jsdoc/declarations/test.js ===
+const {Render} = require("./index");
+>Render : Symbol(Render, Decl(test.js, 0, 7))
+>require : Symbol(require)
+>"./index" : Symbol("tests/cases/conformance/jsdoc/declarations/index", Decl(index.js, 0, 0))
+
+let render = new Render();
+>render : Symbol(render, Decl(test.js, 1, 3))
+>Render : Symbol(Render, Decl(test.js, 0, 7))
+
+render.addRectangle();
+>render.addRectangle : Symbol(Render.addRectangle, Decl(index.js, 9, 5))
+>render : Symbol(render, Decl(test.js, 1, 3))
+>addRectangle : Symbol(Render.addRectangle, Decl(index.js, 9, 5))
+
+console.log("Objects", render.objects);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>render.objects : Symbol(Render.objects, Decl(index.js, 3, 19))
+>render : Symbol(render, Decl(test.js, 1, 3))
+>objects : Symbol(Render.objects, Decl(index.js, 3, 19))
+
+=== tests/cases/conformance/jsdoc/declarations/rectangle.js ===
+class Rectangle {
+>Rectangle : Symbol(Rectangle, Decl(rectangle.js, 0, 0))
+
+    constructor() {
+        console.log("I'm a rectangle!");
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+    }
+}
+
+module.exports = { Rectangle };
+>module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/rectangle", Decl(rectangle.js, 0, 0))
+>module : Symbol(module, Decl(rectangle.js, 4, 1))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/rectangle", Decl(rectangle.js, 0, 0))
+>Rectangle : Symbol(Rectangle, Decl(rectangle.js, 6, 18))
+
+=== tests/cases/conformance/jsdoc/declarations/index.js ===
+const {Rectangle} = require('./rectangle');
+>Rectangle : Symbol(Rectangle, Decl(index.js, 0, 7))
+>require : Symbol(require)
+>'./rectangle' : Symbol("tests/cases/conformance/jsdoc/declarations/rectangle", Decl(rectangle.js, 0, 0))
+
+class Render {
+>Render : Symbol(Render, Decl(index.js, 0, 43))
+
+    constructor() {
+        /**
+         * Object list
+         * @type {Rectangle[]}
+         */
+        this.objects = [];
+>this.objects : Symbol(Render.objects, Decl(index.js, 3, 19))
+>this : Symbol(Render, Decl(index.js, 0, 43))
+>objects : Symbol(Render.objects, Decl(index.js, 3, 19))
+    }
+    /**
+     * Adds a rectangle
+     * 
+     * @returns {Rectangle} the rect
+     */
+    addRectangle() {
+>addRectangle : Symbol(Render.addRectangle, Decl(index.js, 9, 5))
+
+        const obj = new Rectangle();
+>obj : Symbol(obj, Decl(index.js, 16, 13))
+>Rectangle : Symbol(Rectangle, Decl(index.js, 0, 7))
+
+        this.objects.push(obj);
+>this.objects.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>this.objects : Symbol(Render.objects, Decl(index.js, 3, 19))
+>this : Symbol(Render, Decl(index.js, 0, 43))
+>objects : Symbol(Render.objects, Decl(index.js, 3, 19))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>obj : Symbol(obj, Decl(index.js, 16, 13))
+
+        return obj;
+>obj : Symbol(obj, Decl(index.js, 16, 13))
+    }
+}
+
+module.exports = { Render };
+>module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/index", Decl(index.js, 0, 0))
+>module : Symbol(module, Decl(index.js, 20, 1))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/index", Decl(index.js, 0, 0))
+>Render : Symbol(Render, Decl(index.js, 22, 18))
+

--- a/tests/baselines/reference/jsDeclarationsReferenceToClassInstanceCrossFile.types
+++ b/tests/baselines/reference/jsDeclarationsReferenceToClassInstanceCrossFile.types
@@ -1,0 +1,107 @@
+=== tests/cases/conformance/jsdoc/declarations/test.js ===
+const {Render} = require("./index");
+>Render : typeof Render
+>require("./index") : typeof import("tests/cases/conformance/jsdoc/declarations/index")
+>require : any
+>"./index" : "./index"
+
+let render = new Render();
+>render : Render
+>new Render() : Render
+>Render : typeof Render
+
+render.addRectangle();
+>render.addRectangle() : import("tests/cases/conformance/jsdoc/declarations/rectangle").Rectangle
+>render.addRectangle : () => import("tests/cases/conformance/jsdoc/declarations/rectangle").Rectangle
+>render : Render
+>addRectangle : () => import("tests/cases/conformance/jsdoc/declarations/rectangle").Rectangle
+
+console.log("Objects", render.objects);
+>console.log("Objects", render.objects) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>"Objects" : "Objects"
+>render.objects : import("tests/cases/conformance/jsdoc/declarations/rectangle").Rectangle[]
+>render : Render
+>objects : import("tests/cases/conformance/jsdoc/declarations/rectangle").Rectangle[]
+
+=== tests/cases/conformance/jsdoc/declarations/rectangle.js ===
+class Rectangle {
+>Rectangle : Rectangle
+
+    constructor() {
+        console.log("I'm a rectangle!");
+>console.log("I'm a rectangle!") : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>"I'm a rectangle!" : "I'm a rectangle!"
+    }
+}
+
+module.exports = { Rectangle };
+>module.exports = { Rectangle } : typeof import("tests/cases/conformance/jsdoc/declarations/rectangle")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/rectangle")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/rectangle\"": typeof import("tests/cases/conformance/jsdoc/declarations/rectangle"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/rectangle")
+>{ Rectangle } : { Rectangle: typeof Rectangle; }
+>Rectangle : typeof Rectangle
+
+=== tests/cases/conformance/jsdoc/declarations/index.js ===
+const {Rectangle} = require('./rectangle');
+>Rectangle : typeof Rectangle
+>require('./rectangle') : typeof import("tests/cases/conformance/jsdoc/declarations/rectangle")
+>require : any
+>'./rectangle' : "./rectangle"
+
+class Render {
+>Render : Render
+
+    constructor() {
+        /**
+         * Object list
+         * @type {Rectangle[]}
+         */
+        this.objects = [];
+>this.objects = [] : undefined[]
+>this.objects : Rectangle[]
+>this : this
+>objects : Rectangle[]
+>[] : undefined[]
+    }
+    /**
+     * Adds a rectangle
+     * 
+     * @returns {Rectangle} the rect
+     */
+    addRectangle() {
+>addRectangle : () => Rectangle
+
+        const obj = new Rectangle();
+>obj : Rectangle
+>new Rectangle() : Rectangle
+>Rectangle : typeof Rectangle
+
+        this.objects.push(obj);
+>this.objects.push(obj) : number
+>this.objects.push : (...items: Rectangle[]) => number
+>this.objects : Rectangle[]
+>this : this
+>objects : Rectangle[]
+>push : (...items: Rectangle[]) => number
+>obj : Rectangle
+
+        return obj;
+>obj : Rectangle
+    }
+}
+
+module.exports = { Render };
+>module.exports = { Render } : typeof import("tests/cases/conformance/jsdoc/declarations/index")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/index")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/index\"": typeof import("tests/cases/conformance/jsdoc/declarations/index"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/index")
+>{ Render } : { Render: typeof Render; }
+>Render : typeof Render
+

--- a/tests/baselines/reference/jsDeclarationsTypeAliases.symbols
+++ b/tests/baselines/reference/jsDeclarationsTypeAliases.symbols
@@ -50,8 +50,8 @@ class ExportedThing {
 }
 module.exports = {
 >module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/mixed", Decl(mixed.js, 0, 0))
->module : Symbol(export=, Decl(mixed.js, 12, 1))
->exports : Symbol(export=, Decl(mixed.js, 12, 1))
+>module : Symbol(module, Decl(mixed.js, 12, 1))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/mixed", Decl(mixed.js, 0, 0))
 
     doTheThing,
 >doTheThing : Symbol(doTheThing, Decl(mixed.js, 13, 18))

--- a/tests/baselines/reference/jsDeclarationsTypeAliases.types
+++ b/tests/baselines/reference/jsDeclarationsTypeAliases.types
@@ -53,10 +53,10 @@ class ExportedThing {
 >"ok" : "ok"
 }
 module.exports = {
->module.exports = {    doTheThing,    ExportedThing,} : { doTheThing: (x: number) => SomeType; ExportedThing: typeof ExportedThing; }
->module.exports : { doTheThing: (x: number) => SomeType; ExportedThing: typeof ExportedThing; }
->module : { "\"tests/cases/conformance/jsdoc/declarations/mixed\"": { doTheThing: (x: number) => SomeType; ExportedThing: typeof ExportedThing; }; }
->exports : { doTheThing: (x: number) => SomeType; ExportedThing: typeof ExportedThing; }
+>module.exports = {    doTheThing,    ExportedThing,} : typeof import("tests/cases/conformance/jsdoc/declarations/mixed")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/mixed")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/mixed\"": typeof import("tests/cases/conformance/jsdoc/declarations/mixed"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/mixed")
 >{    doTheThing,    ExportedThing,} : { doTheThing: (x: number) => SomeType; ExportedThing: typeof ExportedThing; }
 
     doTheThing,

--- a/tests/baselines/reference/jsDeclarationsTypeReferences.symbols
+++ b/tests/baselines/reference/jsDeclarationsTypeReferences.symbols
@@ -14,8 +14,8 @@ const thing = new Something();
 
 module.exports = {
 >module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/index", Decl(index.js, 0, 0))
->module : Symbol(export=, Decl(index.js, 4, 30))
->exports : Symbol(export=, Decl(index.js, 4, 30))
+>module : Symbol(module, Decl(index.js, 4, 30))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/index", Decl(index.js, 0, 0))
 
     thing
 >thing : Symbol(thing, Decl(index.js, 6, 18))

--- a/tests/baselines/reference/jsDeclarationsTypeReferences.types
+++ b/tests/baselines/reference/jsDeclarationsTypeReferences.types
@@ -15,10 +15,10 @@ const thing = new Something();
 >Something : typeof Something
 
 module.exports = {
->module.exports = {    thing} : { thing: Something; }
->module.exports : { thing: Something; }
->module : { "\"tests/cases/conformance/jsdoc/declarations/index\"": { thing: Something; }; }
->exports : { thing: Something; }
+>module.exports = {    thing} : typeof import("tests/cases/conformance/jsdoc/declarations/index")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/index")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/index\"": typeof import("tests/cases/conformance/jsdoc/declarations/index"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/index")
 >{    thing} : { thing: Something; }
 
     thing

--- a/tests/baselines/reference/jsDeclarationsTypeReferences2.symbols
+++ b/tests/baselines/reference/jsDeclarationsTypeReferences2.symbols
@@ -14,8 +14,8 @@ const thing = a + m
 
 module.exports = {
 >module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/index", Decl(index.js, 0, 0))
->module : Symbol(export=, Decl(index.js, 2, 19))
->exports : Symbol(export=, Decl(index.js, 2, 19))
+>module : Symbol(module, Decl(index.js, 2, 19))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/index", Decl(index.js, 0, 0))
 
     thing
 >thing : Symbol(thing, Decl(index.js, 4, 18))

--- a/tests/baselines/reference/jsDeclarationsTypeReferences2.types
+++ b/tests/baselines/reference/jsDeclarationsTypeReferences2.types
@@ -15,10 +15,10 @@ const thing = a + m
 >m : number
 
 module.exports = {
->module.exports = {    thing} : { thing: number; }
->module.exports : { thing: number; }
->module : { "\"tests/cases/conformance/jsdoc/declarations/index\"": { thing: number; }; }
->exports : { thing: number; }
+>module.exports = {    thing} : typeof import("tests/cases/conformance/jsdoc/declarations/index")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/index")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/index\"": typeof import("tests/cases/conformance/jsdoc/declarations/index"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/index")
 >{    thing} : { thing: number; }
 
     thing

--- a/tests/baselines/reference/jsDeclarationsTypedefAndImportTypes.symbols
+++ b/tests/baselines/reference/jsDeclarationsTypedefAndImportTypes.symbols
@@ -52,8 +52,8 @@ class Wrap {
 
 module.exports = {
 >module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/usage", Decl(usage.js, 0, 0))
->module : Symbol(export=, Decl(usage.js, 13, 1))
->exports : Symbol(export=, Decl(usage.js, 13, 1))
+>module : Symbol(module, Decl(usage.js, 13, 1))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/usage", Decl(usage.js, 0, 0))
 
     Wrap
 >Wrap : Symbol(Wrap, Decl(usage.js, 15, 18))

--- a/tests/baselines/reference/jsDeclarationsTypedefAndImportTypes.types
+++ b/tests/baselines/reference/jsDeclarationsTypedefAndImportTypes.types
@@ -56,10 +56,10 @@ class Wrap {
 }
 
 module.exports = {
->module.exports = {    Wrap} : { Wrap: typeof Wrap; }
->module.exports : { Wrap: typeof Wrap; }
->module : { "\"tests/cases/conformance/jsdoc/declarations/usage\"": { Wrap: typeof Wrap; }; }
->exports : { Wrap: typeof Wrap; }
+>module.exports = {    Wrap} : typeof import("tests/cases/conformance/jsdoc/declarations/usage")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/usage")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/usage\"": typeof import("tests/cases/conformance/jsdoc/declarations/usage"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/usage")
 >{    Wrap} : { Wrap: typeof Wrap; }
 
     Wrap

--- a/tests/baselines/reference/jsDeclarationsTypedefPropertyAndExportAssignment.symbols
+++ b/tests/baselines/reference/jsDeclarationsTypedefPropertyAndExportAssignment.symbols
@@ -77,8 +77,8 @@ const taskNameToGroup = {};
 
 module.exports = {
 >module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/module", Decl(module.js, 0, 0))
->module : Symbol(export=, Decl(module.js, 24, 27))
->exports : Symbol(export=, Decl(module.js, 24, 27))
+>module : Symbol(module, Decl(module.js, 24, 27))
+>exports : Symbol("tests/cases/conformance/jsdoc/declarations/module", Decl(module.js, 0, 0))
 
     taskGroups,
 >taskGroups : Symbol(taskGroups, Decl(module.js, 26, 18))

--- a/tests/baselines/reference/jsDeclarationsTypedefPropertyAndExportAssignment.types
+++ b/tests/baselines/reference/jsDeclarationsTypedefPropertyAndExportAssignment.types
@@ -2,7 +2,7 @@
 const {taskGroups, taskNameToGroup} = require('./module.js');
 >taskGroups : { parseHTML: { id: "parseHTML"; label: string; }; styleLayout: { id: "styleLayout"; label: string; }; }
 >taskNameToGroup : { [x: string]: import("tests/cases/conformance/jsdoc/declarations/module").TaskGroup; }
->require('./module.js') : { taskGroups: { parseHTML: { id: "parseHTML"; label: string; }; styleLayout: { id: "styleLayout"; label: string; }; }; taskNameToGroup: { [x: string]: import("tests/cases/conformance/jsdoc/declarations/module").TaskGroup; }; }
+>require('./module.js') : typeof import("tests/cases/conformance/jsdoc/declarations/module")
 >require : any
 >'./module.js' : "./module.js"
 
@@ -86,10 +86,10 @@ const taskNameToGroup = {};
 >{} : {}
 
 module.exports = {
->module.exports = {    taskGroups,    taskNameToGroup,} : { taskGroups: { parseHTML: { id: "parseHTML"; label: string; }; styleLayout: { id: "styleLayout"; label: string; }; }; taskNameToGroup: { [x: string]: TaskGroup; }; }
->module.exports : { taskGroups: { parseHTML: { id: "parseHTML"; label: string; }; styleLayout: { id: "styleLayout"; label: string; }; }; taskNameToGroup: { [x: string]: TaskGroup; }; }
->module : { "\"tests/cases/conformance/jsdoc/declarations/module\"": { taskGroups: { parseHTML: { id: "parseHTML"; label: string; }; styleLayout: { id: "styleLayout"; label: string; }; }; taskNameToGroup: { [x: string]: TaskGroup; }; }; }
->exports : { taskGroups: { parseHTML: { id: "parseHTML"; label: string; }; styleLayout: { id: "styleLayout"; label: string; }; }; taskNameToGroup: { [x: string]: TaskGroup; }; }
+>module.exports = {    taskGroups,    taskNameToGroup,} : typeof import("tests/cases/conformance/jsdoc/declarations/module")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/declarations/module")
+>module : { "\"tests/cases/conformance/jsdoc/declarations/module\"": typeof import("tests/cases/conformance/jsdoc/declarations/module"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/declarations/module")
 >{    taskGroups,    taskNameToGroup,} : { taskGroups: { parseHTML: { id: "parseHTML"; label: string; }; styleLayout: { id: "styleLayout"; label: string; }; }; taskNameToGroup: { [x: string]: TaskGroup; }; }
 
     taskGroups,

--- a/tests/baselines/reference/jsExportMemberMergedWithModuleAugmentation.errors.txt
+++ b/tests/baselines/reference/jsExportMemberMergedWithModuleAugmentation.errors.txt
@@ -1,0 +1,29 @@
+/index.ts(11,7): error TS2741: Property 'x' is missing in type '{ b: string; }' but required in type 'Abcde'.
+
+
+==== /test.js (0 errors) ====
+    class Abcde {
+      /** @type {string} */
+      x;
+    }
+    
+    module.exports = {
+      Abcde
+    };
+    
+==== /index.ts (1 errors) ====
+    import { Abcde } from "./test";
+    
+    declare module "./test" {
+      interface Abcde { b: string }
+    }
+    
+    new Abcde().x;
+    
+    // Bug: the type meaning from /test.js does not
+    // propagate through the object literal export.
+    const x: Abcde = { b: "" };
+          ~
+!!! error TS2741: Property 'x' is missing in type '{ b: string; }' but required in type 'Abcde'.
+!!! related TS2728 /test.js:3:3: 'x' is declared here.
+    

--- a/tests/baselines/reference/jsExportMemberMergedWithModuleAugmentation.symbols
+++ b/tests/baselines/reference/jsExportMemberMergedWithModuleAugmentation.symbols
@@ -1,6 +1,6 @@
 === /test.js ===
 class Abcde {
->Abcde : Symbol(Abcde, Decl(test.js, 0, 0))
+>Abcde : Symbol(Abcde, Decl(test.js, 0, 0), Decl(index.ts, 2, 25))
 
   /** @type {string} */
   x;
@@ -8,9 +8,9 @@ class Abcde {
 }
 
 module.exports = {
->module.exports : Symbol("/test", Decl(test.js, 0, 0))
->module : Symbol("/test.js", Decl(test.js, 3, 1), Decl(index.ts, 0, 31))
->exports : Symbol("/test.js", Decl(test.js, 3, 1), Decl(index.ts, 0, 31))
+>module.exports : Symbol("/test", Decl(test.js, 0, 0), Decl(index.ts, 0, 31))
+>module : Symbol(module, Decl(test.js, 3, 1))
+>exports : Symbol("/test", Decl(test.js, 0, 0), Decl(index.ts, 0, 31))
 
   Abcde
 >Abcde : Symbol(Abcde, Decl(test.js, 5, 18))
@@ -22,10 +22,10 @@ import { Abcde } from "./test";
 >Abcde : Symbol(Abcde, Decl(index.ts, 0, 8))
 
 declare module "./test" {
->"./test" : Symbol("/test.js", Decl(test.js, 3, 1), Decl(index.ts, 0, 31))
+>"./test" : Symbol("/test", Decl(test.js, 0, 0), Decl(index.ts, 0, 31))
 
   interface Abcde { b: string }
->Abcde : Symbol(Abcde, Decl(index.ts, 2, 25), Decl(test.js, 5, 18))
+>Abcde : Symbol(Abcde, Decl(test.js, 0, 0), Decl(index.ts, 2, 25))
 >b : Symbol(Abcde.b, Decl(index.ts, 3, 19))
 }
 

--- a/tests/baselines/reference/jsExportMemberMergedWithModuleAugmentation.types
+++ b/tests/baselines/reference/jsExportMemberMergedWithModuleAugmentation.types
@@ -8,10 +8,10 @@ class Abcde {
 }
 
 module.exports = {
->module.exports = {  Abcde} : { Abcde: typeof Abcde; }
->module.exports : { Abcde: typeof Abcde; }
->module : { "\"/test\"": { Abcde: typeof Abcde; }; }
->exports : { Abcde: typeof Abcde; }
+>module.exports = {  Abcde} : typeof import("/test")
+>module.exports : typeof import("/test")
+>module : { "\"/test\"": typeof import("/test"); }
+>exports : typeof import("/test")
 >{  Abcde} : { Abcde: typeof Abcde; }
 
   Abcde
@@ -24,7 +24,7 @@ import { Abcde } from "./test";
 >Abcde : typeof Abcde
 
 declare module "./test" {
->"./test" : { Abcde: typeof Abcde; }
+>"./test" : typeof import("/test")
 
   interface Abcde { b: string }
 >b : string

--- a/tests/baselines/reference/moduleExportAlias3.symbols
+++ b/tests/baselines/reference/moduleExportAlias3.symbols
@@ -5,8 +5,8 @@ class C {
 }
 module.exports = {
 >module.exports : Symbol("tests/cases/conformance/salsa/bug24062", Decl(bug24062.js, 0, 0))
->module : Symbol(export=, Decl(bug24062.js, 2, 1))
->exports : Symbol(export=, Decl(bug24062.js, 2, 1))
+>module : Symbol(module, Decl(bug24062.js, 2, 1))
+>exports : Symbol("tests/cases/conformance/salsa/bug24062", Decl(bug24062.js, 0, 0))
 
     C
 >C : Symbol(C, Decl(bug24062.js, 3, 18))

--- a/tests/baselines/reference/moduleExportAlias3.types
+++ b/tests/baselines/reference/moduleExportAlias3.types
@@ -4,10 +4,10 @@ class C {
 >C : C
 }
 module.exports = {
->module.exports = {    C} : { C: typeof C; }
->module.exports : { C: typeof C; }
->module : { "\"tests/cases/conformance/salsa/bug24062\"": { C: typeof C; }; }
->exports : { C: typeof C; }
+>module.exports = {    C} : typeof import("tests/cases/conformance/salsa/bug24062")
+>module.exports : typeof import("tests/cases/conformance/salsa/bug24062")
+>module : { "\"tests/cases/conformance/salsa/bug24062\"": typeof import("tests/cases/conformance/salsa/bug24062"); }
+>exports : typeof import("tests/cases/conformance/salsa/bug24062")
 >{    C} : { C: typeof C; }
 
     C

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsReferenceToClassInstanceCrossFile.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsReferenceToClassInstanceCrossFile.ts
@@ -1,0 +1,43 @@
+// @allowJs: true
+// @checkJs: true
+// @moduleResolution: node
+// @declaration: true
+// @emitDeclarationOnly: true
+// @filename: rectangle.js
+class Rectangle {
+    constructor() {
+        console.log("I'm a rectangle!");
+    }
+}
+
+module.exports = { Rectangle };
+// @filename: index.js
+const {Rectangle} = require('./rectangle');
+
+class Render {
+    constructor() {
+        /**
+         * Object list
+         * @type {Rectangle[]}
+         */
+        this.objects = [];
+    }
+    /**
+     * Adds a rectangle
+     * 
+     * @returns {Rectangle} the rect
+     */
+    addRectangle() {
+        const obj = new Rectangle();
+        this.objects.push(obj);
+        return obj;
+    }
+}
+
+module.exports = { Render };
+// @filename: test.js
+const {Render} = require("./index");
+let render = new Render();
+
+render.addRectangle();
+console.log("Objects", render.objects);

--- a/tests/cases/fourslash/completionsImport_require_addNew.ts
+++ b/tests/cases/fourslash/completionsImport_require_addNew.ts
@@ -15,7 +15,7 @@ verify.completions({
       name: "x",
       source: "/a",
       sourceDisplay: "./a",
-      text: "(property) x: number",
+      text: "(alias) const x: 0\nimport x",
       hasAction: true,
       sortText: completion.SortText.AutoImportSuggestions
   },

--- a/tests/cases/fourslash/completionsImport_require_addToExisting.ts
+++ b/tests/cases/fourslash/completionsImport_require_addToExisting.ts
@@ -18,7 +18,7 @@ verify.completions({
       name: "x",
       source: "/a",
       sourceDisplay: "./a",
-      text: "(property) x: number",
+      text: "(alias) const x: 0\nimport x",
       hasAction: true,
       sortText: completion.SortText.AutoImportSuggestions
   },


### PR DESCRIPTION
Fixes #41250, the last half of it.

This was actually an _incredibly_ small change, thanks to already anticipating aliases like this pretty much everywhere. DO note that in addition to shorthand property references, we could also _probably_ bind `{ Name: EntityName }` references as aliases safely, too, though this PR does not add that currently.
