### PR TITLE
Check lstat before calling realpath

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1697,6 +1697,9 @@ namespace ts {
 
             function realpath(path: string): string {
                 try {
+                    if (!_fs.lstatSync(path).isSymbolicLink()) {
+                        return path;
+                    }
                     return _fs.realpathSync(path);
                 }
                 catch {


### PR DESCRIPTION
The only thing we're using realpath for is to resolve symlinks and most files and directories are not symlinks.  This change skips the expensive realpath call for non-symlinks.

Q: Shouldn't we add lstat to the System interface?
A: Strictly speaking, we probably should, but the behavior of our realpath isn't actually documented anywhere, so we're not really locked in, and we want this at all call sites, so we'd have to add a layer of abstraction anyway.

Q: What if it _is_ a symlink?  Won't it be slower?
A: I believe (based on previous forays in the node/libuv codebase), but haven't proven, that libuv (and probably the OS) caches lstat results so the "real" lstat call in realpath should be basically free, for a negligible net increase.

Q: How was this validated?
A: This was inspired by my profiling of project loading (specifically `createProgram`) in one of the Office codebases.  In that code, the project loading time is 6% faster on Windows and 20% faster on Linux (we call realpath as part of many of our existence checks and I conjecture that the lack of recursive file watching on Linux requires more of these).  I also confirmed that `xstate-analytics`, which is part of a lerna monorepo and pulls in dependencies via symlinks in node_modules, was about 5% faster on Windows.