### PR TITLE
noop in setTypeAcquisiton for undefined

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -706,10 +706,10 @@ namespace ts.server {
             return this.projectName;
         }
 
-        protected removeLocalTypingsFromTypeAcquisition(newTypeAcquisition: TypeAcquisition | undefined): TypeAcquisition {
+        protected removeLocalTypingsFromTypeAcquisition(newTypeAcquisition: TypeAcquisition): TypeAcquisition {
             if (!newTypeAcquisition || !newTypeAcquisition.include) {
                 // Nothing to filter out, so just return as-is
-                return newTypeAcquisition || {};
+                return newTypeAcquisition;
             }
             return { ...newTypeAcquisition, include: this.removeExistingTypings(newTypeAcquisition.include) };
         }
@@ -1410,7 +1410,9 @@ namespace ts.server {
         }
 
         setTypeAcquisition(newTypeAcquisition: TypeAcquisition | undefined): void {
-            this.typeAcquisition = this.removeLocalTypingsFromTypeAcquisition(newTypeAcquisition);
+            if (newTypeAcquisition) {
+                this.typeAcquisition = this.removeLocalTypingsFromTypeAcquisition(newTypeAcquisition);
+            }
         }
 
         getTypeAcquisition() {

--- a/src/testRunner/unittests/tsserver/inferredProjects.ts
+++ b/src/testRunner/unittests/tsserver/inferredProjects.ts
@@ -429,5 +429,26 @@ namespace ts.projectSystem {
                 configuredRemoved.clear();
             }
         });
+
+        it("regression test - should infer typeAcquisition for inferred projects when set undefined", () => {
+            const file1 = { path: "/a/file1.js", content: "" };
+            const host = createServerHost([file1]);
+
+            const projectService = createProjectService(host);
+
+            projectService.openClientFile(file1.path);
+
+            checkNumberOfProjects(projectService, { inferredProjects: 1 });
+            const inferredProject = projectService.inferredProjects[0];
+            checkProjectActualFiles(inferredProject, [file1.path]);
+            inferredProject.setTypeAcquisition(undefined);
+
+            const expected = {
+                enable: true,
+                include: [],
+                exclude: []
+            };
+            assert.deepEqual(inferredProject.getTypeAcquisition(), expected, "typeAcquisition should be inferred for inferred projects");
+        });
     });
 }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9306,7 +9306,7 @@ declare namespace ts.server {
         enableLanguageService(): void;
         disableLanguageService(lastFileExceededProgramSize?: string): void;
         getProjectName(): string;
-        protected removeLocalTypingsFromTypeAcquisition(newTypeAcquisition: TypeAcquisition | undefined): TypeAcquisition;
+        protected removeLocalTypingsFromTypeAcquisition(newTypeAcquisition: TypeAcquisition): TypeAcquisition;
         getExternalFiles(): SortedReadonlyArray<string>;
         getSourceFile(path: Path): SourceFile | undefined;
         close(): void;


### PR DESCRIPTION
#40952 mistakenly sets `typeAcquisition` to `{}` if it isn't explicitly set by the editor, disabling type acquisition in inferred projects. This reverts the changes made to `removeLocalTypingsFromTypeAcquisition` in that PR and noops in `setTypeAcquisition` when `newTypeAcquisition` is `undefined`.

Issue was caught in VS nightly integration tests.
