### PR TITLE
Use fs.realpathSync.native when available

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1185,6 +1185,8 @@ namespace ts {
             let activeSession: import("inspector").Session | "stopping" | undefined;
             let profilePath = "./profile.cpuprofile";
 
+            const realpathSync = _fs.realpathSync.native ?? _fs.realpathSync;
+
             const Buffer: {
                 new (input: string, encoding?: string): any;
                 from?(input: string, encoding?: string): any;
@@ -1749,7 +1751,7 @@ namespace ts {
 
             function realpath(path: string): string {
                 try {
-                    return _fs.realpathSync(path);
+                    return realpathSync(path);
                 }
                 catch {
                     return path;

--- a/src/harness/collectionsImpl.ts
+++ b/src/harness/collectionsImpl.ts
@@ -50,9 +50,9 @@ namespace collections {
             return index >= 0 ? this._values[index] : undefined;
         }
 
-        public getKeyAndValue(key: K): [ K, V ] | [ undefined, undefined ] {
+        public getEntry(key: K): [ K, V ] | undefined {
             const index = ts.binarySearch(this._keys, key, ts.identity, this._comparer);
-            return index >= 0 ? [ this._keys[index], this._values[index] ] : [ undefined, undefined ];
+            return index >= 0 ? [ this._keys[index], this._values[index] ] : undefined;
         }
 
         public set(key: K, value: V) {

--- a/src/harness/collectionsImpl.ts
+++ b/src/harness/collectionsImpl.ts
@@ -50,6 +50,11 @@ namespace collections {
             return index >= 0 ? this._values[index] : undefined;
         }
 
+        public getKeyAndValue(key: K): [ K, V ] | [ undefined, undefined ] {
+            const index = ts.binarySearch(this._keys, key, ts.identity, this._comparer);
+            return index >= 0 ? [ this._keys[index], this._values[index] ] : [ undefined, undefined ];
+        }
+
         public set(key: K, value: V) {
             const index = ts.binarySearch(this._keys, key, ts.identity, this._comparer);
             if (index >= 0) {

--- a/src/harness/vfsUtil.ts
+++ b/src/harness/vfsUtil.ts
@@ -1037,10 +1037,11 @@ namespace vfs {
                 if (depth >= 40) throw createIOError("ELOOP");
                 const lastStep = step === components.length - 1;
                 let basename = components[step];
-                const [key, node] = links.getKeyAndValue(basename);
-                if (key) {
-                    components[step] = basename = key;
+                const linkEntry = links.getEntry(basename);
+                if (linkEntry) {
+                    components[step] = basename = linkEntry[0];
                 }
+                const node = linkEntry?.[1];
                 if (lastStep && (noFollow || !isSymlink(node))) {
                     return { realpath: vpath.format(components), basename, parent, links, node };
                 }

--- a/src/harness/vfsUtil.ts
+++ b/src/harness/vfsUtil.ts
@@ -1036,8 +1036,11 @@ namespace vfs {
             while (true) {
                 if (depth >= 40) throw createIOError("ELOOP");
                 const lastStep = step === components.length - 1;
-                const basename = components[step];
-                const node = links.get(basename);
+                let basename = components[step];
+                const [key, node] = links.getKeyAndValue(basename);
+                if (key) {
+                    components[step] = basename = key;
+                }
                 if (lastStep && (noFollow || !isSymlink(node))) {
                     return { realpath: vpath.format(components), basename, parent, links, node };
                 }

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -828,9 +828,9 @@ interface Array<T> { length: number; [n: number]: T; }`
                 return undefined;
             }
 
-            const realpath = this.realpath(path);
+            const realpath = this.toPath(this.realpath(path));
             if (path !== realpath) {
-                return this.getRealFsEntry(isFsEntry, this.toPath(realpath));
+                return this.getRealFsEntry(isFsEntry, realpath);
             }
 
             return undefined;
@@ -1097,7 +1097,8 @@ interface Array<T> { length: number; [n: number]: T; }`
                 return this.realpath(fsEntry.symLink);
             }
 
-            return realFullPath;
+            // realpath supports non-existent files, so there may not be an fsEntry
+            return fsEntry?.fullPath || realFullPath;
         }
 
         readonly exitMessage = "System Exit";

--- a/src/testRunner/unittests/tscWatch/forceConsistentCasingInFileNames.ts
+++ b/src/testRunner/unittests/tscWatch/forceConsistentCasingInFileNames.ts
@@ -113,7 +113,7 @@ export const Fragment: unique symbol;
                     path: `${projectRoot}/tsconfig.json`,
                     content: JSON.stringify({
                         compilerOptions: { jsx: "react-jsx", jsxImportSource: "react", forceConsistentCasingInFileNames: true },
-                        files: ["node_modules/react/Jsx-runtime/index.d.ts", "index.tsx"]
+                        files: ["node_modules/react/jsx-Runtime/index.d.ts", "index.tsx"] // NB: casing does not match disk
                     })
                 }
             ], { currentDirectory: projectRoot }),

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/jsxImportSource-option-changed.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/jsxImportSource-option-changed.js
@@ -33,7 +33,7 @@ export const Fragment: unique symbol;
 export const App = () => <div propA={true}></div>;
 
 //// [/user/username/projects/myproject/tsconfig.json]
-{"compilerOptions":{"jsx":"react-jsx","jsxImportSource":"react","forceConsistentCasingInFileNames":true},"files":["node_modules/react/Jsx-runtime/index.d.ts","index.tsx"]}
+{"compilerOptions":{"jsx":"react-jsx","jsxImportSource":"react","forceConsistentCasingInFileNames":true},"files":["node_modules/react/jsx-Runtime/index.d.ts","index.tsx"]}
 
 
 /a/lib/tsc.js --w --p . --explainFiles
@@ -41,19 +41,19 @@ Output::
 >> Screen clear
 [[90m12:00:31 AM[0m] Starting compilation in watch mode...
 
-[91merror[0m[90m TS1149: [0mFile name '/user/username/projects/myproject/node_modules/react/jsx-runtime/index.d.ts' differs from already included file name '/user/username/projects/myproject/node_modules/react/Jsx-runtime/index.d.ts' only in casing.
+[91merror[0m[90m TS1149: [0mFile name '/user/username/projects/myproject/node_modules/react/Jsx-runtime/index.d.ts' differs from already included file name '/user/username/projects/myproject/node_modules/react/jsx-Runtime/index.d.ts' only in casing.
   The file is in the program because:
     Part of 'files' list in tsconfig.json
     Imported via "react/jsx-runtime" from file '/user/username/projects/myproject/index.tsx' with packageId 'react/jsx-runtime/index.d.ts@0.0.1' to import 'jsx' and 'jsxs' factory functions
 
   [96mtsconfig.json[0m:[93m1[0m:[93m115[0m
-    [7m1[0m {"compilerOptions":{"jsx":"react-jsx","jsxImportSource":"react","forceConsistentCasingInFileNames":true},"files":["node_modules/react/Jsx-runtime/index.d.ts","index.tsx"]}
+    [7m1[0m {"compilerOptions":{"jsx":"react-jsx","jsxImportSource":"react","forceConsistentCasingInFileNames":true},"files":["node_modules/react/jsx-Runtime/index.d.ts","index.tsx"]}
     [7m [0m [96m                                                                                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
     File is matched by 'files' list specified here.
 
 ../../../../a/lib/lib.d.ts
   Default library
-node_modules/react/Jsx-runtime/index.d.ts
+node_modules/react/jsx-Runtime/index.d.ts
   Part of 'files' list in tsconfig.json
   Imported via "react/jsx-runtime" from file 'index.tsx' with packageId 'react/jsx-runtime/index.d.ts@0.0.1' to import 'jsx' and 'jsxs' factory functions
 index.tsx
@@ -62,12 +62,12 @@ index.tsx
 
 
 
-Program root files: ["/user/username/projects/myproject/node_modules/react/Jsx-runtime/index.d.ts","/user/username/projects/myproject/index.tsx"]
+Program root files: ["/user/username/projects/myproject/node_modules/react/jsx-Runtime/index.d.ts","/user/username/projects/myproject/index.tsx"]
 Program options: {"jsx":4,"jsxImportSource":"react","forceConsistentCasingInFileNames":true,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
 Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
-/user/username/projects/myproject/node_modules/react/Jsx-runtime/index.d.ts
+/user/username/projects/myproject/node_modules/react/jsx-Runtime/index.d.ts
 /user/username/projects/myproject/index.tsx
 
 No cached semantic diagnostics in the builder::
@@ -76,7 +76,7 @@ WatchedFiles::
 /user/username/projects/myproject/tsconfig.json:
   {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
 /user/username/projects/myproject/node_modules/react/jsx-runtime/index.d.ts:
-  {"fileName":"/user/username/projects/myproject/node_modules/react/Jsx-runtime/index.d.ts","pollingInterval":250}
+  {"fileName":"/user/username/projects/myproject/node_modules/react/jsx-Runtime/index.d.ts","pollingInterval":250}
 /user/username/projects/myproject/index.tsx:
   {"fileName":"/user/username/projects/myproject/index.tsx","pollingInterval":250}
 /a/lib/lib.d.ts:

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-Windows-style-drive-root-is-lowercase.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-Windows-style-drive-root-is-lowercase.js
@@ -1,0 +1,167 @@
+Input::
+//// [c:/project/a.ts]
+
+export const a = 1;
+export const b = 2;
+
+
+//// [c:/project/b.ts]
+
+import { a } from "C://project/a"
+import { b } from "c://project/a"
+
+a;b;
+
+
+//// [c:/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [c:/project/tsconfig.json]
+{"compilerOptions":{"forceConsistentCasingInFileNames":true}}
+
+
+c:/a/lib/tsc.js --w --p c://project --explainFiles
+Output::
+>> Screen clear
+[[90m12:00:17 AM[0m] Starting compilation in watch mode...
+
+a/lib/lib.d.ts
+  Default library
+project/a.ts
+  Matched by include pattern '**/*' in 'project/tsconfig.json'
+  Imported via "C://project/a" from file 'project/b.ts'
+  Imported via "c://project/a" from file 'project/b.ts'
+project/b.ts
+  Matched by include pattern '**/*' in 'project/tsconfig.json'
+[[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["c:/project/a.ts","c:/project/b.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"project":"c:/project","explainFiles":true,"configFilePath":"c:/project/tsconfig.json"}
+Program structureReused: Not
+Program files::
+c:/a/lib/lib.d.ts
+c:/project/a.ts
+c:/project/b.ts
+
+Semantic diagnostics in builder refreshed for::
+c:/a/lib/lib.d.ts
+c:/project/a.ts
+c:/project/b.ts
+
+WatchedFiles::
+c:/project/tsconfig.json:
+  {"fileName":"c:/project/tsconfig.json","pollingInterval":250}
+c:/project/a.ts:
+  {"fileName":"c:/project/a.ts","pollingInterval":250}
+c:/project/b.ts:
+  {"fileName":"c:/project/b.ts","pollingInterval":250}
+c:/a/lib/lib.d.ts:
+  {"fileName":"c:/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+c:/project/node_modules/@types:
+  {"directoryName":"c:/project/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+c:/project:
+  {"directoryName":"c:/project","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [c:/project/a.js]
+"use strict";
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+
+//// [c:/project/b.js]
+"use strict";
+exports.__esModule = true;
+var a_1 = require("C://project/a");
+var a_2 = require("c://project/a");
+a_1.a;
+a_2.b;
+
+
+
+Change:: Prepend a line to moduleA
+
+Input::
+//// [c:/project/a.ts]
+// some comment
+                        
+export const a = 1;
+export const b = 2;
+
+
+
+Output::
+>> Screen clear
+[[90m12:00:25 AM[0m] File change detected. Starting incremental compilation...
+
+a/lib/lib.d.ts
+  Default library
+project/a.ts
+  Matched by include pattern '**/*' in 'project/tsconfig.json'
+  Imported via "C://project/a" from file 'project/b.ts'
+  Imported via "c://project/a" from file 'project/b.ts'
+project/b.ts
+  Matched by include pattern '**/*' in 'project/tsconfig.json'
+[[90m12:00:29 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["c:/project/a.ts","c:/project/b.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"project":"c:/project","explainFiles":true,"configFilePath":"c:/project/tsconfig.json"}
+Program structureReused: Completely
+Program files::
+c:/a/lib/lib.d.ts
+c:/project/a.ts
+c:/project/b.ts
+
+Semantic diagnostics in builder refreshed for::
+c:/project/a.ts
+
+WatchedFiles::
+c:/project/tsconfig.json:
+  {"fileName":"c:/project/tsconfig.json","pollingInterval":250}
+c:/project/a.ts:
+  {"fileName":"c:/project/a.ts","pollingInterval":250}
+c:/project/b.ts:
+  {"fileName":"c:/project/b.ts","pollingInterval":250}
+c:/a/lib/lib.d.ts:
+  {"fileName":"c:/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+c:/project/node_modules/@types:
+  {"directoryName":"c:/project/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+c:/project:
+  {"directoryName":"c:/project","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [c:/project/a.js]
+"use strict";
+// some comment
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-Windows-style-drive-root-is-uppercase.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-Windows-style-drive-root-is-uppercase.js
@@ -1,0 +1,167 @@
+Input::
+//// [C:/project/a.ts]
+
+export const a = 1;
+export const b = 2;
+
+
+//// [C:/project/b.ts]
+
+import { a } from "C://project/a"
+import { b } from "c://project/a"
+
+a;b;
+
+
+//// [C:/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [C:/project/tsconfig.json]
+{"compilerOptions":{"forceConsistentCasingInFileNames":true}}
+
+
+C:/a/lib/tsc.js --w --p C://project --explainFiles
+Output::
+>> Screen clear
+[[90m12:00:17 AM[0m] Starting compilation in watch mode...
+
+a/lib/lib.d.ts
+  Default library
+project/a.ts
+  Matched by include pattern '**/*' in 'project/tsconfig.json'
+  Imported via "C://project/a" from file 'project/b.ts'
+  Imported via "c://project/a" from file 'project/b.ts'
+project/b.ts
+  Matched by include pattern '**/*' in 'project/tsconfig.json'
+[[90m12:00:22 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["C:/project/a.ts","C:/project/b.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"project":"C:/project","explainFiles":true,"configFilePath":"C:/project/tsconfig.json"}
+Program structureReused: Not
+Program files::
+C:/a/lib/lib.d.ts
+C:/project/a.ts
+C:/project/b.ts
+
+Semantic diagnostics in builder refreshed for::
+C:/a/lib/lib.d.ts
+C:/project/a.ts
+C:/project/b.ts
+
+WatchedFiles::
+c:/project/tsconfig.json:
+  {"fileName":"C:/project/tsconfig.json","pollingInterval":250}
+c:/project/a.ts:
+  {"fileName":"C:/project/a.ts","pollingInterval":250}
+c:/project/b.ts:
+  {"fileName":"C:/project/b.ts","pollingInterval":250}
+c:/a/lib/lib.d.ts:
+  {"fileName":"C:/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+c:/project/node_modules/@types:
+  {"directoryName":"C:/project/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+c:/project:
+  {"directoryName":"c:/project","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [C:/project/a.js]
+"use strict";
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+
+//// [C:/project/b.js]
+"use strict";
+exports.__esModule = true;
+var a_1 = require("C://project/a");
+var a_2 = require("c://project/a");
+a_1.a;
+a_2.b;
+
+
+
+Change:: Prepend a line to moduleA
+
+Input::
+//// [C:/project/a.ts]
+// some comment
+                        
+export const a = 1;
+export const b = 2;
+
+
+
+Output::
+>> Screen clear
+[[90m12:00:25 AM[0m] File change detected. Starting incremental compilation...
+
+a/lib/lib.d.ts
+  Default library
+project/a.ts
+  Matched by include pattern '**/*' in 'project/tsconfig.json'
+  Imported via "C://project/a" from file 'project/b.ts'
+  Imported via "c://project/a" from file 'project/b.ts'
+project/b.ts
+  Matched by include pattern '**/*' in 'project/tsconfig.json'
+[[90m12:00:29 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["C:/project/a.ts","C:/project/b.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"project":"C:/project","explainFiles":true,"configFilePath":"C:/project/tsconfig.json"}
+Program structureReused: Completely
+Program files::
+C:/a/lib/lib.d.ts
+C:/project/a.ts
+C:/project/b.ts
+
+Semantic diagnostics in builder refreshed for::
+C:/project/a.ts
+
+WatchedFiles::
+c:/project/tsconfig.json:
+  {"fileName":"C:/project/tsconfig.json","pollingInterval":250}
+c:/project/a.ts:
+  {"fileName":"C:/project/a.ts","pollingInterval":250}
+c:/project/b.ts:
+  {"fileName":"C:/project/b.ts","pollingInterval":250}
+c:/a/lib/lib.d.ts:
+  {"fileName":"C:/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+c:/project/node_modules/@types:
+  {"directoryName":"C:/project/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+c:/project:
+  {"directoryName":"c:/project","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [C:/project/a.js]
+"use strict";
+// some comment
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-both-directory-symlink-target-and-import-match-disk.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-both-directory-symlink-target-and-import-match-disk.js
@@ -1,0 +1,239 @@
+Input::
+//// [/user/username/projects/myproject/XY/a.ts]
+
+export const a = 1;
+export const b = 2;
+
+
+//// [/user/username/projects/myproject/link] symlink(/user/username/projects/myproject/XY)
+//// [/user/username/projects/myproject/b.ts]
+
+import { a } from "./XY/a";
+import { b } from "./link/a";
+
+a;b;
+
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/user/username/projects/myproject/tsconfig.json]
+{"compilerOptions":{"forceConsistentCasingInFileNames":true,"outFile":"out.js","module":"system"}}
+
+
+/a/lib/tsc.js --w --p . --explainFiles
+Output::
+>> Screen clear
+[[90m12:00:27 AM[0m] Starting compilation in watch mode...
+
+../../../../a/lib/lib.d.ts
+  Default library
+XY/a.ts
+  Imported via "./XY/a" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+link/a.ts
+  Imported via "./link/a" from file 'b.ts'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/b.ts","/user/username/projects/myproject/XY/a.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"outFile":"/user/username/projects/myproject/out.js","module":4,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
+
+No cached semantic diagnostics in the builder::
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/xy/a.ts:
+  {"fileName":"/user/username/projects/myproject/XY/a.ts","pollingInterval":250}
+/user/username/projects/myproject/link/a.ts:
+  {"fileName":"/user/username/projects/myproject/link/a.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/out.js]
+System.register("XY/a", [], function (exports_1, context_1) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_1("a", a = 1);
+            exports_1("b", b = 2);
+        }
+    };
+});
+System.register("link/a", [], function (exports_2, context_2) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_2 && context_2.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_2("a", a = 1);
+            exports_2("b", b = 2);
+        }
+    };
+});
+System.register("b", ["XY/a", "link/a"], function (exports_3, context_3) {
+    "use strict";
+    var a_1, a_2;
+    var __moduleName = context_3 && context_3.id;
+    return {
+        setters: [
+            function (a_1_1) {
+                a_1 = a_1_1;
+            },
+            function (a_2_1) {
+                a_2 = a_2_1;
+            }
+        ],
+        execute: function () {
+            a_1.a;
+            a_2.b;
+        }
+    };
+});
+
+
+
+Change:: Prepend a line to moduleA
+
+Input::
+//// [/user/username/projects/myproject/XY/a.ts]
+// some comment
+                        
+export const a = 1;
+export const b = 2;
+
+
+
+Output::
+>> Screen clear
+[[90m12:00:33 AM[0m] File change detected. Starting incremental compilation...
+
+../../../../a/lib/lib.d.ts
+  Default library
+XY/a.ts
+  Imported via "./XY/a" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+link/a.ts
+  Imported via "./link/a" from file 'b.ts'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:37 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/b.ts","/user/username/projects/myproject/XY/a.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"outFile":"/user/username/projects/myproject/out.js","module":4,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Completely
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
+
+No cached semantic diagnostics in the builder::
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/xy/a.ts:
+  {"fileName":"/user/username/projects/myproject/XY/a.ts","pollingInterval":250}
+/user/username/projects/myproject/link/a.ts:
+  {"fileName":"/user/username/projects/myproject/link/a.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/out.js]
+// some comment
+System.register("XY/a", [], function (exports_1, context_1) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {// some comment
+            exports_1("a", a = 1);
+            exports_1("b", b = 2);
+        }
+    };
+});
+System.register("link/a", [], function (exports_2, context_2) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_2 && context_2.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_2("a", a = 1);
+            exports_2("b", b = 2);
+        }
+    };
+});
+System.register("b", ["XY/a", "link/a"], function (exports_3, context_3) {
+    "use strict";
+    var a_1, a_2;
+    var __moduleName = context_3 && context_3.id;
+    return {
+        setters: [
+            function (a_1_1) {
+                a_1 = a_1_1;
+            },
+            function (a_2_1) {
+                a_2 = a_2_1;
+            }
+        ],
+        execute: function () {
+            a_1.a;
+            a_2.b;
+        }
+    };
+});
+
+

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-both-file-symlink-target-and-import-match-disk.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-both-file-symlink-target-and-import-match-disk.js
@@ -1,0 +1,187 @@
+Input::
+//// [/user/username/projects/myproject/XY.ts]
+
+export const a = 1;
+export const b = 2;
+
+
+//// [/user/username/projects/myproject/link.ts] symlink(/user/username/projects/myproject/XY.ts)
+//// [/user/username/projects/myproject/b.ts]
+
+import { a } from "./XY";
+import { b } from "./link";
+
+a;b;
+
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/user/username/projects/myproject/tsconfig.json]
+{"compilerOptions":{"forceConsistentCasingInFileNames":true}}
+
+
+/a/lib/tsc.js --w --p . --explainFiles
+Output::
+>> Screen clear
+[[90m12:00:25 AM[0m] Starting compilation in watch mode...
+
+../../../../a/lib/lib.d.ts
+  Default library
+XY.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+  Imported via "./XY" from file 'b.ts'
+link.ts
+  Imported via "./link" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:32 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/XY.ts","/user/username/projects/myproject/b.ts","/user/username/projects/myproject/link.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/xy.ts:
+  {"fileName":"/user/username/projects/myproject/XY.ts","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/link.ts:
+  {"fileName":"/user/username/projects/myproject/link.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/XY.js]
+"use strict";
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+
+//// [/user/username/projects/myproject/link.js]
+"use strict";
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+
+//// [/user/username/projects/myproject/b.js]
+"use strict";
+exports.__esModule = true;
+var XY_1 = require("./XY");
+var link_1 = require("./link");
+XY_1.a;
+link_1.b;
+
+
+
+Change:: Prepend a line to moduleA
+
+Input::
+//// [/user/username/projects/myproject/XY.ts]
+// some comment
+                        
+export const a = 1;
+export const b = 2;
+
+
+
+Output::
+>> Screen clear
+[[90m12:00:35 AM[0m] File change detected. Starting incremental compilation...
+
+../../../../a/lib/lib.d.ts
+  Default library
+XY.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+  Imported via "./XY" from file 'b.ts'
+link.ts
+  Imported via "./link" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:39 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/XY.ts","/user/username/projects/myproject/b.ts","/user/username/projects/myproject/link.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Completely
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+Semantic diagnostics in builder refreshed for::
+/user/username/projects/myproject/XY.ts
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/xy.ts:
+  {"fileName":"/user/username/projects/myproject/XY.ts","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/link.ts:
+  {"fileName":"/user/username/projects/myproject/link.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/XY.js]
+"use strict";
+// some comment
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-directory-symlink-target-matches-disk-but-import-does-not.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-directory-symlink-target-matches-disk-but-import-does-not.js
@@ -1,0 +1,239 @@
+Input::
+//// [/user/username/projects/myproject/XY/a.ts]
+
+export const a = 1;
+export const b = 2;
+
+
+//// [/user/username/projects/myproject/link] symlink(/user/username/projects/myproject/Xy)
+//// [/user/username/projects/myproject/b.ts]
+
+import { a } from "./XY/a";
+import { b } from "./link/a";
+
+a;b;
+
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/user/username/projects/myproject/tsconfig.json]
+{"compilerOptions":{"forceConsistentCasingInFileNames":true,"outFile":"out.js","module":"system"}}
+
+
+/a/lib/tsc.js --w --p . --explainFiles
+Output::
+>> Screen clear
+[[90m12:00:27 AM[0m] Starting compilation in watch mode...
+
+../../../../a/lib/lib.d.ts
+  Default library
+XY/a.ts
+  Imported via "./XY/a" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+link/a.ts
+  Imported via "./link/a" from file 'b.ts'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:30 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/b.ts","/user/username/projects/myproject/XY/a.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"outFile":"/user/username/projects/myproject/out.js","module":4,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
+
+No cached semantic diagnostics in the builder::
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/xy/a.ts:
+  {"fileName":"/user/username/projects/myproject/XY/a.ts","pollingInterval":250}
+/user/username/projects/myproject/link/a.ts:
+  {"fileName":"/user/username/projects/myproject/link/a.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/out.js]
+System.register("XY/a", [], function (exports_1, context_1) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_1("a", a = 1);
+            exports_1("b", b = 2);
+        }
+    };
+});
+System.register("link/a", [], function (exports_2, context_2) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_2 && context_2.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_2("a", a = 1);
+            exports_2("b", b = 2);
+        }
+    };
+});
+System.register("b", ["XY/a", "link/a"], function (exports_3, context_3) {
+    "use strict";
+    var a_1, a_2;
+    var __moduleName = context_3 && context_3.id;
+    return {
+        setters: [
+            function (a_1_1) {
+                a_1 = a_1_1;
+            },
+            function (a_2_1) {
+                a_2 = a_2_1;
+            }
+        ],
+        execute: function () {
+            a_1.a;
+            a_2.b;
+        }
+    };
+});
+
+
+
+Change:: Prepend a line to moduleA
+
+Input::
+//// [/user/username/projects/myproject/XY/a.ts]
+// some comment
+                        
+export const a = 1;
+export const b = 2;
+
+
+
+Output::
+>> Screen clear
+[[90m12:00:33 AM[0m] File change detected. Starting incremental compilation...
+
+../../../../a/lib/lib.d.ts
+  Default library
+XY/a.ts
+  Imported via "./XY/a" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+link/a.ts
+  Imported via "./link/a" from file 'b.ts'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:37 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/b.ts","/user/username/projects/myproject/XY/a.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"outFile":"/user/username/projects/myproject/out.js","module":4,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Completely
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
+
+No cached semantic diagnostics in the builder::
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/xy/a.ts:
+  {"fileName":"/user/username/projects/myproject/XY/a.ts","pollingInterval":250}
+/user/username/projects/myproject/link/a.ts:
+  {"fileName":"/user/username/projects/myproject/link/a.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/out.js]
+// some comment
+System.register("XY/a", [], function (exports_1, context_1) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {// some comment
+            exports_1("a", a = 1);
+            exports_1("b", b = 2);
+        }
+    };
+});
+System.register("link/a", [], function (exports_2, context_2) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_2 && context_2.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_2("a", a = 1);
+            exports_2("b", b = 2);
+        }
+    };
+});
+System.register("b", ["XY/a", "link/a"], function (exports_3, context_3) {
+    "use strict";
+    var a_1, a_2;
+    var __moduleName = context_3 && context_3.id;
+    return {
+        setters: [
+            function (a_1_1) {
+                a_1 = a_1_1;
+            },
+            function (a_2_1) {
+                a_2 = a_2_1;
+            }
+        ],
+        execute: function () {
+            a_1.a;
+            a_2.b;
+        }
+    };
+});
+
+

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-file-symlink-target-matches-disk-but-import-does-not.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-file-symlink-target-matches-disk-but-import-does-not.js
@@ -1,0 +1,187 @@
+Input::
+//// [/user/username/projects/myproject/XY.ts]
+
+export const a = 1;
+export const b = 2;
+
+
+//// [/user/username/projects/myproject/link.ts] symlink(/user/username/projects/myproject/Xy.ts)
+//// [/user/username/projects/myproject/b.ts]
+
+import { a } from "./XY";
+import { b } from "./link";
+
+a;b;
+
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/user/username/projects/myproject/tsconfig.json]
+{"compilerOptions":{"forceConsistentCasingInFileNames":true}}
+
+
+/a/lib/tsc.js --w --p . --explainFiles
+Output::
+>> Screen clear
+[[90m12:00:25 AM[0m] Starting compilation in watch mode...
+
+../../../../a/lib/lib.d.ts
+  Default library
+XY.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+  Imported via "./XY" from file 'b.ts'
+link.ts
+  Imported via "./link" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:32 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/XY.ts","/user/username/projects/myproject/b.ts","/user/username/projects/myproject/link.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/xy.ts:
+  {"fileName":"/user/username/projects/myproject/XY.ts","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/link.ts:
+  {"fileName":"/user/username/projects/myproject/link.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/XY.js]
+"use strict";
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+
+//// [/user/username/projects/myproject/link.js]
+"use strict";
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+
+//// [/user/username/projects/myproject/b.js]
+"use strict";
+exports.__esModule = true;
+var XY_1 = require("./XY");
+var link_1 = require("./link");
+XY_1.a;
+link_1.b;
+
+
+
+Change:: Prepend a line to moduleA
+
+Input::
+//// [/user/username/projects/myproject/XY.ts]
+// some comment
+                        
+export const a = 1;
+export const b = 2;
+
+
+
+Output::
+>> Screen clear
+[[90m12:00:35 AM[0m] File change detected. Starting incremental compilation...
+
+../../../../a/lib/lib.d.ts
+  Default library
+XY.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+  Imported via "./XY" from file 'b.ts'
+link.ts
+  Imported via "./link" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:39 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/XY.ts","/user/username/projects/myproject/b.ts","/user/username/projects/myproject/link.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Completely
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+Semantic diagnostics in builder refreshed for::
+/user/username/projects/myproject/XY.ts
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/xy.ts:
+  {"fileName":"/user/username/projects/myproject/XY.ts","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/link.ts:
+  {"fileName":"/user/username/projects/myproject/link.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/XY.js]
+"use strict";
+// some comment
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import,-directory-symlink-target,-and-disk-are-all-different.js
@@ -1,0 +1,251 @@
+Input::
+//// [/user/username/projects/myproject/XY/a.ts]
+
+export const a = 1;
+export const b = 2;
+
+
+//// [/user/username/projects/myproject/link] symlink(/user/username/projects/myproject/Xy)
+//// [/user/username/projects/myproject/b.ts]
+
+import { a } from "./yX/a";
+import { b } from "./link/a";
+
+a;b;
+
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/user/username/projects/myproject/tsconfig.json]
+{"compilerOptions":{"forceConsistentCasingInFileNames":true,"outFile":"out.js","module":"system"}}
+
+
+/a/lib/tsc.js --w --p . --explainFiles
+Output::
+>> Screen clear
+[[90m12:00:27 AM[0m] Starting compilation in watch mode...
+
+[96mb.ts[0m:[93m2[0m:[93m19[0m - [91merror[0m[90m TS2792: [0mCannot find module './yX/a'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?
+
+[7m2[0m import { a } from "./yX/a";
+[7m [0m [91m                  ~~~~~~~~[0m
+
+../../../../a/lib/lib.d.ts
+  Default library
+link/a.ts
+  Imported via "./link/a" from file 'b.ts'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+XY/a.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:30 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/b.ts","/user/username/projects/myproject/XY/a.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"outFile":"/user/username/projects/myproject/out.js","module":4,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
+/user/username/projects/myproject/XY/a.ts
+
+No cached semantic diagnostics in the builder::
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/link/a.ts:
+  {"fileName":"/user/username/projects/myproject/link/a.ts","pollingInterval":250}
+/user/username/projects/myproject/xy/a.ts:
+  {"fileName":"/user/username/projects/myproject/XY/a.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/yx:
+  {"directoryName":"/user/username/projects/myproject/yX","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/out.js]
+System.register("link/a", [], function (exports_1, context_1) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_1("a", a = 1);
+            exports_1("b", b = 2);
+        }
+    };
+});
+System.register("b", ["./yX/a", "link/a"], function (exports_2, context_2) {
+    "use strict";
+    var a_1, a_2;
+    var __moduleName = context_2 && context_2.id;
+    return {
+        setters: [
+            function (a_1_1) {
+                a_1 = a_1_1;
+            },
+            function (a_2_1) {
+                a_2 = a_2_1;
+            }
+        ],
+        execute: function () {
+            a_1.a;
+            a_2.b;
+        }
+    };
+});
+System.register("XY/a", [], function (exports_3, context_3) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_3 && context_3.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_3("a", a = 1);
+            exports_3("b", b = 2);
+        }
+    };
+});
+
+
+
+Change:: Prepend a line to moduleA
+
+Input::
+//// [/user/username/projects/myproject/XY/a.ts]
+// some comment
+                        
+export const a = 1;
+export const b = 2;
+
+
+
+Output::
+>> Screen clear
+[[90m12:00:33 AM[0m] File change detected. Starting incremental compilation...
+
+[96mb.ts[0m:[93m2[0m:[93m19[0m - [91merror[0m[90m TS2792: [0mCannot find module './yX/a'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?
+
+[7m2[0m import { a } from "./yX/a";
+[7m [0m [91m                  ~~~~~~~~[0m
+
+../../../../a/lib/lib.d.ts
+  Default library
+link/a.ts
+  Imported via "./link/a" from file 'b.ts'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+XY/a.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/b.ts","/user/username/projects/myproject/XY/a.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"outFile":"/user/username/projects/myproject/out.js","module":4,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Completely
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
+/user/username/projects/myproject/XY/a.ts
+
+No cached semantic diagnostics in the builder::
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/link/a.ts:
+  {"fileName":"/user/username/projects/myproject/link/a.ts","pollingInterval":250}
+/user/username/projects/myproject/xy/a.ts:
+  {"fileName":"/user/username/projects/myproject/XY/a.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/yx:
+  {"directoryName":"/user/username/projects/myproject/yX","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/out.js]
+System.register("link/a", [], function (exports_1, context_1) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_1("a", a = 1);
+            exports_1("b", b = 2);
+        }
+    };
+});
+System.register("b", ["./yX/a", "link/a"], function (exports_2, context_2) {
+    "use strict";
+    var a_1, a_2;
+    var __moduleName = context_2 && context_2.id;
+    return {
+        setters: [
+            function (a_1_1) {
+                a_1 = a_1_1;
+            },
+            function (a_2_1) {
+                a_2 = a_2_1;
+            }
+        ],
+        execute: function () {
+            a_1.a;
+            a_2.b;
+        }
+    };
+});
+// some comment
+System.register("XY/a", [], function (exports_3, context_3) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_3 && context_3.id;
+    return {
+        setters: [],
+        execute: function () {// some comment
+            exports_3("a", a = 1);
+            exports_3("b", b = 2);
+        }
+    };
+});
+
+

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import,-file-symlink-target,-and-disk-are-all-different.js
@@ -1,0 +1,203 @@
+Input::
+//// [/user/username/projects/myproject/XY.ts]
+
+export const a = 1;
+export const b = 2;
+
+
+//// [/user/username/projects/myproject/link.ts] symlink(/user/username/projects/myproject/Xy.ts)
+//// [/user/username/projects/myproject/b.ts]
+
+import { a } from "./yX";
+import { b } from "./link";
+
+a;b;
+
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/user/username/projects/myproject/tsconfig.json]
+{"compilerOptions":{"forceConsistentCasingInFileNames":true}}
+
+
+/a/lib/tsc.js --w --p . --explainFiles
+Output::
+>> Screen clear
+[[90m12:00:25 AM[0m] Starting compilation in watch mode...
+
+[96mb.ts[0m:[93m2[0m:[93m19[0m - [91merror[0m[90m TS2307: [0mCannot find module './yX' or its corresponding type declarations.
+
+[7m2[0m import { a } from "./yX";
+[7m [0m [91m                  ~~~~~~[0m
+
+../../../../a/lib/lib.d.ts
+  Default library
+XY.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+link.ts
+  Imported via "./link" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/XY.ts","/user/username/projects/myproject/b.ts","/user/username/projects/myproject/link.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/xy.ts:
+  {"fileName":"/user/username/projects/myproject/XY.ts","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/link.ts:
+  {"fileName":"/user/username/projects/myproject/link.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+FsWatchesRecursive::
+/user/username/projects/myproject/yx:
+  {"directoryName":"/user/username/projects/myproject/yX","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/XY.js]
+"use strict";
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+
+//// [/user/username/projects/myproject/link.js]
+"use strict";
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+
+//// [/user/username/projects/myproject/b.js]
+"use strict";
+exports.__esModule = true;
+var yX_1 = require("./yX");
+var link_1 = require("./link");
+yX_1.a;
+link_1.b;
+
+
+
+Change:: Prepend a line to moduleA
+
+Input::
+//// [/user/username/projects/myproject/XY.ts]
+// some comment
+                        
+export const a = 1;
+export const b = 2;
+
+
+
+Output::
+>> Screen clear
+[[90m12:00:35 AM[0m] File change detected. Starting incremental compilation...
+
+[96mb.ts[0m:[93m2[0m:[93m19[0m - [91merror[0m[90m TS2307: [0mCannot find module './yX' or its corresponding type declarations.
+
+[7m2[0m import { a } from "./yX";
+[7m [0m [91m                  ~~~~~~[0m
+
+../../../../a/lib/lib.d.ts
+  Default library
+XY.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+link.ts
+  Imported via "./link" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:39 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/XY.ts","/user/username/projects/myproject/b.ts","/user/username/projects/myproject/link.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Completely
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+Semantic diagnostics in builder refreshed for::
+/user/username/projects/myproject/XY.ts
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/xy.ts:
+  {"fileName":"/user/username/projects/myproject/XY.ts","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/link.ts:
+  {"fileName":"/user/username/projects/myproject/link.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+FsWatchesRecursive::
+/user/username/projects/myproject/yx:
+  {"directoryName":"/user/username/projects/myproject/yX","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/XY.js]
+"use strict";
+// some comment
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-and-directory-symlink-target-agree-but-do-not-match-disk.js
@@ -1,0 +1,255 @@
+Input::
+//// [/user/username/projects/myproject/XY/a.ts]
+
+export const a = 1;
+export const b = 2;
+
+
+//// [/user/username/projects/myproject/link] symlink(/user/username/projects/myproject/Xy)
+//// [/user/username/projects/myproject/b.ts]
+
+import { a } from "./Xy/a";
+import { b } from "./link/a";
+
+a;b;
+
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/user/username/projects/myproject/tsconfig.json]
+{"compilerOptions":{"forceConsistentCasingInFileNames":true,"outFile":"out.js","module":"system"}}
+
+
+/a/lib/tsc.js --w --p . --explainFiles
+Output::
+>> Screen clear
+[[90m12:00:27 AM[0m] Starting compilation in watch mode...
+
+[96mb.ts[0m:[93m2[0m:[93m19[0m - [91merror[0m[90m TS1261: [0mAlready included file name '/user/username/projects/myproject/Xy/a.ts' differs from file name '/user/username/projects/myproject/XY/a.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Xy/a" from file '/user/username/projects/myproject/b.ts'
+    Matched by include pattern '**/*' in 'tsconfig.json'
+
+[7m2[0m import { a } from "./Xy/a";
+[7m [0m [91m                  ~~~~~~~~[0m
+
+../../../../a/lib/lib.d.ts
+  Default library
+Xy/a.ts
+  Imported via "./Xy/a" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+link/a.ts
+  Imported via "./link/a" from file 'b.ts'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:30 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/b.ts","/user/username/projects/myproject/XY/a.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"outFile":"/user/username/projects/myproject/out.js","module":4,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/Xy/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
+
+No cached semantic diagnostics in the builder::
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/xy/a.ts:
+  {"fileName":"/user/username/projects/myproject/Xy/a.ts","pollingInterval":250}
+/user/username/projects/myproject/link/a.ts:
+  {"fileName":"/user/username/projects/myproject/link/a.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/out.js]
+System.register("Xy/a", [], function (exports_1, context_1) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_1("a", a = 1);
+            exports_1("b", b = 2);
+        }
+    };
+});
+System.register("link/a", [], function (exports_2, context_2) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_2 && context_2.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_2("a", a = 1);
+            exports_2("b", b = 2);
+        }
+    };
+});
+System.register("b", ["Xy/a", "link/a"], function (exports_3, context_3) {
+    "use strict";
+    var a_1, a_2;
+    var __moduleName = context_3 && context_3.id;
+    return {
+        setters: [
+            function (a_1_1) {
+                a_1 = a_1_1;
+            },
+            function (a_2_1) {
+                a_2 = a_2_1;
+            }
+        ],
+        execute: function () {
+            a_1.a;
+            a_2.b;
+        }
+    };
+});
+
+
+
+Change:: Prepend a line to moduleA
+
+Input::
+//// [/user/username/projects/myproject/XY/a.ts]
+// some comment
+                        
+export const a = 1;
+export const b = 2;
+
+
+
+Output::
+>> Screen clear
+[[90m12:00:33 AM[0m] File change detected. Starting incremental compilation...
+
+[96mb.ts[0m:[93m2[0m:[93m19[0m - [91merror[0m[90m TS1261: [0mAlready included file name '/user/username/projects/myproject/Xy/a.ts' differs from file name '/user/username/projects/myproject/XY/a.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Xy/a" from file '/user/username/projects/myproject/b.ts'
+    Matched by include pattern '**/*' in 'tsconfig.json'
+
+[7m2[0m import { a } from "./Xy/a";
+[7m [0m [91m                  ~~~~~~~~[0m
+
+../../../../a/lib/lib.d.ts
+  Default library
+Xy/a.ts
+  Imported via "./Xy/a" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+link/a.ts
+  Imported via "./link/a" from file 'b.ts'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/b.ts","/user/username/projects/myproject/XY/a.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"outFile":"/user/username/projects/myproject/out.js","module":4,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Completely
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/Xy/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
+
+No cached semantic diagnostics in the builder::
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/xy/a.ts:
+  {"fileName":"/user/username/projects/myproject/Xy/a.ts","pollingInterval":250}
+/user/username/projects/myproject/link/a.ts:
+  {"fileName":"/user/username/projects/myproject/link/a.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/out.js]
+// some comment
+System.register("Xy/a", [], function (exports_1, context_1) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {// some comment
+            exports_1("a", a = 1);
+            exports_1("b", b = 2);
+        }
+    };
+});
+System.register("link/a", [], function (exports_2, context_2) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_2 && context_2.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_2("a", a = 1);
+            exports_2("b", b = 2);
+        }
+    };
+});
+System.register("b", ["Xy/a", "link/a"], function (exports_3, context_3) {
+    "use strict";
+    var a_1, a_2;
+    var __moduleName = context_3 && context_3.id;
+    return {
+        setters: [
+            function (a_1_1) {
+                a_1 = a_1_1;
+            },
+            function (a_2_1) {
+                a_2 = a_2_1;
+            }
+        ],
+        execute: function () {
+            a_1.a;
+            a_2.b;
+        }
+    };
+});
+
+

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-and-file-symlink-target-agree-but-do-not-match-disk.js
@@ -1,0 +1,203 @@
+Input::
+//// [/user/username/projects/myproject/XY.ts]
+
+export const a = 1;
+export const b = 2;
+
+
+//// [/user/username/projects/myproject/link.ts] symlink(/user/username/projects/myproject/Xy.ts)
+//// [/user/username/projects/myproject/b.ts]
+
+import { a } from "./Xy";
+import { b } from "./link";
+
+a;b;
+
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/user/username/projects/myproject/tsconfig.json]
+{"compilerOptions":{"forceConsistentCasingInFileNames":true}}
+
+
+/a/lib/tsc.js --w --p . --explainFiles
+Output::
+>> Screen clear
+[[90m12:00:25 AM[0m] Starting compilation in watch mode...
+
+[96mb.ts[0m:[93m2[0m:[93m19[0m - [91merror[0m[90m TS1149: [0mFile name '/user/username/projects/myproject/Xy.ts' differs from already included file name '/user/username/projects/myproject/XY.ts' only in casing.
+  The file is in the program because:
+    Matched by include pattern '**/*' in 'tsconfig.json'
+    Imported via "./Xy" from file '/user/username/projects/myproject/b.ts'
+
+[7m2[0m import { a } from "./Xy";
+[7m [0m [91m                  ~~~~~~[0m
+
+../../../../a/lib/lib.d.ts
+  Default library
+XY.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+  Imported via "./Xy" from file 'b.ts'
+link.ts
+  Imported via "./link" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/XY.ts","/user/username/projects/myproject/b.ts","/user/username/projects/myproject/link.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/xy.ts:
+  {"fileName":"/user/username/projects/myproject/XY.ts","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/link.ts:
+  {"fileName":"/user/username/projects/myproject/link.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/XY.js]
+"use strict";
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+
+//// [/user/username/projects/myproject/link.js]
+"use strict";
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+
+//// [/user/username/projects/myproject/b.js]
+"use strict";
+exports.__esModule = true;
+var Xy_1 = require("./Xy");
+var link_1 = require("./link");
+Xy_1.a;
+link_1.b;
+
+
+
+Change:: Prepend a line to moduleA
+
+Input::
+//// [/user/username/projects/myproject/XY.ts]
+// some comment
+                        
+export const a = 1;
+export const b = 2;
+
+
+
+Output::
+>> Screen clear
+[[90m12:00:35 AM[0m] File change detected. Starting incremental compilation...
+
+[96mb.ts[0m:[93m2[0m:[93m19[0m - [91merror[0m[90m TS1149: [0mFile name '/user/username/projects/myproject/Xy.ts' differs from already included file name '/user/username/projects/myproject/XY.ts' only in casing.
+  The file is in the program because:
+    Matched by include pattern '**/*' in 'tsconfig.json'
+    Imported via "./Xy" from file '/user/username/projects/myproject/b.ts'
+
+[7m2[0m import { a } from "./Xy";
+[7m [0m [91m                  ~~~~~~[0m
+
+../../../../a/lib/lib.d.ts
+  Default library
+XY.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+  Imported via "./Xy" from file 'b.ts'
+link.ts
+  Imported via "./link" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:39 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/XY.ts","/user/username/projects/myproject/b.ts","/user/username/projects/myproject/link.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Completely
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+Semantic diagnostics in builder refreshed for::
+/user/username/projects/myproject/XY.ts
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/xy.ts:
+  {"fileName":"/user/username/projects/myproject/XY.ts","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/link.ts:
+  {"fileName":"/user/username/projects/myproject/link.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/XY.js]
+"use strict";
+// some comment
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-matches-disk-but-directory-symlink-target-does-not.js
@@ -1,0 +1,255 @@
+Input::
+//// [/user/username/projects/myproject/XY/a.ts]
+
+export const a = 1;
+export const b = 2;
+
+
+//// [/user/username/projects/myproject/link] symlink(/user/username/projects/myproject/XY)
+//// [/user/username/projects/myproject/b.ts]
+
+import { a } from "./Xy/a";
+import { b } from "./link/a";
+
+a;b;
+
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/user/username/projects/myproject/tsconfig.json]
+{"compilerOptions":{"forceConsistentCasingInFileNames":true,"outFile":"out.js","module":"system"}}
+
+
+/a/lib/tsc.js --w --p . --explainFiles
+Output::
+>> Screen clear
+[[90m12:00:27 AM[0m] Starting compilation in watch mode...
+
+[96mb.ts[0m:[93m2[0m:[93m19[0m - [91merror[0m[90m TS1261: [0mAlready included file name '/user/username/projects/myproject/Xy/a.ts' differs from file name '/user/username/projects/myproject/XY/a.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Xy/a" from file '/user/username/projects/myproject/b.ts'
+    Matched by include pattern '**/*' in 'tsconfig.json'
+
+[7m2[0m import { a } from "./Xy/a";
+[7m [0m [91m                  ~~~~~~~~[0m
+
+../../../../a/lib/lib.d.ts
+  Default library
+Xy/a.ts
+  Imported via "./Xy/a" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+link/a.ts
+  Imported via "./link/a" from file 'b.ts'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:30 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/b.ts","/user/username/projects/myproject/XY/a.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"outFile":"/user/username/projects/myproject/out.js","module":4,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/Xy/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
+
+No cached semantic diagnostics in the builder::
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/xy/a.ts:
+  {"fileName":"/user/username/projects/myproject/Xy/a.ts","pollingInterval":250}
+/user/username/projects/myproject/link/a.ts:
+  {"fileName":"/user/username/projects/myproject/link/a.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/out.js]
+System.register("Xy/a", [], function (exports_1, context_1) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_1("a", a = 1);
+            exports_1("b", b = 2);
+        }
+    };
+});
+System.register("link/a", [], function (exports_2, context_2) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_2 && context_2.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_2("a", a = 1);
+            exports_2("b", b = 2);
+        }
+    };
+});
+System.register("b", ["Xy/a", "link/a"], function (exports_3, context_3) {
+    "use strict";
+    var a_1, a_2;
+    var __moduleName = context_3 && context_3.id;
+    return {
+        setters: [
+            function (a_1_1) {
+                a_1 = a_1_1;
+            },
+            function (a_2_1) {
+                a_2 = a_2_1;
+            }
+        ],
+        execute: function () {
+            a_1.a;
+            a_2.b;
+        }
+    };
+});
+
+
+
+Change:: Prepend a line to moduleA
+
+Input::
+//// [/user/username/projects/myproject/XY/a.ts]
+// some comment
+                        
+export const a = 1;
+export const b = 2;
+
+
+
+Output::
+>> Screen clear
+[[90m12:00:33 AM[0m] File change detected. Starting incremental compilation...
+
+[96mb.ts[0m:[93m2[0m:[93m19[0m - [91merror[0m[90m TS1261: [0mAlready included file name '/user/username/projects/myproject/Xy/a.ts' differs from file name '/user/username/projects/myproject/XY/a.ts' only in casing.
+  The file is in the program because:
+    Imported via "./Xy/a" from file '/user/username/projects/myproject/b.ts'
+    Matched by include pattern '**/*' in 'tsconfig.json'
+
+[7m2[0m import { a } from "./Xy/a";
+[7m [0m [91m                  ~~~~~~~~[0m
+
+../../../../a/lib/lib.d.ts
+  Default library
+Xy/a.ts
+  Imported via "./Xy/a" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+link/a.ts
+  Imported via "./link/a" from file 'b.ts'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/b.ts","/user/username/projects/myproject/XY/a.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"outFile":"/user/username/projects/myproject/out.js","module":4,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Completely
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/Xy/a.ts
+/user/username/projects/myproject/link/a.ts
+/user/username/projects/myproject/b.ts
+
+No cached semantic diagnostics in the builder::
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/xy/a.ts:
+  {"fileName":"/user/username/projects/myproject/Xy/a.ts","pollingInterval":250}
+/user/username/projects/myproject/link/a.ts:
+  {"fileName":"/user/username/projects/myproject/link/a.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/out.js]
+// some comment
+System.register("Xy/a", [], function (exports_1, context_1) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {// some comment
+            exports_1("a", a = 1);
+            exports_1("b", b = 2);
+        }
+    };
+});
+System.register("link/a", [], function (exports_2, context_2) {
+    "use strict";
+    var a, b;
+    var __moduleName = context_2 && context_2.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_2("a", a = 1);
+            exports_2("b", b = 2);
+        }
+    };
+});
+System.register("b", ["Xy/a", "link/a"], function (exports_3, context_3) {
+    "use strict";
+    var a_1, a_2;
+    var __moduleName = context_3 && context_3.id;
+    return {
+        setters: [
+            function (a_1_1) {
+                a_1 = a_1_1;
+            },
+            function (a_2_1) {
+                a_2 = a_2_1;
+            }
+        ],
+        execute: function () {
+            a_1.a;
+            a_2.b;
+        }
+    };
+});
+
+

--- a/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not.js
+++ b/tests/baselines/reference/tscWatch/forceConsistentCasingInFileNames/when-import-matches-disk-but-file-symlink-target-does-not.js
@@ -1,0 +1,203 @@
+Input::
+//// [/user/username/projects/myproject/XY.ts]
+
+export const a = 1;
+export const b = 2;
+
+
+//// [/user/username/projects/myproject/link.ts] symlink(/user/username/projects/myproject/XY.ts)
+//// [/user/username/projects/myproject/b.ts]
+
+import { a } from "./Xy";
+import { b } from "./link";
+
+a;b;
+
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/user/username/projects/myproject/tsconfig.json]
+{"compilerOptions":{"forceConsistentCasingInFileNames":true}}
+
+
+/a/lib/tsc.js --w --p . --explainFiles
+Output::
+>> Screen clear
+[[90m12:00:25 AM[0m] Starting compilation in watch mode...
+
+[96mb.ts[0m:[93m2[0m:[93m19[0m - [91merror[0m[90m TS1149: [0mFile name '/user/username/projects/myproject/Xy.ts' differs from already included file name '/user/username/projects/myproject/XY.ts' only in casing.
+  The file is in the program because:
+    Matched by include pattern '**/*' in 'tsconfig.json'
+    Imported via "./Xy" from file '/user/username/projects/myproject/b.ts'
+
+[7m2[0m import { a } from "./Xy";
+[7m [0m [91m                  ~~~~~~[0m
+
+../../../../a/lib/lib.d.ts
+  Default library
+XY.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+  Imported via "./Xy" from file 'b.ts'
+link.ts
+  Imported via "./link" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/XY.ts","/user/username/projects/myproject/b.ts","/user/username/projects/myproject/link.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/xy.ts:
+  {"fileName":"/user/username/projects/myproject/XY.ts","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/link.ts:
+  {"fileName":"/user/username/projects/myproject/link.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/XY.js]
+"use strict";
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+
+//// [/user/username/projects/myproject/link.js]
+"use strict";
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+
+//// [/user/username/projects/myproject/b.js]
+"use strict";
+exports.__esModule = true;
+var Xy_1 = require("./Xy");
+var link_1 = require("./link");
+Xy_1.a;
+link_1.b;
+
+
+
+Change:: Prepend a line to moduleA
+
+Input::
+//// [/user/username/projects/myproject/XY.ts]
+// some comment
+                        
+export const a = 1;
+export const b = 2;
+
+
+
+Output::
+>> Screen clear
+[[90m12:00:35 AM[0m] File change detected. Starting incremental compilation...
+
+[96mb.ts[0m:[93m2[0m:[93m19[0m - [91merror[0m[90m TS1149: [0mFile name '/user/username/projects/myproject/Xy.ts' differs from already included file name '/user/username/projects/myproject/XY.ts' only in casing.
+  The file is in the program because:
+    Matched by include pattern '**/*' in 'tsconfig.json'
+    Imported via "./Xy" from file '/user/username/projects/myproject/b.ts'
+
+[7m2[0m import { a } from "./Xy";
+[7m [0m [91m                  ~~~~~~[0m
+
+../../../../a/lib/lib.d.ts
+  Default library
+XY.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+  Imported via "./Xy" from file 'b.ts'
+link.ts
+  Imported via "./link" from file 'b.ts'
+  Matched by include pattern '**/*' in 'tsconfig.json'
+b.ts
+  Matched by include pattern '**/*' in 'tsconfig.json'
+[[90m12:00:39 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/XY.ts","/user/username/projects/myproject/b.ts","/user/username/projects/myproject/link.ts"]
+Program options: {"forceConsistentCasingInFileNames":true,"watch":true,"project":"/user/username/projects/myproject","explainFiles":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Completely
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/XY.ts
+/user/username/projects/myproject/link.ts
+/user/username/projects/myproject/b.ts
+
+Semantic diagnostics in builder refreshed for::
+/user/username/projects/myproject/XY.ts
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/xy.ts:
+  {"fileName":"/user/username/projects/myproject/XY.ts","pollingInterval":250}
+/user/username/projects/myproject/b.ts:
+  {"fileName":"/user/username/projects/myproject/b.ts","pollingInterval":250}
+/user/username/projects/myproject/link.ts:
+  {"fileName":"/user/username/projects/myproject/link.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/XY.js]
+"use strict";
+// some comment
+exports.__esModule = true;
+exports.b = exports.a = void 0;
+exports.a = 1;
+exports.b = 2;
+
+


### PR DESCRIPTION
In local measurements of an Office project, we saw initial project loading get 5% faster on Windows and 13% faster on Linux.  The only identified behavioral change is that it restores the case used on disk, whereas realpathSync retains the input lowercase.