### PR TITLE
Fix typos in comments

### DIFF
--- a/tests/baselines/reference/commaOperatorOtherInvalidOperation.errors.txt
+++ b/tests/baselines/reference/commaOperatorOtherInvalidOperation.errors.txt
@@ -5,7 +5,7 @@ tests/cases/conformance/expressions/commaOperator/commaOperatorOtherInvalidOpera
 
 ==== tests/cases/conformance/expressions/commaOperator/commaOperatorOtherInvalidOperation.ts (2 errors) ====
     //Expect to have compiler errors
-    //Comma operator in fuction arguments and return
+    //Comma operator in function arguments and return
     function foo(x: number, y: string) {
         return x, y;
     }

--- a/tests/baselines/reference/commaOperatorOtherInvalidOperation.js
+++ b/tests/baselines/reference/commaOperatorOtherInvalidOperation.js
@@ -1,6 +1,6 @@
 //// [commaOperatorOtherInvalidOperation.ts]
 //Expect to have compiler errors
-//Comma operator in fuction arguments and return
+//Comma operator in function arguments and return
 function foo(x: number, y: string) {
     return x, y;
 }
@@ -15,7 +15,7 @@ function foo1<T1, T2>() {
 
 //// [commaOperatorOtherInvalidOperation.js]
 //Expect to have compiler errors
-//Comma operator in fuction arguments and return
+//Comma operator in function arguments and return
 function foo(x, y) {
     return x, y;
 }

--- a/tests/baselines/reference/commaOperatorOtherInvalidOperation.symbols
+++ b/tests/baselines/reference/commaOperatorOtherInvalidOperation.symbols
@@ -1,6 +1,6 @@
 === tests/cases/conformance/expressions/commaOperator/commaOperatorOtherInvalidOperation.ts ===
 //Expect to have compiler errors
-//Comma operator in fuction arguments and return
+//Comma operator in function arguments and return
 function foo(x: number, y: string) {
 >foo : Symbol(foo, Decl(commaOperatorOtherInvalidOperation.ts, 0, 0))
 >x : Symbol(x, Decl(commaOperatorOtherInvalidOperation.ts, 2, 13))

--- a/tests/baselines/reference/commaOperatorOtherInvalidOperation.types
+++ b/tests/baselines/reference/commaOperatorOtherInvalidOperation.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/expressions/commaOperator/commaOperatorOtherInvalidOperation.ts ===
 //Expect to have compiler errors
-//Comma operator in fuction arguments and return
+//Comma operator in function arguments and return
 function foo(x: number, y: string) {
 >foo : (x: number, y: string) => string
 >x : number

--- a/tests/baselines/reference/commaOperatorOtherValidOperation.js
+++ b/tests/baselines/reference/commaOperatorOtherValidOperation.js
@@ -4,7 +4,7 @@ for (var i = 0, j = 10; i < j; i++, j--)
 {
 }
 
-//Comma operator in fuction arguments and return
+//Comma operator in function arguments and return
 function foo(x: number, y: string)
 {
     return x, y;
@@ -25,7 +25,7 @@ function foo1<T1, T2>()
 //Comma operator in for loop
 for (var i = 0, j = 10; i < j; i++, j--) {
 }
-//Comma operator in fuction arguments and return
+//Comma operator in function arguments and return
 function foo(x, y) {
     return x, y;
 }

--- a/tests/baselines/reference/commaOperatorOtherValidOperation.symbols
+++ b/tests/baselines/reference/commaOperatorOtherValidOperation.symbols
@@ -10,7 +10,7 @@ for (var i = 0, j = 10; i < j; i++, j--)
 {
 }
 
-//Comma operator in fuction arguments and return
+//Comma operator in function arguments and return
 function foo(x: number, y: string)
 >foo : Symbol(foo, Decl(commaOperatorOtherValidOperation.ts, 3, 1))
 >x : Symbol(x, Decl(commaOperatorOtherValidOperation.ts, 6, 13))

--- a/tests/baselines/reference/commaOperatorOtherValidOperation.types
+++ b/tests/baselines/reference/commaOperatorOtherValidOperation.types
@@ -16,7 +16,7 @@ for (var i = 0, j = 10; i < j; i++, j--)
 {
 }
 
-//Comma operator in fuction arguments and return
+//Comma operator in function arguments and return
 function foo(x: number, y: string)
 >foo : (x: number, y: string) => string
 >x : number

--- a/tests/baselines/reference/commentsVarDecl.js
+++ b/tests/baselines/reference/commentsVarDecl.js
@@ -17,7 +17,7 @@ var anotherAnotherVariable = 70; /* these are multiple trailing comments */ /* m
 /** comment line 2*/
 var x = 70; /* multiline trailing comment 
 this is multiline trailing comment */
-/** Triple slash comment on the assignement shouldnt be in .d.ts file*/
+/** Triple slash comment on the assignment shouldnt be in .d.ts file*/
 x = myVariable;
 
 /** triple slash comment1*/
@@ -57,7 +57,7 @@ var anotherAnotherVariable = 70; /* these are multiple trailing comments */ /* m
 /** comment line 2*/
 var x = 70; /* multiline trailing comment
 this is multiline trailing comment */
-/** Triple slash comment on the assignement shouldnt be in .d.ts file*/
+/** Triple slash comment on the assignment shouldnt be in .d.ts file*/
 x = myVariable;
 /** triple slash comment1*/
 /** jsdocstyle comment - only this comment should be in .d.ts file*/

--- a/tests/baselines/reference/commentsVarDecl.symbols
+++ b/tests/baselines/reference/commentsVarDecl.symbols
@@ -23,7 +23,7 @@ var x = 70; /* multiline trailing comment
 >x : Symbol(x, Decl(commentsVarDecl.ts, 16, 3))
 
 this is multiline trailing comment */
-/** Triple slash comment on the assignement shouldnt be in .d.ts file*/
+/** Triple slash comment on the assignment shouldnt be in .d.ts file*/
 x = myVariable;
 >x : Symbol(x, Decl(commentsVarDecl.ts, 16, 3))
 >myVariable : Symbol(myVariable, Decl(commentsVarDecl.ts, 1, 3))

--- a/tests/baselines/reference/commentsVarDecl.types
+++ b/tests/baselines/reference/commentsVarDecl.types
@@ -28,7 +28,7 @@ var x = 70; /* multiline trailing comment
 >70 : 70
 
 this is multiline trailing comment */
-/** Triple slash comment on the assignement shouldnt be in .d.ts file*/
+/** Triple slash comment on the assignment shouldnt be in .d.ts file*/
 x = myVariable;
 >x = myVariable : number
 >x : number

--- a/tests/baselines/reference/switchStatements.errors.txt
+++ b/tests/baselines/reference/switchStatements.errors.txt
@@ -31,7 +31,7 @@ tests/cases/conformance/statements/switchStatements/switchStatements.ts(35,20): 
         default:
     }
     
-    // basic assignable check, rest covered in tests for 'assignement compatibility'
+    // basic assignable check, rest covered in tests for 'assignment compatibility'
     class C { id: number; }
     class D extends C { name: string }
     

--- a/tests/baselines/reference/switchStatements.js
+++ b/tests/baselines/reference/switchStatements.js
@@ -27,7 +27,7 @@ switch (x) {
     default:
 }
 
-// basic assignable check, rest covered in tests for 'assignement compatibility'
+// basic assignable check, rest covered in tests for 'assignment compatibility'
 class C { id: number; }
 class D extends C { name: string }
 
@@ -97,7 +97,7 @@ switch (x) {
     case (function (x) { return ''; })(2):
     default:
 }
-// basic assignable check, rest covered in tests for 'assignement compatibility'
+// basic assignable check, rest covered in tests for 'assignment compatibility'
 var C = /** @class */ (function () {
     function C() {
     }

--- a/tests/baselines/reference/switchStatements.symbols
+++ b/tests/baselines/reference/switchStatements.symbols
@@ -58,7 +58,7 @@ switch (x) {
     default:
 }
 
-// basic assignable check, rest covered in tests for 'assignement compatibility'
+// basic assignable check, rest covered in tests for 'assignment compatibility'
 class C { id: number; }
 >C : Symbol(C, Decl(switchStatements.ts, 26, 1))
 >id : Symbol(C.id, Decl(switchStatements.ts, 29, 9))

--- a/tests/baselines/reference/switchStatements.types
+++ b/tests/baselines/reference/switchStatements.types
@@ -90,7 +90,7 @@ switch (x) {
     default:
 }
 
-// basic assignable check, rest covered in tests for 'assignement compatibility'
+// basic assignable check, rest covered in tests for 'assignment compatibility'
 class C { id: number; }
 >C : C
 >id : number

--- a/tests/cases/compiler/commentsVarDecl.ts
+++ b/tests/cases/compiler/commentsVarDecl.ts
@@ -20,7 +20,7 @@ var anotherAnotherVariable = 70; /* these are multiple trailing comments */ /* m
 /** comment line 2*/
 var x = 70; /* multiline trailing comment 
 this is multiline trailing comment */
-/** Triple slash comment on the assignement shouldnt be in .d.ts file*/
+/** Triple slash comment on the assignment shouldnt be in .d.ts file*/
 x = myVariable;
 
 /** triple slash comment1*/

--- a/tests/cases/conformance/expressions/commaOperator/commaOperatorOtherInvalidOperation.ts
+++ b/tests/cases/conformance/expressions/commaOperator/commaOperatorOtherInvalidOperation.ts
@@ -1,7 +1,7 @@
 // @allowUnreachableCode: true
 
 //Expect to have compiler errors
-//Comma operator in fuction arguments and return
+//Comma operator in function arguments and return
 function foo(x: number, y: string) {
     return x, y;
 }

--- a/tests/cases/conformance/expressions/commaOperator/commaOperatorOtherValidOperation.ts
+++ b/tests/cases/conformance/expressions/commaOperator/commaOperatorOtherValidOperation.ts
@@ -5,7 +5,7 @@ for (var i = 0, j = 10; i < j; i++, j--)
 {
 }
 
-//Comma operator in fuction arguments and return
+//Comma operator in function arguments and return
 function foo(x: number, y: string)
 {
     return x, y;

--- a/tests/cases/conformance/statements/switchStatements/switchStatements.ts
+++ b/tests/cases/conformance/statements/switchStatements/switchStatements.ts
@@ -26,7 +26,7 @@ switch (x) {
     default:
 }
 
-// basic assignable check, rest covered in tests for 'assignement compatibility'
+// basic assignable check, rest covered in tests for 'assignment compatibility'
 class C { id: number; }
 class D extends C { name: string }
 


### PR DESCRIPTION
Corrects typos in comments:
- `fuction -> function`
- `assignement -> assignment`