### PR TITLE
Don't relate unmatched parameter positions in signatures

### DIFF
--- a/tests/baselines/reference/unmatchedParameterPositions.js
+++ b/tests/baselines/reference/unmatchedParameterPositions.js
@@ -1,0 +1,13 @@
+//// [unmatchedParameterPositions.ts]
+// Repros from #40251
+
+declare let s: (...items: never[]) => never[];
+let t1: () => unknown[] = s;
+let t2: (...args: []) => unknown[] = s;
+
+
+//// [unmatchedParameterPositions.js]
+"use strict";
+// Repros from #40251
+var t1 = s;
+var t2 = s;

--- a/tests/baselines/reference/unmatchedParameterPositions.symbols
+++ b/tests/baselines/reference/unmatchedParameterPositions.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/unmatchedParameterPositions.ts ===
+// Repros from #40251
+
+declare let s: (...items: never[]) => never[];
+>s : Symbol(s, Decl(unmatchedParameterPositions.ts, 2, 11))
+>items : Symbol(items, Decl(unmatchedParameterPositions.ts, 2, 16))
+
+let t1: () => unknown[] = s;
+>t1 : Symbol(t1, Decl(unmatchedParameterPositions.ts, 3, 3))
+>s : Symbol(s, Decl(unmatchedParameterPositions.ts, 2, 11))
+
+let t2: (...args: []) => unknown[] = s;
+>t2 : Symbol(t2, Decl(unmatchedParameterPositions.ts, 4, 3))
+>args : Symbol(args, Decl(unmatchedParameterPositions.ts, 4, 9))
+>s : Symbol(s, Decl(unmatchedParameterPositions.ts, 2, 11))
+

--- a/tests/baselines/reference/unmatchedParameterPositions.types
+++ b/tests/baselines/reference/unmatchedParameterPositions.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/unmatchedParameterPositions.ts ===
+// Repros from #40251
+
+declare let s: (...items: never[]) => never[];
+>s : (...items: never[]) => never[]
+>items : never[]
+
+let t1: () => unknown[] = s;
+>t1 : () => unknown[]
+>s : (...items: never[]) => never[]
+
+let t2: (...args: []) => unknown[] = s;
+>t2 : () => unknown[]
+>args : []
+>s : (...items: never[]) => never[]
+

--- a/tests/cases/compiler/unmatchedParameterPositions.ts
+++ b/tests/cases/compiler/unmatchedParameterPositions.ts
@@ -1,0 +1,7 @@
+// @strict: true
+
+// Repros from #40251
+
+declare let s: (...items: never[]) => never[];
+let t1: () => unknown[] = s;
+let t2: (...args: []) => unknown[] = s;


### PR DESCRIPTION
Fixes #40251.