### PR TITLE
Bind comma expression LHS call expressions

### DIFF
--- a/tests/baselines/reference/controlFlowCommaExpressionAssertionWithinTernary.js
+++ b/tests/baselines/reference/controlFlowCommaExpressionAssertionWithinTernary.js
@@ -1,0 +1,16 @@
+//// [controlFlowCommaExpressionAssertionWithinTernary.ts]
+declare function assert(value: any): asserts value;
+
+function foo2(param: number | null | undefined): number | null {
+    const val = param !== undefined;
+    return val ? (assert(param !== undefined), param) : null;
+    // ^^^^^ Still typed as number | null | undefined
+}
+
+//// [controlFlowCommaExpressionAssertionWithinTernary.js]
+"use strict";
+function foo2(param) {
+    var val = param !== undefined;
+    return val ? (assert(param !== undefined), param) : null;
+    // ^^^^^ Still typed as number | null | undefined
+}

--- a/tests/baselines/reference/controlFlowCommaExpressionAssertionWithinTernary.symbols
+++ b/tests/baselines/reference/controlFlowCommaExpressionAssertionWithinTernary.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/controlFlowCommaExpressionAssertionWithinTernary.ts ===
+declare function assert(value: any): asserts value;
+>assert : Symbol(assert, Decl(controlFlowCommaExpressionAssertionWithinTernary.ts, 0, 0))
+>value : Symbol(value, Decl(controlFlowCommaExpressionAssertionWithinTernary.ts, 0, 24))
+>value : Symbol(value, Decl(controlFlowCommaExpressionAssertionWithinTernary.ts, 0, 24))
+
+function foo2(param: number | null | undefined): number | null {
+>foo2 : Symbol(foo2, Decl(controlFlowCommaExpressionAssertionWithinTernary.ts, 0, 51))
+>param : Symbol(param, Decl(controlFlowCommaExpressionAssertionWithinTernary.ts, 2, 14))
+
+    const val = param !== undefined;
+>val : Symbol(val, Decl(controlFlowCommaExpressionAssertionWithinTernary.ts, 3, 9))
+>param : Symbol(param, Decl(controlFlowCommaExpressionAssertionWithinTernary.ts, 2, 14))
+>undefined : Symbol(undefined)
+
+    return val ? (assert(param !== undefined), param) : null;
+>val : Symbol(val, Decl(controlFlowCommaExpressionAssertionWithinTernary.ts, 3, 9))
+>assert : Symbol(assert, Decl(controlFlowCommaExpressionAssertionWithinTernary.ts, 0, 0))
+>param : Symbol(param, Decl(controlFlowCommaExpressionAssertionWithinTernary.ts, 2, 14))
+>undefined : Symbol(undefined)
+>param : Symbol(param, Decl(controlFlowCommaExpressionAssertionWithinTernary.ts, 2, 14))
+
+    // ^^^^^ Still typed as number | null | undefined
+}

--- a/tests/baselines/reference/controlFlowCommaExpressionAssertionWithinTernary.types
+++ b/tests/baselines/reference/controlFlowCommaExpressionAssertionWithinTernary.types
@@ -1,0 +1,32 @@
+=== tests/cases/compiler/controlFlowCommaExpressionAssertionWithinTernary.ts ===
+declare function assert(value: any): asserts value;
+>assert : (value: any) => asserts value
+>value : any
+
+function foo2(param: number | null | undefined): number | null {
+>foo2 : (param: number | null | undefined) => number | null
+>param : number | null | undefined
+>null : null
+>null : null
+
+    const val = param !== undefined;
+>val : boolean
+>param !== undefined : boolean
+>param : number | null | undefined
+>undefined : undefined
+
+    return val ? (assert(param !== undefined), param) : null;
+>val ? (assert(param !== undefined), param) : null : number | null
+>val : boolean
+>(assert(param !== undefined), param) : number | null
+>assert(param !== undefined), param : number | null
+>assert(param !== undefined) : void
+>assert : (value: any) => asserts value
+>param !== undefined : boolean
+>param : number | null | undefined
+>undefined : undefined
+>param : number | null
+>null : null
+
+    // ^^^^^ Still typed as number | null | undefined
+}

--- a/tests/cases/compiler/controlFlowCommaExpressionAssertionWithinTernary.ts
+++ b/tests/cases/compiler/controlFlowCommaExpressionAssertionWithinTernary.ts
@@ -1,0 +1,8 @@
+// @strict: true
+declare function assert(value: any): asserts value;
+
+function foo2(param: number | null | undefined): number | null {
+    const val = param !== undefined;
+    return val ? (assert(param !== undefined), param) : null;
+    // ^^^^^ Still typed as number | null | undefined
+}


### PR DESCRIPTION
We originally made a conscious choice to, generally speaking, only bind calls when they're the child of an expression statement. This expands our binding to also include the LHS of comma expressions, since, just like lists of statements, they generally only exist to compose lists of possibly-side-effecting actions (like, say, assertions).

Fixes #41264
