### PR TITLE
Fix crashes when the global JSX namespace is an alias

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25142,7 +25142,7 @@ namespace ts {
                 const resolvedNamespace = resolveName(location, namespaceName, SymbolFlags.Namespace, /*diagnosticMessage*/ undefined, namespaceName, /*isUse*/ false);
                 if (resolvedNamespace) {
                     const candidate = resolveSymbol(getSymbol(getExportsOfSymbol(resolveSymbol(resolvedNamespace)), JsxNames.JSX, SymbolFlags.Namespace));
-                    if (candidate) {
+                    if (candidate && candidate !== unknownSymbol) {
                         if (links) {
                             links.jsxNamespace = candidate;
                         }
@@ -25154,7 +25154,11 @@ namespace ts {
                 }
             }
             // JSX global fallback
-            return getGlobalSymbol(JsxNames.JSX, SymbolFlags.Namespace, /*diagnosticMessage*/ undefined)!; // TODO: GH#18217
+            const s = resolveSymbol(getGlobalSymbol(JsxNames.JSX, SymbolFlags.Namespace, /*diagnosticMessage*/ undefined));
+            if (s === unknownSymbol) {
+                return undefined!; // TODO: GH#18217
+            }
+            return s!; // TODO: GH#18217
         }
 
         /**

--- a/tests/baselines/reference/jsxNamespaceGlobalReexport.js
+++ b/tests/baselines/reference/jsxNamespaceGlobalReexport.js
@@ -1,0 +1,114 @@
+//// [tests/cases/compiler/jsxNamespaceGlobalReexport.tsx] ////
+
+//// [index.d.ts]
+type Defaultize<Props, Defaults> =
+	// Distribute over unions
+	Props extends any // Make any properties included in Default optional
+		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> &
+				// Include the remaining properties from Props
+				Pick<Props, Exclude<keyof Props, keyof Defaults>>
+		: never;
+export namespace JSXInternal {
+    interface HTMLAttributes<T = {}> { }
+    interface SVGAttributes<T = {}> { }
+    type LibraryManagedAttributes<Component, Props> = Component extends {
+        defaultProps: infer Defaults;
+    }
+        ? Defaultize<Props, Defaults>
+        : Props;
+
+    interface IntrinsicAttributes {
+        key?: any;
+    }
+
+    interface Element extends VNode<any> { }
+
+    interface ElementClass extends Component<any, any> { }
+
+    interface ElementAttributesProperty {
+        props: any;
+    }
+
+    interface ElementChildrenAttribute {
+        children: any;
+    }
+
+    interface IntrinsicElements {
+        div: HTMLAttributes;
+    }
+}
+export const Fragment: unique symbol;
+export type ComponentType<T = {}> = {};
+export type ComponentChild = {};
+export type ComponentChildren = {};
+export type VNode<T = {}> = {};
+export type Attributes = {};
+export type Component<T = {}, U = {}> = {};
+//// [index.d.ts]
+export { Fragment } from '..';
+import {
+    ComponentType,
+    ComponentChild,
+    ComponentChildren,
+    VNode,
+    Attributes
+} from '..';
+import { JSXInternal } from '..';
+
+export function jsx(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChild },
+    key?: string
+): VNode<any>;
+export function jsx<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChild },
+    key?: string
+): VNode<any>;
+
+export function jsxs(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChild[] },
+    key?: string
+): VNode<any>;
+export function jsxs<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChild[] },
+    key?: string
+): VNode<any>;
+
+export function jsxDEV(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChildren },
+    key?: string
+): VNode<any>;
+export function jsxDEV<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChildren },
+    key?: string
+): VNode<any>;
+// This shouldn't be preferred over
+//export namespace jsxDEV {
+//    export import JSX = JSXInternal;
+//}
+// but it sort-of should work and it shouldn't crash.
+declare global {
+    // @ts-ignore
+    export import JSX = JSXInternal;
+}
+//// [index.tsx]
+export const Comp = () => <div></div>;
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+exports.Comp = void 0;
+var jsx_runtime_1 = require("preact/jsx-runtime");
+var Comp = function () { return jsx_runtime_1.jsx("div", {}, void 0); };
+exports.Comp = Comp;

--- a/tests/baselines/reference/jsxNamespaceGlobalReexport.symbols
+++ b/tests/baselines/reference/jsxNamespaceGlobalReexport.symbols
@@ -1,0 +1,305 @@
+=== /node_modules/preact/index.d.ts ===
+type Defaultize<Props, Defaults> =
+>Defaultize : Symbol(Defaultize, Decl(index.d.ts, 0, 0))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 0, 22))
+
+	// Distribute over unions
+	Props extends any // Make any properties included in Default optional
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+
+		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> &
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 0, 22))
+
+				// Include the remaining properties from Props
+				Pick<Props, Exclude<keyof Props, keyof Defaults>>
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 0, 22))
+
+		: never;
+export namespace JSXInternal {
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 6, 10))
+
+    interface HTMLAttributes<T = {}> { }
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(index.d.ts, 7, 30))
+>T : Symbol(T, Decl(index.d.ts, 8, 29))
+
+    interface SVGAttributes<T = {}> { }
+>SVGAttributes : Symbol(SVGAttributes, Decl(index.d.ts, 8, 40))
+>T : Symbol(T, Decl(index.d.ts, 9, 28))
+
+    type LibraryManagedAttributes<Component, Props> = Component extends {
+>LibraryManagedAttributes : Symbol(LibraryManagedAttributes, Decl(index.d.ts, 9, 39))
+>Component : Symbol(Component, Decl(index.d.ts, 10, 34))
+>Props : Symbol(Props, Decl(index.d.ts, 10, 44))
+>Component : Symbol(Component, Decl(index.d.ts, 10, 34))
+
+        defaultProps: infer Defaults;
+>defaultProps : Symbol(defaultProps, Decl(index.d.ts, 10, 73))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 11, 27))
+    }
+        ? Defaultize<Props, Defaults>
+>Defaultize : Symbol(Defaultize, Decl(index.d.ts, 0, 0))
+>Props : Symbol(Props, Decl(index.d.ts, 10, 44))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 11, 27))
+
+        : Props;
+>Props : Symbol(Props, Decl(index.d.ts, 10, 44))
+
+    interface IntrinsicAttributes {
+>IntrinsicAttributes : Symbol(IntrinsicAttributes, Decl(index.d.ts, 14, 16))
+
+        key?: any;
+>key : Symbol(IntrinsicAttributes.key, Decl(index.d.ts, 16, 35))
+    }
+
+    interface Element extends VNode<any> { }
+>Element : Symbol(Element, Decl(index.d.ts, 18, 5))
+>VNode : Symbol(VNode, Decl(index.d.ts, 39, 35))
+
+    interface ElementClass extends Component<any, any> { }
+>ElementClass : Symbol(ElementClass, Decl(index.d.ts, 20, 44))
+>Component : Symbol(Component, Decl(index.d.ts, 41, 28))
+
+    interface ElementAttributesProperty {
+>ElementAttributesProperty : Symbol(ElementAttributesProperty, Decl(index.d.ts, 22, 58))
+
+        props: any;
+>props : Symbol(ElementAttributesProperty.props, Decl(index.d.ts, 24, 41))
+    }
+
+    interface ElementChildrenAttribute {
+>ElementChildrenAttribute : Symbol(ElementChildrenAttribute, Decl(index.d.ts, 26, 5))
+
+        children: any;
+>children : Symbol(ElementChildrenAttribute.children, Decl(index.d.ts, 28, 40))
+    }
+
+    interface IntrinsicElements {
+>IntrinsicElements : Symbol(IntrinsicElements, Decl(index.d.ts, 30, 5))
+
+        div: HTMLAttributes;
+>div : Symbol(IntrinsicElements.div, Decl(index.d.ts, 32, 33))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(index.d.ts, 7, 30))
+    }
+}
+export const Fragment: unique symbol;
+>Fragment : Symbol(Fragment, Decl(index.d.ts, 36, 12))
+
+export type ComponentType<T = {}> = {};
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 36, 37))
+>T : Symbol(T, Decl(index.d.ts, 37, 26))
+
+export type ComponentChild = {};
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 37, 39))
+
+export type ComponentChildren = {};
+>ComponentChildren : Symbol(ComponentChildren, Decl(index.d.ts, 38, 32))
+
+export type VNode<T = {}> = {};
+>VNode : Symbol(VNode, Decl(index.d.ts, 39, 35))
+>T : Symbol(T, Decl(index.d.ts, 40, 18))
+
+export type Attributes = {};
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 40, 31))
+
+export type Component<T = {}, U = {}> = {};
+>Component : Symbol(Component, Decl(index.d.ts, 41, 28))
+>T : Symbol(T, Decl(index.d.ts, 42, 22))
+>U : Symbol(U, Decl(index.d.ts, 42, 29))
+
+=== /node_modules/preact/jsx-runtime/index.d.ts ===
+export { Fragment } from '..';
+>Fragment : Symbol(Fragment, Decl(index.d.ts, 0, 8))
+
+import {
+    ComponentType,
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 1, 8))
+
+    ComponentChild,
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    ComponentChildren,
+>ComponentChildren : Symbol(ComponentChildren, Decl(index.d.ts, 3, 19))
+
+    VNode,
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+    Attributes
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 5, 10))
+
+} from '..';
+import { JSXInternal } from '..';
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+
+export function jsx(
+>jsx : Symbol(jsx, Decl(index.d.ts, 8, 33), Decl(index.d.ts, 16, 14))
+
+    type: string,
+>type : Symbol(type, Decl(index.d.ts, 10, 20))
+
+    props: JSXInternal.HTMLAttributes &
+>props : Symbol(props, Decl(index.d.ts, 11, 17))
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>HTMLAttributes : Symbol(JSXInternal.HTMLAttributes, Decl(index.d.ts, 7, 30))
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>SVGAttributes : Symbol(JSXInternal.SVGAttributes, Decl(index.d.ts, 8, 40))
+
+        Record<string, any> & { children?: ComponentChild },
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>children : Symbol(children, Decl(index.d.ts, 14, 31))
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 14, 60))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+export function jsx<P>(
+>jsx : Symbol(jsx, Decl(index.d.ts, 8, 33), Decl(index.d.ts, 16, 14))
+>P : Symbol(P, Decl(index.d.ts, 17, 20))
+
+    type: ComponentType<P>,
+>type : Symbol(type, Decl(index.d.ts, 17, 23))
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 1, 8))
+>P : Symbol(P, Decl(index.d.ts, 17, 20))
+
+    props: Attributes & P & { children?: ComponentChild },
+>props : Symbol(props, Decl(index.d.ts, 18, 27))
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 5, 10))
+>P : Symbol(P, Decl(index.d.ts, 17, 20))
+>children : Symbol(children, Decl(index.d.ts, 19, 29))
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 19, 58))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+export function jsxs(
+>jsxs : Symbol(jsxs, Decl(index.d.ts, 21, 14), Decl(index.d.ts, 29, 14))
+
+    type: string,
+>type : Symbol(type, Decl(index.d.ts, 23, 21))
+
+    props: JSXInternal.HTMLAttributes &
+>props : Symbol(props, Decl(index.d.ts, 24, 17))
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>HTMLAttributes : Symbol(JSXInternal.HTMLAttributes, Decl(index.d.ts, 7, 30))
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>SVGAttributes : Symbol(JSXInternal.SVGAttributes, Decl(index.d.ts, 8, 40))
+
+        Record<string, any> & { children?: ComponentChild[] },
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>children : Symbol(children, Decl(index.d.ts, 27, 31))
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 27, 62))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+export function jsxs<P>(
+>jsxs : Symbol(jsxs, Decl(index.d.ts, 21, 14), Decl(index.d.ts, 29, 14))
+>P : Symbol(P, Decl(index.d.ts, 30, 21))
+
+    type: ComponentType<P>,
+>type : Symbol(type, Decl(index.d.ts, 30, 24))
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 1, 8))
+>P : Symbol(P, Decl(index.d.ts, 30, 21))
+
+    props: Attributes & P & { children?: ComponentChild[] },
+>props : Symbol(props, Decl(index.d.ts, 31, 27))
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 5, 10))
+>P : Symbol(P, Decl(index.d.ts, 30, 21))
+>children : Symbol(children, Decl(index.d.ts, 32, 29))
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 32, 60))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+export function jsxDEV(
+>jsxDEV : Symbol(jsxDEV, Decl(index.d.ts, 34, 14), Decl(index.d.ts, 42, 14))
+
+    type: string,
+>type : Symbol(type, Decl(index.d.ts, 36, 23))
+
+    props: JSXInternal.HTMLAttributes &
+>props : Symbol(props, Decl(index.d.ts, 37, 17))
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>HTMLAttributes : Symbol(JSXInternal.HTMLAttributes, Decl(index.d.ts, 7, 30))
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>SVGAttributes : Symbol(JSXInternal.SVGAttributes, Decl(index.d.ts, 8, 40))
+
+        Record<string, any> & { children?: ComponentChildren },
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>children : Symbol(children, Decl(index.d.ts, 40, 31))
+>ComponentChildren : Symbol(ComponentChildren, Decl(index.d.ts, 3, 19))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 40, 63))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+export function jsxDEV<P>(
+>jsxDEV : Symbol(jsxDEV, Decl(index.d.ts, 34, 14), Decl(index.d.ts, 42, 14))
+>P : Symbol(P, Decl(index.d.ts, 43, 23))
+
+    type: ComponentType<P>,
+>type : Symbol(type, Decl(index.d.ts, 43, 26))
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 1, 8))
+>P : Symbol(P, Decl(index.d.ts, 43, 23))
+
+    props: Attributes & P & { children?: ComponentChildren },
+>props : Symbol(props, Decl(index.d.ts, 44, 27))
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 5, 10))
+>P : Symbol(P, Decl(index.d.ts, 43, 23))
+>children : Symbol(children, Decl(index.d.ts, 45, 29))
+>ComponentChildren : Symbol(ComponentChildren, Decl(index.d.ts, 3, 19))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 45, 61))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+// This shouldn't be preferred over
+//export namespace jsxDEV {
+//    export import JSX = JSXInternal;
+//}
+// but it sort-of should work and it shouldn't crash.
+declare global {
+>global : Symbol(global, Decl(index.d.ts, 47, 14))
+
+    // @ts-ignore
+    export import JSX = JSXInternal;
+>JSX : Symbol(JSX, Decl(index.d.ts, 53, 16))
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+}
+=== /index.tsx ===
+export const Comp = () => <div></div>;
+>Comp : Symbol(Comp, Decl(index.tsx, 0, 12))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(index.d.ts, 32, 33))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(index.d.ts, 32, 33))
+

--- a/tests/baselines/reference/jsxNamespaceGlobalReexport.types
+++ b/tests/baselines/reference/jsxNamespaceGlobalReexport.types
@@ -1,0 +1,216 @@
+=== /node_modules/preact/index.d.ts ===
+type Defaultize<Props, Defaults> =
+>Defaultize : Defaultize<Props, Defaults>
+
+	// Distribute over unions
+	Props extends any // Make any properties included in Default optional
+		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> &
+				// Include the remaining properties from Props
+				Pick<Props, Exclude<keyof Props, keyof Defaults>>
+		: never;
+export namespace JSXInternal {
+    interface HTMLAttributes<T = {}> { }
+    interface SVGAttributes<T = {}> { }
+    type LibraryManagedAttributes<Component, Props> = Component extends {
+>LibraryManagedAttributes : LibraryManagedAttributes<Component, Props>
+
+        defaultProps: infer Defaults;
+>defaultProps : Defaults
+    }
+        ? Defaultize<Props, Defaults>
+        : Props;
+
+    interface IntrinsicAttributes {
+        key?: any;
+>key : any
+    }
+
+    interface Element extends VNode<any> { }
+
+    interface ElementClass extends Component<any, any> { }
+
+    interface ElementAttributesProperty {
+        props: any;
+>props : any
+    }
+
+    interface ElementChildrenAttribute {
+        children: any;
+>children : any
+    }
+
+    interface IntrinsicElements {
+        div: HTMLAttributes;
+>div : HTMLAttributes<{}>
+    }
+}
+export const Fragment: unique symbol;
+>Fragment : unique symbol
+
+export type ComponentType<T = {}> = {};
+>ComponentType : ComponentType<T>
+
+export type ComponentChild = {};
+>ComponentChild : ComponentChild
+
+export type ComponentChildren = {};
+>ComponentChildren : ComponentChildren
+
+export type VNode<T = {}> = {};
+>VNode : VNode<T>
+
+export type Attributes = {};
+>Attributes : Attributes
+
+export type Component<T = {}, U = {}> = {};
+>Component : Component<T, U>
+
+=== /node_modules/preact/jsx-runtime/index.d.ts ===
+export { Fragment } from '..';
+>Fragment : unique symbol
+
+import {
+    ComponentType,
+>ComponentType : any
+
+    ComponentChild,
+>ComponentChild : any
+
+    ComponentChildren,
+>ComponentChildren : any
+
+    VNode,
+>VNode : any
+
+    Attributes
+>Attributes : any
+
+} from '..';
+import { JSXInternal } from '..';
+>JSXInternal : any
+
+export function jsx(
+>jsx : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChild;}, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; }
+
+    type: string,
+>type : string
+
+    props: JSXInternal.HTMLAttributes &
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }
+>JSXInternal : any
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : any
+
+        Record<string, any> & { children?: ComponentChild },
+>children : ComponentChild | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+export function jsx<P>(
+>jsx : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChild;}, key?: string | undefined): VNode<any>; }
+
+    type: ComponentType<P>,
+>type : ComponentType<P>
+
+    props: Attributes & P & { children?: ComponentChild },
+>props : P & { children?: ComponentChild | undefined; }
+>children : ComponentChild | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+
+export function jsxs(
+>jsxs : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChild[];}, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; }
+
+    type: string,
+>type : string
+
+    props: JSXInternal.HTMLAttributes &
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }
+>JSXInternal : any
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : any
+
+        Record<string, any> & { children?: ComponentChild[] },
+>children : ComponentChild[] | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+export function jsxs<P>(
+>jsxs : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChild[];}, key?: string | undefined): VNode<any>; }
+
+    type: ComponentType<P>,
+>type : ComponentType<P>
+
+    props: Attributes & P & { children?: ComponentChild[] },
+>props : P & { children?: ComponentChild[] | undefined; }
+>children : ComponentChild[] | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+
+export function jsxDEV(
+>jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChildren;}, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; }
+
+    type: string,
+>type : string
+
+    props: JSXInternal.HTMLAttributes &
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }
+>JSXInternal : any
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : any
+
+        Record<string, any> & { children?: ComponentChildren },
+>children : ComponentChildren | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+export function jsxDEV<P>(
+>jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChildren;}, key?: string | undefined): VNode<any>; }
+
+    type: ComponentType<P>,
+>type : ComponentType<P>
+
+    props: Attributes & P & { children?: ComponentChildren },
+>props : P & { children?: ComponentChildren | undefined; }
+>children : ComponentChildren | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+// This shouldn't be preferred over
+//export namespace jsxDEV {
+//    export import JSX = JSXInternal;
+//}
+// but it sort-of should work and it shouldn't crash.
+declare global {
+>global : typeof global
+
+    // @ts-ignore
+    export import JSX = JSXInternal;
+>JSX : any
+>JSXInternal : error
+}
+=== /index.tsx ===
+export const Comp = () => <div></div>;
+>Comp : () => JSX.Element
+>() => <div></div> : () => JSX.Element
+><div></div> : JSX.Element
+>div : any
+>div : any
+

--- a/tests/baselines/reference/jsxNamespaceGlobalReexportMissingAliasTarget.errors.txt
+++ b/tests/baselines/reference/jsxNamespaceGlobalReexportMissingAliasTarget.errors.txt
@@ -1,0 +1,108 @@
+/index.tsx(1,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+/index.tsx(1,32): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+
+
+==== /node_modules/preact/index.d.ts (0 errors) ====
+    type Defaultize<Props, Defaults> =
+    	// Distribute over unions
+    	Props extends any // Make any properties included in Default optional
+    		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> &
+    				// Include the remaining properties from Props
+    				Pick<Props, Exclude<keyof Props, keyof Defaults>>
+    		: never;
+    export namespace JSXInternal {
+        interface HTMLAttributes<T = {}> { }
+        interface SVGAttributes<T = {}> { }
+        type LibraryManagedAttributes<Component, Props> = Component extends {
+            defaultProps: infer Defaults;
+        }
+            ? Defaultize<Props, Defaults>
+            : Props;
+    
+        interface IntrinsicAttributes {
+            key?: any;
+        }
+    
+        interface Element extends VNode<any> { }
+    
+        interface ElementClass extends Component<any, any> { }
+    
+        interface ElementAttributesProperty {
+            props: any;
+        }
+    
+        interface ElementChildrenAttribute {
+            children: any;
+        }
+    
+        interface IntrinsicElements {
+            div: HTMLAttributes;
+        }
+    }
+    export const Fragment: unique symbol;
+    export type ComponentType<T = {}> = {};
+    export type ComponentChild = {};
+    export type ComponentChildren = {};
+    export type VNode<T = {}> = {};
+    export type Attributes = {};
+    export type Component<T = {}, U = {}> = {};
+==== /node_modules/preact/jsx-runtime/index.d.ts (0 errors) ====
+    export { Fragment } from '..';
+    import {
+        ComponentType,
+        ComponentChild,
+        ComponentChildren,
+        VNode,
+        Attributes
+    } from '..';
+    import { JSXInternal } from '..';
+    
+    export function jsx(
+        type: string,
+        props: JSXInternal.HTMLAttributes &
+            JSXInternal.SVGAttributes &
+            Record<string, any> & { children?: ComponentChild },
+        key?: string
+    ): VNode<any>;
+    export function jsx<P>(
+        type: ComponentType<P>,
+        props: Attributes & P & { children?: ComponentChild },
+        key?: string
+    ): VNode<any>;
+    
+    export function jsxs(
+        type: string,
+        props: JSXInternal.HTMLAttributes &
+            JSXInternal.SVGAttributes &
+            Record<string, any> & { children?: ComponentChild[] },
+        key?: string
+    ): VNode<any>;
+    export function jsxs<P>(
+        type: ComponentType<P>,
+        props: Attributes & P & { children?: ComponentChild[] },
+        key?: string
+    ): VNode<any>;
+    
+    export function jsxDEV(
+        type: string,
+        props: JSXInternal.HTMLAttributes &
+            JSXInternal.SVGAttributes &
+            Record<string, any> & { children?: ComponentChildren },
+        key?: string
+    ): VNode<any>;
+    export function jsxDEV<P>(
+        type: ComponentType<P>,
+        props: Attributes & P & { children?: ComponentChildren },
+        key?: string
+    ): VNode<any>;
+    
+    declare global {
+        // @ts-ignore
+        export import JSX = NotFound;
+    }
+==== /index.tsx (2 errors) ====
+    export const Comp = () => <div></div>;
+                              ~~~~~
+!!! error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+                                   ~~~~~~
+!!! error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.

--- a/tests/baselines/reference/jsxNamespaceGlobalReexportMissingAliasTarget.js
+++ b/tests/baselines/reference/jsxNamespaceGlobalReexportMissingAliasTarget.js
@@ -1,0 +1,110 @@
+//// [tests/cases/compiler/jsxNamespaceGlobalReexportMissingAliasTarget.tsx] ////
+
+//// [index.d.ts]
+type Defaultize<Props, Defaults> =
+	// Distribute over unions
+	Props extends any // Make any properties included in Default optional
+		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> &
+				// Include the remaining properties from Props
+				Pick<Props, Exclude<keyof Props, keyof Defaults>>
+		: never;
+export namespace JSXInternal {
+    interface HTMLAttributes<T = {}> { }
+    interface SVGAttributes<T = {}> { }
+    type LibraryManagedAttributes<Component, Props> = Component extends {
+        defaultProps: infer Defaults;
+    }
+        ? Defaultize<Props, Defaults>
+        : Props;
+
+    interface IntrinsicAttributes {
+        key?: any;
+    }
+
+    interface Element extends VNode<any> { }
+
+    interface ElementClass extends Component<any, any> { }
+
+    interface ElementAttributesProperty {
+        props: any;
+    }
+
+    interface ElementChildrenAttribute {
+        children: any;
+    }
+
+    interface IntrinsicElements {
+        div: HTMLAttributes;
+    }
+}
+export const Fragment: unique symbol;
+export type ComponentType<T = {}> = {};
+export type ComponentChild = {};
+export type ComponentChildren = {};
+export type VNode<T = {}> = {};
+export type Attributes = {};
+export type Component<T = {}, U = {}> = {};
+//// [index.d.ts]
+export { Fragment } from '..';
+import {
+    ComponentType,
+    ComponentChild,
+    ComponentChildren,
+    VNode,
+    Attributes
+} from '..';
+import { JSXInternal } from '..';
+
+export function jsx(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChild },
+    key?: string
+): VNode<any>;
+export function jsx<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChild },
+    key?: string
+): VNode<any>;
+
+export function jsxs(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChild[] },
+    key?: string
+): VNode<any>;
+export function jsxs<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChild[] },
+    key?: string
+): VNode<any>;
+
+export function jsxDEV(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChildren },
+    key?: string
+): VNode<any>;
+export function jsxDEV<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChildren },
+    key?: string
+): VNode<any>;
+
+declare global {
+    // @ts-ignore
+    export import JSX = NotFound;
+}
+//// [index.tsx]
+export const Comp = () => <div></div>;
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+exports.Comp = void 0;
+var jsx_runtime_1 = require("preact/jsx-runtime");
+var Comp = function () { return jsx_runtime_1.jsx("div", {}, void 0); };
+exports.Comp = Comp;

--- a/tests/baselines/reference/jsxNamespaceGlobalReexportMissingAliasTarget.symbols
+++ b/tests/baselines/reference/jsxNamespaceGlobalReexportMissingAliasTarget.symbols
@@ -1,0 +1,297 @@
+=== /node_modules/preact/index.d.ts ===
+type Defaultize<Props, Defaults> =
+>Defaultize : Symbol(Defaultize, Decl(index.d.ts, 0, 0))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 0, 22))
+
+	// Distribute over unions
+	Props extends any // Make any properties included in Default optional
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+
+		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> &
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 0, 22))
+
+				// Include the remaining properties from Props
+				Pick<Props, Exclude<keyof Props, keyof Defaults>>
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 0, 22))
+
+		: never;
+export namespace JSXInternal {
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 6, 10))
+
+    interface HTMLAttributes<T = {}> { }
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(index.d.ts, 7, 30))
+>T : Symbol(T, Decl(index.d.ts, 8, 29))
+
+    interface SVGAttributes<T = {}> { }
+>SVGAttributes : Symbol(SVGAttributes, Decl(index.d.ts, 8, 40))
+>T : Symbol(T, Decl(index.d.ts, 9, 28))
+
+    type LibraryManagedAttributes<Component, Props> = Component extends {
+>LibraryManagedAttributes : Symbol(LibraryManagedAttributes, Decl(index.d.ts, 9, 39))
+>Component : Symbol(Component, Decl(index.d.ts, 10, 34))
+>Props : Symbol(Props, Decl(index.d.ts, 10, 44))
+>Component : Symbol(Component, Decl(index.d.ts, 10, 34))
+
+        defaultProps: infer Defaults;
+>defaultProps : Symbol(defaultProps, Decl(index.d.ts, 10, 73))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 11, 27))
+    }
+        ? Defaultize<Props, Defaults>
+>Defaultize : Symbol(Defaultize, Decl(index.d.ts, 0, 0))
+>Props : Symbol(Props, Decl(index.d.ts, 10, 44))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 11, 27))
+
+        : Props;
+>Props : Symbol(Props, Decl(index.d.ts, 10, 44))
+
+    interface IntrinsicAttributes {
+>IntrinsicAttributes : Symbol(IntrinsicAttributes, Decl(index.d.ts, 14, 16))
+
+        key?: any;
+>key : Symbol(IntrinsicAttributes.key, Decl(index.d.ts, 16, 35))
+    }
+
+    interface Element extends VNode<any> { }
+>Element : Symbol(Element, Decl(index.d.ts, 18, 5))
+>VNode : Symbol(VNode, Decl(index.d.ts, 39, 35))
+
+    interface ElementClass extends Component<any, any> { }
+>ElementClass : Symbol(ElementClass, Decl(index.d.ts, 20, 44))
+>Component : Symbol(Component, Decl(index.d.ts, 41, 28))
+
+    interface ElementAttributesProperty {
+>ElementAttributesProperty : Symbol(ElementAttributesProperty, Decl(index.d.ts, 22, 58))
+
+        props: any;
+>props : Symbol(ElementAttributesProperty.props, Decl(index.d.ts, 24, 41))
+    }
+
+    interface ElementChildrenAttribute {
+>ElementChildrenAttribute : Symbol(ElementChildrenAttribute, Decl(index.d.ts, 26, 5))
+
+        children: any;
+>children : Symbol(ElementChildrenAttribute.children, Decl(index.d.ts, 28, 40))
+    }
+
+    interface IntrinsicElements {
+>IntrinsicElements : Symbol(IntrinsicElements, Decl(index.d.ts, 30, 5))
+
+        div: HTMLAttributes;
+>div : Symbol(IntrinsicElements.div, Decl(index.d.ts, 32, 33))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(index.d.ts, 7, 30))
+    }
+}
+export const Fragment: unique symbol;
+>Fragment : Symbol(Fragment, Decl(index.d.ts, 36, 12))
+
+export type ComponentType<T = {}> = {};
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 36, 37))
+>T : Symbol(T, Decl(index.d.ts, 37, 26))
+
+export type ComponentChild = {};
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 37, 39))
+
+export type ComponentChildren = {};
+>ComponentChildren : Symbol(ComponentChildren, Decl(index.d.ts, 38, 32))
+
+export type VNode<T = {}> = {};
+>VNode : Symbol(VNode, Decl(index.d.ts, 39, 35))
+>T : Symbol(T, Decl(index.d.ts, 40, 18))
+
+export type Attributes = {};
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 40, 31))
+
+export type Component<T = {}, U = {}> = {};
+>Component : Symbol(Component, Decl(index.d.ts, 41, 28))
+>T : Symbol(T, Decl(index.d.ts, 42, 22))
+>U : Symbol(U, Decl(index.d.ts, 42, 29))
+
+=== /node_modules/preact/jsx-runtime/index.d.ts ===
+export { Fragment } from '..';
+>Fragment : Symbol(Fragment, Decl(index.d.ts, 0, 8))
+
+import {
+    ComponentType,
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 1, 8))
+
+    ComponentChild,
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    ComponentChildren,
+>ComponentChildren : Symbol(ComponentChildren, Decl(index.d.ts, 3, 19))
+
+    VNode,
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+    Attributes
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 5, 10))
+
+} from '..';
+import { JSXInternal } from '..';
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+
+export function jsx(
+>jsx : Symbol(jsx, Decl(index.d.ts, 8, 33), Decl(index.d.ts, 16, 14))
+
+    type: string,
+>type : Symbol(type, Decl(index.d.ts, 10, 20))
+
+    props: JSXInternal.HTMLAttributes &
+>props : Symbol(props, Decl(index.d.ts, 11, 17))
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>HTMLAttributes : Symbol(JSXInternal.HTMLAttributes, Decl(index.d.ts, 7, 30))
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>SVGAttributes : Symbol(JSXInternal.SVGAttributes, Decl(index.d.ts, 8, 40))
+
+        Record<string, any> & { children?: ComponentChild },
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>children : Symbol(children, Decl(index.d.ts, 14, 31))
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 14, 60))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+export function jsx<P>(
+>jsx : Symbol(jsx, Decl(index.d.ts, 8, 33), Decl(index.d.ts, 16, 14))
+>P : Symbol(P, Decl(index.d.ts, 17, 20))
+
+    type: ComponentType<P>,
+>type : Symbol(type, Decl(index.d.ts, 17, 23))
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 1, 8))
+>P : Symbol(P, Decl(index.d.ts, 17, 20))
+
+    props: Attributes & P & { children?: ComponentChild },
+>props : Symbol(props, Decl(index.d.ts, 18, 27))
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 5, 10))
+>P : Symbol(P, Decl(index.d.ts, 17, 20))
+>children : Symbol(children, Decl(index.d.ts, 19, 29))
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 19, 58))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+export function jsxs(
+>jsxs : Symbol(jsxs, Decl(index.d.ts, 21, 14), Decl(index.d.ts, 29, 14))
+
+    type: string,
+>type : Symbol(type, Decl(index.d.ts, 23, 21))
+
+    props: JSXInternal.HTMLAttributes &
+>props : Symbol(props, Decl(index.d.ts, 24, 17))
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>HTMLAttributes : Symbol(JSXInternal.HTMLAttributes, Decl(index.d.ts, 7, 30))
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>SVGAttributes : Symbol(JSXInternal.SVGAttributes, Decl(index.d.ts, 8, 40))
+
+        Record<string, any> & { children?: ComponentChild[] },
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>children : Symbol(children, Decl(index.d.ts, 27, 31))
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 27, 62))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+export function jsxs<P>(
+>jsxs : Symbol(jsxs, Decl(index.d.ts, 21, 14), Decl(index.d.ts, 29, 14))
+>P : Symbol(P, Decl(index.d.ts, 30, 21))
+
+    type: ComponentType<P>,
+>type : Symbol(type, Decl(index.d.ts, 30, 24))
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 1, 8))
+>P : Symbol(P, Decl(index.d.ts, 30, 21))
+
+    props: Attributes & P & { children?: ComponentChild[] },
+>props : Symbol(props, Decl(index.d.ts, 31, 27))
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 5, 10))
+>P : Symbol(P, Decl(index.d.ts, 30, 21))
+>children : Symbol(children, Decl(index.d.ts, 32, 29))
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 32, 60))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+export function jsxDEV(
+>jsxDEV : Symbol(jsxDEV, Decl(index.d.ts, 34, 14), Decl(index.d.ts, 42, 14))
+
+    type: string,
+>type : Symbol(type, Decl(index.d.ts, 36, 23))
+
+    props: JSXInternal.HTMLAttributes &
+>props : Symbol(props, Decl(index.d.ts, 37, 17))
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>HTMLAttributes : Symbol(JSXInternal.HTMLAttributes, Decl(index.d.ts, 7, 30))
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>SVGAttributes : Symbol(JSXInternal.SVGAttributes, Decl(index.d.ts, 8, 40))
+
+        Record<string, any> & { children?: ComponentChildren },
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>children : Symbol(children, Decl(index.d.ts, 40, 31))
+>ComponentChildren : Symbol(ComponentChildren, Decl(index.d.ts, 3, 19))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 40, 63))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+export function jsxDEV<P>(
+>jsxDEV : Symbol(jsxDEV, Decl(index.d.ts, 34, 14), Decl(index.d.ts, 42, 14))
+>P : Symbol(P, Decl(index.d.ts, 43, 23))
+
+    type: ComponentType<P>,
+>type : Symbol(type, Decl(index.d.ts, 43, 26))
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 1, 8))
+>P : Symbol(P, Decl(index.d.ts, 43, 23))
+
+    props: Attributes & P & { children?: ComponentChildren },
+>props : Symbol(props, Decl(index.d.ts, 44, 27))
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 5, 10))
+>P : Symbol(P, Decl(index.d.ts, 43, 23))
+>children : Symbol(children, Decl(index.d.ts, 45, 29))
+>ComponentChildren : Symbol(ComponentChildren, Decl(index.d.ts, 3, 19))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 45, 61))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+declare global {
+>global : Symbol(global, Decl(index.d.ts, 47, 14))
+
+    // @ts-ignore
+    export import JSX = NotFound;
+>JSX : Symbol(JSX, Decl(index.d.ts, 49, 16))
+}
+=== /index.tsx ===
+export const Comp = () => <div></div>;
+>Comp : Symbol(Comp, Decl(index.tsx, 0, 12))
+

--- a/tests/baselines/reference/jsxNamespaceGlobalReexportMissingAliasTarget.types
+++ b/tests/baselines/reference/jsxNamespaceGlobalReexportMissingAliasTarget.types
@@ -1,0 +1,212 @@
+=== /node_modules/preact/index.d.ts ===
+type Defaultize<Props, Defaults> =
+>Defaultize : Defaultize<Props, Defaults>
+
+	// Distribute over unions
+	Props extends any // Make any properties included in Default optional
+		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> &
+				// Include the remaining properties from Props
+				Pick<Props, Exclude<keyof Props, keyof Defaults>>
+		: never;
+export namespace JSXInternal {
+    interface HTMLAttributes<T = {}> { }
+    interface SVGAttributes<T = {}> { }
+    type LibraryManagedAttributes<Component, Props> = Component extends {
+>LibraryManagedAttributes : LibraryManagedAttributes<Component, Props>
+
+        defaultProps: infer Defaults;
+>defaultProps : Defaults
+    }
+        ? Defaultize<Props, Defaults>
+        : Props;
+
+    interface IntrinsicAttributes {
+        key?: any;
+>key : any
+    }
+
+    interface Element extends VNode<any> { }
+
+    interface ElementClass extends Component<any, any> { }
+
+    interface ElementAttributesProperty {
+        props: any;
+>props : any
+    }
+
+    interface ElementChildrenAttribute {
+        children: any;
+>children : any
+    }
+
+    interface IntrinsicElements {
+        div: HTMLAttributes;
+>div : HTMLAttributes<{}>
+    }
+}
+export const Fragment: unique symbol;
+>Fragment : unique symbol
+
+export type ComponentType<T = {}> = {};
+>ComponentType : ComponentType<T>
+
+export type ComponentChild = {};
+>ComponentChild : ComponentChild
+
+export type ComponentChildren = {};
+>ComponentChildren : ComponentChildren
+
+export type VNode<T = {}> = {};
+>VNode : VNode<T>
+
+export type Attributes = {};
+>Attributes : Attributes
+
+export type Component<T = {}, U = {}> = {};
+>Component : Component<T, U>
+
+=== /node_modules/preact/jsx-runtime/index.d.ts ===
+export { Fragment } from '..';
+>Fragment : unique symbol
+
+import {
+    ComponentType,
+>ComponentType : any
+
+    ComponentChild,
+>ComponentChild : any
+
+    ComponentChildren,
+>ComponentChildren : any
+
+    VNode,
+>VNode : any
+
+    Attributes
+>Attributes : any
+
+} from '..';
+import { JSXInternal } from '..';
+>JSXInternal : any
+
+export function jsx(
+>jsx : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChild;}, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; }
+
+    type: string,
+>type : string
+
+    props: JSXInternal.HTMLAttributes &
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }
+>JSXInternal : any
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : any
+
+        Record<string, any> & { children?: ComponentChild },
+>children : ComponentChild | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+export function jsx<P>(
+>jsx : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChild;}, key?: string | undefined): VNode<any>; }
+
+    type: ComponentType<P>,
+>type : ComponentType<P>
+
+    props: Attributes & P & { children?: ComponentChild },
+>props : P & { children?: ComponentChild | undefined; }
+>children : ComponentChild | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+
+export function jsxs(
+>jsxs : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChild[];}, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; }
+
+    type: string,
+>type : string
+
+    props: JSXInternal.HTMLAttributes &
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }
+>JSXInternal : any
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : any
+
+        Record<string, any> & { children?: ComponentChild[] },
+>children : ComponentChild[] | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+export function jsxs<P>(
+>jsxs : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChild[];}, key?: string | undefined): VNode<any>; }
+
+    type: ComponentType<P>,
+>type : ComponentType<P>
+
+    props: Attributes & P & { children?: ComponentChild[] },
+>props : P & { children?: ComponentChild[] | undefined; }
+>children : ComponentChild[] | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+
+export function jsxDEV(
+>jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChildren;}, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; }
+
+    type: string,
+>type : string
+
+    props: JSXInternal.HTMLAttributes &
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }
+>JSXInternal : any
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : any
+
+        Record<string, any> & { children?: ComponentChildren },
+>children : ComponentChildren | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+export function jsxDEV<P>(
+>jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChildren;}, key?: string | undefined): VNode<any>; }
+
+    type: ComponentType<P>,
+>type : ComponentType<P>
+
+    props: Attributes & P & { children?: ComponentChildren },
+>props : P & { children?: ComponentChildren | undefined; }
+>children : ComponentChildren | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+
+declare global {
+>global : typeof global
+
+    // @ts-ignore
+    export import JSX = NotFound;
+>JSX : any
+>NotFound : any
+}
+=== /index.tsx ===
+export const Comp = () => <div></div>;
+>Comp : () => any
+>() => <div></div> : () => any
+><div></div> : any
+>div : any
+>div : any
+

--- a/tests/cases/compiler/jsxNamespaceGlobalReexport.tsx
+++ b/tests/cases/compiler/jsxNamespaceGlobalReexport.tsx
@@ -1,0 +1,108 @@
+// @strict: true
+// @jsx: react-jsx
+// @jsxImportSource: preact
+// @types: preact/jsx-runtime
+// @filename: /node_modules/preact/index.d.ts
+type Defaultize<Props, Defaults> =
+	// Distribute over unions
+	Props extends any // Make any properties included in Default optional
+		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> &
+				// Include the remaining properties from Props
+				Pick<Props, Exclude<keyof Props, keyof Defaults>>
+		: never;
+export namespace JSXInternal {
+    interface HTMLAttributes<T = {}> { }
+    interface SVGAttributes<T = {}> { }
+    type LibraryManagedAttributes<Component, Props> = Component extends {
+        defaultProps: infer Defaults;
+    }
+        ? Defaultize<Props, Defaults>
+        : Props;
+
+    interface IntrinsicAttributes {
+        key?: any;
+    }
+
+    interface Element extends VNode<any> { }
+
+    interface ElementClass extends Component<any, any> { }
+
+    interface ElementAttributesProperty {
+        props: any;
+    }
+
+    interface ElementChildrenAttribute {
+        children: any;
+    }
+
+    interface IntrinsicElements {
+        div: HTMLAttributes;
+    }
+}
+export const Fragment: unique symbol;
+export type ComponentType<T = {}> = {};
+export type ComponentChild = {};
+export type ComponentChildren = {};
+export type VNode<T = {}> = {};
+export type Attributes = {};
+export type Component<T = {}, U = {}> = {};
+// @filename: /node_modules/preact/jsx-runtime/index.d.ts
+export { Fragment } from '..';
+import {
+    ComponentType,
+    ComponentChild,
+    ComponentChildren,
+    VNode,
+    Attributes
+} from '..';
+import { JSXInternal } from '..';
+
+export function jsx(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChild },
+    key?: string
+): VNode<any>;
+export function jsx<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChild },
+    key?: string
+): VNode<any>;
+
+export function jsxs(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChild[] },
+    key?: string
+): VNode<any>;
+export function jsxs<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChild[] },
+    key?: string
+): VNode<any>;
+
+export function jsxDEV(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChildren },
+    key?: string
+): VNode<any>;
+export function jsxDEV<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChildren },
+    key?: string
+): VNode<any>;
+// This shouldn't be preferred over
+//export namespace jsxDEV {
+//    export import JSX = JSXInternal;
+//}
+// but it sort-of should work and it shouldn't crash.
+declare global {
+    // @ts-ignore
+    export import JSX = JSXInternal;
+}
+// @filename: /index.tsx
+export const Comp = () => <div></div>;

--- a/tests/cases/compiler/jsxNamespaceGlobalReexportMissingAliasTarget.tsx
+++ b/tests/cases/compiler/jsxNamespaceGlobalReexportMissingAliasTarget.tsx
@@ -1,0 +1,104 @@
+// @strict: true
+// @jsx: react-jsx
+// @jsxImportSource: preact
+// @types: preact/jsx-runtime
+// @filename: /node_modules/preact/index.d.ts
+type Defaultize<Props, Defaults> =
+	// Distribute over unions
+	Props extends any // Make any properties included in Default optional
+		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> &
+				// Include the remaining properties from Props
+				Pick<Props, Exclude<keyof Props, keyof Defaults>>
+		: never;
+export namespace JSXInternal {
+    interface HTMLAttributes<T = {}> { }
+    interface SVGAttributes<T = {}> { }
+    type LibraryManagedAttributes<Component, Props> = Component extends {
+        defaultProps: infer Defaults;
+    }
+        ? Defaultize<Props, Defaults>
+        : Props;
+
+    interface IntrinsicAttributes {
+        key?: any;
+    }
+
+    interface Element extends VNode<any> { }
+
+    interface ElementClass extends Component<any, any> { }
+
+    interface ElementAttributesProperty {
+        props: any;
+    }
+
+    interface ElementChildrenAttribute {
+        children: any;
+    }
+
+    interface IntrinsicElements {
+        div: HTMLAttributes;
+    }
+}
+export const Fragment: unique symbol;
+export type ComponentType<T = {}> = {};
+export type ComponentChild = {};
+export type ComponentChildren = {};
+export type VNode<T = {}> = {};
+export type Attributes = {};
+export type Component<T = {}, U = {}> = {};
+// @filename: /node_modules/preact/jsx-runtime/index.d.ts
+export { Fragment } from '..';
+import {
+    ComponentType,
+    ComponentChild,
+    ComponentChildren,
+    VNode,
+    Attributes
+} from '..';
+import { JSXInternal } from '..';
+
+export function jsx(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChild },
+    key?: string
+): VNode<any>;
+export function jsx<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChild },
+    key?: string
+): VNode<any>;
+
+export function jsxs(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChild[] },
+    key?: string
+): VNode<any>;
+export function jsxs<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChild[] },
+    key?: string
+): VNode<any>;
+
+export function jsxDEV(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChildren },
+    key?: string
+): VNode<any>;
+export function jsxDEV<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChildren },
+    key?: string
+): VNode<any>;
+
+declare global {
+    // @ts-ignore
+    export import JSX = NotFound;
+}
+// @filename: /index.tsx
+export const Comp = () => <div></div>;


### PR DESCRIPTION
Fixes the crashes mentioned for the workarounds in #41118 (the functional issue of not finding the module-local jsx namespace without an explicit import of the jsx runtime still stands).
