### PR TITLE
Auto-include types for the jsx import source in the new jsx transforms

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25132,6 +25132,31 @@ namespace ts {
             return links.resolvedSymbol;
         }
 
+        function getJsxNamespaceContainerForImplicitImport(location: Node | undefined): Symbol | undefined {
+            const file = location && getSourceFileOfNode(location);
+            const links = file && getNodeLinks(file);
+            if (links && links.jsxImplicitImportContainer === false) {
+                return undefined;
+            }
+            if (links && links.jsxImplicitImportContainer) {
+                return links.jsxImplicitImportContainer;
+            }
+            const runtimeImportSpecifier = getJSXRuntimeImport(getJSXImplicitImportBase(compilerOptions, file), compilerOptions);
+            if (!runtimeImportSpecifier) {
+                return undefined;
+            }
+            const isClassic = getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Classic;
+            const errorMessage = isClassic
+                                    ? Diagnostics.Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_node_or_to_add_aliases_to_the_paths_option
+                                    : Diagnostics.Cannot_find_module_0_or_its_corresponding_type_declarations;
+            const mod = resolveExternalModule(location!, runtimeImportSpecifier, errorMessage, location!);
+            const result = mod && mod !== unknownSymbol ? getMergedSymbol(resolveSymbol(mod)) : undefined;
+            if (links) {
+                links.jsxImplicitImportContainer = result || false;
+            }
+            return result;
+        }
+
         function getJsxNamespaceAt(location: Node | undefined): Symbol {
             const links = location && getNodeLinks(location);
             if (links && links.jsxNamespace) {
@@ -25139,7 +25164,10 @@ namespace ts {
             }
             if (!links || links.jsxNamespace !== false) {
                 const namespaceName = getJsxNamespace(location);
-                const resolvedNamespace = resolveName(location, namespaceName, SymbolFlags.Namespace, /*diagnosticMessage*/ undefined, namespaceName, /*isUse*/ false);
+                let resolvedNamespace = resolveName(location, namespaceName, SymbolFlags.Namespace, /*diagnosticMessage*/ undefined, namespaceName, /*isUse*/ false);
+                if (!resolvedNamespace || resolvedNamespace === unknownSymbol) {
+                    resolvedNamespace = getJsxNamespaceContainerForImplicitImport(location);
+                }
                 if (resolvedNamespace) {
                     const candidate = resolveSymbol(getSymbol(getExportsOfSymbol(resolveSymbol(resolvedNamespace)), JsxNames.JSX, SymbolFlags.Namespace));
                     if (candidate && candidate !== unknownSymbol) {
@@ -25148,9 +25176,9 @@ namespace ts {
                         }
                         return candidate;
                     }
-                    if (links) {
-                        links.jsxNamespace = false;
-                    }
+                }
+                if (links) {
+                    links.jsxNamespace = false;
                 }
             }
             // JSX global fallback

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -803,6 +803,8 @@ namespace ts {
         {
             name: "jsxImportSource",
             type: "string",
+            affectsSemanticDiagnostics: true,
+            affectsEmit: true,
             affectsModuleResolution: true,
             category: Diagnostics.Advanced_Options,
             description: Diagnostics.Specify_the_module_specifier_to_be_used_to_import_the_jsx_and_jsxs_factory_functions_from_eg_react

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -382,6 +382,7 @@ namespace ts {
             type: jsxOptionMap,
             affectsSourceFile: true,
             affectsEmit: true,
+            affectsModuleResolution: true,
             paramType: Diagnostics.KIND,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Basic_Options,
@@ -802,6 +803,7 @@ namespace ts {
         {
             name: "jsxImportSource",
             type: "string",
+            affectsModuleResolution: true,
             category: Diagnostics.Advanced_Options,
             description: Diagnostics.Specify_the_module_specifier_to_be_used_to_import_the_jsx_and_jsxs_factory_functions_from_eg_react
         },

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -402,10 +402,8 @@ namespace ts {
      */
     export function getAutomaticTypeDirectiveNames(options: CompilerOptions, host: ModuleResolutionHost): string[] {
         // Use explicit type list from tsconfig.json
-        // jsxImportSource, if present and in use, creates implicit imports
-        const implicitImport = getJSXRuntimeImport(getJSXImplicitImportBase(options), options);
         if (options.types) {
-            return [...options.types, ...(implicitImport ? [implicitImport] : [])];
+            return options.types;
         }
 
         // Walk the primary type lookup locations
@@ -435,9 +433,6 @@ namespace ts {
                     }
                 }
             }
-        }
-        if (implicitImport) {
-            result.push(implicitImport);
         }
         return result;
     }

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -402,8 +402,10 @@ namespace ts {
      */
     export function getAutomaticTypeDirectiveNames(options: CompilerOptions, host: ModuleResolutionHost): string[] {
         // Use explicit type list from tsconfig.json
+        // jsxImportSource, if present and in use, creates implicit imports
+        const implicitImport = getJSXRuntimeImport(getJSXImplicitImportBase(options), options);
         if (options.types) {
-            return options.types;
+            return [...options.types, ...(implicitImport ? [implicitImport] : [])];
         }
 
         // Walk the primary type lookup locations
@@ -433,6 +435,9 @@ namespace ts {
                     }
                 }
             }
+        }
+        if (implicitImport) {
+            result.push(implicitImport);
         }
         return result;
     }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2234,8 +2234,7 @@ namespace ts {
                 const jsxImport = getJSXRuntimeImport(getJSXImplicitImportBase(options, file), options);
                 if (jsxImport) {
                     // synthesize `import "base/jsx-runtime"` declaration
-                    imports ||= [];
-                    imports.push(createSyntheticImport(jsxImport, file));
+                    (imports ||= []).push(createSyntheticImport(jsxImport, file));
                 }
             }
 

--- a/src/compiler/transformers/jsx.ts
+++ b/src/compiler/transformers/jsx.ts
@@ -42,7 +42,7 @@ namespace ts {
         function getImplicitImportForName(name: string) {
             const importSource = name === "createElement"
                 ? currentFileState.importSpecifier!
-                : `${currentFileState.importSpecifier}/${compilerOptions.jsx === JsxEmit.ReactJSXDev ? "jsx-dev-runtime" : "jsx-runtime"}`;
+                : getJSXRuntimeImport(currentFileState.importSpecifier, compilerOptions)!;
             const existing = currentFileState.utilizedImplicitRuntimeImports?.get(importSource)?.get(name);
             if (existing) {
                 return existing.name;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4843,6 +4843,7 @@ namespace ts {
         resolvedJSDocType?: Type;           // Resolved type of a JSDoc type reference
         switchTypes?: Type[];               // Cached array of switch case expression types
         jsxNamespace?: Symbol | false;      // Resolved jsx namespace symbol for this node
+        jsxImplicitImportContainer?: Symbol | false; // Resolved module symbol the implicit jsx import of this file should refer to
         contextFreeType?: Type;             // Cached context-free type used by the first pass of inference; used when a function's return is partially contextually sensitive
         deferredNodes?: ESMap<NodeId, Node>; // Set of nodes whose checking has been deferred
         capturedBlockScopeBindings?: Symbol[]; // Block-scoped bindings captured beneath this part of an IterationStatement

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6009,8 +6009,8 @@ namespace ts {
         return jsx === JsxEmit.React || jsx === JsxEmit.ReactJSX || jsx === JsxEmit.ReactJSXDev;
     }
 
-    export function getJSXImplicitImportBase(compilerOptions: CompilerOptions, file: SourceFile): string | undefined {
-        const jsxImportSourcePragmas = file.pragmas.get("jsximportsource");
+    export function getJSXImplicitImportBase(compilerOptions: CompilerOptions, file?: SourceFile): string | undefined {
+        const jsxImportSourcePragmas = file?.pragmas.get("jsximportsource");
         const jsxImportSourcePragma = isArray(jsxImportSourcePragmas) ? jsxImportSourcePragmas[0] : jsxImportSourcePragmas;
         return compilerOptions.jsx === JsxEmit.ReactJSX ||
             compilerOptions.jsx === JsxEmit.ReactJSXDev ||
@@ -6018,6 +6018,10 @@ namespace ts {
             jsxImportSourcePragma ?
                 jsxImportSourcePragma?.arguments.factory || compilerOptions.jsxImportSource || "react" :
                 undefined;
+    }
+
+    export function getJSXRuntimeImport(base: string | undefined, options: CompilerOptions) {
+        return base ? `${base}/${options.jsx === JsxEmit.ReactJSXDev ? "jsx-dev-runtime" : "jsx-runtime"}` : undefined;
     }
 
     export function hasZeroOrOneAsteriskCharacter(str: string): boolean {

--- a/src/testRunner/unittests/tscWatch/incremental.ts
+++ b/src/testRunner/unittests/tscWatch/incremental.ts
@@ -276,5 +276,33 @@ export interface A {
             ],
             modifyFs: host => host.deleteFile(`${project}/globals.d.ts`)
         });
+
+        const jsxImportSourceOptions = { module: "commonjs", jsx: "react-jsx", incremental: true, jsxImportSource: "react" };
+        const jsxLibraryContent = `export namespace JSX {
+    interface Element {}
+    interface IntrinsicElements {
+        div: {
+            propA?: boolean;
+        };
+    }
+}
+export function jsx(...args: any[]): void;
+export function jsxs(...args: any[]): void;
+export const Fragment: unique symbol;
+`;
+
+        verifyIncrementalWatchEmit({
+            subScenario: "jsxImportSource option changed",
+            files: () => [
+                { path: libFile.path, content: libContent },
+                { path: `${project}/node_modules/react/jsx-runtime/index.d.ts`, content: jsxLibraryContent },
+                { path: `${project}/node_modules/react/package.json`, content: JSON.stringify({ name: "react", version: "0.0.1" }) },
+                { path: `${project}/node_modules/preact/jsx-runtime/index.d.ts`, content: jsxLibraryContent.replace("propA", "propB") },
+                { path: `${project}/node_modules/preact/package.json`, content: JSON.stringify({ name: "preact", version: "0.0.1" }) },
+                { path: `${project}/index.tsx`, content: `export const App = () => <div propA={true}></div>;` },
+                { path: configFile.path, content: JSON.stringify({ compilerOptions: jsxImportSourceOptions }) }
+            ],
+            modifyFs: host => host.writeFile(configFile.path, JSON.stringify({ compilerOptions: { ...jsxImportSourceOptions, jsxImportSource: "preact" } }))
+        });
     });
 }

--- a/tests/baselines/reference/jsxJsxsCjsTransformCustomImport(jsx=react-jsx).errors.txt
+++ b/tests/baselines/reference/jsxJsxsCjsTransformCustomImport(jsx=react-jsx).errors.txt
@@ -1,0 +1,14 @@
+tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformCustomImport.tsx(2,11): error TS2307: Cannot find module 'preact/jsx-runtime' or its corresponding type declarations.
+
+
+==== tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformCustomImport.tsx (1 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    const a = <>
+              ~~
+!!! error TS2307: Cannot find module 'preact/jsx-runtime' or its corresponding type declarations.
+      <p></p>
+      text
+      <div className="foo"></div>
+    </>
+    
+    export {};

--- a/tests/baselines/reference/jsxJsxsCjsTransformCustomImport(jsx=react-jsxdev).errors.txt
+++ b/tests/baselines/reference/jsxJsxsCjsTransformCustomImport(jsx=react-jsxdev).errors.txt
@@ -1,0 +1,14 @@
+tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformCustomImport.tsx(2,11): error TS2307: Cannot find module 'preact/jsx-dev-runtime' or its corresponding type declarations.
+
+
+==== tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformCustomImport.tsx (1 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    const a = <>
+              ~~
+!!! error TS2307: Cannot find module 'preact/jsx-dev-runtime' or its corresponding type declarations.
+      <p></p>
+      text
+      <div className="foo"></div>
+    </>
+    
+    export {};

--- a/tests/baselines/reference/jsxJsxsCjsTransformCustomImportPragma(jsx=react-jsx).errors.txt
+++ b/tests/baselines/reference/jsxJsxsCjsTransformCustomImportPragma(jsx=react-jsx).errors.txt
@@ -1,0 +1,26 @@
+tests/cases/conformance/jsx/jsxs/preact.tsx(3,11): error TS2307: Cannot find module 'preact/jsx-runtime' or its corresponding type declarations.
+
+
+==== tests/cases/conformance/jsx/jsxs/react.tsx (0 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    /* @jsxImportSource react */
+    import "./preact";
+    const a = <>
+      <p></p>
+      text
+      <div className="foo"></div>
+    </>
+    
+    export {};
+==== tests/cases/conformance/jsx/jsxs/preact.tsx (1 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    /* @jsxImportSource preact */
+    const a = <>
+              ~~
+!!! error TS2307: Cannot find module 'preact/jsx-runtime' or its corresponding type declarations.
+      <p></p>
+      text
+      <div className="foo"></div>
+    </>
+    
+    export {};

--- a/tests/baselines/reference/jsxJsxsCjsTransformCustomImportPragma(jsx=react-jsxdev).errors.txt
+++ b/tests/baselines/reference/jsxJsxsCjsTransformCustomImportPragma(jsx=react-jsxdev).errors.txt
@@ -1,0 +1,26 @@
+tests/cases/conformance/jsx/jsxs/preact.tsx(3,11): error TS2307: Cannot find module 'preact/jsx-dev-runtime' or its corresponding type declarations.
+
+
+==== tests/cases/conformance/jsx/jsxs/react.tsx (0 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    /* @jsxImportSource react */
+    import "./preact";
+    const a = <>
+      <p></p>
+      text
+      <div className="foo"></div>
+    </>
+    
+    export {};
+==== tests/cases/conformance/jsx/jsxs/preact.tsx (1 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    /* @jsxImportSource preact */
+    const a = <>
+              ~~
+!!! error TS2307: Cannot find module 'preact/jsx-dev-runtime' or its corresponding type declarations.
+      <p></p>
+      text
+      <div className="foo"></div>
+    </>
+    
+    export {};

--- a/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImport(jsx=react-jsx).errors.txt
+++ b/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImport(jsx=react-jsx).errors.txt
@@ -1,0 +1,13 @@
+tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformKeyPropCustomImport.tsx(3,11): error TS2307: Cannot find module 'preact/jsx-runtime' or its corresponding type declarations.
+
+
+==== tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformKeyPropCustomImport.tsx (1 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    const props = { answer: 42 }
+    const a = <div key="foo" {...props}>text</div>;
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'preact/jsx-runtime' or its corresponding type declarations.
+    const b = <div {...props} key="bar">text</div>;
+    
+    export {};
+    

--- a/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImport(jsx=react-jsxdev).errors.txt
+++ b/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImport(jsx=react-jsxdev).errors.txt
@@ -1,0 +1,13 @@
+tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformKeyPropCustomImport.tsx(3,11): error TS2307: Cannot find module 'preact/jsx-dev-runtime' or its corresponding type declarations.
+
+
+==== tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformKeyPropCustomImport.tsx (1 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    const props = { answer: 42 }
+    const a = <div key="foo" {...props}>text</div>;
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'preact/jsx-dev-runtime' or its corresponding type declarations.
+    const b = <div {...props} key="bar">text</div>;
+    
+    export {};
+    

--- a/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImportPragma(jsx=react-jsx).errors.txt
+++ b/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImportPragma(jsx=react-jsx).errors.txt
@@ -1,0 +1,24 @@
+tests/cases/conformance/jsx/jsxs/preact.tsx(4,11): error TS2307: Cannot find module 'preact/jsx-runtime' or its corresponding type declarations.
+
+
+==== tests/cases/conformance/jsx/jsxs/react.tsx (0 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    /* @jsxImportSource react */
+    import "./preact";
+    const props2 = { answer: 42 }
+    const a2 = <div key="foo" {...props2}>text</div>;
+    const b2 = <div {...props2} key="bar">text</div>;
+    
+    export {};
+    
+==== tests/cases/conformance/jsx/jsxs/preact.tsx (1 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    /* @jsxImportSource preact */
+    const props = { answer: 42 }
+    const a = <div key="foo" {...props}>text</div>;
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'preact/jsx-runtime' or its corresponding type declarations.
+    const b = <div {...props} key="bar">text</div>;
+    
+    export {};
+    

--- a/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImportPragma(jsx=react-jsxdev).errors.txt
+++ b/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImportPragma(jsx=react-jsxdev).errors.txt
@@ -1,0 +1,24 @@
+tests/cases/conformance/jsx/jsxs/preact.tsx(4,11): error TS2307: Cannot find module 'preact/jsx-dev-runtime' or its corresponding type declarations.
+
+
+==== tests/cases/conformance/jsx/jsxs/react.tsx (0 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    /* @jsxImportSource react */
+    import "./preact";
+    const props2 = { answer: 42 }
+    const a2 = <div key="foo" {...props2}>text</div>;
+    const b2 = <div {...props2} key="bar">text</div>;
+    
+    export {};
+    
+==== tests/cases/conformance/jsx/jsxs/preact.tsx (1 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    /* @jsxImportSource preact */
+    const props = { answer: 42 }
+    const a = <div key="foo" {...props}>text</div>;
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'preact/jsx-dev-runtime' or its corresponding type declarations.
+    const b = <div {...props} key="bar">text</div>;
+    
+    export {};
+    

--- a/tests/baselines/reference/jsxNamespaceImplicitImportJSXNamespace.js
+++ b/tests/baselines/reference/jsxNamespaceImplicitImportJSXNamespace.js
@@ -1,0 +1,110 @@
+//// [tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespace.tsx] ////
+
+//// [index.d.ts]
+type Defaultize<Props, Defaults> =
+	// Distribute over unions
+	Props extends any // Make any properties included in Default optional
+		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> &
+				// Include the remaining properties from Props
+				Pick<Props, Exclude<keyof Props, keyof Defaults>>
+		: never;
+export namespace JSXInternal {
+    interface HTMLAttributes<T = {}> { }
+    interface SVGAttributes<T = {}> { }
+    type LibraryManagedAttributes<Component, Props> = Component extends {
+        defaultProps: infer Defaults;
+    }
+        ? Defaultize<Props, Defaults>
+        : Props;
+
+    interface IntrinsicAttributes {
+        key?: any;
+    }
+
+    interface Element extends VNode<any> { }
+
+    interface ElementClass extends Component<any, any> { }
+
+    interface ElementAttributesProperty {
+        props: any;
+    }
+
+    interface ElementChildrenAttribute {
+        children: any;
+    }
+
+    interface IntrinsicElements {
+        div: HTMLAttributes;
+    }
+}
+export const Fragment: unique symbol;
+export type ComponentType<T = {}> = {};
+export type ComponentChild = {};
+export type ComponentChildren = {};
+export type VNode<T = {}> = {};
+export type Attributes = {};
+export type Component<T = {}, U = {}> = {};
+//// [index.d.ts]
+export { Fragment } from '..';
+import {
+    ComponentType,
+    ComponentChild,
+    ComponentChildren,
+    VNode,
+    Attributes
+} from '..';
+import { JSXInternal } from '..';
+
+export function jsx(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChild },
+    key?: string
+): VNode<any>;
+export function jsx<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChild },
+    key?: string
+): VNode<any>;
+
+
+export function jsxs(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChild[] },
+    key?: string
+): VNode<any>;
+export function jsxs<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChild[] },
+    key?: string
+): VNode<any>;
+
+
+export function jsxDEV(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChildren },
+    key?: string
+): VNode<any>;
+export function jsxDEV<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChildren },
+    key?: string
+): VNode<any>;
+
+export import JSX = JSXInternal;
+
+//// [index.tsx]
+export const Comp = () => <div></div>;
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+exports.Comp = void 0;
+var jsx_runtime_1 = require("preact/jsx-runtime");
+var Comp = function () { return jsx_runtime_1.jsx("div", {}, void 0); };
+exports.Comp = Comp;

--- a/tests/baselines/reference/jsxNamespaceImplicitImportJSXNamespace.symbols
+++ b/tests/baselines/reference/jsxNamespaceImplicitImportJSXNamespace.symbols
@@ -1,0 +1,298 @@
+=== /node_modules/preact/index.d.ts ===
+type Defaultize<Props, Defaults> =
+>Defaultize : Symbol(Defaultize, Decl(index.d.ts, 0, 0))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 0, 22))
+
+	// Distribute over unions
+	Props extends any // Make any properties included in Default optional
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+
+		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> &
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 0, 22))
+
+				// Include the remaining properties from Props
+				Pick<Props, Exclude<keyof Props, keyof Defaults>>
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
+>Props : Symbol(Props, Decl(index.d.ts, 0, 16))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 0, 22))
+
+		: never;
+export namespace JSXInternal {
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 6, 10))
+
+    interface HTMLAttributes<T = {}> { }
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(index.d.ts, 7, 30))
+>T : Symbol(T, Decl(index.d.ts, 8, 29))
+
+    interface SVGAttributes<T = {}> { }
+>SVGAttributes : Symbol(SVGAttributes, Decl(index.d.ts, 8, 40))
+>T : Symbol(T, Decl(index.d.ts, 9, 28))
+
+    type LibraryManagedAttributes<Component, Props> = Component extends {
+>LibraryManagedAttributes : Symbol(LibraryManagedAttributes, Decl(index.d.ts, 9, 39))
+>Component : Symbol(Component, Decl(index.d.ts, 10, 34))
+>Props : Symbol(Props, Decl(index.d.ts, 10, 44))
+>Component : Symbol(Component, Decl(index.d.ts, 10, 34))
+
+        defaultProps: infer Defaults;
+>defaultProps : Symbol(defaultProps, Decl(index.d.ts, 10, 73))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 11, 27))
+    }
+        ? Defaultize<Props, Defaults>
+>Defaultize : Symbol(Defaultize, Decl(index.d.ts, 0, 0))
+>Props : Symbol(Props, Decl(index.d.ts, 10, 44))
+>Defaults : Symbol(Defaults, Decl(index.d.ts, 11, 27))
+
+        : Props;
+>Props : Symbol(Props, Decl(index.d.ts, 10, 44))
+
+    interface IntrinsicAttributes {
+>IntrinsicAttributes : Symbol(IntrinsicAttributes, Decl(index.d.ts, 14, 16))
+
+        key?: any;
+>key : Symbol(IntrinsicAttributes.key, Decl(index.d.ts, 16, 35))
+    }
+
+    interface Element extends VNode<any> { }
+>Element : Symbol(Element, Decl(index.d.ts, 18, 5))
+>VNode : Symbol(VNode, Decl(index.d.ts, 39, 35))
+
+    interface ElementClass extends Component<any, any> { }
+>ElementClass : Symbol(ElementClass, Decl(index.d.ts, 20, 44))
+>Component : Symbol(Component, Decl(index.d.ts, 41, 28))
+
+    interface ElementAttributesProperty {
+>ElementAttributesProperty : Symbol(ElementAttributesProperty, Decl(index.d.ts, 22, 58))
+
+        props: any;
+>props : Symbol(ElementAttributesProperty.props, Decl(index.d.ts, 24, 41))
+    }
+
+    interface ElementChildrenAttribute {
+>ElementChildrenAttribute : Symbol(ElementChildrenAttribute, Decl(index.d.ts, 26, 5))
+
+        children: any;
+>children : Symbol(ElementChildrenAttribute.children, Decl(index.d.ts, 28, 40))
+    }
+
+    interface IntrinsicElements {
+>IntrinsicElements : Symbol(IntrinsicElements, Decl(index.d.ts, 30, 5))
+
+        div: HTMLAttributes;
+>div : Symbol(IntrinsicElements.div, Decl(index.d.ts, 32, 33))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(index.d.ts, 7, 30))
+    }
+}
+export const Fragment: unique symbol;
+>Fragment : Symbol(Fragment, Decl(index.d.ts, 36, 12))
+
+export type ComponentType<T = {}> = {};
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 36, 37))
+>T : Symbol(T, Decl(index.d.ts, 37, 26))
+
+export type ComponentChild = {};
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 37, 39))
+
+export type ComponentChildren = {};
+>ComponentChildren : Symbol(ComponentChildren, Decl(index.d.ts, 38, 32))
+
+export type VNode<T = {}> = {};
+>VNode : Symbol(VNode, Decl(index.d.ts, 39, 35))
+>T : Symbol(T, Decl(index.d.ts, 40, 18))
+
+export type Attributes = {};
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 40, 31))
+
+export type Component<T = {}, U = {}> = {};
+>Component : Symbol(Component, Decl(index.d.ts, 41, 28))
+>T : Symbol(T, Decl(index.d.ts, 42, 22))
+>U : Symbol(U, Decl(index.d.ts, 42, 29))
+
+=== /node_modules/preact/jsx-runtime/index.d.ts ===
+export { Fragment } from '..';
+>Fragment : Symbol(Fragment, Decl(index.d.ts, 0, 8))
+
+import {
+    ComponentType,
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 1, 8))
+
+    ComponentChild,
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    ComponentChildren,
+>ComponentChildren : Symbol(ComponentChildren, Decl(index.d.ts, 3, 19))
+
+    VNode,
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+    Attributes
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 5, 10))
+
+} from '..';
+import { JSXInternal } from '..';
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+
+export function jsx(
+>jsx : Symbol(jsx, Decl(index.d.ts, 8, 33), Decl(index.d.ts, 16, 14))
+
+    type: string,
+>type : Symbol(type, Decl(index.d.ts, 10, 20))
+
+    props: JSXInternal.HTMLAttributes &
+>props : Symbol(props, Decl(index.d.ts, 11, 17))
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>HTMLAttributes : Symbol(JSXInternal.HTMLAttributes, Decl(index.d.ts, 7, 30))
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>SVGAttributes : Symbol(JSXInternal.SVGAttributes, Decl(index.d.ts, 8, 40))
+
+        Record<string, any> & { children?: ComponentChild },
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>children : Symbol(children, Decl(index.d.ts, 14, 31))
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 14, 60))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+export function jsx<P>(
+>jsx : Symbol(jsx, Decl(index.d.ts, 8, 33), Decl(index.d.ts, 16, 14))
+>P : Symbol(P, Decl(index.d.ts, 17, 20))
+
+    type: ComponentType<P>,
+>type : Symbol(type, Decl(index.d.ts, 17, 23))
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 1, 8))
+>P : Symbol(P, Decl(index.d.ts, 17, 20))
+
+    props: Attributes & P & { children?: ComponentChild },
+>props : Symbol(props, Decl(index.d.ts, 18, 27))
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 5, 10))
+>P : Symbol(P, Decl(index.d.ts, 17, 20))
+>children : Symbol(children, Decl(index.d.ts, 19, 29))
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 19, 58))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+
+export function jsxs(
+>jsxs : Symbol(jsxs, Decl(index.d.ts, 21, 14), Decl(index.d.ts, 30, 14))
+
+    type: string,
+>type : Symbol(type, Decl(index.d.ts, 24, 21))
+
+    props: JSXInternal.HTMLAttributes &
+>props : Symbol(props, Decl(index.d.ts, 25, 17))
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>HTMLAttributes : Symbol(JSXInternal.HTMLAttributes, Decl(index.d.ts, 7, 30))
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>SVGAttributes : Symbol(JSXInternal.SVGAttributes, Decl(index.d.ts, 8, 40))
+
+        Record<string, any> & { children?: ComponentChild[] },
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>children : Symbol(children, Decl(index.d.ts, 28, 31))
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 28, 62))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+export function jsxs<P>(
+>jsxs : Symbol(jsxs, Decl(index.d.ts, 21, 14), Decl(index.d.ts, 30, 14))
+>P : Symbol(P, Decl(index.d.ts, 31, 21))
+
+    type: ComponentType<P>,
+>type : Symbol(type, Decl(index.d.ts, 31, 24))
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 1, 8))
+>P : Symbol(P, Decl(index.d.ts, 31, 21))
+
+    props: Attributes & P & { children?: ComponentChild[] },
+>props : Symbol(props, Decl(index.d.ts, 32, 27))
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 5, 10))
+>P : Symbol(P, Decl(index.d.ts, 31, 21))
+>children : Symbol(children, Decl(index.d.ts, 33, 29))
+>ComponentChild : Symbol(ComponentChild, Decl(index.d.ts, 2, 18))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 33, 60))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+
+export function jsxDEV(
+>jsxDEV : Symbol(jsxDEV, Decl(index.d.ts, 35, 14), Decl(index.d.ts, 44, 14))
+
+    type: string,
+>type : Symbol(type, Decl(index.d.ts, 38, 23))
+
+    props: JSXInternal.HTMLAttributes &
+>props : Symbol(props, Decl(index.d.ts, 39, 17))
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>HTMLAttributes : Symbol(JSXInternal.HTMLAttributes, Decl(index.d.ts, 7, 30))
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+>SVGAttributes : Symbol(JSXInternal.SVGAttributes, Decl(index.d.ts, 8, 40))
+
+        Record<string, any> & { children?: ComponentChildren },
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>children : Symbol(children, Decl(index.d.ts, 42, 31))
+>ComponentChildren : Symbol(ComponentChildren, Decl(index.d.ts, 3, 19))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 42, 63))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+export function jsxDEV<P>(
+>jsxDEV : Symbol(jsxDEV, Decl(index.d.ts, 35, 14), Decl(index.d.ts, 44, 14))
+>P : Symbol(P, Decl(index.d.ts, 45, 23))
+
+    type: ComponentType<P>,
+>type : Symbol(type, Decl(index.d.ts, 45, 26))
+>ComponentType : Symbol(ComponentType, Decl(index.d.ts, 1, 8))
+>P : Symbol(P, Decl(index.d.ts, 45, 23))
+
+    props: Attributes & P & { children?: ComponentChildren },
+>props : Symbol(props, Decl(index.d.ts, 46, 27))
+>Attributes : Symbol(Attributes, Decl(index.d.ts, 5, 10))
+>P : Symbol(P, Decl(index.d.ts, 45, 23))
+>children : Symbol(children, Decl(index.d.ts, 47, 29))
+>ComponentChildren : Symbol(ComponentChildren, Decl(index.d.ts, 3, 19))
+
+    key?: string
+>key : Symbol(key, Decl(index.d.ts, 47, 61))
+
+): VNode<any>;
+>VNode : Symbol(VNode, Decl(index.d.ts, 4, 22))
+
+export import JSX = JSXInternal;
+>JSX : Symbol(JSX, Decl(index.d.ts, 49, 14))
+>JSXInternal : Symbol(JSXInternal, Decl(index.d.ts, 8, 8))
+
+=== /index.tsx ===
+export const Comp = () => <div></div>;
+>Comp : Symbol(Comp, Decl(index.tsx, 0, 12))
+>div : Symbol(JSXInternal.IntrinsicElements.div, Decl(index.d.ts, 32, 33))
+>div : Symbol(JSXInternal.IntrinsicElements.div, Decl(index.d.ts, 32, 33))
+

--- a/tests/baselines/reference/jsxNamespaceImplicitImportJSXNamespace.types
+++ b/tests/baselines/reference/jsxNamespaceImplicitImportJSXNamespace.types
@@ -1,0 +1,210 @@
+=== /node_modules/preact/index.d.ts ===
+type Defaultize<Props, Defaults> =
+>Defaultize : Defaultize<Props, Defaults>
+
+	// Distribute over unions
+	Props extends any // Make any properties included in Default optional
+		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> &
+				// Include the remaining properties from Props
+				Pick<Props, Exclude<keyof Props, keyof Defaults>>
+		: never;
+export namespace JSXInternal {
+    interface HTMLAttributes<T = {}> { }
+    interface SVGAttributes<T = {}> { }
+    type LibraryManagedAttributes<Component, Props> = Component extends {
+>LibraryManagedAttributes : LibraryManagedAttributes<Component, Props>
+
+        defaultProps: infer Defaults;
+>defaultProps : Defaults
+    }
+        ? Defaultize<Props, Defaults>
+        : Props;
+
+    interface IntrinsicAttributes {
+        key?: any;
+>key : any
+    }
+
+    interface Element extends VNode<any> { }
+
+    interface ElementClass extends Component<any, any> { }
+
+    interface ElementAttributesProperty {
+        props: any;
+>props : any
+    }
+
+    interface ElementChildrenAttribute {
+        children: any;
+>children : any
+    }
+
+    interface IntrinsicElements {
+        div: HTMLAttributes;
+>div : HTMLAttributes<{}>
+    }
+}
+export const Fragment: unique symbol;
+>Fragment : unique symbol
+
+export type ComponentType<T = {}> = {};
+>ComponentType : ComponentType<T>
+
+export type ComponentChild = {};
+>ComponentChild : ComponentChild
+
+export type ComponentChildren = {};
+>ComponentChildren : ComponentChildren
+
+export type VNode<T = {}> = {};
+>VNode : VNode<T>
+
+export type Attributes = {};
+>Attributes : Attributes
+
+export type Component<T = {}, U = {}> = {};
+>Component : Component<T, U>
+
+=== /node_modules/preact/jsx-runtime/index.d.ts ===
+export { Fragment } from '..';
+>Fragment : unique symbol
+
+import {
+    ComponentType,
+>ComponentType : any
+
+    ComponentChild,
+>ComponentChild : any
+
+    ComponentChildren,
+>ComponentChildren : any
+
+    VNode,
+>VNode : any
+
+    Attributes
+>Attributes : any
+
+} from '..';
+import { JSXInternal } from '..';
+>JSXInternal : any
+
+export function jsx(
+>jsx : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChild;}, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; }
+
+    type: string,
+>type : string
+
+    props: JSXInternal.HTMLAttributes &
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }
+>JSXInternal : any
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : any
+
+        Record<string, any> & { children?: ComponentChild },
+>children : ComponentChild | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+export function jsx<P>(
+>jsx : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChild;}, key?: string | undefined): VNode<any>; }
+
+    type: ComponentType<P>,
+>type : ComponentType<P>
+
+    props: Attributes & P & { children?: ComponentChild },
+>props : P & { children?: ComponentChild | undefined; }
+>children : ComponentChild | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+
+
+export function jsxs(
+>jsxs : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChild[];}, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; }
+
+    type: string,
+>type : string
+
+    props: JSXInternal.HTMLAttributes &
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }
+>JSXInternal : any
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : any
+
+        Record<string, any> & { children?: ComponentChild[] },
+>children : ComponentChild[] | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+export function jsxs<P>(
+>jsxs : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChild[];}, key?: string | undefined): VNode<any>; }
+
+    type: ComponentType<P>,
+>type : ComponentType<P>
+
+    props: Attributes & P & { children?: ComponentChild[] },
+>props : P & { children?: ComponentChild[] | undefined; }
+>children : ComponentChild[] | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+
+
+export function jsxDEV(
+>jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChildren;}, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; }
+
+    type: string,
+>type : string
+
+    props: JSXInternal.HTMLAttributes &
+>props : JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }
+>JSXInternal : any
+
+        JSXInternal.SVGAttributes &
+>JSXInternal : any
+
+        Record<string, any> & { children?: ComponentChildren },
+>children : ComponentChildren | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+export function jsxDEV<P>(
+>jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChildren;}, key?: string | undefined): VNode<any>; }
+
+    type: ComponentType<P>,
+>type : ComponentType<P>
+
+    props: Attributes & P & { children?: ComponentChildren },
+>props : P & { children?: ComponentChildren | undefined; }
+>children : ComponentChildren | undefined
+
+    key?: string
+>key : string | undefined
+
+): VNode<any>;
+
+export import JSX = JSXInternal;
+>JSX : any
+>JSXInternal : error
+
+=== /index.tsx ===
+export const Comp = () => <div></div>;
+>Comp : () => import("/node_modules/preact/index").JSXInternal.Element
+>() => <div></div> : () => import("/node_modules/preact/index").JSXInternal.Element
+><div></div> : import("/node_modules/preact/index").JSXInternal.Element
+>div : any
+>div : any
+

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-incremental.js
@@ -64,13 +64,13 @@ Program options: {"module":1,"jsx":4,"incremental":true,"jsxImportSource":"react
 Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
-/users/username/projects/project/index.tsx
 /users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts
+/users/username/projects/project/index.tsx
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts
-/users/username/projects/project/index.tsx
 /users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts
+/users/username/projects/project/index.tsx
 
 WatchedFiles::
 
@@ -98,14 +98,14 @@ exports.App = App;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
-      "./index.tsx": {
-        "version": "-14760199789-export const App = () => <div propA={true}></div>;",
-        "signature": "-17269688391-export declare const App: () => import(\"react/jsx-runtime\").JSX.Element;\n",
-        "affectsGlobalScope": false
-      },
       "./node_modules/react/jsx-runtime/index.d.ts": {
         "version": "-35656056833-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propA?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
         "signature": "-35656056833-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propA?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
+        "affectsGlobalScope": false
+      },
+      "./index.tsx": {
+        "version": "-14760199789-export const App = () => <div propA={true}></div>;",
+        "signature": "-17269688391-export declare const App: () => import(\"react/jsx-runtime\").JSX.Element;\n",
         "affectsGlobalScope": false
       }
     },
@@ -156,13 +156,13 @@ Program options: {"module":1,"jsx":4,"incremental":true,"jsxImportSource":"preac
 Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
-/users/username/projects/project/index.tsx
 /users/username/projects/project/node_modules/preact/jsx-runtime/index.d.ts
+/users/username/projects/project/index.tsx
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts
-/users/username/projects/project/index.tsx
 /users/username/projects/project/node_modules/preact/jsx-runtime/index.d.ts
+/users/username/projects/project/index.tsx
 
 WatchedFiles::
 
@@ -190,14 +190,14 @@ exports.App = App;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
-      "./index.tsx": {
-        "version": "-14760199789-export const App = () => <div propA={true}></div>;",
-        "signature": "-17269688391-export declare const App: () => import(\"react/jsx-runtime\").JSX.Element;\n",
-        "affectsGlobalScope": false
-      },
       "./node_modules/preact/jsx-runtime/index.d.ts": {
         "version": "-17896129664-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propB?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
         "signature": "-17896129664-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propB?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
+        "affectsGlobalScope": false
+      },
+      "./index.tsx": {
+        "version": "-14760199789-export const App = () => <div propA={true}></div>;",
+        "signature": "-17269688391-export declare const App: () => import(\"react/jsx-runtime\").JSX.Element;\n",
         "affectsGlobalScope": false
       }
     },

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-incremental.js
@@ -1,0 +1,248 @@
+Input::
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+//// [/users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts]
+export namespace JSX {
+    interface Element {}
+    interface IntrinsicElements {
+        div: {
+            propA?: boolean;
+        };
+    }
+}
+export function jsx(...args: any[]): void;
+export function jsxs(...args: any[]): void;
+export const Fragment: unique symbol;
+
+
+//// [/users/username/projects/project/node_modules/react/package.json]
+{"name":"react","version":"0.0.1"}
+
+//// [/users/username/projects/project/node_modules/preact/jsx-runtime/index.d.ts]
+export namespace JSX {
+    interface Element {}
+    interface IntrinsicElements {
+        div: {
+            propB?: boolean;
+        };
+    }
+}
+export function jsx(...args: any[]): void;
+export function jsxs(...args: any[]): void;
+export const Fragment: unique symbol;
+
+
+//// [/users/username/projects/project/node_modules/preact/package.json]
+{"name":"preact","version":"0.0.1"}
+
+//// [/users/username/projects/project/index.tsx]
+export const App = () => <div propA={true}></div>;
+
+//// [/users/username/projects/project/tsconfig.json]
+{"compilerOptions":{"module":"commonjs","jsx":"react-jsx","incremental":true,"jsxImportSource":"react"}}
+
+
+/a/lib/tsc.js -i
+Output::
+
+
+Program root files: ["/users/username/projects/project/index.tsx"]
+Program options: {"module":1,"jsx":4,"incremental":true,"jsxImportSource":"react","configFilePath":"/users/username/projects/project/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/users/username/projects/project/index.tsx
+/users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/users/username/projects/project/index.tsx
+/users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts
+
+WatchedFiles::
+
+FsWatches::
+
+FsWatchesRecursive::
+
+exitCode:: ExitStatus.Success
+
+//// [/users/username/projects/project/index.js]
+"use strict";
+exports.__esModule = true;
+exports.App = void 0;
+var jsx_runtime_1 = require("react/jsx-runtime");
+var App = function () { return jsx_runtime_1.jsx("div", { propA: true }, void 0); };
+exports.App = App;
+
+
+//// [/users/username/projects/project/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../../../a/lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true
+      },
+      "./index.tsx": {
+        "version": "-14760199789-export const App = () => <div propA={true}></div>;",
+        "signature": "-17269688391-export declare const App: () => import(\"react/jsx-runtime\").JSX.Element;\n",
+        "affectsGlobalScope": false
+      },
+      "./node_modules/react/jsx-runtime/index.d.ts": {
+        "version": "-35656056833-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propA?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
+        "signature": "-35656056833-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propA?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "module": 1,
+      "jsx": 4,
+      "incremental": true,
+      "jsxImportSource": "react",
+      "configFilePath": "./tsconfig.json"
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {
+      "./index.tsx": [
+        "./node_modules/react/jsx-runtime/index.d.ts"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../../../a/lib/lib.d.ts",
+      "./index.tsx",
+      "./node_modules/react/jsx-runtime/index.d.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+
+
+Change::
+
+Input::
+//// [/users/username/projects/project/tsconfig.json]
+{"compilerOptions":{"module":"commonjs","jsx":"react-jsx","incremental":true,"jsxImportSource":"preact"}}
+
+
+Output::
+[96mindex.tsx[0m:[93m1[0m:[93m31[0m - [91merror[0m[90m TS2322: [0mType '{ propA: boolean; }' is not assignable to type '{ propB?: boolean; }'.
+  Property 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?
+
+[7m1[0m export const App = () => <div propA={true}></div>;
+[7m [0m [91m                              ~~~~~[0m
+
+
+Found 1 error.
+
+
+
+Program root files: ["/users/username/projects/project/index.tsx"]
+Program options: {"module":1,"jsx":4,"incremental":true,"jsxImportSource":"preact","configFilePath":"/users/username/projects/project/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/users/username/projects/project/index.tsx
+/users/username/projects/project/node_modules/preact/jsx-runtime/index.d.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/users/username/projects/project/index.tsx
+/users/username/projects/project/node_modules/preact/jsx-runtime/index.d.ts
+
+WatchedFiles::
+
+FsWatches::
+
+FsWatchesRecursive::
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+//// [/users/username/projects/project/index.js]
+"use strict";
+exports.__esModule = true;
+exports.App = void 0;
+var jsx_runtime_1 = require("preact/jsx-runtime");
+var App = function () { return jsx_runtime_1.jsx("div", { propA: true }, void 0); };
+exports.App = App;
+
+
+//// [/users/username/projects/project/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../../../a/lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true
+      },
+      "./index.tsx": {
+        "version": "-14760199789-export const App = () => <div propA={true}></div>;",
+        "signature": "-17269688391-export declare const App: () => import(\"react/jsx-runtime\").JSX.Element;\n",
+        "affectsGlobalScope": false
+      },
+      "./node_modules/preact/jsx-runtime/index.d.ts": {
+        "version": "-17896129664-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propB?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
+        "signature": "-17896129664-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propB?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "module": 1,
+      "jsx": 4,
+      "incremental": true,
+      "jsxImportSource": "preact",
+      "configFilePath": "./tsconfig.json"
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {
+      "./index.tsx": [
+        "./node_modules/react/jsx-runtime/index.d.ts"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../../../a/lib/lib.d.ts",
+      [
+        "./index.tsx",
+        [
+          {
+            "file": "./index.tsx",
+            "start": 30,
+            "length": 5,
+            "code": 2322,
+            "category": 1,
+            "messageText": {
+              "messageText": "Type '{ propA: boolean; }' is not assignable to type '{ propB?: boolean; }'.",
+              "category": 1,
+              "code": 2322,
+              "next": [
+                {
+                  "messageText": "Property 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?",
+                  "category": 1,
+                  "code": 2551
+                }
+              ]
+            }
+          }
+        ]
+      ],
+      "./node_modules/preact/jsx-runtime/index.d.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-watch.js
@@ -1,0 +1,285 @@
+Input::
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+//// [/users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts]
+export namespace JSX {
+    interface Element {}
+    interface IntrinsicElements {
+        div: {
+            propA?: boolean;
+        };
+    }
+}
+export function jsx(...args: any[]): void;
+export function jsxs(...args: any[]): void;
+export const Fragment: unique symbol;
+
+
+//// [/users/username/projects/project/node_modules/react/package.json]
+{"name":"react","version":"0.0.1"}
+
+//// [/users/username/projects/project/node_modules/preact/jsx-runtime/index.d.ts]
+export namespace JSX {
+    interface Element {}
+    interface IntrinsicElements {
+        div: {
+            propB?: boolean;
+        };
+    }
+}
+export function jsx(...args: any[]): void;
+export function jsxs(...args: any[]): void;
+export const Fragment: unique symbol;
+
+
+//// [/users/username/projects/project/node_modules/preact/package.json]
+{"name":"preact","version":"0.0.1"}
+
+//// [/users/username/projects/project/index.tsx]
+export const App = () => <div propA={true}></div>;
+
+//// [/users/username/projects/project/tsconfig.json]
+{"compilerOptions":{"module":"commonjs","jsx":"react-jsx","incremental":true,"jsxImportSource":"react"}}
+
+
+/a/lib/tsc.js -w
+Output::
+>> Screen clear
+[[90m12:00:39 AM[0m] Starting compilation in watch mode...
+
+[[90m12:00:44 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/users/username/projects/project/index.tsx"]
+Program options: {"module":1,"jsx":4,"incremental":true,"jsxImportSource":"react","watch":true,"configFilePath":"/users/username/projects/project/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/users/username/projects/project/index.tsx
+/users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/users/username/projects/project/index.tsx
+/users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts
+
+WatchedFiles::
+/users/username/projects/project/tsconfig.json:
+  {"fileName":"/users/username/projects/project/tsconfig.json","pollingInterval":250}
+/users/username/projects/project/index.tsx:
+  {"fileName":"/users/username/projects/project/index.tsx","pollingInterval":250}
+/users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts:
+  {"fileName":"/users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/users/username/projects/project/node_modules:
+  {"directoryName":"/users/username/projects/project/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/users/username/projects/project/node_modules/@types:
+  {"directoryName":"/users/username/projects/project/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/users/username/projects/project:
+  {"directoryName":"/users/username/projects/project","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/users/username/projects/project/index.js]
+"use strict";
+exports.__esModule = true;
+exports.App = void 0;
+var jsx_runtime_1 = require("react/jsx-runtime");
+var App = function () { return jsx_runtime_1.jsx("div", { propA: true }, void 0); };
+exports.App = App;
+
+
+//// [/users/username/projects/project/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../../../a/lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true
+      },
+      "./index.tsx": {
+        "version": "-14760199789-export const App = () => <div propA={true}></div>;",
+        "signature": "-17269688391-export declare const App: () => import(\"react/jsx-runtime\").JSX.Element;\n",
+        "affectsGlobalScope": false
+      },
+      "./node_modules/react/jsx-runtime/index.d.ts": {
+        "version": "-35656056833-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propA?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
+        "signature": "-35656056833-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propA?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "module": 1,
+      "jsx": 4,
+      "incremental": true,
+      "jsxImportSource": "react",
+      "watch": true,
+      "configFilePath": "./tsconfig.json"
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {
+      "./index.tsx": [
+        "./node_modules/react/jsx-runtime/index.d.ts"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../../../a/lib/lib.d.ts",
+      "./index.tsx",
+      "./node_modules/react/jsx-runtime/index.d.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+
+
+Change::
+
+Input::
+//// [/users/username/projects/project/tsconfig.json]
+{"compilerOptions":{"module":"commonjs","jsx":"react-jsx","incremental":true,"jsxImportSource":"preact"}}
+
+
+Output::
+>> Screen clear
+[[90m12:00:48 AM[0m] Starting compilation in watch mode...
+
+[96mindex.tsx[0m:[93m1[0m:[93m31[0m - [91merror[0m[90m TS2322: [0mType '{ propA: boolean; }' is not assignable to type '{ propB?: boolean; }'.
+  Property 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?
+
+[7m1[0m export const App = () => <div propA={true}></div>;
+[7m [0m [91m                              ~~~~~[0m
+
+[[90m12:00:55 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/users/username/projects/project/index.tsx"]
+Program options: {"module":1,"jsx":4,"incremental":true,"jsxImportSource":"preact","watch":true,"configFilePath":"/users/username/projects/project/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/users/username/projects/project/index.tsx
+/users/username/projects/project/node_modules/preact/jsx-runtime/index.d.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/users/username/projects/project/index.tsx
+/users/username/projects/project/node_modules/preact/jsx-runtime/index.d.ts
+
+WatchedFiles::
+/users/username/projects/project/tsconfig.json:
+  {"fileName":"/users/username/projects/project/tsconfig.json","pollingInterval":250}
+/users/username/projects/project/index.tsx:
+  {"fileName":"/users/username/projects/project/index.tsx","pollingInterval":250}
+/users/username/projects/project/node_modules/preact/jsx-runtime/index.d.ts:
+  {"fileName":"/users/username/projects/project/node_modules/preact/jsx-runtime/index.d.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/users/username/projects/project/node_modules:
+  {"directoryName":"/users/username/projects/project/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/users/username/projects/project/node_modules/@types:
+  {"directoryName":"/users/username/projects/project/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/users/username/projects/project:
+  {"directoryName":"/users/username/projects/project","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/users/username/projects/project/index.js]
+"use strict";
+exports.__esModule = true;
+exports.App = void 0;
+var jsx_runtime_1 = require("preact/jsx-runtime");
+var App = function () { return jsx_runtime_1.jsx("div", { propA: true }, void 0); };
+exports.App = App;
+
+
+//// [/users/username/projects/project/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../../../a/lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true
+      },
+      "./index.tsx": {
+        "version": "-14760199789-export const App = () => <div propA={true}></div>;",
+        "signature": "-17269688391-export declare const App: () => import(\"react/jsx-runtime\").JSX.Element;\n",
+        "affectsGlobalScope": false
+      },
+      "./node_modules/preact/jsx-runtime/index.d.ts": {
+        "version": "-17896129664-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propB?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
+        "signature": "-17896129664-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propB?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "module": 1,
+      "jsx": 4,
+      "incremental": true,
+      "jsxImportSource": "preact",
+      "watch": true,
+      "configFilePath": "./tsconfig.json"
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {
+      "./index.tsx": [
+        "./node_modules/react/jsx-runtime/index.d.ts"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../../../a/lib/lib.d.ts",
+      [
+        "./index.tsx",
+        [
+          {
+            "file": "./index.tsx",
+            "start": 30,
+            "length": 5,
+            "code": 2322,
+            "category": 1,
+            "messageText": {
+              "messageText": "Type '{ propA: boolean; }' is not assignable to type '{ propB?: boolean; }'.",
+              "category": 1,
+              "code": 2322,
+              "next": [
+                {
+                  "messageText": "Property 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?",
+                  "category": 1,
+                  "code": 2551
+                }
+              ]
+            }
+          }
+        ]
+      ],
+      "./node_modules/preact/jsx-runtime/index.d.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-watch.js
@@ -69,13 +69,13 @@ Program options: {"module":1,"jsx":4,"incremental":true,"jsxImportSource":"react
 Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
-/users/username/projects/project/index.tsx
 /users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts
+/users/username/projects/project/index.tsx
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts
-/users/username/projects/project/index.tsx
 /users/username/projects/project/node_modules/react/jsx-runtime/index.d.ts
+/users/username/projects/project/index.tsx
 
 WatchedFiles::
 /users/username/projects/project/tsconfig.json:
@@ -117,14 +117,14 @@ exports.App = App;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
-      "./index.tsx": {
-        "version": "-14760199789-export const App = () => <div propA={true}></div>;",
-        "signature": "-17269688391-export declare const App: () => import(\"react/jsx-runtime\").JSX.Element;\n",
-        "affectsGlobalScope": false
-      },
       "./node_modules/react/jsx-runtime/index.d.ts": {
         "version": "-35656056833-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propA?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
         "signature": "-35656056833-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propA?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
+        "affectsGlobalScope": false
+      },
+      "./index.tsx": {
+        "version": "-14760199789-export const App = () => <div propA={true}></div>;",
+        "signature": "-17269688391-export declare const App: () => import(\"react/jsx-runtime\").JSX.Element;\n",
         "affectsGlobalScope": false
       }
     },
@@ -178,13 +178,13 @@ Program options: {"module":1,"jsx":4,"incremental":true,"jsxImportSource":"preac
 Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
-/users/username/projects/project/index.tsx
 /users/username/projects/project/node_modules/preact/jsx-runtime/index.d.ts
+/users/username/projects/project/index.tsx
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts
-/users/username/projects/project/index.tsx
 /users/username/projects/project/node_modules/preact/jsx-runtime/index.d.ts
+/users/username/projects/project/index.tsx
 
 WatchedFiles::
 /users/username/projects/project/tsconfig.json:
@@ -226,14 +226,14 @@ exports.App = App;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
-      "./index.tsx": {
-        "version": "-14760199789-export const App = () => <div propA={true}></div>;",
-        "signature": "-17269688391-export declare const App: () => import(\"react/jsx-runtime\").JSX.Element;\n",
-        "affectsGlobalScope": false
-      },
       "./node_modules/preact/jsx-runtime/index.d.ts": {
         "version": "-17896129664-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propB?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
         "signature": "-17896129664-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propB?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",
+        "affectsGlobalScope": false
+      },
+      "./index.tsx": {
+        "version": "-14760199789-export const App = () => <div propA={true}></div>;",
+        "signature": "-17269688391-export declare const App: () => import(\"react/jsx-runtime\").JSX.Element;\n",
         "affectsGlobalScope": false
       }
     },

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-emit-on-jsx-option-change.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-emit-on-jsx-option-change.js
@@ -80,7 +80,7 @@ Output::
 
 Program root files: ["/user/username/projects/myproject/index.tsx"]
 Program options: {"jsx":2,"watch":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
-Program structureReused: Completely
+Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
 /user/username/projects/myproject/index.tsx
@@ -98,10 +98,10 @@ WatchedFiles::
 FsWatches::
 
 FsWatchesRecursive::
-/user/username/projects/myproject/node_modules/@types:
-  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
 /user/username/projects/myproject:
   {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
 
 exitCode:: ExitStatus.undefined
 

--- a/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespace.tsx
+++ b/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespace.tsx
@@ -1,0 +1,103 @@
+// @strict: true
+// @jsx: react-jsx
+// @jsxImportSource: preact
+// @filename: /node_modules/preact/index.d.ts
+type Defaultize<Props, Defaults> =
+	// Distribute over unions
+	Props extends any // Make any properties included in Default optional
+		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> &
+				// Include the remaining properties from Props
+				Pick<Props, Exclude<keyof Props, keyof Defaults>>
+		: never;
+export namespace JSXInternal {
+    interface HTMLAttributes<T = {}> { }
+    interface SVGAttributes<T = {}> { }
+    type LibraryManagedAttributes<Component, Props> = Component extends {
+        defaultProps: infer Defaults;
+    }
+        ? Defaultize<Props, Defaults>
+        : Props;
+
+    interface IntrinsicAttributes {
+        key?: any;
+    }
+
+    interface Element extends VNode<any> { }
+
+    interface ElementClass extends Component<any, any> { }
+
+    interface ElementAttributesProperty {
+        props: any;
+    }
+
+    interface ElementChildrenAttribute {
+        children: any;
+    }
+
+    interface IntrinsicElements {
+        div: HTMLAttributes;
+    }
+}
+export const Fragment: unique symbol;
+export type ComponentType<T = {}> = {};
+export type ComponentChild = {};
+export type ComponentChildren = {};
+export type VNode<T = {}> = {};
+export type Attributes = {};
+export type Component<T = {}, U = {}> = {};
+// @filename: /node_modules/preact/jsx-runtime/index.d.ts
+export { Fragment } from '..';
+import {
+    ComponentType,
+    ComponentChild,
+    ComponentChildren,
+    VNode,
+    Attributes
+} from '..';
+import { JSXInternal } from '..';
+
+export function jsx(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChild },
+    key?: string
+): VNode<any>;
+export function jsx<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChild },
+    key?: string
+): VNode<any>;
+
+
+export function jsxs(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChild[] },
+    key?: string
+): VNode<any>;
+export function jsxs<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChild[] },
+    key?: string
+): VNode<any>;
+
+
+export function jsxDEV(
+    type: string,
+    props: JSXInternal.HTMLAttributes &
+        JSXInternal.SVGAttributes &
+        Record<string, any> & { children?: ComponentChildren },
+    key?: string
+): VNode<any>;
+export function jsxDEV<P>(
+    type: ComponentType<P>,
+    props: Attributes & P & { children?: ComponentChildren },
+    key?: string
+): VNode<any>;
+
+export import JSX = JSXInternal;
+
+// @filename: /index.tsx
+export const Comp = () => <div></div>;

--- a/tests/lib/react16.d.ts
+++ b/tests/lib/react16.d.ts
@@ -2567,3 +2567,17 @@ declare module "react" {
         }
     }
 }
+
+declare module "react/jsx-runtime" {
+    import * as React from "react";
+    export function jsx(...args: any): React.ReactElement<any>;
+    export function jsxs(...args: any): React.ReactElement<any>;
+    export import Fragment = React.Fragment;
+}
+
+
+declare module "react/jsx-dev-runtime" {
+    import * as React from "react";
+    export function jsxDEV(...args: any): React.ReactElement<any>;
+    export import Fragment = React.Fragment;
+}


### PR DESCRIPTION
Fixes #41118
Fixes #40502

A note on #41118 for @ddprrt - `preact`'s source, in that case, is currently (re)exporting a `JSX` namespace under each factory function (multiple factory functions are used within a compilation). That's not quite what I'm looking for, for local JSX namespaces on implicit jsx runtime imports with this PR - a single top-level `JSX` export, alongside all those factory functions, is instead what I want to find. This should simplify the file a bit, as a single `export {JSXInternal as JSX} from "../../"` should suffice.