### PR TITLE
Fix double alias of complex export/import/default/namespace combination

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2497,10 +2497,7 @@ namespace ts {
 
         function resolveExportByName(moduleSymbol: Symbol, name: __String, sourceNode: TypeOnlyCompatibleAliasDeclaration | undefined, dontResolveAlias: boolean) {
             const exportValue = moduleSymbol.exports!.get(InternalSymbolName.ExportEquals);
-            if (exportValue) {
-                return getPropertyOfType(getTypeOfSymbol(exportValue), name);
-            }
-            const exportSymbol = moduleSymbol.exports!.get(name);
+            const exportSymbol = exportValue ? getPropertyOfType(getTypeOfSymbol(exportValue), name) : moduleSymbol.exports!.get(name);
             const resolved = resolveSymbol(exportSymbol, dontResolveAlias);
             markSymbolOfAliasDeclarationIfTypeOnly(sourceNode, exportSymbol, resolved, /*overwriteEmpty*/ false);
             return resolved;

--- a/tests/baselines/reference/exportAssignmentOfExportNamespaceWithDefault.js
+++ b/tests/baselines/reference/exportAssignmentOfExportNamespaceWithDefault.js
@@ -1,0 +1,31 @@
+//// [tests/cases/conformance/externalModules/exportAssignmentOfExportNamespaceWithDefault.ts] ////
+
+//// [main.ts]
+// https://github.com/microsoft/TypeScript/issues/39149
+import a from "a";
+a();
+
+//// [external.d.ts]
+declare module "b" {
+    export function a(): void;
+    export namespace a {
+        var _a: typeof a;
+        export { _a as default };
+    }
+    export default a;
+}
+
+declare module "a" {
+    import { a } from "b";
+    export = a;
+}
+
+//// [main.js]
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// https://github.com/microsoft/TypeScript/issues/39149
+const a_1 = __importDefault(require("a"));
+a_1.default();

--- a/tests/baselines/reference/exportAssignmentOfExportNamespaceWithDefault.symbols
+++ b/tests/baselines/reference/exportAssignmentOfExportNamespaceWithDefault.symbols
@@ -1,0 +1,39 @@
+=== tests/cases/conformance/externalModules/main.ts ===
+// https://github.com/microsoft/TypeScript/issues/39149
+import a from "a";
+>a : Symbol(a, Decl(main.ts, 1, 6))
+
+a();
+>a : Symbol(a, Decl(main.ts, 1, 6))
+
+=== tests/cases/conformance/externalModules/external.d.ts ===
+declare module "b" {
+>"b" : Symbol("b", Decl(external.d.ts, 0, 0))
+
+    export function a(): void;
+>a : Symbol(a, Decl(external.d.ts, 0, 20), Decl(external.d.ts, 1, 30))
+
+    export namespace a {
+>a : Symbol(a, Decl(external.d.ts, 0, 20), Decl(external.d.ts, 1, 30))
+
+        var _a: typeof a;
+>_a : Symbol(_a, Decl(external.d.ts, 3, 11))
+>a : Symbol(a, Decl(external.d.ts, 0, 20), Decl(external.d.ts, 1, 30))
+
+        export { _a as default };
+>_a : Symbol(_a, Decl(external.d.ts, 3, 11))
+>default : Symbol(default, Decl(external.d.ts, 4, 16))
+    }
+    export default a;
+>a : Symbol(a, Decl(external.d.ts, 0, 20), Decl(external.d.ts, 1, 30))
+}
+
+declare module "a" {
+>"a" : Symbol("a", Decl(external.d.ts, 7, 1))
+
+    import { a } from "b";
+>a : Symbol(a, Decl(external.d.ts, 10, 12))
+
+    export = a;
+>a : Symbol(a, Decl(external.d.ts, 10, 12))
+}

--- a/tests/baselines/reference/exportAssignmentOfExportNamespaceWithDefault.types
+++ b/tests/baselines/reference/exportAssignmentOfExportNamespaceWithDefault.types
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/externalModules/main.ts ===
+// https://github.com/microsoft/TypeScript/issues/39149
+import a from "a";
+>a : typeof import("b").a
+
+a();
+>a() : void
+>a : typeof import("b").a
+
+=== tests/cases/conformance/externalModules/external.d.ts ===
+declare module "b" {
+>"b" : typeof import("b")
+
+    export function a(): void;
+>a : typeof a
+
+    export namespace a {
+>a : typeof a
+
+        var _a: typeof a;
+>_a : typeof a
+>a : typeof a
+
+        export { _a as default };
+>_a : typeof a
+>default : typeof a
+    }
+    export default a;
+>a : typeof a
+}
+
+declare module "a" {
+>"a" : typeof import("a")
+
+    import { a } from "b";
+>a : typeof a
+
+    export = a;
+>a : typeof a
+}

--- a/tests/cases/conformance/externalModules/exportAssignmentOfExportNamespaceWithDefault.ts
+++ b/tests/cases/conformance/externalModules/exportAssignmentOfExportNamespaceWithDefault.ts
@@ -1,0 +1,22 @@
+// @esModuleInterop: true
+// @target: esnext
+// @filename: main.ts
+// @module: commonjs
+// https://github.com/microsoft/TypeScript/issues/39149
+import a from "a";
+a();
+
+// @filename: external.d.ts
+declare module "b" {
+    export function a(): void;
+    export namespace a {
+        var _a: typeof a;
+        export { _a as default };
+    }
+    export default a;
+}
+
+declare module "a" {
+    import { a } from "b";
+    export = a;
+}


### PR DESCRIPTION
Fixes a case where we failed to resolve an aliased symbol when the following combination of features are employed:

1. An exported `namespace` declaration that merges with a function and that has an export named `default`
2. An import of the exported namespace in (1)
3. Exporting (2) using `export=`
4. Importing (3) using a default import while `--esModuleInterop` is set.

This seems to be caused by the fact that we weren't calling `resolveSymbol` for an export resolved from an `export=` symbol in `resolveExportByName`, resulting in a `Symbol` that was an alias to an alias, rather than the actual target.

Fixes #39149
