### PR TITLE
Report implicit any error for 'yield' result with no contextual type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30635,8 +30635,17 @@ namespace ts {
                 return getIterationTypeOfGeneratorFunctionReturnType(IterationTypeKind.Next, returnType, isAsync)
                     || anyType;
             }
-
-            return getContextualIterationType(IterationTypeKind.Next, func) || anyType;
+            let type = getContextualIterationType(IterationTypeKind.Next, func);
+            if (!type) {
+                type = anyType;
+                if (produceDiagnostics && noImplicitAny && !expressionResultIsUnused(node)) {
+                    const contextualType = getContextualType(node);
+                    if (!contextualType || isTypeAny(contextualType)) {
+                        error(node, Diagnostics.yield_expression_implicitly_results_in_an_any_type_because_its_containing_generator_lacks_a_return_type_annotation);
+                    }
+                }
+            }
+            return type;
         }
 
         function checkConditionalExpression(node: ConditionalExpression, checkMode?: CheckMode): Type {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4948,6 +4948,10 @@
         "category": "Error",
         "code": 7056
     },
+    "'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation.": {
+        "category": "Error",
+        "code": 7057
+    },
 
     "You cannot rename this element.": {
         "category": "Error",

--- a/tests/baselines/reference/generatorImplicitAny.errors.txt
+++ b/tests/baselines/reference/generatorImplicitAny.errors.txt
@@ -1,0 +1,40 @@
+tests/cases/conformance/generators/generatorImplicitAny.ts(8,19): error TS7057: 'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation.
+tests/cases/conformance/generators/generatorImplicitAny.ts(26,7): error TS7057: 'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation.
+
+
+==== tests/cases/conformance/generators/generatorImplicitAny.ts (2 errors) ====
+    function* g() {}
+    
+    // https://github.com/microsoft/TypeScript/issues/35105
+    declare function noop(): void;
+    declare function f<T>(value: T): void;
+    
+    function* g2() {
+        const value = yield; // error: implicit any
+                      ~~~~~
+!!! error TS7057: 'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation.
+    }
+    
+    function* g3() {
+        const value: string = yield; // ok, contextually typed by `value`.
+    }
+    
+    function* g4() {
+        yield; // ok, result is unused
+        yield, noop(); // ok, result is unused
+        noop(), yield, noop(); // ok, result is unused
+        (yield); // ok, result is unused
+        (yield, noop()), noop(); // ok, result is unused
+        for(yield; false; yield); // ok, results are unused
+        void (yield); // ok, results are unused
+    }
+    
+    function* g5() {
+        f(yield); // error: implicit any
+          ~~~~~
+!!! error TS7057: 'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation.
+    }
+    
+    function* g6() {
+        f<string>(yield); // ok, contextually typed by f<string>
+    }

--- a/tests/baselines/reference/generatorImplicitAny.js
+++ b/tests/baselines/reference/generatorImplicitAny.js
@@ -1,5 +1,57 @@
 //// [generatorImplicitAny.ts]
 function* g() {}
 
+// https://github.com/microsoft/TypeScript/issues/35105
+declare function noop(): void;
+declare function f<T>(value: T): void;
+
+function* g2() {
+    const value = yield; // error: implicit any
+}
+
+function* g3() {
+    const value: string = yield; // ok, contextually typed by `value`.
+}
+
+function* g4() {
+    yield; // ok, result is unused
+    yield, noop(); // ok, result is unused
+    noop(), yield, noop(); // ok, result is unused
+    (yield); // ok, result is unused
+    (yield, noop()), noop(); // ok, result is unused
+    for(yield; false; yield); // ok, results are unused
+    void (yield); // ok, results are unused
+}
+
+function* g5() {
+    f(yield); // error: implicit any
+}
+
+function* g6() {
+    f<string>(yield); // ok, contextually typed by f<string>
+}
+
 //// [generatorImplicitAny.js]
 function* g() { }
+function* g2() {
+    const value = yield; // error: implicit any
+}
+function* g3() {
+    const value = yield; // ok, contextually typed by `value`.
+}
+function* g4() {
+    yield; // ok, result is unused
+    yield, noop(); // ok, result is unused
+    noop(), yield, noop(); // ok, result is unused
+    (yield); // ok, result is unused
+    (yield, noop()), noop(); // ok, result is unused
+    for (yield; false; yield)
+        ; // ok, results are unused
+    void (yield); // ok, results are unused
+}
+function* g5() {
+    f(yield); // error: implicit any
+}
+function* g6() {
+    f(yield); // ok, contextually typed by f<string>
+}

--- a/tests/baselines/reference/generatorImplicitAny.symbols
+++ b/tests/baselines/reference/generatorImplicitAny.symbols
@@ -2,3 +2,60 @@
 function* g() {}
 >g : Symbol(g, Decl(generatorImplicitAny.ts, 0, 0))
 
+// https://github.com/microsoft/TypeScript/issues/35105
+declare function noop(): void;
+>noop : Symbol(noop, Decl(generatorImplicitAny.ts, 0, 16))
+
+declare function f<T>(value: T): void;
+>f : Symbol(f, Decl(generatorImplicitAny.ts, 3, 30))
+>T : Symbol(T, Decl(generatorImplicitAny.ts, 4, 19))
+>value : Symbol(value, Decl(generatorImplicitAny.ts, 4, 22))
+>T : Symbol(T, Decl(generatorImplicitAny.ts, 4, 19))
+
+function* g2() {
+>g2 : Symbol(g2, Decl(generatorImplicitAny.ts, 4, 38))
+
+    const value = yield; // error: implicit any
+>value : Symbol(value, Decl(generatorImplicitAny.ts, 7, 9))
+}
+
+function* g3() {
+>g3 : Symbol(g3, Decl(generatorImplicitAny.ts, 8, 1))
+
+    const value: string = yield; // ok, contextually typed by `value`.
+>value : Symbol(value, Decl(generatorImplicitAny.ts, 11, 9))
+}
+
+function* g4() {
+>g4 : Symbol(g4, Decl(generatorImplicitAny.ts, 12, 1))
+
+    yield; // ok, result is unused
+    yield, noop(); // ok, result is unused
+>noop : Symbol(noop, Decl(generatorImplicitAny.ts, 0, 16))
+
+    noop(), yield, noop(); // ok, result is unused
+>noop : Symbol(noop, Decl(generatorImplicitAny.ts, 0, 16))
+>noop : Symbol(noop, Decl(generatorImplicitAny.ts, 0, 16))
+
+    (yield); // ok, result is unused
+    (yield, noop()), noop(); // ok, result is unused
+>noop : Symbol(noop, Decl(generatorImplicitAny.ts, 0, 16))
+>noop : Symbol(noop, Decl(generatorImplicitAny.ts, 0, 16))
+
+    for(yield; false; yield); // ok, results are unused
+    void (yield); // ok, results are unused
+}
+
+function* g5() {
+>g5 : Symbol(g5, Decl(generatorImplicitAny.ts, 22, 1))
+
+    f(yield); // error: implicit any
+>f : Symbol(f, Decl(generatorImplicitAny.ts, 3, 30))
+}
+
+function* g6() {
+>g6 : Symbol(g6, Decl(generatorImplicitAny.ts, 26, 1))
+
+    f<string>(yield); // ok, contextually typed by f<string>
+>f : Symbol(f, Decl(generatorImplicitAny.ts, 3, 30))
+}

--- a/tests/baselines/reference/generatorImplicitAny.types
+++ b/tests/baselines/reference/generatorImplicitAny.types
@@ -2,3 +2,90 @@
 function* g() {}
 >g : () => Generator<never, void, unknown>
 
+// https://github.com/microsoft/TypeScript/issues/35105
+declare function noop(): void;
+>noop : () => void
+
+declare function f<T>(value: T): void;
+>f : <T>(value: T) => void
+>value : T
+
+function* g2() {
+>g2 : () => Generator<undefined, void, unknown>
+
+    const value = yield; // error: implicit any
+>value : any
+>yield : any
+}
+
+function* g3() {
+>g3 : () => Generator<undefined, void, string>
+
+    const value: string = yield; // ok, contextually typed by `value`.
+>value : string
+>yield : any
+}
+
+function* g4() {
+>g4 : () => Generator<undefined, void, unknown>
+
+    yield; // ok, result is unused
+>yield : any
+
+    yield, noop(); // ok, result is unused
+>yield, noop() : void
+>yield : any
+>noop() : void
+>noop : () => void
+
+    noop(), yield, noop(); // ok, result is unused
+>noop(), yield, noop() : void
+>noop(), yield : any
+>noop() : void
+>noop : () => void
+>yield : any
+>noop() : void
+>noop : () => void
+
+    (yield); // ok, result is unused
+>(yield) : any
+>yield : any
+
+    (yield, noop()), noop(); // ok, result is unused
+>(yield, noop()), noop() : void
+>(yield, noop()) : void
+>yield, noop() : void
+>yield : any
+>noop() : void
+>noop : () => void
+>noop() : void
+>noop : () => void
+
+    for(yield; false; yield); // ok, results are unused
+>yield : any
+>false : false
+>yield : any
+
+    void (yield); // ok, results are unused
+>void (yield) : undefined
+>(yield) : any
+>yield : any
+}
+
+function* g5() {
+>g5 : () => Generator<undefined, void, any>
+
+    f(yield); // error: implicit any
+>f(yield) : void
+>f : <T>(value: T) => void
+>yield : any
+}
+
+function* g6() {
+>g6 : () => Generator<undefined, void, string>
+
+    f<string>(yield); // ok, contextually typed by f<string>
+>f<string>(yield) : void
+>f : <T>(value: T) => void
+>yield : any
+}

--- a/tests/baselines/reference/generatorReturnTypeInference.errors.txt
+++ b/tests/baselines/reference/generatorReturnTypeInference.errors.txt
@@ -1,13 +1,7 @@
-tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts(9,11): error TS7055: 'g001', which lacks return-type annotation, implicitly has an 'any' yield type.
-tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts(17,11): error TS7055: 'g003', which lacks return-type annotation, implicitly has an 'any' yield type.
-tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts(74,15): error TS7057: 'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation.
-tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts(79,11): error TS7055: 'g301', which lacks return-type annotation, implicitly has an 'any' yield type.
-tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts(89,11): error TS7055: 'g303', which lacks return-type annotation, implicitly has an 'any' yield type.
-tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts(126,11): error TS7055: 'g310', which lacks return-type annotation, implicitly has an 'any' yield type.
-tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts(131,10): error TS7025: Generator implicitly has yield type 'any' because it does not yield any values. Consider supplying a return type annotation.
+tests/cases/conformance/generators/generatorReturnTypeInference.ts(72,15): error TS7057: 'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation.
 
 
-==== tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts (7 errors) ====
+==== tests/cases/conformance/generators/generatorReturnTypeInference.ts (1 errors) ====
     declare const iterableIterator: IterableIterator<number>;
     declare const generator: Generator<number, string, boolean>;
     declare const never: never;
@@ -16,9 +10,7 @@ tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts(131,
     }
     
     // 'yield' iteration type inference
-    function* g001() { // Generator<any (implicit), void, unknown>
-              ~~~~
-!!! error TS7055: 'g001', which lacks return-type annotation, implicitly has an 'any' yield type.
+    function* g001() { // Generator<undefined, void, unknown>
         yield;
     }
     
@@ -26,11 +18,7 @@ tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts(131,
         yield 1;
     }
     
-    function* g003() { // Generator<any (implicit), void, unknown>
-              ~~~~
-!!! error TS7055: 'g003', which lacks return-type annotation, implicitly has an 'any' yield type.
-        // NOTE: In strict mode, `[]` produces the type `never[]`.
-        //       In non-strict mode, `[]` produces the type `undefined[]` which is implicitly any.
+    function* g003() { // Generator<never, void, undefined>
         yield* [];
     }
     
@@ -92,9 +80,7 @@ tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts(131,
     
     // mixed iteration types inference
     
-    function* g301() { // Generator<any (implicit), void, unknown>
-              ~~~~
-!!! error TS7055: 'g301', which lacks return-type annotation, implicitly has an 'any' yield type.
+    function* g301() { // Generator<undefined, void, unknown>
         yield;
         return;
     }
@@ -104,9 +90,7 @@ tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts(131,
         return;
     }
     
-    function* g303() { // Generator<any (implicit), string, unknown>
-              ~~~~
-!!! error TS7055: 'g303', which lacks return-type annotation, implicitly has an 'any' yield type.
+    function* g303() { // Generator<undefined, string, unknown>
         yield;
         return "a";
     }
@@ -143,16 +127,12 @@ tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts(131,
         return y;
     }
     
-    function* g310() { // Generator<any (implicit), void, [(1 | undefined)?, (2 | undefined)?]>
-              ~~~~
-!!! error TS7055: 'g310', which lacks return-type annotation, implicitly has an 'any' yield type.
+    function* g310() { // Generator<undefined, void, [(1 | undefined)?, (2 | undefined)?]>
     	const [a = 1, b = 2] = yield;
     }
     
-    function* g311() { // Generator<any (implicit), void, string>
+    function* g311() { // Generator<undefined, void, string>
     	yield* (function*() {
-    	        ~~~~~~~~
-!!! error TS7025: Generator implicitly has yield type 'any' because it does not yield any values. Consider supplying a return type annotation.
     		const y: string = yield;
     	})();
     }

--- a/tests/baselines/reference/generatorTypeCheck50.errors.txt
+++ b/tests/baselines/reference/generatorTypeCheck50.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck50.ts(2,11): error TS7057: 'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation.
+
+
+==== tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck50.ts (1 errors) ====
+    function* g() {
+        yield yield;
+              ~~~~~
+!!! error TS7057: 'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation.
+    }

--- a/tests/baselines/reference/yieldExpressionInControlFlow.errors.txt
+++ b/tests/baselines/reference/yieldExpressionInControlFlow.errors.txt
@@ -1,12 +1,15 @@
 tests/cases/conformance/es6/yieldExpressions/alsoFails.ts(3,9): error TS7034: Variable 'o' implicitly has type 'any[]' in some locations where its type cannot be determined.
 tests/cases/conformance/es6/yieldExpressions/alsoFails.ts(5,20): error TS7005: Variable 'o' implicitly has an 'any[]' type.
+tests/cases/conformance/es6/yieldExpressions/bug25149.js(4,13): error TS7057: 'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation.
 
 
-==== tests/cases/conformance/es6/yieldExpressions/bug25149.js (0 errors) ====
+==== tests/cases/conformance/es6/yieldExpressions/bug25149.js (1 errors) ====
     function* f() {
         var o
         while (true) {
             o = yield o
+                ~~~~~~~
+!!! error TS7057: 'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation.
         }
     }
     

--- a/tests/baselines/reference/yieldExpressionInFlowLoop.errors.txt
+++ b/tests/baselines/reference/yieldExpressionInFlowLoop.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/yieldExpressionInFlowLoop.ts(4,18): error TS7057: 'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation.
+
+
+==== tests/cases/compiler/yieldExpressionInFlowLoop.ts (1 errors) ====
+    function* f() {
+        let result;
+        while (1) {
+            result = yield result;
+                     ~~~~~~~~~~~~
+!!! error TS7057: 'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation.
+        }
+    }
+    

--- a/tests/cases/conformance/generators/generatorImplicitAny.ts
+++ b/tests/cases/conformance/generators/generatorImplicitAny.ts
@@ -4,3 +4,33 @@
 // @noImplicitAny: true
 
 function* g() {}
+
+// https://github.com/microsoft/TypeScript/issues/35105
+declare function noop(): void;
+declare function f<T>(value: T): void;
+
+function* g2() {
+    const value = yield; // error: implicit any
+}
+
+function* g3() {
+    const value: string = yield; // ok, contextually typed by `value`.
+}
+
+function* g4() {
+    yield; // ok, result is unused
+    yield, noop(); // ok, result is unused
+    noop(), yield, noop(); // ok, result is unused
+    (yield); // ok, result is unused
+    (yield, noop()), noop(); // ok, result is unused
+    for(yield; false; yield); // ok, results are unused
+    void (yield); // ok, results are unused
+}
+
+function* g5() {
+    f(yield); // error: implicit any
+}
+
+function* g6() {
+    f<string>(yield); // ok, contextually typed by f<string>
+}


### PR DESCRIPTION
Adds an "implicit any" error when the result of a `yield` expression is used and that expression is untyped. For example:

```ts
function* g1() {
  const value = yield 1; // report implicit any error
}
function* g2() {
  yield 1; // result is unused, no error
}
function* g3() {
  const value: string = yield 1; // result is contextually typed by type annotation of `value`, no error.
}
function* g3(): Generator<number, void, string> {
  const value = yield 1; // result is contextually typed by return-type annotation of `g3`, no error.
}
```

Fixes #35105
