### PR TITLE
fix(37539): Parameter not renamed in JSDoc if it's inside non-prototype-based JS class

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2547,7 +2547,7 @@ namespace ts {
         return result || emptyArray;
     }
 
-    function getNextJSDocCommentLocation(node: Node) {
+    export function getNextJSDocCommentLocation(node: Node) {
         const parent = node.parent;
         if (parent.kind === SyntaxKind.PropertyAssignment ||
             parent.kind === SyntaxKind.ExportAssignment ||

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1206,8 +1206,13 @@ namespace ts.FindAllReferences {
                     return undefined;
                 }
 
-                // The search scope is the container node
                 scope = container;
+                if (isFunctionExpression(scope)) {
+                    let next: Node | undefined;
+                    while (next = getNextJSDocCommentLocation(scope)) {
+                        scope = next;
+                    }
+                }
             }
 
             // If symbol.parent, this means we are in an export of an external module. (Otherwise we would have returned `undefined` above.)

--- a/tests/baselines/reference/renameFunctionParameter1.baseline
+++ b/tests/baselines/reference/renameFunctionParameter1.baseline
@@ -1,0 +1,10 @@
+/*====== /tests/cases/fourslash/renameFunctionParameter1.ts ======*/
+
+function Foo() {
+    /**
+     * @param {number} RENAME
+     */
+    this.foo = function foo([|RENAME|]) {
+        return RENAME;
+    }
+}

--- a/tests/baselines/reference/renameFunctionParameter2.baseline
+++ b/tests/baselines/reference/renameFunctionParameter2.baseline
@@ -1,0 +1,8 @@
+/*====== /tests/cases/fourslash/renameFunctionParameter2.ts ======*/
+
+/**
+ * @param {number} RENAME
+ */
+const foo = function foo([|RENAME|]) {
+    return RENAME;
+}

--- a/tests/cases/fourslash/renameFunctionParameter1.ts
+++ b/tests/cases/fourslash/renameFunctionParameter1.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts" />
+
+////function Foo() {
+////    /**
+////     * @param {number} p
+////     */
+////    this.foo = function foo(p/**/) {
+////        return p;
+////    }
+////}
+
+verify.baselineRename("", {});

--- a/tests/cases/fourslash/renameFunctionParameter2.ts
+++ b/tests/cases/fourslash/renameFunctionParameter2.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts" />
+
+/////**
+//// * @param {number} p
+//// */
+////const foo = function foo(p/**/) {
+////    return p;
+////}
+
+verify.baselineRename("", {});


### PR DESCRIPTION
Fixes #37539