### PR TITLE
Add tracing support to tsserver

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10973,7 +10973,7 @@ namespace ts {
                         // very high likelihood we're dealing with an infinite generic type that perpetually generates
                         // new type identities as we descend into it. We stop the recursion here and mark this type
                         // and the outer types as having circular constraints.
-                        tracing.instant(tracing.Phase.Check, "getImmediateBaseConstraint_DepthLimit", { typeId: t.id, originalTypeId: type.id, depth: constraintDepth });
+                        tracing.instant(tracing.Phase.CheckTypes, "getImmediateBaseConstraint_DepthLimit", { typeId: t.id, originalTypeId: type.id, depth: constraintDepth });
                         error(currentNode, Diagnostics.Type_instantiation_is_excessively_deep_and_possibly_infinite);
                         nonTerminating = true;
                         return t.immediateBaseConstraint = noConstraintType;
@@ -13083,7 +13083,7 @@ namespace ts {
                             // caps union types at 5000 unique literal types and 1000 unique object types.
                             const estimatedCount = (count / (len - i)) * len;
                             if (estimatedCount > (primitivesOnly ? 25000000 : 1000000)) {
-                                tracing.instant(tracing.Phase.Check, "removeSubtypes_DepthLimit", { typeIds: types.map(t => t.id) });
+                                tracing.instant(tracing.Phase.CheckTypes, "removeSubtypes_DepthLimit", { typeIds: types.map(t => t.id) });
                                 error(currentNode, Diagnostics.Expression_produces_a_union_type_that_is_too_complex_to_represent);
                                 return false;
                             }
@@ -13505,7 +13505,7 @@ namespace ts {
         function checkCrossProductUnion(types: readonly Type[]) {
             const size = reduceLeft(types, (n, t) => n * (t.flags & TypeFlags.Union ? (<UnionType>t).types.length : t.flags & TypeFlags.Never ? 0 : 1), 1);
             if (size >= 100000) {
-                tracing.instant(tracing.Phase.Check, "checkCrossProductUnion_DepthLimit", { typeIds: types.map(t => t.id), size });
+                tracing.instant(tracing.Phase.CheckTypes, "checkCrossProductUnion_DepthLimit", { typeIds: types.map(t => t.id), size });
                 error(currentNode, Diagnostics.Expression_produces_a_union_type_that_is_too_complex_to_represent);
                 return false;
             }
@@ -15381,7 +15381,7 @@ namespace ts {
                 // We have reached 50 recursive type instantiations and there is a very high likelyhood we're dealing
                 // with a combination of infinite generic types that perpetually generate new type identities. We stop
                 // the recursion here by yielding the error type.
-                tracing.instant(tracing.Phase.Check, "instantiateType_DepthLimit", { typeId: type.id, instantiationDepth, instantiationCount });
+                tracing.instant(tracing.Phase.CheckTypes, "instantiateType_DepthLimit", { typeId: type.id, instantiationDepth, instantiationCount });
                 error(currentNode, Diagnostics.Type_instantiation_is_excessively_deep_and_possibly_infinite);
                 return errorType;
             }
@@ -16504,7 +16504,7 @@ namespace ts {
                 reportIncompatibleStack();
             }
             if (overflow) {
-                tracing.instant(tracing.Phase.Check, "checkTypeRelatedTo_DepthLimit", { sourceId: source.id, targetId: target.id, depth });
+                tracing.instant(tracing.Phase.CheckTypes, "checkTypeRelatedTo_DepthLimit", { sourceId: source.id, targetId: target.id, depth });
                 const diag = error(errorNode || currentNode, Diagnostics.Excessive_stack_depth_comparing_types_0_and_1, typeToString(source), typeToString(target));
                 if (errorOutputContainer) {
                     (errorOutputContainer.errors || (errorOutputContainer.errors = [])).push(diag);
@@ -17327,7 +17327,7 @@ namespace ts {
                 }
 
                 if (expandingFlags === ExpandingFlags.Both) {
-                    tracing.instant(tracing.Phase.Check, "recursiveTypeRelatedTo_DepthLimit", {
+                    tracing.instant(tracing.Phase.CheckTypes, "recursiveTypeRelatedTo_DepthLimit", {
                         sourceId: source.id,
                         sourceIdStack: sourceStack.map(t => t.id),
                         targetId: target.id,
@@ -17364,10 +17364,13 @@ namespace ts {
             }
 
             function structuredTypeRelatedTo(source: Type, target: Type, reportErrors: boolean, intersectionState: IntersectionState): Ternary {
-                tracing.push(tracing.Phase.Check, "structuredTypeRelatedTo", { sourceId: source.id, targetId: target.id });
-                const result = structuredTypeRelatedToWorker(source, target, reportErrors, intersectionState);
-                tracing.pop();
-                return result;
+                tracing.push(tracing.Phase.CheckTypes, "structuredTypeRelatedTo", { sourceId: source.id, targetId: target.id });
+                try {
+                    return structuredTypeRelatedToWorker(source, target, reportErrors, intersectionState);
+                }
+                finally {
+                    tracing.pop();
+                }
             }
 
             function structuredTypeRelatedToWorker(source: Type, target: Type, reportErrors: boolean, intersectionState: IntersectionState): Ternary {
@@ -17860,7 +17863,7 @@ namespace ts {
                     numCombinations *= countTypes(getTypeOfSymbol(sourceProperty));
                     if (numCombinations > 25) {
                         // We've reached the complexity limit.
-                        tracing.instant(tracing.Phase.Check, "typeRelatedToDiscriminatedType_DepthLimit", { sourceId: source.id, targetId: target.id, numCombinations });
+                        tracing.instant(tracing.Phase.CheckTypes, "typeRelatedToDiscriminatedType_DepthLimit", { sourceId: source.id, targetId: target.id, numCombinations });
                         return Ternary.False;
                     }
                 }
@@ -18621,42 +18624,46 @@ namespace ts {
         function getVariancesWorker<TCache extends { variances?: VarianceFlags[] }>(typeParameters: readonly TypeParameter[] = emptyArray, cache: TCache, createMarkerType: (input: TCache, param: TypeParameter, marker: Type) => Type): VarianceFlags[] {
             let variances = cache.variances;
             if (!variances) {
-                tracing.push(tracing.Phase.Check, "getVariancesWorker", { arity: typeParameters.length, id: (cache as any).id ?? (cache as any).declaredType?.id ?? -1 });
-                // The emptyArray singleton is used to signal a recursive invocation.
-                cache.variances = emptyArray;
-                variances = [];
-                for (const tp of typeParameters) {
-                    let unmeasurable = false;
-                    let unreliable = false;
-                    const oldHandler = outofbandVarianceMarkerHandler;
-                    outofbandVarianceMarkerHandler = (onlyUnreliable) => onlyUnreliable ? unreliable = true : unmeasurable = true;
-                    // We first compare instantiations where the type parameter is replaced with
-                    // marker types that have a known subtype relationship. From this we can infer
-                    // invariance, covariance, contravariance or bivariance.
-                    const typeWithSuper = createMarkerType(cache, tp, markerSuperType);
-                    const typeWithSub = createMarkerType(cache, tp, markerSubType);
-                    let variance = (isTypeAssignableTo(typeWithSub, typeWithSuper) ? VarianceFlags.Covariant : 0) |
-                        (isTypeAssignableTo(typeWithSuper, typeWithSub) ? VarianceFlags.Contravariant : 0);
-                    // If the instantiations appear to be related bivariantly it may be because the
-                    // type parameter is independent (i.e. it isn't witnessed anywhere in the generic
-                    // type). To determine this we compare instantiations where the type parameter is
-                    // replaced with marker types that are known to be unrelated.
-                    if (variance === VarianceFlags.Bivariant && isTypeAssignableTo(createMarkerType(cache, tp, markerOtherType), typeWithSuper)) {
-                        variance = VarianceFlags.Independent;
-                    }
-                    outofbandVarianceMarkerHandler = oldHandler;
-                    if (unmeasurable || unreliable) {
-                        if (unmeasurable) {
-                            variance |= VarianceFlags.Unmeasurable;
+                tracing.push(tracing.Phase.CheckTypes, "getVariancesWorker", { arity: typeParameters.length, id: (cache as any).id ?? (cache as any).declaredType?.id ?? -1 });
+                try {
+                    // The emptyArray singleton is used to signal a recursive invocation.
+                    cache.variances = emptyArray;
+                    variances = [];
+                    for (const tp of typeParameters) {
+                        let unmeasurable = false;
+                        let unreliable = false;
+                        const oldHandler = outofbandVarianceMarkerHandler;
+                        outofbandVarianceMarkerHandler = (onlyUnreliable) => onlyUnreliable ? unreliable = true : unmeasurable = true;
+                        // We first compare instantiations where the type parameter is replaced with
+                        // marker types that have a known subtype relationship. From this we can infer
+                        // invariance, covariance, contravariance or bivariance.
+                        const typeWithSuper = createMarkerType(cache, tp, markerSuperType);
+                        const typeWithSub = createMarkerType(cache, tp, markerSubType);
+                        let variance = (isTypeAssignableTo(typeWithSub, typeWithSuper) ? VarianceFlags.Covariant : 0) |
+                            (isTypeAssignableTo(typeWithSuper, typeWithSub) ? VarianceFlags.Contravariant : 0);
+                        // If the instantiations appear to be related bivariantly it may be because the
+                        // type parameter is independent (i.e. it isn't witnessed anywhere in the generic
+                        // type). To determine this we compare instantiations where the type parameter is
+                        // replaced with marker types that are known to be unrelated.
+                        if (variance === VarianceFlags.Bivariant && isTypeAssignableTo(createMarkerType(cache, tp, markerOtherType), typeWithSuper)) {
+                            variance = VarianceFlags.Independent;
                         }
-                        if (unreliable) {
-                            variance |= VarianceFlags.Unreliable;
+                        outofbandVarianceMarkerHandler = oldHandler;
+                        if (unmeasurable || unreliable) {
+                            if (unmeasurable) {
+                                variance |= VarianceFlags.Unmeasurable;
+                            }
+                            if (unreliable) {
+                                variance |= VarianceFlags.Unreliable;
+                            }
                         }
+                        variances.push(variance);
                     }
-                    variances.push(variance);
+                    cache.variances = variances;
                 }
-                cache.variances = variances;
-                tracing.pop();
+                finally {
+                    tracing.pop();
+                }
             }
             return variances;
         }
@@ -21719,7 +21726,7 @@ namespace ts {
                 if (flowDepth === 2000) {
                     // We have made 2000 recursive invocations. To avoid overflowing the call stack we report an error
                     // and disable further control flow analysis in the containing function or module body.
-                    tracing.instant(tracing.Phase.Check, "getTypeAtFlowNode_DepthLimit", { flowId: flow.id });
+                    tracing.instant(tracing.Phase.CheckTypes, "getTypeAtFlowNode_DepthLimit", { flowId: flow.id });
                     flowAnalysisDisabled = true;
                     reportFlowControlError(reference);
                     return errorType;
@@ -31110,17 +31117,21 @@ namespace ts {
 
         function checkExpression(node: Expression | QualifiedName, checkMode?: CheckMode, forceTuple?: boolean): Type {
             tracing.push(tracing.Phase.Check, "checkExpression", { kind: node.kind, pos: node.pos, end: node.end });
-            const saveCurrentNode = currentNode;
-            currentNode = node;
-            instantiationCount = 0;
-            const uninstantiatedType = checkExpressionWorker(node, checkMode, forceTuple);
-            const type = instantiateTypeWithSingleGenericCallSignature(node, uninstantiatedType, checkMode);
-            if (isConstEnumObjectType(type)) {
-                checkConstEnumAccess(node, type);
+            try {
+                const saveCurrentNode = currentNode;
+                currentNode = node;
+                instantiationCount = 0;
+                const uninstantiatedType = checkExpressionWorker(node, checkMode, forceTuple);
+                const type = instantiateTypeWithSingleGenericCallSignature(node, uninstantiatedType, checkMode);
+                if (isConstEnumObjectType(type)) {
+                    checkConstEnumAccess(node, type);
+                }
+                currentNode = saveCurrentNode;
+                return type;
             }
-            currentNode = saveCurrentNode;
-            tracing.pop();
-            return type;
+            finally {
+                tracing.pop();
+            }
         }
 
         function checkConstEnumAccess(node: Expression | QualifiedName, type: Type) {
@@ -33912,9 +33923,13 @@ namespace ts {
 
         function checkVariableDeclaration(node: VariableDeclaration) {
             tracing.push(tracing.Phase.Check, "checkVariableDeclaration", { kind: node.kind, pos: node.pos, end: node.end });
-            checkGrammarVariableDeclaration(node);
-            checkVariableLikeDeclaration(node);
-            tracing.pop();
+            try {
+                checkGrammarVariableDeclaration(node);
+                checkVariableLikeDeclaration(node);
+            }
+            finally {
+                tracing.pop();
+            }
         }
 
         function checkBindingElement(node: BindingElement) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17366,7 +17366,7 @@ namespace ts {
             function structuredTypeRelatedTo(source: Type, target: Type, reportErrors: boolean, intersectionState: IntersectionState): Ternary {
                 tracing.push(tracing.Phase.CheckTypes, "structuredTypeRelatedTo", { sourceId: source.id, targetId: target.id });
                 const result = structuredTypeRelatedToWorker(source, target, reportErrors, intersectionState);
-                tracing.pop(); // If we start reporting this event on the server, this will need to be wrapped in a finally block
+                tracing.pop();
                 return result;
             }
 
@@ -18656,7 +18656,7 @@ namespace ts {
                     variances.push(variance);
                 }
                 cache.variances = variances;
-                tracing.pop(); // If we start reporting this event on the server, this will need to be wrapped in a finally block
+                tracing.pop();
             }
             return variances;
         }
@@ -31110,21 +31110,17 @@ namespace ts {
 
         function checkExpression(node: Expression | QualifiedName, checkMode?: CheckMode, forceTuple?: boolean): Type {
             tracing.push(tracing.Phase.Check, "checkExpression", { kind: node.kind, pos: node.pos, end: node.end });
-            try {
-                const saveCurrentNode = currentNode;
-                currentNode = node;
-                instantiationCount = 0;
-                const uninstantiatedType = checkExpressionWorker(node, checkMode, forceTuple);
-                const type = instantiateTypeWithSingleGenericCallSignature(node, uninstantiatedType, checkMode);
-                if (isConstEnumObjectType(type)) {
-                    checkConstEnumAccess(node, type);
-                }
-                currentNode = saveCurrentNode;
-                return type;
+            const saveCurrentNode = currentNode;
+            currentNode = node;
+            instantiationCount = 0;
+            const uninstantiatedType = checkExpressionWorker(node, checkMode, forceTuple);
+            const type = instantiateTypeWithSingleGenericCallSignature(node, uninstantiatedType, checkMode);
+            if (isConstEnumObjectType(type)) {
+                checkConstEnumAccess(node, type);
             }
-            finally {
-                tracing.pop();
-            }
+            currentNode = saveCurrentNode;
+            tracing.pop();
+            return type;
         }
 
         function checkConstEnumAccess(node: Expression | QualifiedName, type: Type) {
@@ -33916,13 +33912,9 @@ namespace ts {
 
         function checkVariableDeclaration(node: VariableDeclaration) {
             tracing.push(tracing.Phase.Check, "checkVariableDeclaration", { kind: node.kind, pos: node.pos, end: node.end });
-            try {
-                checkGrammarVariableDeclaration(node);
-                checkVariableLikeDeclaration(node);
-            }
-            finally {
-                tracing.pop();
-            }
+            checkGrammarVariableDeclaration(node);
+            checkVariableLikeDeclaration(node);
+            tracing.pop();
         }
 
         function checkBindingElement(node: BindingElement) {

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -699,9 +699,15 @@ namespace ts {
         if (!program) return false;
         // If any compiler options change, we can't reuse old source file even if version match
         // The change in options like these could result in change in syntax tree or `sourceFile.bindDiagnostics`.
-        const oldOptions = program.getCompilerOptions();
-        return !!sourceFileAffectingCompilerOptions.some(option =>
-            !isJsonEqual(getCompilerOptionValue(oldOptions, option), getCompilerOptionValue(newOptions, option)));
+        tracing.push(tracing.Phase.Program, "shouldProgramCreateNewSourceFiles", { hasOldProgram: !!program });
+        try {
+            const oldOptions = program.getCompilerOptions();
+            return !!sourceFileAffectingCompilerOptions.some(option =>
+                !isJsonEqual(getCompilerOptionValue(oldOptions, option), getCompilerOptionValue(newOptions, option)));
+        }
+        finally {
+            tracing.pop();
+        }
     }
 
     function createCreateProgramOptions(rootNames: readonly string[], options: CompilerOptions, host?: CompilerHost, oldProgram?: Program, configFileParsingDiagnostics?: readonly Diagnostic[]): CreateProgramOptions {
@@ -780,7 +786,7 @@ namespace ts {
         // Track source files that are source files found by searching under node_modules, as these shouldn't be compiled.
         const sourceFilesFoundSearchingNodeModules = new Map<string, boolean>();
 
-        tracing.push(tracing.Phase.Program, "createProgram", {}, /*separateBeginAndEnd*/ true);
+        tracing.push(tracing.Phase.Program, "createProgram", { configFilePath: options.configFilePath, rootDir: options.rootDir }, /*separateBeginAndEnd*/ true);
         performance.mark("beforeProgram");
 
         const host = createProgramOptions.host || createCompilerHost(options);
@@ -866,15 +872,17 @@ namespace ts {
             forEachResolvedProjectReference
         });
 
-        tracing.push(tracing.Phase.Program, "shouldProgramCreateNewSourceFiles", { hasOldProgram: !!oldProgram });
         const shouldCreateNewSourceFile = shouldProgramCreateNewSourceFiles(oldProgram, options);
-        tracing.pop();
         // We set `structuralIsReused` to `undefined` because `tryReuseStructureFromOldProgram` calls `tryReuseStructureFromOldProgram` which checks
         // `structuralIsReused`, which would be a TDZ violation if it was not set in advance to `undefined`.
         let structureIsReused: StructureIsReused;
         tracing.push(tracing.Phase.Program, "tryReuseStructureFromOldProgram", {});
-        structureIsReused = tryReuseStructureFromOldProgram(); // eslint-disable-line prefer-const
-        tracing.pop();
+        try {
+            structureIsReused = tryReuseStructureFromOldProgram(); // eslint-disable-line prefer-const
+        }
+        finally {
+            tracing.pop();
+        }
         if (structureIsReused !== StructureIsReused.Completely) {
             processingDefaultLibFiles = [];
             processingOtherFiles = [];
@@ -911,22 +919,30 @@ namespace ts {
             }
 
             tracing.push(tracing.Phase.Program, "processRootFiles", { count: rootNames.length });
-            forEach(rootNames, name => processRootFile(name, /*isDefaultLib*/ false, /*ignoreNoDefaultLib*/ false));
-            tracing.pop();
+            try {
+                forEach(rootNames, name => processRootFile(name, /*isDefaultLib*/ false, /*ignoreNoDefaultLib*/ false));
+            }
+            finally {
+                tracing.pop();
+            }
 
             // load type declarations specified via 'types' argument or implicitly from types/ and node_modules/@types folders
             const typeReferences: string[] = rootNames.length ? getAutomaticTypeDirectiveNames(options, host) : emptyArray;
 
             if (typeReferences.length) {
                 tracing.push(tracing.Phase.Program, "processTypeReferences", { count: typeReferences.length });
-                // This containingFilename needs to match with the one used in managed-side
-                const containingDirectory = options.configFilePath ? getDirectoryPath(options.configFilePath) : host.getCurrentDirectory();
-                const containingFilename = combinePaths(containingDirectory, inferredTypesContainingFile);
-                const resolutions = resolveTypeReferenceDirectiveNamesWorker(typeReferences, containingFilename);
-                for (let i = 0; i < typeReferences.length; i++) {
-                    processTypeReferenceDirective(typeReferences[i], resolutions[i]);
+                try {
+                    // This containingFilename needs to match with the one used in managed-side
+                    const containingDirectory = options.configFilePath ? getDirectoryPath(options.configFilePath) : host.getCurrentDirectory();
+                    const containingFilename = combinePaths(containingDirectory, inferredTypesContainingFile);
+                    const resolutions = resolveTypeReferenceDirectiveNamesWorker(typeReferences, containingFilename);
+                    for (let i = 0; i < typeReferences.length; i++) {
+                        processTypeReferenceDirective(typeReferences[i], resolutions[i]);
+                    }
                 }
-                tracing.pop();
+                finally {
+                    tracing.pop();
+                }
             }
 
             // Do not process the default library if:
@@ -1050,11 +1066,14 @@ namespace ts {
             const redirectedReference = getRedirectReferenceForResolution(containingFile);
             tracing.push(tracing.Phase.Program, "resolveModuleNamesWorker", { containingFileName });
             performance.mark("beforeResolveModule");
-            const result = actualResolveModuleNamesWorker(moduleNames, containingFileName, reusedNames, redirectedReference);
-            performance.mark("afterResolveModule");
-            performance.measure("ResolveModule", "beforeResolveModule", "afterResolveModule");
-            tracing.pop();
-            return result;
+            try {
+                return actualResolveModuleNamesWorker(moduleNames, containingFileName, reusedNames, redirectedReference);
+            }
+            finally {
+                performance.mark("afterResolveModule");
+                performance.measure("ResolveModule", "beforeResolveModule", "afterResolveModule");
+                tracing.pop();
+            }
         }
 
         function resolveTypeReferenceDirectiveNamesWorker(typeDirectiveNames: string[], containingFile: string | SourceFile): readonly (ResolvedTypeReferenceDirective | undefined)[] {
@@ -1063,11 +1082,14 @@ namespace ts {
             const redirectedReference = !isString(containingFile) ? getRedirectReferenceForResolution(containingFile) : undefined;
             tracing.push(tracing.Phase.Program, "resolveTypeReferenceDirectiveNamesWorker", { containingFileName });
             performance.mark("beforeResolveTypeReference");
-            const result = actualResolveTypeReferenceDirectiveNamesWorker(typeDirectiveNames, containingFileName, redirectedReference);
-            performance.mark("afterResolveTypeReference");
-            performance.measure("ResolveTypeReference", "beforeResolveTypeReference", "afterResolveTypeReference");
-            tracing.pop();
-            return result;
+            try {
+                return actualResolveTypeReferenceDirectiveNamesWorker(typeDirectiveNames, containingFileName, redirectedReference);
+            }
+            finally {
+                performance.mark("afterResolveTypeReference");
+                performance.measure("ResolveTypeReference", "beforeResolveTypeReference", "afterResolveTypeReference");
+                tracing.pop();
+            }
         }
 
         function getRedirectReferenceForResolution(file: SourceFile) {
@@ -2454,9 +2476,12 @@ namespace ts {
                 isDefaultLib: isDefaultLib || undefined,
                 refKind: refFile ? (RefFileKind as any)[refFile.kind] : undefined,
             });
-            const result = findSourceFileWorker(fileName, path, isDefaultLib, ignoreNoDefaultLib, refFile, packageId);
-            tracing.pop();
-            return result;
+            try {
+                return findSourceFileWorker(fileName, path, isDefaultLib, ignoreNoDefaultLib, refFile, packageId);
+            }
+            finally {
+               tracing.pop();
+            }
         }
 
         function findSourceFileWorker(fileName: string, path: Path, isDefaultLib: boolean, ignoreNoDefaultLib: boolean, refFile: RefFile | undefined, packageId: PackageId | undefined): SourceFile | undefined {
@@ -2785,8 +2810,12 @@ namespace ts {
             refFile?: RefFile
         ): void {
             tracing.push(tracing.Phase.Program, "processTypeReferenceDirective", { directive: typeReferenceDirective, hasResolved: !!resolveModuleNamesReusingOldState, refKind: refFile?.kind, refPath: refFile?.file.path });
-            processTypeReferenceDirectiveWorker(typeReferenceDirective, resolvedTypeReferenceDirective, refFile);
-            tracing.pop();
+            try {
+                processTypeReferenceDirectiveWorker(typeReferenceDirective, resolvedTypeReferenceDirective, refFile);
+            }
+            finally {
+                tracing.pop();
+            }
         }
 
         function processTypeReferenceDirectiveWorker(

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -131,7 +131,7 @@ namespace ts.tracing {
     }
     export function pop() {
         if (!traceFd) return;
-        Debug.assert(completeEvents.length > 0);
+        Debug.assert(canPop());
         const { phase, name, args, time, separateBeginAndEnd } = completeEvents.pop()!;
         if (separateBeginAndEnd) {
             writeEvent("E", phase, name, args);
@@ -140,6 +140,9 @@ namespace ts.tracing {
             const dur = 1000 * timestamp() - time;
             writeEvent("X", phase, name, args, `"dur":${dur}`, time);
         }
+    }
+    export function canPop() {
+        return completeEvents.length > 0;
     }
 
     function writeEvent(eventType: string, phase: Phase, name: string, args: object | undefined, extras?: string,

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -141,8 +141,18 @@ namespace ts.tracing {
             writeEvent("X", phase, name, args, `"dur":${dur}`, time);
         }
     }
-    export function canPop() {
-        return completeEvents.length > 0;
+    export function popAll() {
+        if (!traceFd) return;
+        const endTime = 1000 * timestamp();
+        for (let i = completeEvents.length - 1; i >= 0; i--) {
+            const { phase, name, args, time } = completeEvents[i];
+            const dur = endTime - time;
+            writeEvent("X", phase, name, args, `"dur":${dur}`, time);
+        }
+        completeEvents.length = 0;
+    }
+    export function assertStackEmpty() {
+        Debug.assert(completeEvents.length === 0);
     }
 
     function writeEvent(eventType: string, phase: Phase, name: string, args: object | undefined, extras?: string,

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -142,9 +142,6 @@ namespace ts.tracing {
         }
         eventStack.length = 0;
     }
-    export function assertStackEmpty() {
-        Debug.assert(eventStack.length === 0, `Found ${eventStack.length} events on the stack`);
-    }
     function writeStackEvent(index: number, endTime: number) {
         const { phase, name, args, time, separateBeginAndEnd } = eventStack[index];
         if (separateBeginAndEnd) {

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -152,7 +152,7 @@ namespace ts.tracing {
         completeEvents.length = 0;
     }
     export function assertStackEmpty() {
-        Debug.assert(completeEvents.length === 0);
+        Debug.assert(completeEvents.length === 0, `Found ${completeEvents.length} events on the stack`);
     }
 
     function writeEvent(eventType: string, phase: Phase, name: string, args: object | undefined, extras?: string,

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -46,7 +46,7 @@ namespace ts.tracing {
         }
 
         const countPart =
-            mode === Mode.Build ? `.${++traceCount}` :
+            mode === Mode.Build ? `.${process.pid}.${++traceCount}` :
             mode === Mode.Server ? `.${process.pid}` :
             ``;
         const tracePath = combinePaths(traceDir, `trace${countPart}.json`);

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -12,7 +12,7 @@ namespace ts.tracing {
     let traceCount = 0;
     let traceFd: number | undefined;
 
-    let mode: Mode = Mode.Project; // This initial value should never be consumed
+    let mode: Mode;
 
     let legendPath: string | undefined;
     const legend: TraceRecord[] = [];
@@ -78,7 +78,7 @@ namespace ts.tracing {
         }
 
         Debug.assert(fs);
-        Debug.assert(!!typeCatalog === (mode !== Mode.Server));
+        Debug.assert(!!typeCatalog === (mode !== Mode.Server)); // Have a type catalog iff not in server mode
 
         fs.writeSync(traceFd, `\n]\n`);
         fs.closeSync(traceFd);

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -131,7 +131,7 @@ namespace ts.tracing {
     }
     export function pop() {
         if (!traceFd) return;
-        Debug.assert(canPop());
+        Debug.assert(completeEvents.length > 0);
         const { phase, name, args, time, separateBeginAndEnd } = completeEvents.pop()!;
         if (separateBeginAndEnd) {
             writeEvent("E", phase, name, args);

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -621,7 +621,7 @@ namespace ts {
         }
 
         if (canTrace(system, compilerOptions)) {
-            tracing.startTracing(compilerOptions.configFilePath, compilerOptions.generateTrace!, isBuildMode);
+            tracing.startTracing(isBuildMode ? tracing.Mode.Build : tracing.Mode.Project, compilerOptions.generateTrace!, compilerOptions.configFilePath);
         }
     }
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -211,15 +211,13 @@ namespace ts.server {
                     tracing.instant(tracing.Phase.Session, "stepCancellation", { seq: this.requestId });
                 }
                 else {
-                    Debug.assert(!tracing.canPop());
+                    tracing.assertStackEmpty();
                     tracing.push(tracing.Phase.Session, "stepAction", { seq: this.requestId });
                     try {
                         action(this);
                     }
                     finally {
-                        while (tracing.canPop()) {
-                            tracing.pop();
-                        }
+                        tracing.popAll();
                     }
                 }
             }
@@ -2934,7 +2932,7 @@ namespace ts.server {
             let request: protocol.Request | undefined;
             let relevantFile: protocol.FileRequestArgs | undefined;
             try {
-                Debug.assert(!tracing.canPop());
+                tracing.assertStackEmpty();
                 try {
                     request = <protocol.Request>JSON.parse(message);
                     relevantFile = request.arguments && (request as protocol.FileRequest).arguments.file ? (request as protocol.FileRequest).arguments : undefined;
@@ -2966,9 +2964,7 @@ namespace ts.server {
                 }
                 finally {
                     // Cancellation or an error may have left incomplete events on the tracing stack.
-                    while (tracing.canPop()) {
-                        tracing.pop();
-                    }
+                    tracing.popAll();
                 }
             }
             catch (err) {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -208,16 +208,12 @@ namespace ts.server {
             try {
                 if (this.operationHost.isCancellationRequested()) {
                     stop = true;
-                    tracing.instant(tracing.Phase.Session, "stepCancellation", { seq: this.requestId });
+                    tracing.instant(tracing.Phase.Session, "stepEarlyCancellation", { seq: this.requestId });
                 }
                 else {
-                    tracing.assertStackEmpty(); // Confirm it's safe to popAll if there's an exception
-
                     tracing.push(tracing.Phase.Session, "stepAction", { seq: this.requestId });
                     action(this);
                     tracing.pop();
-
-                    tracing.assertStackEmpty(); // Stack should be empty if everything succeeeded
                 }
             }
             catch (e) {
@@ -2927,8 +2923,6 @@ namespace ts.server {
             let request: protocol.Request | undefined;
             let relevantFile: protocol.FileRequestArgs | undefined;
             try {
-                tracing.assertStackEmpty(); // Confirm it's safe to popAll if there's an exception
-
                 request = <protocol.Request>JSON.parse(message);
                 relevantFile = request.arguments && (request as protocol.FileRequest).arguments.file ? (request as protocol.FileRequest).arguments : undefined;
 
@@ -2958,8 +2952,6 @@ namespace ts.server {
                 else if (responseRequired) {
                     this.doOutput(/*info*/ undefined, request.command, request.seq, /*success*/ false, "No content available.");
                 }
-
-                tracing.assertStackEmpty(); // Stack should be empty if everything succeeeded
             }
             catch (err) {
                 // Cancellation or an error may have left incomplete events on the tracing stack.

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -208,7 +208,7 @@ namespace ts.server {
             try {
                 if (this.operationHost.isCancellationRequested()) {
                     stop = true;
-                    tracing.instant(tracing.Phase.Session, "stepEarlyCancellation", { seq: this.requestId });
+                    tracing.instant(tracing.Phase.Session, "stepCanceled", { seq: this.requestId, early: true });
                 }
                 else {
                     tracing.push(tracing.Phase.Session, "stepAction", { seq: this.requestId });

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -208,11 +208,11 @@ namespace ts.server {
             try {
                 if (this.operationHost.isCancellationRequested()) {
                     stop = true;
-                    tracing.instant(tracing.Phase.Session, "StepCancellation", { seq: this.requestId });
+                    tracing.instant(tracing.Phase.Session, "stepCancellation", { seq: this.requestId });
                 }
                 else {
                     Debug.assert(!tracing.canPop());
-                    tracing.push(tracing.Phase.Session, "StepAction", { seq: this.requestId });
+                    tracing.push(tracing.Phase.Session, "stepAction", { seq: this.requestId });
                     try {
                         action(this);
                     }
@@ -227,10 +227,10 @@ namespace ts.server {
                 stop = true;
                 // ignore cancellation request
                 if (e instanceof OperationCanceledException) {
-                    tracing.instant(tracing.Phase.Session, "StepUnhandledCancellation", { seq: this.requestId });
+                    tracing.instant(tracing.Phase.Session, "stepUnhandledCancellation", { seq: this.requestId });
                 }
                 else {
-                    tracing.instant(tracing.Phase.Session, "StepUnhandledError", { seq: this.requestId, message: (<Error>e).message });
+                    tracing.instant(tracing.Phase.Session, "stepUnhandledError", { seq: this.requestId, message: (<Error>e).message });
                     this.operationHost.logError(e, `delayed processing of request ${this.requestId}`);
                 }
             }
@@ -928,7 +928,7 @@ namespace ts.server {
         }
 
         public event<T extends object>(body: T, eventName: string): void {
-            tracing.instant(tracing.Phase.Session, "Event", { eventName });
+            tracing.instant(tracing.Phase.Session, "event", { eventName });
             this.send(toEvent(eventName, body));
         }
 
@@ -2939,7 +2939,7 @@ namespace ts.server {
                     request = <protocol.Request>JSON.parse(message);
                     relevantFile = request.arguments && (request as protocol.FileRequest).arguments.file ? (request as protocol.FileRequest).arguments : undefined;
 
-                    tracing.instant(tracing.Phase.Session, "Request", { seq: request.seq, command: request.command });
+                    tracing.instant(tracing.Phase.Session, "request", { seq: request.seq, command: request.command });
                     perfLogger.logStartCommand("" + request.command, message.substring(0, 100));
 
                     const { response, responseRequired } = this.executeCommand(request);
@@ -2956,7 +2956,7 @@ namespace ts.server {
 
                     // Note: Log before writing the response, else the editor can complete its activity before the server does
                     perfLogger.logStopCommand("" + request.command, "Success");
-                    tracing.instant(tracing.Phase.Session, "Response", { seq: request.seq, command: request.command, success: !!response });
+                    tracing.instant(tracing.Phase.Session, "response", { seq: request.seq, command: request.command, success: !!response });
                     if (response) {
                         this.doOutput(response, request.command, request.seq, /*success*/ true);
                     }
@@ -2975,14 +2975,14 @@ namespace ts.server {
                 if (err instanceof OperationCanceledException) {
                     // Handle cancellation exceptions
                     perfLogger.logStopCommand("" + (request && request.command), "Canceled: " + err);
-                    tracing.instant(tracing.Phase.Session, "UnhandledCancellation", { seq: request?.seq, command: request?.command });
+                    tracing.instant(tracing.Phase.Session, "unhandledCancellation", { seq: request?.seq, command: request?.command });
                     this.doOutput({ canceled: true }, request!.command, request!.seq, /*success*/ true);
                     return;
                 }
 
                 this.logErrorWorker(err, message, relevantFile);
                 perfLogger.logStopCommand("" + (request && request.command), "Error: " + err);
-                tracing.instant(tracing.Phase.Session, "UnhandledError", { seq: request?.seq, command: request?.command, message: (<Error>err).message });
+                tracing.instant(tracing.Phase.Session, "unhandledError", { seq: request?.seq, command: request?.command, message: (<Error>err).message });
 
                 this.doOutput(
                     /*info*/ undefined,

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1137,7 +1137,7 @@ namespace ts {
 
         public isCancellationRequested(): boolean {
             if (this.cancellationToken.isCancellationRequested()) {
-                tracing.instant(tracing.Phase.Session, "CancellationDetected", { kind: "CancellationTokenObject" });
+                tracing.instant(tracing.Phase.Session, "cancellationDetected", { kind: "CancellationTokenObject" });
                 return true;
             }
             return false;
@@ -1168,7 +1168,7 @@ namespace ts {
                 // Check no more than once every throttle wait milliseconds
                 this.lastCancellationCheckTime = time;
                 if (this.hostCancellationToken.isCancellationRequested()) {
-                    tracing.instant(tracing.Phase.Session, "CancellationDetected", { kind: "ThrottledCancellationToken" });
+                    tracing.instant(tracing.Phase.Session, "cancellationDetected", { kind: "ThrottledCancellationToken" });
                     return true;
                 }
                 return false;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1136,15 +1136,12 @@ namespace ts {
         }
 
         public isCancellationRequested(): boolean {
-            if (this.cancellationToken.isCancellationRequested()) {
-                tracing.instant(tracing.Phase.Session, "cancellationDetected", { kind: "CancellationTokenObject" });
-                return true;
-            }
-            return false;
+            return this.cancellationToken.isCancellationRequested();
         }
 
         public throwIfCancellationRequested(): void {
             if (this.isCancellationRequested()) {
+                tracing.instant(tracing.Phase.Session, "cancellationThrown", { kind: "CancellationTokenObject" });
                 throw new OperationCanceledException();
             }
         }
@@ -1167,11 +1164,7 @@ namespace ts {
             if (duration >= this.throttleWaitMilliseconds) {
                 // Check no more than once every throttle wait milliseconds
                 this.lastCancellationCheckTime = time;
-                if (this.hostCancellationToken.isCancellationRequested()) {
-                    tracing.instant(tracing.Phase.Session, "cancellationDetected", { kind: "ThrottledCancellationToken" });
-                    return true;
-                }
-                return false;
+                return this.hostCancellationToken.isCancellationRequested();
             }
 
             return false;
@@ -1179,6 +1172,7 @@ namespace ts {
 
         public throwIfCancellationRequested(): void {
             if (this.isCancellationRequested()) {
+                tracing.instant(tracing.Phase.Session, "cancellationThrown", { kind: "ThrottledCancellationToken" });
                 throw new OperationCanceledException();
             }
         }

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -980,7 +980,10 @@ namespace ts.server {
     const telemetryEnabled = hasArgument(Arguments.EnableTelemetry);
     const noGetErrOnBackgroundUpdate = hasArgument("--noGetErrOnBackgroundUpdate");
 
-    const traceDir = process.env.TSS_TRACE;
+    const commandLineTraceDir = findArgument("--traceDirectory");
+    const traceDir = commandLineTraceDir
+        ? stripQuotes(commandLineTraceDir)
+        : process.env.TSS_TRACE;
     if (traceDir) {
         tracing.startTracing(tracing.Mode.Server, traceDir);
     }

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -564,7 +564,7 @@ namespace ts.server {
         exit() {
             this.logger.info("Exiting...");
             this.projectService.closeLog();
-            if (process.env.TSS_TRACE) {
+            if (traceDir) {
                 tracing.stopTracing(ts.emptyArray);
             }
             process.exit(0);

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -565,7 +565,7 @@ namespace ts.server {
             this.logger.info("Exiting...");
             this.projectService.closeLog();
             if (process.env.TSS_TRACE) {
-                ts.tracing.stopTracing(ts.emptyArray);
+                tracing.stopTracing(ts.emptyArray);
             }
             process.exit(0);
         }
@@ -982,7 +982,7 @@ namespace ts.server {
 
     const traceDir = process.env.TSS_TRACE;
     if (traceDir) {
-        ts.tracing.startTracing(tracing.Mode.Server, traceDir);
+        tracing.startTracing(tracing.Mode.Server, traceDir);
     }
 
     logger.info(`Starting TS Server`);

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -564,6 +564,9 @@ namespace ts.server {
         exit() {
             this.logger.info("Exiting...");
             this.projectService.closeLog();
+            if (process.env.TSS_TRACE) {
+                ts.tracing.stopTracing(ts.emptyArray);
+            }
             process.exit(0);
         }
 
@@ -976,6 +979,11 @@ namespace ts.server {
     const serverMode = parseServerMode();
     const telemetryEnabled = hasArgument(Arguments.EnableTelemetry);
     const noGetErrOnBackgroundUpdate = hasArgument("--noGetErrOnBackgroundUpdate");
+
+    const traceDir = process.env.TSS_TRACE;
+    if (traceDir) {
+        ts.tracing.startTracing(tracing.Mode.Server, traceDir);
+    }
 
     logger.info(`Starting TS Server`);
     logger.info(`Version: ${version}`);


### PR DESCRIPTION
Read the `TSS_TRACE` environment variable to determine which directory trace files should be written to.

Notable changes from tsc tracing:
1) Drop all tracepoints that depend on type IDs
2) Write output to trace.PID.json
3) New, server-specific events (request/response, cancellation, etc)