### PR TITLE
IntelliSense doc string.replace typo

### DIFF
--- a/lib/lib.es2015.symbol.wellknown.d.ts
+++ b/lib/lib.es2015.symbol.wellknown.d.ts
@@ -236,7 +236,10 @@ interface String {
     /**
      * Replaces text in a string, using an object that supports replacement within a string.
      * @param searchValue A object can search for and replace matches within a string.
-     * @param replaceValue A string containing the text to replace for every successful match of searchValue in this string.
+     * @param replaceValue A string containing the text to replace for successful
+     * match of searchValue in this string. You can use regex g flag i.e.
+     * str.replace(/replace_word/g, 'replace_me') to replace all values and gi
+     * flag to replace all case-insensitive values.
      */
     replace(searchValue: { [Symbol.replace](string: string, replaceValue: string): string; }, replaceValue: string): string;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #41361

As per https://www.w3schools.com/jsref/jsref_replace.asp
replace only replaces first value unless flags are used.
