### PR TITLE
Cache flow branch label results the same way as flow loop results

### DIFF
--- a/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.js
+++ b/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.js
@@ -1,0 +1,125 @@
+//// [controlFlowManyCallExpressionStatementsPerf.ts]
+function test(x: boolean): boolean { return x; }
+
+let state = true;
+
+if (state) {
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+}
+
+//// [controlFlowManyCallExpressionStatementsPerf.js]
+function test(x) { return x; }
+var state = true;
+if (state) {
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+}

--- a/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.symbols
+++ b/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.symbols
@@ -1,0 +1,292 @@
+=== tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts ===
+function test(x: boolean): boolean { return x; }
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>x : Symbol(x, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 14))
+>x : Symbol(x, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 14))
+
+let state = true;
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+if (state) {
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+}

--- a/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.types
+++ b/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.types
@@ -1,0 +1,461 @@
+=== tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts ===
+function test(x: boolean): boolean { return x; }
+>test : (x: boolean) => boolean
+>x : boolean
+>x : boolean
+
+let state = true;
+>state : boolean
+>true : true
+
+if (state) {
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+}

--- a/tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts
+++ b/tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts
@@ -1,0 +1,62 @@
+function test(x: boolean): boolean { return x; }
+
+let state = true;
+
+if (state) {
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+}


### PR DESCRIPTION
Fixes #41124

Fundamentally, the underlying issue actually _wasn't_ tied to control flow call nodes, but rather the repeated branch labels produced by the `&&` expressions. As we checked the file, on the first call expression line, we'd check a control flow graph like

![image](https://user-images.githubusercontent.com/2932786/98037856-15708c80-1dd1-11eb-80da-ea6991efb538.png)

and then on the second:

![image](https://user-images.githubusercontent.com/2932786/98037894-21f4e500-1dd1-11eb-874d-c67ded3d8f65.png)

and so on. The graph _of the last call expression line_ grows linearly with lines, however because no results were cached across invocations (as only branch labels were actually considered, since all the `Call` nodes are noops), this meant that the actual number of control flow nodes checked across all invocations would grow at a much faster rate than input size. By caching the results at branch label locations (like we already do for loop labels, since we always knew we visit them multiple times), we can avoid this growth in most circumstances. Technically this caching is extraneous in certain edge cases where the full control flow graph is trivially small (so is essentially one label and a `Start`, so we won't revisit the branch on a future invocation because there won't be a future invocation), but the structure of the control flow graph precludes detecting those scenarios (we can't know if the graph we're looking at is a subset of a large graph or not).

I say we can avoid super-linear growth in _most_ circumstances because there is an exception - `ReduceLabel` control flow nodes, used for `finally` block handling, require we bust the cache, as they cause us to mutate other nodes, which has follow on undesirable analysis effects if cached. Discovering this leads me to believe we may have an existing bug with `for` loops and `finally` blocks not giving correct results, but as I couldn't come up with a test case, I left the for-loop label result caching logic as-is.
