### PR TITLE
Fix module resolution for import call emit

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -38417,7 +38417,10 @@ namespace ts {
                 isOptionalParameter,
                 moduleExportsSomeValue,
                 isArgumentsLocalBinding,
-                getExternalModuleFileFromDeclaration,
+                getExternalModuleFileFromDeclaration: nodeIn => {
+                    const node = getParseTreeNode(nodeIn, hasPossibleExternalModuleReference);
+                    return node && getExternalModuleFileFromDeclaration(node);
+                },
                 getTypeReferenceDirectivesForEntityName,
                 getTypeReferenceDirectivesForSymbol,
                 isLiteralConstDeclaration,
@@ -38578,7 +38581,7 @@ namespace ts {
             }
         }
 
-        function getExternalModuleFileFromDeclaration(declaration: AnyImportOrReExport | ModuleDeclaration | ImportTypeNode): SourceFile | undefined {
+        function getExternalModuleFileFromDeclaration(declaration: AnyImportOrReExport | ModuleDeclaration | ImportTypeNode | ImportCall): SourceFile | undefined {
             const specifier = declaration.kind === SyntaxKind.ModuleDeclaration ? tryCast(declaration.name, isStringLiteral) : getExternalModuleName(declaration);
             const moduleSymbol = resolveExternalModuleNameWorker(specifier!, specifier!, /*moduleNotFoundError*/ undefined); // TODO: GH#18217
             if (!moduleSymbol) {

--- a/src/compiler/factory/utilities.ts
+++ b/src/compiler/factory/utilities.ts
@@ -511,12 +511,12 @@ namespace ts {
      *  3- The containing SourceFile has an entry in renamedDependencies for the import as requested by some module loaders (e.g. System).
      * Otherwise, a new StringLiteral node representing the module name will be returned.
      */
-    export function getExternalModuleNameLiteral(factory: NodeFactory, importNode: ImportDeclaration | ExportDeclaration | ImportEqualsDeclaration, sourceFile: SourceFile, host: EmitHost, resolver: EmitResolver, compilerOptions: CompilerOptions) {
-        const moduleName = getExternalModuleName(importNode)!; // TODO: GH#18217
-        if (moduleName.kind === SyntaxKind.StringLiteral) {
+    export function getExternalModuleNameLiteral(factory: NodeFactory, importNode: ImportDeclaration | ExportDeclaration | ImportEqualsDeclaration | ImportCall, sourceFile: SourceFile, host: EmitHost, resolver: EmitResolver, compilerOptions: CompilerOptions) {
+        const moduleName = getExternalModuleName(importNode);
+        if (moduleName && isStringLiteral(moduleName)) {
             return tryGetModuleNameFromDeclaration(importNode, host, factory, resolver, compilerOptions)
-                || tryRenameExternalModule(factory, <StringLiteral>moduleName, sourceFile)
-                || factory.cloneNode(<StringLiteral>moduleName);
+                || tryRenameExternalModule(factory, moduleName, sourceFile)
+                || factory.cloneNode(moduleName);
         }
 
         return undefined;
@@ -528,7 +528,7 @@ namespace ts {
      */
     function tryRenameExternalModule(factory: NodeFactory, moduleName: LiteralExpression, sourceFile: SourceFile) {
         const rename = sourceFile.renamedDependencies && sourceFile.renamedDependencies.get(moduleName.text);
-        return rename && factory.createStringLiteral(rename);
+        return rename ? factory.createStringLiteral(rename) : undefined;
     }
 
     /**
@@ -551,7 +551,7 @@ namespace ts {
         return undefined;
     }
 
-    function tryGetModuleNameFromDeclaration(declaration: ImportEqualsDeclaration | ImportDeclaration | ExportDeclaration, host: EmitHost, factory: NodeFactory, resolver: EmitResolver, compilerOptions: CompilerOptions) {
+    function tryGetModuleNameFromDeclaration(declaration: ImportEqualsDeclaration | ImportDeclaration | ExportDeclaration | ImportCall, host: EmitHost, factory: NodeFactory, resolver: EmitResolver, compilerOptions: CompilerOptions) {
         return tryGetModuleNameFromFile(factory, resolver.getExternalModuleFileFromDeclaration(declaration), host, compilerOptions);
     }
 

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -609,7 +609,10 @@ namespace ts {
         }
 
         function visitImportCallExpression(node: ImportCall): Expression {
-            const argument = visitNode(firstOrUndefined(node.arguments), moduleExpressionElementVisitor);
+            const externalModuleName = getExternalModuleNameLiteral(factory, node, currentSourceFile, host, resolver, compilerOptions);
+            const firstArgument = visitNode(firstOrUndefined(node.arguments), moduleExpressionElementVisitor);
+            // Only use the external module name if it differs from the first argument. This allows us to preserve the quote style of the argument on output.
+            const argument = externalModuleName && (!firstArgument || !isStringLiteral(firstArgument) || firstArgument.text !== externalModuleName.text) ? externalModuleName : firstArgument;
             const containsLexicalThis = !!(node.transformFlags & TransformFlags.ContainsLexicalThis);
             switch (compilerOptions.module) {
                 case ModuleKind.AMD:

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -1495,13 +1495,17 @@ namespace ts {
             //         }
             //     };
             // });
+            const externalModuleName = getExternalModuleNameLiteral(factory, node, currentSourceFile, host, resolver, compilerOptions);
+            const firstArgument = visitNode(firstOrUndefined(node.arguments), destructuringAndImportCallVisitor);
+            // Only use the external module name if it differs from the first argument. This allows us to preserve the quote style of the argument on output.
+            const argument = externalModuleName && (!firstArgument || !isStringLiteral(firstArgument) || firstArgument.text !== externalModuleName.text) ? externalModuleName : firstArgument;
             return factory.createCallExpression(
                 factory.createPropertyAccessExpression(
                     contextObject,
                     factory.createIdentifier("import")
                 ),
                 /*typeArguments*/ undefined,
-                some(node.arguments) ? [visitNode(node.arguments[0], destructuringAndImportCallVisitor)] : []
+                argument ? [argument] : []
             );
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4529,7 +4529,7 @@ namespace ts {
         isOptionalParameter(node: ParameterDeclaration): boolean;
         moduleExportsSomeValue(moduleReferenceExpression: Expression): boolean;
         isArgumentsLocalBinding(node: Identifier): boolean;
-        getExternalModuleFileFromDeclaration(declaration: ImportEqualsDeclaration | ImportDeclaration | ExportDeclaration | ModuleDeclaration | ImportTypeNode): SourceFile | undefined;
+        getExternalModuleFileFromDeclaration(declaration: ImportEqualsDeclaration | ImportDeclaration | ExportDeclaration | ModuleDeclaration | ImportTypeNode | ImportCall): SourceFile | undefined;
         getTypeReferenceDirectivesForEntityName(name: EntityNameOrEntityNameExpression): string[] | undefined;
         getTypeReferenceDirectivesForSymbol(symbol: Symbol, meaning?: SymbolFlags): string[] | undefined;
         isLiteralConstDeclaration(node: VariableDeclaration | PropertyDeclaration | PropertySignature | ParameterDeclaration): boolean;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -897,6 +897,10 @@ namespace ts {
         }
     }
 
+    export function hasPossibleExternalModuleReference(node: Node): node is AnyImportOrReExport | ModuleDeclaration | ImportTypeNode | ImportCall {
+        return isAnyImportOrReExport(node) || isModuleDeclaration(node) || isImportTypeNode(node) || isImportCall(node);
+    }
+
     export function isAnyImportOrReExport(node: Node): node is AnyImportOrReExport {
         return isAnyImportSyntax(node) || isExportDeclaration(node);
     }
@@ -2382,7 +2386,7 @@ namespace ts {
         }
     }
 
-    export function getExternalModuleName(node: AnyImportOrReExport | ImportTypeNode): Expression | undefined {
+    export function getExternalModuleName(node: AnyImportOrReExport | ImportTypeNode | ImportCall): Expression | undefined {
         switch (node.kind) {
             case SyntaxKind.ImportDeclaration:
             case SyntaxKind.ExportDeclaration:
@@ -2391,6 +2395,8 @@ namespace ts {
                 return node.moduleReference.kind === SyntaxKind.ExternalModuleReference ? node.moduleReference.expression : undefined;
             case SyntaxKind.ImportType:
                 return isLiteralImportTypeNode(node) ? node.argument.literal : undefined;
+            case SyntaxKind.CallExpression:
+                return node.arguments[0];
             default:
                 return Debug.assertNever(node);
         }

--- a/tests/baselines/reference/outFilerootDirModuleNamesAmd.js
+++ b/tests/baselines/reference/outFilerootDirModuleNamesAmd.js
@@ -9,6 +9,8 @@ foo();
 import Foo from "./a";
 export default function foo() { new Foo(); }
 
+// https://github.com/microsoft/TypeScript/issues/37429
+import("./a");
 
 //// [output.js]
 define("b", ["require", "exports", "a"], function (require, exports, a_1) {
@@ -16,6 +18,8 @@ define("b", ["require", "exports", "a"], function (require, exports, a_1) {
     Object.defineProperty(exports, "__esModule", { value: true });
     function foo() { new a_1.default(); }
     exports.default = foo;
+    // https://github.com/microsoft/TypeScript/issues/37429
+    new Promise((resolve_1, reject_1) => { require(["a"], resolve_1, reject_1); });
 });
 define("a", ["require", "exports", "b"], function (require, exports, b_1) {
     "use strict";

--- a/tests/baselines/reference/outFilerootDirModuleNamesAmd.symbols
+++ b/tests/baselines/reference/outFilerootDirModuleNamesAmd.symbols
@@ -16,3 +16,7 @@ export default function foo() { new Foo(); }
 >foo : Symbol(foo, Decl(b.ts, 0, 22))
 >Foo : Symbol(Foo, Decl(b.ts, 0, 6))
 
+// https://github.com/microsoft/TypeScript/issues/37429
+import("./a");
+>"./a" : Symbol("tests/cases/conformance/es6/moduleExportsAmd/src/a", Decl(a.ts, 0, 0))
+

--- a/tests/baselines/reference/outFilerootDirModuleNamesAmd.types
+++ b/tests/baselines/reference/outFilerootDirModuleNamesAmd.types
@@ -18,3 +18,8 @@ export default function foo() { new Foo(); }
 >new Foo() : Foo
 >Foo : typeof Foo
 
+// https://github.com/microsoft/TypeScript/issues/37429
+import("./a");
+>import("./a") : Promise<typeof import("tests/cases/conformance/es6/moduleExportsAmd/src/a")>
+>"./a" : "./a"
+

--- a/tests/baselines/reference/outFilerootDirModuleNamesSystem.js
+++ b/tests/baselines/reference/outFilerootDirModuleNamesSystem.js
@@ -9,6 +9,9 @@ foo();
 import Foo from "./a";
 export default function foo() { new Foo(); }
 
+// https://github.com/microsoft/TypeScript/issues/37429
+import("./a");
+
 
 //// [output.js]
 System.register("b", ["a"], function (exports_1, context_1) {
@@ -24,6 +27,8 @@ System.register("b", ["a"], function (exports_1, context_1) {
             }
         ],
         execute: function () {
+            // https://github.com/microsoft/TypeScript/issues/37429
+            context_1.import("a");
         }
     };
 });

--- a/tests/baselines/reference/outFilerootDirModuleNamesSystem.symbols
+++ b/tests/baselines/reference/outFilerootDirModuleNamesSystem.symbols
@@ -16,3 +16,7 @@ export default function foo() { new Foo(); }
 >foo : Symbol(foo, Decl(b.ts, 0, 22))
 >Foo : Symbol(Foo, Decl(b.ts, 0, 6))
 
+// https://github.com/microsoft/TypeScript/issues/37429
+import("./a");
+>"./a" : Symbol("tests/cases/conformance/es6/moduleExportsSystem/src/a", Decl(a.ts, 0, 0))
+

--- a/tests/baselines/reference/outFilerootDirModuleNamesSystem.types
+++ b/tests/baselines/reference/outFilerootDirModuleNamesSystem.types
@@ -18,3 +18,8 @@ export default function foo() { new Foo(); }
 >new Foo() : Foo
 >Foo : typeof Foo
 
+// https://github.com/microsoft/TypeScript/issues/37429
+import("./a");
+>import("./a") : Promise<typeof import("tests/cases/conformance/es6/moduleExportsSystem/src/a")>
+>"./a" : "./a"
+

--- a/tests/cases/conformance/es6/moduleExportsAmd/outFilerootDirModuleNamesAmd.ts
+++ b/tests/cases/conformance/es6/moduleExportsAmd/outFilerootDirModuleNamesAmd.ts
@@ -10,3 +10,6 @@ foo();
 // @filename: src/b.ts
 import Foo from "./a";
 export default function foo() { new Foo(); }
+
+// https://github.com/microsoft/TypeScript/issues/37429
+import("./a");

--- a/tests/cases/conformance/es6/moduleExportsSystem/outFilerootDirModuleNamesSystem.ts
+++ b/tests/cases/conformance/es6/moduleExportsSystem/outFilerootDirModuleNamesSystem.ts
@@ -10,3 +10,6 @@ foo();
 // @filename: src/b.ts
 import Foo from "./a";
 export default function foo() { new Foo(); }
+
+// https://github.com/microsoft/TypeScript/issues/37429
+import("./a");


### PR DESCRIPTION
Fixes `import()` emit for bundled SystemJS/AMD output.

Fixes #37429
