### PR TITLE
dispose Mocha Runner after use to avoid MaxlistenersExceededWarning

### DIFF
--- a/src/testRunner/parallel/worker.ts
+++ b/src/testRunner/parallel/worker.ts
@@ -210,12 +210,11 @@ namespace Harness.Parallel.Worker {
             const passes: TestInfo[] = [];
             const start = +new Date();
             const runner = new Mocha.Runner(suite, /*delay*/ false);
-            const uncaught = (err: any) => runner.uncaught(err);
+            // const uncaught = (err: any) => runner.uncaught(err);
 
             runner
                 .on("start", () => {
                     unhookUncaughtExceptions(); // turn off global uncaught handling
-                    process.on("unhandledRejection", uncaught); // turn on unhandled rejection handling (not currently handled in mocha)
                 })
                 .on("pass", (test: Mocha.Test) => {
                     passes.push({ name: test.titlePath() });
@@ -224,8 +223,9 @@ namespace Harness.Parallel.Worker {
                     errors.push({ name: test.titlePath(), error: err.message, stack: err.stack });
                 })
                 .on("end", () => {
-                    process.removeListener("unhandledRejection", uncaught);
                     hookUncaughtExceptions();
+                    // @ts-ignore
+                    runner.dispose();
                 })
                 .run(() => {
                     fn({ task, errors, passes, passing: passes.length, duration: +new Date() - start });

--- a/src/testRunner/parallel/worker.ts
+++ b/src/testRunner/parallel/worker.ts
@@ -210,7 +210,6 @@ namespace Harness.Parallel.Worker {
             const passes: TestInfo[] = [];
             const start = +new Date();
             const runner = new Mocha.Runner(suite, /*delay*/ false);
-            // const uncaught = (err: any) => runner.uncaught(err);
 
             runner
                 .on("start", () => {
@@ -224,7 +223,6 @@ namespace Harness.Parallel.Worker {
                 })
                 .on("end", () => {
                     hookUncaughtExceptions();
-                    // @ts-ignore
                     runner.dispose();
                 })
                 .run(() => {


### PR DESCRIPTION
This change eliminates the frequent `MaxListenersExceededWarning`s emitted when running `gulp runtests-parallel`.  The [Runner#dispose](https://mochajs.org/api/runner#dispose) method removes all EE listeners the `Runner` instance created.  When using the `Runner` manually like this, you'll want to call this function.  It is a relatively new, and the Mocha typings have not been updated to reflect its presence (hence the `@ts-ignore`).

~~Apologies, I could not find an issue here associated with this change, but I'm sure there is one somewhere.  I'll leave this as a draft until I find it.~~ Created #41404.



<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #41404, mochajs/mocha#4329 reported by @weswigham 

* * *

Commit summary:

- call `runner.dispose()` on listener for `end` event
- removed manual `unhandledRejection` listener as Mocha v8.2.0 now has one
