### PR TITLE
Ensure shared flow nodes are cached

### DIFF
--- a/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.js
+++ b/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.js
@@ -1,0 +1,125 @@
+//// [controlFlowManyCallExpressionStatementsPerf.ts]
+function test(x: boolean): boolean { return x; }
+
+let state = true;
+
+if (state) {
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+}
+
+//// [controlFlowManyCallExpressionStatementsPerf.js]
+function test(x) { return x; }
+var state = true;
+if (state) {
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+}

--- a/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.symbols
+++ b/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.symbols
@@ -1,0 +1,292 @@
+=== tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts ===
+function test(x: boolean): boolean { return x; }
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>x : Symbol(x, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 14))
+>x : Symbol(x, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 14))
+
+let state = true;
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+if (state) {
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+}

--- a/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.types
+++ b/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.types
@@ -1,0 +1,461 @@
+=== tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts ===
+function test(x: boolean): boolean { return x; }
+>test : (x: boolean) => boolean
+>x : boolean
+>x : boolean
+
+let state = true;
+>state : boolean
+>true : true
+
+if (state) {
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : boolean
+>state as any : any
+>state : true
+>state : true
+}

--- a/tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts
+++ b/tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts
@@ -1,0 +1,62 @@
+function test(x: boolean): boolean { return x; }
+
+let state = true;
+
+if (state) {
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+}


### PR DESCRIPTION
Fixes #41124
Alternative to #41387.

Flow nodes that optionally provide a flow type will delegate to their antecedent
to determine a flow type using a loop in `getFlowTypeOfReference`. If these nodes
are marked as shared then their result should be cached for future lookups, but
the registration inside `getFlowTypeOfReference` did only consider the most-recently
processed flow node. Any flow nodes up to that point that did not provide a type
but were marked as shared would therefore not be cached at all.

This commit keeps track of the first seen shared flow node and ensures that the
result type is cached for that node.