### PR TITLE
Add more team members to pr_owners.txt

### DIFF
--- a/.github/pr_owners.txt
+++ b/.github/pr_owners.txt
@@ -6,3 +6,8 @@ RyanCavanaugh
 sheetalkamat
 orta
 rbuckton
+ahejlsberg
+amcasey
+jessetrinity
+minestarks
+uniqueiniquity


### PR DESCRIPTION
1. I may have missed some frequent committers. Please let me know if I did.
2. I'm not sure what pr_owners.txt is used for, besides the bot's isTeamMember check. Maybe there's a reason the list is so small.