### PR TITLE
Update return type Object.keys(o)

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -238,7 +238,7 @@ interface ObjectConstructor {
      * Returns the names of the enumerable string properties and methods of an object.
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
-    keys(o: object): string[];
+    keys<T extends object>(o: T): keyof T extends never ? string[] : Array<keyof T>;
 }
 
 /**


### PR DESCRIPTION
Object.keys(o) does not return an array of strings, but an array of keys o.

Fixes #
