### PR TITLE
Fix post-LKG build

### DIFF
--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -1381,7 +1381,7 @@ namespace Harness {
                 else {
                     IO.writeFile(actualFileName, encodedActual);
                 }
-                if (require && opts && opts.PrintDiff) {
+                if (!!require && opts && opts.PrintDiff) {
                     const Diff = require("diff");
                     const patch = Diff.createTwoFilesPatch("Expected", "Actual", expected, actual, "The current baseline", "The new version");
                     throw new Error(`The baseline file ${relativeFileName} has changed.${ts.ForegroundColorEscapeSequences.Grey}\n\n${patch}`);


### PR DESCRIPTION
Our nightly last night failed to publish because post-LKG, our analysis flags this condition as always-true without an indicator like this.
