### PR TITLE
Switches the bundlePackageName error message to be a suggestion, and not a compiler error

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1192,8 +1192,8 @@
         "category": "Message",
         "code": 1390
     },
-    "The `bundledPackageName` option must be provided when using outFile and node module resolution with declaration emit.": {
-        "category": "Error",
+    "The `bundledPackageName` option should be provided when using outFile and node module resolution with declaration emit.": {
+        "category": "Suggestion",
         "code": 1391
     },
     "The types of '{0}' are incompatible between these types.": {

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3221,9 +3221,9 @@ namespace ts {
                 }
             }
 
-            // Without a package name, for multiple files being bundled into a .d.ts file you basically get a file which doesn't wrk
+            // Without a package name, for multiple files being bundled into a .d.ts file you basically get a file which doesn't work
             if (outputFile && getEmitDeclarations(options) && getEmitModuleResolutionKind(options) === ModuleResolutionKind.NodeJs && !options.bundledPackageName) {
-                createDiagnosticForOptionName(Diagnostics.The_bundledPackageName_option_must_be_provided_when_using_outFile_and_node_module_resolution_with_declaration_emit, options.out ? "out" : "outFile");
+                createDiagnosticForOptionName(Diagnostics.The_bundledPackageName_option_should_be_provided_when_using_outFile_and_node_module_resolution_with_declaration_emit, options.out ? "out" : "outFile");
             }
 
             if (options.resolveJsonModule) {

--- a/tests/baselines/reference/bundledDtsLateExportRenaming.errors.txt
+++ b/tests/baselines/reference/bundledDtsLateExportRenaming.errors.txt
@@ -1,7 +1,7 @@
-error TS1391: The `bundledPackageName` option must be provided when using outFile and node module resolution with declaration emit.
+suggestion TS1391: The `bundledPackageName` option should be provided when using outFile and node module resolution with declaration emit.
 
 
-!!! error TS1391: The `bundledPackageName` option must be provided when using outFile and node module resolution with declaration emit.
+!!! suggestion TS1391: The `bundledPackageName` option should be provided when using outFile and node module resolution with declaration emit.
 ==== tests/cases/compiler/index.ts (0 errors) ====
     export * from "./nested";
     

--- a/tests/baselines/reference/bundledNodeDTSFailsWithOutFlag.errors.txt
+++ b/tests/baselines/reference/bundledNodeDTSFailsWithOutFlag.errors.txt
@@ -1,7 +1,7 @@
-error TS1391: The `bundledPackageName` option must be provided when using outFile and node module resolution with declaration emit.
+suggestion TS1391: The `bundledPackageName` option should be provided when using outFile and node module resolution with declaration emit.
 
 
-!!! error TS1391: The `bundledPackageName` option must be provided when using outFile and node module resolution with declaration emit.
+!!! suggestion TS1391: The `bundledPackageName` option should be provided when using outFile and node module resolution with declaration emit.
 ==== tests/cases/conformance/declarationEmit/index.ts (0 errors) ====
     export * from "./nested";
     

--- a/tests/baselines/reference/typeReferenceDirectives12.errors.txt
+++ b/tests/baselines/reference/typeReferenceDirectives12.errors.txt
@@ -1,8 +1,8 @@
-error TS1391: The `bundledPackageName` option must be provided when using outFile and node module resolution with declaration emit.
+suggestion TS1391: The `bundledPackageName` option should be provided when using outFile and node module resolution with declaration emit.
 /main.ts(1,14): error TS6131: Cannot compile modules using option 'out' unless the '--module' flag is 'amd' or 'system'.
 
 
-!!! error TS1391: The `bundledPackageName` option must be provided when using outFile and node module resolution with declaration emit.
+!!! suggestion TS1391: The `bundledPackageName` option should be provided when using outFile and node module resolution with declaration emit.
 ==== /mod2.ts (0 errors) ====
     import { Cls } from "./main";
     import "./mod1";


### PR DESCRIPTION
Alternative to #41499 where the compiler flag instead recommends using `bundlePackageName` on the `out` in your JSON instead of outright removing the feature.
