### PR TITLE
Remove obsolete go-to-definition code after CommonJS alias changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1592,13 +1592,21 @@
             }
         },
         "browserify-rsa": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
-            "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
-                "bn.js": "^5.0.0",
+                "bn.js": "^4.1.0",
                 "randombytes": "^2.0.1"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+                    "dev": true
+                }
             }
         },
         "browserify-sign": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1592,21 +1592,13 @@
             }
         },
         "browserify-rsa": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+            "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
+                "bn.js": "^5.0.0",
                 "randombytes": "^2.0.1"
-            },
-            "dependencies": {
-                "bn.js": {
-                    "version": "4.11.9",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-                    "dev": true
-                }
             }
         },
         "browserify-sign": {

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -96,12 +96,6 @@ namespace ts.GoToDefinition {
         return getDefinitionFromSymbol(typeChecker, symbol, node);
     }
 
-    function isShorthandPropertyAssignmentOfModuleExports(symbol: Symbol): boolean {
-        const shorthandProperty = tryCast(symbol.valueDeclaration, isShorthandPropertyAssignment);
-        const binaryExpression = tryCast(shorthandProperty?.parent.parent, isAssignmentExpression);
-        return !!binaryExpression && getAssignmentDeclarationKind(binaryExpression) === AssignmentDeclarationKind.ModuleExports;
-    }
-
     /**
      * True if we should not add definitions for both the signature symbol and the definition symbol.
      * True for `const |f = |() => 0`, false for `function |f() {} const |g = f;`.
@@ -204,29 +198,15 @@ namespace ts.GoToDefinition {
     }
 
     function getSymbol(node: Node, checker: TypeChecker): Symbol | undefined {
-        let symbol = checker.getSymbolAtLocation(node);
+        const symbol = checker.getSymbolAtLocation(node);
         // If this is an alias, and the request came at the declaration location
         // get the aliased symbol instead. This allows for goto def on an import e.g.
         //   import {A, B} from "mod";
         // to jump to the implementation directly.
-        while (symbol) {
-            if (symbol.flags & SymbolFlags.Alias && shouldSkipAlias(node, symbol.declarations[0])) {
-                const aliased = checker.getAliasedSymbol(symbol);
-                if (!aliased.declarations) {
-                    break;
-                }
-                symbol = aliased;
-            }
-            else if (isShorthandPropertyAssignmentOfModuleExports(symbol)) {
-                // Skip past `module.exports = { Foo }` even though 'Foo' is not a real alias
-                const shorthandTarget = checker.resolveName(symbol.name, symbol.valueDeclaration, SymbolFlags.Value, /*excludeGlobals*/ false);
-                if (!some(shorthandTarget?.declarations)) {
-                    break;
-                }
-                symbol = shorthandTarget;
-            }
-            else {
-                break;
+        if (symbol && symbol.flags & SymbolFlags.Alias && shouldSkipAlias(node, symbol.declarations[0])) {
+            const aliased = checker.getAliasedSymbol(symbol);
+            if (aliased.declarations) {
+                return aliased;
             }
         }
         return symbol;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Reverts the non-test changes of https://github.com/microsoft/TypeScript/pull/40835, which became unnecessary shortly afterward when we started creating real aliases for CommonJS imports and exports in the binder.
