### PR TITLE
Add a comment to clarify the #private field

### DIFF
--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -1373,7 +1373,7 @@ namespace ts {
 
                     const hasPrivateIdentifier = some(input.members, member => !!member.name && isPrivateIdentifier(member.name));
                     // When the class has at least one private identifier, create a unique constant identifier to retain the nominal typing behavior
-                    // Prevents other classes with the same public API to be used in place of the current class
+                    // Prevents other classes with the same public members from being used in place of the current class
                     const privateIdentifier = hasPrivateIdentifier ? [
                         factory.createPropertyDeclaration(
                             /*decorators*/ undefined,

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -1372,6 +1372,8 @@ namespace ts {
                     }
 
                     const hasPrivateIdentifier = some(input.members, member => !!member.name && isPrivateIdentifier(member.name));
+                    // When the class has at least one private identifier, create a unique constant identifier to retain the nominal typing behavior
+                    // Prevents other classes with the same public API to be used in place of the current class
                     const privateIdentifier = hasPrivateIdentifier ? [
                         factory.createPropertyDeclaration(
                             /*decorators*/ undefined,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

After having struggled understanding what was the purpose of the `#private` field in declaration files when using ES private class fields, I was invited to add some comments about it.
Related StackOverflow question: https://stackoverflow.com/questions/64707399/typescript-generates-declaration-d-ts-file-with-private-field/64827614#64827614
Comments on the original commit: https://github.com/bloomberg/TypeScript/commit/3f8b49012636a365762598847a463f1cf189a59f#commitcomment-44176989
