### PR TITLE
Produce source maps for local typescriptServices build

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -590,6 +590,7 @@ task("LKG").description = "Makes a new LKG out of the built js files";
 task("LKG").flags = {
     "   --built": "Compile using the built version of the compiler.",
 };
+task("lkg", series("LKG"));
 
 const generateSpec = () => exec("cscript", ["//nologo", "scripts/word2md.js", path.resolve("doc/TypeScript Language Specification - ARCHIVED.docx"), path.resolve("doc/spec-ARCHIVED.md")]);
 task("generate-spec", series(buildScripts, generateSpec));

--- a/src/tsconfig-library-base.json
+++ b/src/tsconfig-library-base.json
@@ -2,7 +2,6 @@
     "extends": "./tsconfig-base",
     "compilerOptions": {
         "declarationMap": false,
-        "sourceMap":  false,
         "composite": false,
         "incremental":  true,
         "declaration": true,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #41439. Confirmed `gulp lkg` doesn’t put any new map files in `lib`.
