### PR TITLE
Adds Format param to the tsserver session

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -838,7 +838,6 @@ namespace ts.server.protocol {
     export interface EncodedSemanticClassificationsRequest extends FileRequest {
         arguments: EncodedSemanticClassificationsRequestArgs;
     }
-
     /**
      * Arguments for EncodedSemanticClassificationsRequest request.
      */
@@ -852,6 +851,10 @@ namespace ts.server.protocol {
          * Length of the span.
          */
         length: number;
+        /**
+         * Optional for backwards compat, use "2020" for modern LSP-like classifications
+         */
+        format?: ts.SemanticClassificationFormat
     }
 
     /**
@@ -3318,6 +3321,8 @@ namespace ts.server.protocol {
         Preserve = "Preserve",
         ReactNative = "ReactNative",
         React = "React",
+        ReactJSX = "ReactJSX",
+        ReactJSXDev = "ReactJSXDev",
     }
 
     export const enum ModuleKind {
@@ -3328,6 +3333,7 @@ namespace ts.server.protocol {
         System = "System",
         ES6 = "ES6",
         ES2015 = "ES2015",
+        ES2020 = "ES2020",
         ESNext = "ESNext"
     }
 
@@ -3351,6 +3357,7 @@ namespace ts.server.protocol {
         ES2018 = "ES2018",
         ES2019 = "ES2019",
         ES2020 = "ES2020",
+        JSON = "JSON",
         ESNext = "ESNext"
     }
 }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1079,11 +1079,8 @@ namespace ts.server {
             return languageService.getEncodedSyntacticClassifications(file, args);
         }
 
-
-
         private getEncodedSemanticClassifications(args: protocol.EncodedSemanticClassificationsRequestArgs) {
             const { file, project } = this.getFileAndProject(args);
-
             return project.getLanguageService().getEncodedSemanticClassifications(file, args, args.format);
         }
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1079,9 +1079,12 @@ namespace ts.server {
             return languageService.getEncodedSyntacticClassifications(file, args);
         }
 
+
+
         private getEncodedSemanticClassifications(args: protocol.EncodedSemanticClassificationsRequestArgs) {
             const { file, project } = this.getFileAndProject(args);
-            return project.getLanguageService().getEncodedSemanticClassifications(file, args);
+
+            return project.getLanguageService().getEncodedSemanticClassifications(file, args, args.format);
         }
 
         private getProject(projectFileName: string | undefined): Project | undefined {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9084,7 +9084,9 @@ declare namespace ts.server.protocol {
         None = "None",
         Preserve = "Preserve",
         ReactNative = "ReactNative",
-        React = "React"
+        React = "React",
+        ReactJSX = "ReactJSX",
+        ReactJSXDev = "ReactJSXDev"
     }
     enum ModuleKind {
         None = "None",
@@ -9094,6 +9096,7 @@ declare namespace ts.server.protocol {
         System = "System",
         ES6 = "ES6",
         ES2015 = "ES2015",
+        ES2020 = "ES2020",
         ESNext = "ESNext"
     }
     enum ModuleResolutionKind {
@@ -9114,6 +9117,7 @@ declare namespace ts.server.protocol {
         ES2018 = "ES2018",
         ES2019 = "ES2019",
         ES2020 = "ES2020",
+        JSON = "JSON",
         ESNext = "ESNext"
     }
 }


### PR DESCRIPTION
I think this should unblock https://github.com/microsoft/TypeScript/issues/41262 - the param `format?` was introduced to the tsserver API in https://github.com/microsoft/TypeScript/issues/38435 . In order to be used by vscode, it needs to be exposed via the session.ts and protocol.ts. 

Which is what this PR does, it also adds some extra values to some of the types in the protocol. 
