### PR TITLE
Un‑consolidate and fix `WeakMap` constructor overloads

### DIFF
--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -30,7 +30,8 @@ interface WeakMap<K extends object, V> {
 }
 
 interface WeakMapConstructor {
-    new <K extends object = object, V = any>(entries?: readonly [K, V][] | null): WeakMap<K, V>;
+    new(): WeakMap<object, any>;
+    new <K extends object, V>(entries?: readonly [K, V][] | null): WeakMap<K, V>;
     readonly prototype: WeakMap<object, any>;
 }
 declare var WeakMap: WeakMapConstructor;

--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -30,7 +30,6 @@ interface WeakMap<K extends object, V> {
 }
 
 interface WeakMapConstructor {
-    new(): WeakMap<object, any>;
     new <K extends object, V>(entries?: readonly [K, V][] | null): WeakMap<K, V>;
     readonly prototype: WeakMap<object, any>;
 }

--- a/src/lib/es2015.iterable.d.ts
+++ b/src/lib/es2015.iterable.d.ts
@@ -143,7 +143,7 @@ interface MapConstructor {
 interface WeakMap<K extends object, V> { }
 
 interface WeakMapConstructor {
-    new <K extends object, V>(iterable: Iterable<[K, V]>): WeakMap<K, V>;
+    new <K extends object, V>(iterable: Iterable<readonly [K, V]>): WeakMap<K, V>;
 }
 
 interface Set<T> {

--- a/tests/baselines/reference/extendingSetWithCheckJs.symbols
+++ b/tests/baselines/reference/extendingSetWithCheckJs.symbols
@@ -1,6 +1,6 @@
-=== tests/cases/compiler/extendingSetWithCheckJs.ts ===
+=== tests/cases/compiler/extendingCollectionsWithCheckJs.js ===
 class MySet extends Set {
->MySet : Symbol(MySet, Decl(extendingSetWithCheckJs.ts, 0, 0))
+>MySet : Symbol(MySet, Decl(extendingCollectionsWithCheckJs.js, 0, 0))
 >Set : Symbol(Set, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     constructor() {
@@ -10,7 +10,7 @@ class MySet extends Set {
 }
 
 class MyWeakSet extends WeakSet {
->MyWeakSet : Symbol(MyWeakSet, Decl(extendingSetWithCheckJs.ts, 4, 1))
+>MyWeakSet : Symbol(MyWeakSet, Decl(extendingCollectionsWithCheckJs.js, 4, 1))
 >WeakSet : Symbol(WeakSet, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     constructor() {
@@ -20,7 +20,7 @@ class MyWeakSet extends WeakSet {
 }
 
 class MyMap extends Map {
->MyMap : Symbol(MyMap, Decl(extendingSetWithCheckJs.ts, 10, 1))
+>MyMap : Symbol(MyMap, Decl(extendingCollectionsWithCheckJs.js, 10, 1))
 >Map : Symbol(Map, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     constructor() {
@@ -30,7 +30,7 @@ class MyMap extends Map {
 }
 
 class MyWeakMap extends WeakMap {
->MyWeakMap : Symbol(MyWeakMap, Decl(extendingSetWithCheckJs.ts, 16, 1))
+>MyWeakMap : Symbol(MyWeakMap, Decl(extendingCollectionsWithCheckJs.js, 16, 1))
 >WeakMap : Symbol(WeakMap, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
     constructor() {
@@ -38,3 +38,4 @@ class MyWeakMap extends WeakMap {
 >super : Symbol(WeakMapConstructor, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
     }
 }
+

--- a/tests/baselines/reference/extendingSetWithCheckJs.types
+++ b/tests/baselines/reference/extendingSetWithCheckJs.types
@@ -1,4 +1,4 @@
-=== tests/cases/compiler/extendingSetWithCheckJs.ts ===
+=== tests/cases/compiler/extendingCollectionsWithCheckJs.js ===
 class MySet extends Set {
 >MySet : MySet
 >Set : Set<any>
@@ -34,7 +34,7 @@ class MyMap extends Map {
 
 class MyWeakMap extends WeakMap {
 >MyWeakMap : MyWeakMap
->WeakMap : WeakMap<object, any>
+>WeakMap : WeakMap<any, any>
 
     constructor() {
         super();
@@ -42,3 +42,4 @@ class MyWeakMap extends WeakMap {
 >super : WeakMapConstructor
     }
 }
+

--- a/tests/baselines/reference/newMap.errors.txt
+++ b/tests/baselines/reference/newMap.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/newMap.ts(1,9): error TS2743: No overload expects 1 type arguments, but overloads do exist that expect either 0 or 2 type arguments.
-tests/cases/compiler/newMap.ts(2,13): error TS2743: No overload expects 1 type arguments, but overloads do exist that expect either 0 or 2 type arguments.
+tests/cases/compiler/newMap.ts(2,13): error TS2558: Expected 2 type arguments, but got 1.
 
 
 ==== tests/cases/compiler/newMap.ts (2 errors) ====
@@ -8,5 +8,5 @@ tests/cases/compiler/newMap.ts(2,13): error TS2743: No overload expects 1 type a
 !!! error TS2743: No overload expects 1 type arguments, but overloads do exist that expect either 0 or 2 type arguments.
     new WeakMap<object>();
                 ~~~~~~
-!!! error TS2743: No overload expects 1 type arguments, but overloads do exist that expect either 0 or 2 type arguments.
+!!! error TS2558: Expected 2 type arguments, but got 1.
     

--- a/tests/baselines/reference/newMap.errors.txt
+++ b/tests/baselines/reference/newMap.errors.txt
@@ -1,8 +1,12 @@
 tests/cases/compiler/newMap.ts(1,9): error TS2743: No overload expects 1 type arguments, but overloads do exist that expect either 0 or 2 type arguments.
+tests/cases/compiler/newMap.ts(2,13): error TS2743: No overload expects 1 type arguments, but overloads do exist that expect either 0 or 2 type arguments.
 
 
-==== tests/cases/compiler/newMap.ts (1 errors) ====
+==== tests/cases/compiler/newMap.ts (2 errors) ====
     new Map<string>();
             ~~~~~~
+!!! error TS2743: No overload expects 1 type arguments, but overloads do exist that expect either 0 or 2 type arguments.
+    new WeakMap<object>();
+                ~~~~~~
 !!! error TS2743: No overload expects 1 type arguments, but overloads do exist that expect either 0 or 2 type arguments.
     

--- a/tests/baselines/reference/newMap.js
+++ b/tests/baselines/reference/newMap.js
@@ -1,6 +1,8 @@
 //// [newMap.ts]
 new Map<string>();
+new WeakMap<object>();
 
 
 //// [newMap.js]
 new Map();
+new WeakMap();

--- a/tests/baselines/reference/newMap.symbols
+++ b/tests/baselines/reference/newMap.symbols
@@ -2,3 +2,6 @@
 new Map<string>();
 >Map : Symbol(Map, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
+new WeakMap<object>();
+>WeakMap : Symbol(WeakMap, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+

--- a/tests/baselines/reference/newMap.types
+++ b/tests/baselines/reference/newMap.types
@@ -3,3 +3,7 @@ new Map<string>();
 >new Map<string>() : Map<string, unknown>
 >Map : MapConstructor
 
+new WeakMap<object>();
+>new WeakMap<object>() : WeakMap<object, unknown>
+>WeakMap : WeakMapConstructor
+

--- a/tests/cases/compiler/extendingSetWithCheckJs.ts
+++ b/tests/cases/compiler/extendingSetWithCheckJs.ts
@@ -3,6 +3,7 @@
 // @noEmit: true
 // @lib: es2017
 
+// @filename: extendingCollectionsWithCheckJs.js
 class MySet extends Set {
     constructor() {
         super();

--- a/tests/cases/compiler/newMap.ts
+++ b/tests/cases/compiler/newMap.ts
@@ -1,2 +1,3 @@
 // @lib: es6
 new Map<string>();
+new WeakMap<object>();


### PR DESCRIPTION
Fixes <https://github.com/microsoft/TypeScript/issues/27951> for `WeakMap`.
Fixes <https://github.com/microsoft/TypeScript/issues/23551> which regressed as a result of <https://github.com/microsoft/TypeScript/pull/28052> only changing the `Iterable`‑taking constructor overload.