### PR TITLE
Experimentally add bounds checks to charCodeAt calls to avoid deoptimization

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3777,11 +3777,13 @@ namespace ts {
         // with at least two underscores. The @ character indicates that the name is denoted by a well known ES
         // Symbol instance and the # character indicates that the name is a PrivateIdentifier.
         function isReservedMemberName(name: __String) {
-            return (name as string).charCodeAt(0) === CharacterCodes._ &&
-                (name as string).charCodeAt(1) === CharacterCodes._ &&
-                (name as string).charCodeAt(2) !== CharacterCodes._ &&
-                (name as string).charCodeAt(2) !== CharacterCodes.at &&
-                (name as string).charCodeAt(2) !== CharacterCodes.hash;
+            const nameString = name as string;
+            return nameString.length > 2 &&
+                nameString.charCodeAt(0) === CharacterCodes._ &&
+                nameString.charCodeAt(1) === CharacterCodes._ &&
+                nameString.charCodeAt(2) !== CharacterCodes._ &&
+                nameString.charCodeAt(2) !== CharacterCodes.at &&
+                nameString.charCodeAt(2) !== CharacterCodes.hash;
         }
 
         function getNamedMembers(members: SymbolTable): Symbol[] {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9719,9 +9719,11 @@ namespace ts {
         }
 
         function isLateBoundName(name: __String): boolean {
-            return (name as string).charCodeAt(0) === CharacterCodes._ &&
-                (name as string).charCodeAt(1) === CharacterCodes._ &&
-                (name as string).charCodeAt(2) === CharacterCodes.at;
+            const nameString = name as string;
+            return nameString.length > 2 &&
+                nameString.charCodeAt(0) === CharacterCodes._ &&
+                nameString.charCodeAt(1) === CharacterCodes._ &&
+                nameString.charCodeAt(2) === CharacterCodes.at;
         }
 
         /**

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -55,9 +55,10 @@ namespace ts {
 
     /*@internal*/
     export function isJSDocLikeText(text: string, start: number) {
-        return text.charCodeAt(start + 1) === CharacterCodes.asterisk &&
+        return start + 2 < text.length &&
+            text.charCodeAt(start + 1) === CharacterCodes.asterisk &&
             text.charCodeAt(start + 2) === CharacterCodes.asterisk &&
-            text.charCodeAt(start + 3) !== CharacterCodes.slash;
+            (start + 3 === text.length || text.charCodeAt(start + 3) !== CharacterCodes.slash);
     }
 
     /**

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -360,7 +360,7 @@ namespace ts {
             pos++;
             switch (ch) {
                 case CharacterCodes.carriageReturn:
-                    if (text.charCodeAt(pos) === CharacterCodes.lineFeed) {
+                    if (pos < text.length && text.charCodeAt(pos) === CharacterCodes.lineFeed) {
                         pos++;
                     }
                 // falls through
@@ -744,7 +744,7 @@ namespace ts {
             const ch = text.charCodeAt(pos);
             switch (ch) {
                 case CharacterCodes.carriageReturn:
-                    if (text.charCodeAt(pos + 1) === CharacterCodes.lineFeed) {
+                    if (pos + 1 < text.length && text.charCodeAt(pos + 1) === CharacterCodes.lineFeed) {
                         pos++;
                     }
                 // falls through


### PR DESCRIPTION
Noticed in #41482
