### PR TITLE
fix(41653): Enum Keys in Destructure Prevents ES6 Function Convert with --target ES5

### DIFF
--- a/src/compiler/transformers/destructuring.ts
+++ b/src/compiler/transformers/destructuring.ts
@@ -199,7 +199,7 @@ namespace ts {
                 bindingOrAssignmentElementContainsNonLiteralComputedName(node))) {
                 // If the right-hand value of the assignment is also an assignment target then
                 // we need to cache the right-hand value.
-                initializer = ensureIdentifier(flattenContext, initializer, /*reuseIdentifierExpressions*/ false, initializer);
+                initializer = ensureIdentifier(flattenContext, visitNode(initializer, flattenContext.visitor), /*reuseIdentifierExpressions*/ false, initializer);
                 node = context.factory.updateVariableDeclaration(node, node.name, /*exclamationToken*/ undefined, /*type*/ undefined, initializer);
             }
         }

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment6(target=es5).js
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment6(target=es5).js
@@ -1,0 +1,18 @@
+//// [destructuringObjectBindingPatternAndAssignment6.ts]
+const a = "a";
+const b = "b";
+
+const { [a]: aVal, [b]: bVal } = (() => {
+	return { [a]: 1, [b]: 1 };
+})();
+console.log(aVal, bVal);
+
+
+//// [destructuringObjectBindingPatternAndAssignment6.js]
+var a = "a";
+var b = "b";
+var _a = (function () {
+    var _a;
+    return _a = {}, _a[a] = 1, _a[b] = 1, _a;
+})(), _b = a, aVal = _a[_b], _c = b, bVal = _a[_c];
+console.log(aVal, bVal);

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment6(target=es5).symbols
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment6(target=es5).symbols
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment6.ts ===
+const a = "a";
+>a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 0, 5))
+
+const b = "b";
+>b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 1, 5))
+
+const { [a]: aVal, [b]: bVal } = (() => {
+>a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 0, 5))
+>aVal : Symbol(aVal, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 3, 7))
+>b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 1, 5))
+>bVal : Symbol(bVal, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 3, 18))
+
+	return { [a]: 1, [b]: 1 };
+>[a] : Symbol([a], Decl(destructuringObjectBindingPatternAndAssignment6.ts, 4, 9))
+>a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 0, 5))
+>[b] : Symbol([b], Decl(destructuringObjectBindingPatternAndAssignment6.ts, 4, 17))
+>b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 1, 5))
+
+})();
+console.log(aVal, bVal);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>aVal : Symbol(aVal, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 3, 7))
+>bVal : Symbol(bVal, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 3, 18))
+

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment6(target=es5).types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment6(target=es5).types
@@ -1,0 +1,36 @@
+=== tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment6.ts ===
+const a = "a";
+>a : "a"
+>"a" : "a"
+
+const b = "b";
+>b : "b"
+>"b" : "b"
+
+const { [a]: aVal, [b]: bVal } = (() => {
+>a : "a"
+>aVal : number
+>b : "b"
+>bVal : number
+>(() => {	return { [a]: 1, [b]: 1 };})() : { a: number; b: number; }
+>(() => {	return { [a]: 1, [b]: 1 };}) : () => { a: number; b: number; }
+>() => {	return { [a]: 1, [b]: 1 };} : () => { a: number; b: number; }
+
+	return { [a]: 1, [b]: 1 };
+>{ [a]: 1, [b]: 1 } : { a: number; b: number; }
+>[a] : number
+>a : "a"
+>1 : 1
+>[b] : number
+>b : "b"
+>1 : 1
+
+})();
+console.log(aVal, bVal);
+>console.log(aVal, bVal) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>aVal : number
+>bVal : number
+

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment6(target=esnext).js
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment6(target=esnext).js
@@ -1,0 +1,17 @@
+//// [destructuringObjectBindingPatternAndAssignment6.ts]
+const a = "a";
+const b = "b";
+
+const { [a]: aVal, [b]: bVal } = (() => {
+	return { [a]: 1, [b]: 1 };
+})();
+console.log(aVal, bVal);
+
+
+//// [destructuringObjectBindingPatternAndAssignment6.js]
+const a = "a";
+const b = "b";
+const { [a]: aVal, [b]: bVal } = (() => {
+    return { [a]: 1, [b]: 1 };
+})();
+console.log(aVal, bVal);

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment6(target=esnext).symbols
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment6(target=esnext).symbols
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment6.ts ===
+const a = "a";
+>a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 0, 5))
+
+const b = "b";
+>b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 1, 5))
+
+const { [a]: aVal, [b]: bVal } = (() => {
+>a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 0, 5))
+>aVal : Symbol(aVal, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 3, 7))
+>b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 1, 5))
+>bVal : Symbol(bVal, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 3, 18))
+
+	return { [a]: 1, [b]: 1 };
+>[a] : Symbol([a], Decl(destructuringObjectBindingPatternAndAssignment6.ts, 4, 9))
+>a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 0, 5))
+>[b] : Symbol([b], Decl(destructuringObjectBindingPatternAndAssignment6.ts, 4, 17))
+>b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 1, 5))
+
+})();
+console.log(aVal, bVal);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>aVal : Symbol(aVal, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 3, 7))
+>bVal : Symbol(bVal, Decl(destructuringObjectBindingPatternAndAssignment6.ts, 3, 18))
+

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment6(target=esnext).types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment6(target=esnext).types
@@ -1,0 +1,36 @@
+=== tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment6.ts ===
+const a = "a";
+>a : "a"
+>"a" : "a"
+
+const b = "b";
+>b : "b"
+>"b" : "b"
+
+const { [a]: aVal, [b]: bVal } = (() => {
+>a : "a"
+>aVal : number
+>b : "b"
+>bVal : number
+>(() => {	return { [a]: 1, [b]: 1 };})() : { a: number; b: number; }
+>(() => {	return { [a]: 1, [b]: 1 };}) : () => { a: number; b: number; }
+>() => {	return { [a]: 1, [b]: 1 };} : () => { a: number; b: number; }
+
+	return { [a]: 1, [b]: 1 };
+>{ [a]: 1, [b]: 1 } : { a: number; b: number; }
+>[a] : number
+>a : "a"
+>1 : 1
+>[b] : number
+>b : "b"
+>1 : 1
+
+})();
+console.log(aVal, bVal);
+>console.log(aVal, bVal) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>aVal : number
+>bVal : number
+

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment7(target=es5).js
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment7(target=es5).js
@@ -1,0 +1,22 @@
+//// [destructuringObjectBindingPatternAndAssignment7.ts]
+enum K {
+    a = "a",
+    b = "b"
+}
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+	return { [K.a]: 1, [K.b]: 1 };
+})();
+console.log(aVal, bVal);
+
+
+//// [destructuringObjectBindingPatternAndAssignment7.js]
+var K;
+(function (K) {
+    K["a"] = "a";
+    K["b"] = "b";
+})(K || (K = {}));
+var _a = (function () {
+    var _a;
+    return _a = {}, _a[K.a] = 1, _a[K.b] = 1, _a;
+})(), _b = K.a, aVal = _a[_b], _c = K.b, bVal = _a[_c];
+console.log(aVal, bVal);

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment7(target=es5).symbols
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment7(target=es5).symbols
@@ -1,0 +1,38 @@
+=== tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment7.ts ===
+enum K {
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 0))
+
+    a = "a",
+>a : Symbol(K.a, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 8))
+
+    b = "b"
+>b : Symbol(K.b, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 1, 12))
+}
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+>K.a : Symbol(K.a, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 8))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 0))
+>a : Symbol(K.a, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 8))
+>aVal : Symbol(aVal, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 4, 7))
+>K.b : Symbol(K.b, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 1, 12))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 0))
+>b : Symbol(K.b, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 1, 12))
+>bVal : Symbol(bVal, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 4, 20))
+
+	return { [K.a]: 1, [K.b]: 1 };
+>[K.a] : Symbol([K.a], Decl(destructuringObjectBindingPatternAndAssignment7.ts, 5, 9))
+>K.a : Symbol(K.a, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 8))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 0))
+>a : Symbol(K.a, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 8))
+>[K.b] : Symbol([K.b], Decl(destructuringObjectBindingPatternAndAssignment7.ts, 5, 19))
+>K.b : Symbol(K.b, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 1, 12))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 0))
+>b : Symbol(K.b, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 1, 12))
+
+})();
+console.log(aVal, bVal);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>aVal : Symbol(aVal, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 4, 7))
+>bVal : Symbol(bVal, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 4, 20))
+

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment7(target=es5).types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment7(target=es5).types
@@ -1,0 +1,47 @@
+=== tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment7.ts ===
+enum K {
+>K : K
+
+    a = "a",
+>a : K.a
+>"a" : "a"
+
+    b = "b"
+>b : K.b
+>"b" : "b"
+}
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+>K.a : K.a
+>K : typeof K
+>a : K.a
+>aVal : number
+>K.b : K.b
+>K : typeof K
+>b : K.b
+>bVal : number
+>(() => {	return { [K.a]: 1, [K.b]: 1 };})() : { a: number; b: number; }
+>(() => {	return { [K.a]: 1, [K.b]: 1 };}) : () => { a: number; b: number; }
+>() => {	return { [K.a]: 1, [K.b]: 1 };} : () => { a: number; b: number; }
+
+	return { [K.a]: 1, [K.b]: 1 };
+>{ [K.a]: 1, [K.b]: 1 } : { a: number; b: number; }
+>[K.a] : number
+>K.a : K.a
+>K : typeof K
+>a : K.a
+>1 : 1
+>[K.b] : number
+>K.b : K.b
+>K : typeof K
+>b : K.b
+>1 : 1
+
+})();
+console.log(aVal, bVal);
+>console.log(aVal, bVal) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>aVal : number
+>bVal : number
+

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment7(target=esnext).js
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment7(target=esnext).js
@@ -1,0 +1,21 @@
+//// [destructuringObjectBindingPatternAndAssignment7.ts]
+enum K {
+    a = "a",
+    b = "b"
+}
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+	return { [K.a]: 1, [K.b]: 1 };
+})();
+console.log(aVal, bVal);
+
+
+//// [destructuringObjectBindingPatternAndAssignment7.js]
+var K;
+(function (K) {
+    K["a"] = "a";
+    K["b"] = "b";
+})(K || (K = {}));
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+    return { [K.a]: 1, [K.b]: 1 };
+})();
+console.log(aVal, bVal);

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment7(target=esnext).symbols
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment7(target=esnext).symbols
@@ -1,0 +1,38 @@
+=== tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment7.ts ===
+enum K {
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 0))
+
+    a = "a",
+>a : Symbol(K.a, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 8))
+
+    b = "b"
+>b : Symbol(K.b, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 1, 12))
+}
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+>K.a : Symbol(K.a, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 8))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 0))
+>a : Symbol(K.a, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 8))
+>aVal : Symbol(aVal, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 4, 7))
+>K.b : Symbol(K.b, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 1, 12))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 0))
+>b : Symbol(K.b, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 1, 12))
+>bVal : Symbol(bVal, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 4, 20))
+
+	return { [K.a]: 1, [K.b]: 1 };
+>[K.a] : Symbol([K.a], Decl(destructuringObjectBindingPatternAndAssignment7.ts, 5, 9))
+>K.a : Symbol(K.a, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 8))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 0))
+>a : Symbol(K.a, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 8))
+>[K.b] : Symbol([K.b], Decl(destructuringObjectBindingPatternAndAssignment7.ts, 5, 19))
+>K.b : Symbol(K.b, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 1, 12))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 0, 0))
+>b : Symbol(K.b, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 1, 12))
+
+})();
+console.log(aVal, bVal);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>aVal : Symbol(aVal, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 4, 7))
+>bVal : Symbol(bVal, Decl(destructuringObjectBindingPatternAndAssignment7.ts, 4, 20))
+

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment7(target=esnext).types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment7(target=esnext).types
@@ -1,0 +1,47 @@
+=== tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment7.ts ===
+enum K {
+>K : K
+
+    a = "a",
+>a : K.a
+>"a" : "a"
+
+    b = "b"
+>b : K.b
+>"b" : "b"
+}
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+>K.a : K.a
+>K : typeof K
+>a : K.a
+>aVal : number
+>K.b : K.b
+>K : typeof K
+>b : K.b
+>bVal : number
+>(() => {	return { [K.a]: 1, [K.b]: 1 };})() : { a: number; b: number; }
+>(() => {	return { [K.a]: 1, [K.b]: 1 };}) : () => { a: number; b: number; }
+>() => {	return { [K.a]: 1, [K.b]: 1 };} : () => { a: number; b: number; }
+
+	return { [K.a]: 1, [K.b]: 1 };
+>{ [K.a]: 1, [K.b]: 1 } : { a: number; b: number; }
+>[K.a] : number
+>K.a : K.a
+>K : typeof K
+>a : K.a
+>1 : 1
+>[K.b] : number
+>K.b : K.b
+>K : typeof K
+>b : K.b
+>1 : 1
+
+})();
+console.log(aVal, bVal);
+>console.log(aVal, bVal) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>aVal : number
+>bVal : number
+

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment8(target=es5).js
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment8(target=es5).js
@@ -1,0 +1,21 @@
+//// [destructuringObjectBindingPatternAndAssignment8.ts]
+const K = {
+    a: "a",
+    b: "b"
+}
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+	return { [K.a]: 1, [K.b]: 1 };
+})();
+console.log(aVal, bVal);
+
+
+//// [destructuringObjectBindingPatternAndAssignment8.js]
+var K = {
+    a: "a",
+    b: "b"
+};
+var _a = (function () {
+    var _a;
+    return _a = {}, _a[K.a] = 1, _a[K.b] = 1, _a;
+})(), _b = K.a, aVal = _a[_b], _c = K.b, bVal = _a[_c];
+console.log(aVal, bVal);

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment8(target=es5).symbols
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment8(target=es5).symbols
@@ -1,0 +1,38 @@
+=== tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment8.ts ===
+const K = {
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 5))
+
+    a: "a",
+>a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 11))
+
+    b: "b"
+>b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 1, 11))
+}
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+>K.a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 11))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 5))
+>a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 11))
+>aVal : Symbol(aVal, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 4, 7))
+>K.b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 1, 11))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 5))
+>b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 1, 11))
+>bVal : Symbol(bVal, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 4, 20))
+
+	return { [K.a]: 1, [K.b]: 1 };
+>[K.a] : Symbol([K.a], Decl(destructuringObjectBindingPatternAndAssignment8.ts, 5, 9))
+>K.a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 11))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 5))
+>a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 11))
+>[K.b] : Symbol([K.b], Decl(destructuringObjectBindingPatternAndAssignment8.ts, 5, 19))
+>K.b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 1, 11))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 5))
+>b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 1, 11))
+
+})();
+console.log(aVal, bVal);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>aVal : Symbol(aVal, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 4, 7))
+>bVal : Symbol(bVal, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 4, 20))
+

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment8(target=es5).types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment8(target=es5).types
@@ -1,0 +1,48 @@
+=== tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment8.ts ===
+const K = {
+>K : { a: string; b: string; }
+>{    a: "a",    b: "b"} : { a: string; b: string; }
+
+    a: "a",
+>a : string
+>"a" : "a"
+
+    b: "b"
+>b : string
+>"b" : "b"
+}
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+>K.a : string
+>K : { a: string; b: string; }
+>a : string
+>aVal : number
+>K.b : string
+>K : { a: string; b: string; }
+>b : string
+>bVal : number
+>(() => {	return { [K.a]: 1, [K.b]: 1 };})() : { [x: string]: number; }
+>(() => {	return { [K.a]: 1, [K.b]: 1 };}) : () => { [x: string]: number; }
+>() => {	return { [K.a]: 1, [K.b]: 1 };} : () => { [x: string]: number; }
+
+	return { [K.a]: 1, [K.b]: 1 };
+>{ [K.a]: 1, [K.b]: 1 } : { [x: string]: number; }
+>[K.a] : number
+>K.a : string
+>K : { a: string; b: string; }
+>a : string
+>1 : 1
+>[K.b] : number
+>K.b : string
+>K : { a: string; b: string; }
+>b : string
+>1 : 1
+
+})();
+console.log(aVal, bVal);
+>console.log(aVal, bVal) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>aVal : number
+>bVal : number
+

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment8(target=esnext).js
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment8(target=esnext).js
@@ -1,0 +1,20 @@
+//// [destructuringObjectBindingPatternAndAssignment8.ts]
+const K = {
+    a: "a",
+    b: "b"
+}
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+	return { [K.a]: 1, [K.b]: 1 };
+})();
+console.log(aVal, bVal);
+
+
+//// [destructuringObjectBindingPatternAndAssignment8.js]
+const K = {
+    a: "a",
+    b: "b"
+};
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+    return { [K.a]: 1, [K.b]: 1 };
+})();
+console.log(aVal, bVal);

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment8(target=esnext).symbols
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment8(target=esnext).symbols
@@ -1,0 +1,38 @@
+=== tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment8.ts ===
+const K = {
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 5))
+
+    a: "a",
+>a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 11))
+
+    b: "b"
+>b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 1, 11))
+}
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+>K.a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 11))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 5))
+>a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 11))
+>aVal : Symbol(aVal, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 4, 7))
+>K.b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 1, 11))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 5))
+>b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 1, 11))
+>bVal : Symbol(bVal, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 4, 20))
+
+	return { [K.a]: 1, [K.b]: 1 };
+>[K.a] : Symbol([K.a], Decl(destructuringObjectBindingPatternAndAssignment8.ts, 5, 9))
+>K.a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 11))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 5))
+>a : Symbol(a, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 11))
+>[K.b] : Symbol([K.b], Decl(destructuringObjectBindingPatternAndAssignment8.ts, 5, 19))
+>K.b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 1, 11))
+>K : Symbol(K, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 0, 5))
+>b : Symbol(b, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 1, 11))
+
+})();
+console.log(aVal, bVal);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>aVal : Symbol(aVal, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 4, 7))
+>bVal : Symbol(bVal, Decl(destructuringObjectBindingPatternAndAssignment8.ts, 4, 20))
+

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment8(target=esnext).types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment8(target=esnext).types
@@ -1,0 +1,48 @@
+=== tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment8.ts ===
+const K = {
+>K : { a: string; b: string; }
+>{    a: "a",    b: "b"} : { a: string; b: string; }
+
+    a: "a",
+>a : string
+>"a" : "a"
+
+    b: "b"
+>b : string
+>"b" : "b"
+}
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+>K.a : string
+>K : { a: string; b: string; }
+>a : string
+>aVal : number
+>K.b : string
+>K : { a: string; b: string; }
+>b : string
+>bVal : number
+>(() => {	return { [K.a]: 1, [K.b]: 1 };})() : { [x: string]: number; }
+>(() => {	return { [K.a]: 1, [K.b]: 1 };}) : () => { [x: string]: number; }
+>() => {	return { [K.a]: 1, [K.b]: 1 };} : () => { [x: string]: number; }
+
+	return { [K.a]: 1, [K.b]: 1 };
+>{ [K.a]: 1, [K.b]: 1 } : { [x: string]: number; }
+>[K.a] : number
+>K.a : string
+>K : { a: string; b: string; }
+>a : string
+>1 : 1
+>[K.b] : number
+>K.b : string
+>K : { a: string; b: string; }
+>b : string
+>1 : 1
+
+})();
+console.log(aVal, bVal);
+>console.log(aVal, bVal) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>aVal : number
+>bVal : number
+

--- a/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment6.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment6.ts
@@ -1,0 +1,9 @@
+// @target: es5,esnext
+
+const a = "a";
+const b = "b";
+
+const { [a]: aVal, [b]: bVal } = (() => {
+	return { [a]: 1, [b]: 1 };
+})();
+console.log(aVal, bVal);

--- a/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment7.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment7.ts
@@ -1,0 +1,10 @@
+// @target: es5,esnext
+
+enum K {
+    a = "a",
+    b = "b"
+}
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+	return { [K.a]: 1, [K.b]: 1 };
+})();
+console.log(aVal, bVal);

--- a/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment8.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment8.ts
@@ -1,0 +1,10 @@
+// @target: es5,esnext
+
+const K = {
+    a: "a",
+    b: "b"
+}
+const { [K.a]: aVal, [K.b]: bVal } = (() => {
+	return { [K.a]: 1, [K.b]: 1 };
+})();
+console.log(aVal, bVal);


### PR DESCRIPTION
Fixes #41653