### PR TITLE
fix(41688): Provide correct intellisense completion/suggestion list after `infer` keyword

### DIFF
--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -993,7 +993,7 @@ namespace FourSlashInterface {
         export const keywords: readonly ExpectedCompletionEntryObject[] = keywordsWithUndefined.filter(k => k.name !== "undefined");
 
         export const typeKeywords: readonly ExpectedCompletionEntryObject[] =
-            ["false", "null", "true", "void", "asserts", "any", "boolean", "keyof", "never", "readonly", "number", "object", "string", "symbol", "undefined", "unique", "unknown", "bigint"].map(keywordEntry);
+            ["false", "null", "true", "void", "asserts", "any", "boolean", "infer", "keyof", "never", "readonly", "number", "object", "string", "symbol", "undefined", "unique", "unknown", "bigint"].map(keywordEntry);
 
         const globalTypeDecls: readonly ExpectedCompletionEntryObject[] = [
             interfaceEntry("Symbol"),
@@ -1254,6 +1254,7 @@ namespace FourSlashInterface {
             "await",
             "boolean",
             "declare",
+            "infer",
             "keyof",
             "module",
             "namespace",
@@ -1456,6 +1457,7 @@ namespace FourSlashInterface {
             "await",
             "boolean",
             "declare",
+            "infer",
             "keyof",
             "module",
             "namespace",

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2266,6 +2266,7 @@ namespace ts.Completions {
                 case SyntaxKind.ImportKeyword:
                 case SyntaxKind.LetKeyword:
                 case SyntaxKind.ConstKeyword:
+                case SyntaxKind.InferKeyword:
                 case SyntaxKind.TypeKeyword:  // type htm|
                     return true;
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1723,6 +1723,7 @@ namespace ts {
         SyntaxKind.BigIntKeyword,
         SyntaxKind.BooleanKeyword,
         SyntaxKind.FalseKeyword,
+        SyntaxKind.InferKeyword,
         SyntaxKind.KeyOfKeyword,
         SyntaxKind.NeverKeyword,
         SyntaxKind.NullKeyword,

--- a/tests/cases/fourslash/completionListAtIdentifierDefinitionLocations_infers.ts
+++ b/tests/cases/fourslash/completionListAtIdentifierDefinitionLocations_infers.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+
+//// type UType = 1;
+//// type Bar<T> = T extends { a: (x: infer /*1*/) => void; b: (x: infer U/*2*/) => void }
+////    ? U
+////    : never;
+
+verify.completions({ marker: test.markers(), exact: undefined });

--- a/tests/cases/fourslash/completionListInferKeyword.ts
+++ b/tests/cases/fourslash/completionListInferKeyword.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts' />
+
+//// type Bar<T> = T extends { a: (x: in/**/) => void }
+////    ? U
+////    : never;
+
+verify.completions({
+    marker: "",
+    includes: [{ name: "infer", kind: "keyword", sortText: completion.SortText.GlobalsOrKeywords }]
+});


### PR DESCRIPTION
Fixes #41688