### PR TITLE
Improve uncalled function checks with parenthesized expressions in condition

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30185,7 +30185,8 @@ namespace ts {
                         const operator = node.operatorToken.kind;
                         if (operator === SyntaxKind.AmpersandAmpersandToken || operator === SyntaxKind.BarBarToken || operator === SyntaxKind.QuestionQuestionToken) {
                             if (operator === SyntaxKind.AmpersandAmpersandToken) {
-                                checkTestingKnownTruthyCallableType(node.left, leftType, isIfStatement(node.parent) ? node.parent.thenStatement : undefined);
+                                const parent = walkUpParenthesizedExpressions(node.parent);
+                                checkTestingKnownTruthyCallableType(node.left, leftType, isIfStatement(parent) ? parent.thenStatement : undefined);
                             }
                             checkTruthinessOfType(leftType, node.left);
                         }

--- a/tests/baselines/reference/truthinessCallExpressionCoercion2.errors.txt
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion2.errors.txt
@@ -2,15 +2,16 @@ tests/cases/compiler/truthinessCallExpressionCoercion2.ts(11,5): error TS2774: T
 tests/cases/compiler/truthinessCallExpressionCoercion2.ts(14,10): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
 tests/cases/compiler/truthinessCallExpressionCoercion2.ts(41,18): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
 tests/cases/compiler/truthinessCallExpressionCoercion2.ts(44,9): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
-tests/cases/compiler/truthinessCallExpressionCoercion2.ts(55,46): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
-tests/cases/compiler/truthinessCallExpressionCoercion2.ts(66,5): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
-tests/cases/compiler/truthinessCallExpressionCoercion2.ts(69,10): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
-tests/cases/compiler/truthinessCallExpressionCoercion2.ts(89,5): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
-tests/cases/compiler/truthinessCallExpressionCoercion2.ts(99,9): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
-tests/cases/compiler/truthinessCallExpressionCoercion2.ts(102,14): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion2.ts(48,11): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion2.ts(65,46): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion2.ts(76,5): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion2.ts(79,10): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion2.ts(99,5): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion2.ts(109,9): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion2.ts(112,14): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
 
 
-==== tests/cases/compiler/truthinessCallExpressionCoercion2.ts (10 errors) ====
+==== tests/cases/compiler/truthinessCallExpressionCoercion2.ts (11 errors) ====
     declare class A {
         static from(): string;
     }
@@ -64,9 +65,21 @@ tests/cases/compiler/truthinessCallExpressionCoercion2.ts(102,14): error TS2774:
             ~~~~~~~~~
 !!! error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
         }
+    
+        // error
+        if (((required1 && b))) {
+              ~~~~~~~~~
+!!! error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+        }
+    
         // ok
         if (required1 && b) {
-            required1()
+            required1();
+        }
+    
+        // ok
+        if (((required1 && b))) {
+            required1();
         }
     }
     

--- a/tests/baselines/reference/truthinessCallExpressionCoercion2.js
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion2.js
@@ -44,9 +44,19 @@ function test(required1: () => boolean, required2: () => boolean, b: boolean, op
     // error
     if (required1 && b) {
     }
+
+    // error
+    if (((required1 && b))) {
+    }
+
     // ok
     if (required1 && b) {
-        required1()
+        required1();
+    }
+
+    // ok
+    if (((required1 && b))) {
+        required1();
     }
 }
 
@@ -141,8 +151,15 @@ function test(required1, required2, b, optional) {
     // error
     if (required1 && b) {
     }
+    // error
+    if (((required1 && b))) {
+    }
     // ok
     if (required1 && b) {
+        required1();
+    }
+    // ok
+    if (((required1 && b))) {
         required1();
     }
 }

--- a/tests/baselines/reference/truthinessCallExpressionCoercion2.symbols
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion2.symbols
@@ -104,18 +104,34 @@ function test(required1: () => boolean, required2: () => boolean, b: boolean, op
 >required1 : Symbol(required1, Decl(truthinessCallExpressionCoercion2.ts, 8, 14))
 >b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 8, 65))
     }
+
+    // error
+    if (((required1 && b))) {
+>required1 : Symbol(required1, Decl(truthinessCallExpressionCoercion2.ts, 8, 14))
+>b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 8, 65))
+    }
+
     // ok
     if (required1 && b) {
 >required1 : Symbol(required1, Decl(truthinessCallExpressionCoercion2.ts, 8, 14))
 >b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 8, 65))
 
-        required1()
+        required1();
+>required1 : Symbol(required1, Decl(truthinessCallExpressionCoercion2.ts, 8, 14))
+    }
+
+    // ok
+    if (((required1 && b))) {
+>required1 : Symbol(required1, Decl(truthinessCallExpressionCoercion2.ts, 8, 14))
+>b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 8, 65))
+
+        required1();
 >required1 : Symbol(required1, Decl(truthinessCallExpressionCoercion2.ts, 8, 14))
     }
 }
 
 function checksConsole() {
->checksConsole : Symbol(checksConsole, Decl(truthinessCallExpressionCoercion2.ts, 49, 1))
+>checksConsole : Symbol(checksConsole, Decl(truthinessCallExpressionCoercion2.ts, 59, 1))
 
     // error
     typeof window !== 'undefined' && window.console &&
@@ -141,70 +157,70 @@ function checksConsole() {
 }
 
 function checksPropertyAccess() {
->checksPropertyAccess : Symbol(checksPropertyAccess, Decl(truthinessCallExpressionCoercion2.ts, 55, 1))
+>checksPropertyAccess : Symbol(checksPropertyAccess, Decl(truthinessCallExpressionCoercion2.ts, 65, 1))
 
     const x = {
->x : Symbol(x, Decl(truthinessCallExpressionCoercion2.ts, 58, 9))
+>x : Symbol(x, Decl(truthinessCallExpressionCoercion2.ts, 68, 9))
 
         foo: {
->foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 58, 15))
+>foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 68, 15))
 
             bar() { return true; }
->bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 59, 14))
+>bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 69, 14))
         }
     }
 
     // error
     x.foo.bar && console.log('x.foo.bar');
->x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 59, 14))
->x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 58, 15))
->x : Symbol(x, Decl(truthinessCallExpressionCoercion2.ts, 58, 9))
->foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 58, 15))
->bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 59, 14))
+>x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 69, 14))
+>x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 68, 15))
+>x : Symbol(x, Decl(truthinessCallExpressionCoercion2.ts, 68, 9))
+>foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 68, 15))
+>bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 69, 14))
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 
     // error
     1 && x.foo.bar && console.log('x.foo.bar');
->x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 59, 14))
->x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 58, 15))
->x : Symbol(x, Decl(truthinessCallExpressionCoercion2.ts, 58, 9))
->foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 58, 15))
->bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 59, 14))
+>x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 69, 14))
+>x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 68, 15))
+>x : Symbol(x, Decl(truthinessCallExpressionCoercion2.ts, 68, 9))
+>foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 68, 15))
+>bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 69, 14))
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 
     // ok
     x.foo.bar && x.foo.bar();
->x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 59, 14))
->x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 58, 15))
->x : Symbol(x, Decl(truthinessCallExpressionCoercion2.ts, 58, 9))
->foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 58, 15))
->bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 59, 14))
->x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 59, 14))
->x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 58, 15))
->x : Symbol(x, Decl(truthinessCallExpressionCoercion2.ts, 58, 9))
->foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 58, 15))
->bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 59, 14))
+>x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 69, 14))
+>x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 68, 15))
+>x : Symbol(x, Decl(truthinessCallExpressionCoercion2.ts, 68, 9))
+>foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 68, 15))
+>bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 69, 14))
+>x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 69, 14))
+>x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 68, 15))
+>x : Symbol(x, Decl(truthinessCallExpressionCoercion2.ts, 68, 9))
+>foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 68, 15))
+>bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 69, 14))
 
     // ok
     x.foo.bar && 1 && x.foo.bar();
->x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 59, 14))
->x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 58, 15))
->x : Symbol(x, Decl(truthinessCallExpressionCoercion2.ts, 58, 9))
->foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 58, 15))
->bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 59, 14))
->x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 59, 14))
->x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 58, 15))
->x : Symbol(x, Decl(truthinessCallExpressionCoercion2.ts, 58, 9))
->foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 58, 15))
->bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 59, 14))
+>x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 69, 14))
+>x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 68, 15))
+>x : Symbol(x, Decl(truthinessCallExpressionCoercion2.ts, 68, 9))
+>foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 68, 15))
+>bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 69, 14))
+>x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 69, 14))
+>x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 68, 15))
+>x : Symbol(x, Decl(truthinessCallExpressionCoercion2.ts, 68, 9))
+>foo : Symbol(foo, Decl(truthinessCallExpressionCoercion2.ts, 68, 15))
+>bar : Symbol(bar, Decl(truthinessCallExpressionCoercion2.ts, 69, 14))
 
     // ok
     const y = A.from && (A.from as Function) !== B.from ? true : false;
->y : Symbol(y, Decl(truthinessCallExpressionCoercion2.ts, 77, 9))
+>y : Symbol(y, Decl(truthinessCallExpressionCoercion2.ts, 87, 9))
 >A.from : Symbol(A.from, Decl(truthinessCallExpressionCoercion2.ts, 0, 17))
 >A : Symbol(A, Decl(truthinessCallExpressionCoercion2.ts, 0, 0))
 >from : Symbol(A.from, Decl(truthinessCallExpressionCoercion2.ts, 0, 17))
@@ -217,98 +233,98 @@ function checksPropertyAccess() {
 >from : Symbol(B.from, Decl(truthinessCallExpressionCoercion2.ts, 4, 17))
 
     y;
->y : Symbol(y, Decl(truthinessCallExpressionCoercion2.ts, 77, 9))
+>y : Symbol(y, Decl(truthinessCallExpressionCoercion2.ts, 87, 9))
 
     const x1 = {
->x1 : Symbol(x1, Decl(truthinessCallExpressionCoercion2.ts, 80, 9))
+>x1 : Symbol(x1, Decl(truthinessCallExpressionCoercion2.ts, 90, 9))
 
         a: { b: { c: () => {} } }
->a : Symbol(a, Decl(truthinessCallExpressionCoercion2.ts, 80, 16))
->b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 81, 12))
->c : Symbol(c, Decl(truthinessCallExpressionCoercion2.ts, 81, 17))
+>a : Symbol(a, Decl(truthinessCallExpressionCoercion2.ts, 90, 16))
+>b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 91, 12))
+>c : Symbol(c, Decl(truthinessCallExpressionCoercion2.ts, 91, 17))
     }
     const x2 = {
->x2 : Symbol(x2, Decl(truthinessCallExpressionCoercion2.ts, 83, 9))
+>x2 : Symbol(x2, Decl(truthinessCallExpressionCoercion2.ts, 93, 9))
 
         a: { b: { c: () => {} } }
->a : Symbol(a, Decl(truthinessCallExpressionCoercion2.ts, 83, 16))
->b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 84, 12))
->c : Symbol(c, Decl(truthinessCallExpressionCoercion2.ts, 84, 17))
+>a : Symbol(a, Decl(truthinessCallExpressionCoercion2.ts, 93, 16))
+>b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 94, 12))
+>c : Symbol(c, Decl(truthinessCallExpressionCoercion2.ts, 94, 17))
     }
 
     // error
     x1.a.b.c && x2.a.b.c();
->x1.a.b.c : Symbol(c, Decl(truthinessCallExpressionCoercion2.ts, 81, 17))
->x1.a.b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 81, 12))
->x1.a : Symbol(a, Decl(truthinessCallExpressionCoercion2.ts, 80, 16))
->x1 : Symbol(x1, Decl(truthinessCallExpressionCoercion2.ts, 80, 9))
->a : Symbol(a, Decl(truthinessCallExpressionCoercion2.ts, 80, 16))
->b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 81, 12))
->c : Symbol(c, Decl(truthinessCallExpressionCoercion2.ts, 81, 17))
->x2.a.b.c : Symbol(c, Decl(truthinessCallExpressionCoercion2.ts, 84, 17))
->x2.a.b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 84, 12))
->x2.a : Symbol(a, Decl(truthinessCallExpressionCoercion2.ts, 83, 16))
->x2 : Symbol(x2, Decl(truthinessCallExpressionCoercion2.ts, 83, 9))
->a : Symbol(a, Decl(truthinessCallExpressionCoercion2.ts, 83, 16))
->b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 84, 12))
->c : Symbol(c, Decl(truthinessCallExpressionCoercion2.ts, 84, 17))
+>x1.a.b.c : Symbol(c, Decl(truthinessCallExpressionCoercion2.ts, 91, 17))
+>x1.a.b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 91, 12))
+>x1.a : Symbol(a, Decl(truthinessCallExpressionCoercion2.ts, 90, 16))
+>x1 : Symbol(x1, Decl(truthinessCallExpressionCoercion2.ts, 90, 9))
+>a : Symbol(a, Decl(truthinessCallExpressionCoercion2.ts, 90, 16))
+>b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 91, 12))
+>c : Symbol(c, Decl(truthinessCallExpressionCoercion2.ts, 91, 17))
+>x2.a.b.c : Symbol(c, Decl(truthinessCallExpressionCoercion2.ts, 94, 17))
+>x2.a.b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 94, 12))
+>x2.a : Symbol(a, Decl(truthinessCallExpressionCoercion2.ts, 93, 16))
+>x2 : Symbol(x2, Decl(truthinessCallExpressionCoercion2.ts, 93, 9))
+>a : Symbol(a, Decl(truthinessCallExpressionCoercion2.ts, 93, 16))
+>b : Symbol(b, Decl(truthinessCallExpressionCoercion2.ts, 94, 12))
+>c : Symbol(c, Decl(truthinessCallExpressionCoercion2.ts, 94, 17))
 }
 
 class Foo {
->Foo : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 89, 1))
+>Foo : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 99, 1))
 
     optional?: () => boolean;
->optional : Symbol(Foo.optional, Decl(truthinessCallExpressionCoercion2.ts, 91, 11))
+>optional : Symbol(Foo.optional, Decl(truthinessCallExpressionCoercion2.ts, 101, 11))
 
     required() {
->required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 92, 29))
+>required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 102, 29))
 
         return true;
     }
     test() {
->test : Symbol(Foo.test, Decl(truthinessCallExpressionCoercion2.ts, 95, 5))
+>test : Symbol(Foo.test, Decl(truthinessCallExpressionCoercion2.ts, 105, 5))
 
         // error
         this.required && console.log('required');
->this.required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 92, 29))
->this : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 89, 1))
->required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 92, 29))
+>this.required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 102, 29))
+>this : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 99, 1))
+>required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 102, 29))
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 
         // error
         1 && this.required && console.log('required');
->this.required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 92, 29))
->this : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 89, 1))
->required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 92, 29))
+>this.required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 102, 29))
+>this : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 99, 1))
+>required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 102, 29))
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 
         // ok
         this.required && this.required();
->this.required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 92, 29))
->this : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 89, 1))
->required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 92, 29))
->this.required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 92, 29))
->this : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 89, 1))
->required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 92, 29))
+>this.required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 102, 29))
+>this : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 99, 1))
+>required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 102, 29))
+>this.required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 102, 29))
+>this : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 99, 1))
+>required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 102, 29))
 
         // ok
         this.required && 1 && this.required();
->this.required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 92, 29))
->this : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 89, 1))
->required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 92, 29))
->this.required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 92, 29))
->this : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 89, 1))
->required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 92, 29))
+>this.required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 102, 29))
+>this : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 99, 1))
+>required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 102, 29))
+>this.required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 102, 29))
+>this : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 99, 1))
+>required : Symbol(Foo.required, Decl(truthinessCallExpressionCoercion2.ts, 102, 29))
 
         // ok
         1 && this.optional && console.log('optional');
->this.optional : Symbol(Foo.optional, Decl(truthinessCallExpressionCoercion2.ts, 91, 11))
->this : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 89, 1))
->optional : Symbol(Foo.optional, Decl(truthinessCallExpressionCoercion2.ts, 91, 11))
+>this.optional : Symbol(Foo.optional, Decl(truthinessCallExpressionCoercion2.ts, 101, 11))
+>this : Symbol(Foo, Decl(truthinessCallExpressionCoercion2.ts, 99, 1))
+>optional : Symbol(Foo.optional, Decl(truthinessCallExpressionCoercion2.ts, 101, 11))
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))

--- a/tests/baselines/reference/truthinessCallExpressionCoercion2.types
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion2.types
@@ -153,13 +153,36 @@ function test(required1: () => boolean, required2: () => boolean, b: boolean, op
 >required1 : () => boolean
 >b : boolean
     }
+
+    // error
+    if (((required1 && b))) {
+>((required1 && b)) : boolean
+>(required1 && b) : boolean
+>required1 && b : boolean
+>required1 : () => boolean
+>b : boolean
+    }
+
     // ok
     if (required1 && b) {
 >required1 && b : boolean
 >required1 : () => boolean
 >b : boolean
 
-        required1()
+        required1();
+>required1() : boolean
+>required1 : () => boolean
+    }
+
+    // ok
+    if (((required1 && b))) {
+>((required1 && b)) : boolean
+>(required1 && b) : boolean
+>required1 && b : boolean
+>required1 : () => boolean
+>b : boolean
+
+        required1();
 >required1() : boolean
 >required1 : () => boolean
     }

--- a/tests/cases/compiler/truthinessCallExpressionCoercion2.ts
+++ b/tests/cases/compiler/truthinessCallExpressionCoercion2.ts
@@ -46,9 +46,19 @@ function test(required1: () => boolean, required2: () => boolean, b: boolean, op
     // error
     if (required1 && b) {
     }
+
+    // error
+    if (((required1 && b))) {
+    }
+
     // ok
     if (required1 && b) {
-        required1()
+        required1();
+    }
+
+    // ok
+    if (((required1 && b))) {
+        required1();
     }
 }
 


### PR DESCRIPTION
Fixes the following issue:

```ts
if (((required1 && b))) {
    required1();
}
```

/cc @sandersn 