### PR TITLE
Under jsx: preserve, actually preserve expressions which contain only comments

### DIFF
--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -1790,7 +1790,7 @@ namespace ts {
                         const name = importDeclaration.propertyName || importDeclaration.name;
                         return setTextRange(
                             factory.createPropertyAccessExpression(
-                                factory.getGeneratedNameForNode(importDeclaration.parent.parent.parent),
+                                factory.getGeneratedNameForNode(importDeclaration.parent?.parent?.parent || importDeclaration),
                                 factory.cloneNode(name)
                             ),
                             /*location*/ node

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -1678,7 +1678,7 @@ namespace ts {
                             factory.createPropertyAssignment(
                                 factory.cloneNode(name),
                                 factory.createPropertyAccessExpression(
-                                    factory.getGeneratedNameForNode(importDeclaration.parent.parent.parent),
+                                    factory.getGeneratedNameForNode(importDeclaration.parent?.parent?.parent || importDeclaration),
                                     factory.cloneNode(importDeclaration.propertyName || importDeclaration.name)
                                 ),
                             ),
@@ -1747,7 +1747,7 @@ namespace ts {
                     else if (isImportSpecifier(importDeclaration)) {
                         return setTextRange(
                             factory.createPropertyAccessExpression(
-                                factory.getGeneratedNameForNode(importDeclaration.parent.parent.parent),
+                                factory.getGeneratedNameForNode(importDeclaration.parent?.parent?.parent || importDeclaration),
                                 factory.cloneNode(importDeclaration.propertyName || importDeclaration.name)
                             ),
                             /*location*/ node

--- a/tests/baselines/reference/commentEmittingInPreserveJsx1.js
+++ b/tests/baselines/reference/commentEmittingInPreserveJsx1.js
@@ -39,19 +39,21 @@ var React = require("react");
 </div>;
 <div>
     // Not Comment
-    
+    {
+    //Comment just Fine
+    }
     // Another not Comment
 </div>;
 <div>
     // Not Comment
     {
-//Comment just Fine
-"Hi"}
+    //Comment just Fine
+    "Hi"}
     // Another not Comment
 </div>;
 <div>
     /* Not Comment */
     {
-//Comment just Fine
-"Hi"}
+    //Comment just Fine
+    "Hi"}
 </div>;

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=commonjs).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=commonjs).js
@@ -1,14 +1,21 @@
 //// [commentsOnJSXExpressionsArePreserved.tsx]
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
-    type JSXElement = any;
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
     render() {
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }
@@ -21,6 +28,16 @@ var Component = /** @class */ (function () {
         return <div>
             {/* missing */}
             {null /* preserved */}
+            {
+            // ??? 1
+            }
+            {// ??? 2
+            }
+            {// ??? 3
+            }
+            {
+            // ??? 4
+            /* ??? 5 */ }
         </div>;
     };
     return Component;

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=commonjs).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=commonjs).js
@@ -1,0 +1,27 @@
+//// [commentsOnJSXExpressionsArePreserved.tsx]
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+    type JSXElement = any;
+}
+class Component {
+    render() {
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}
+
+//// [commentsOnJSXExpressionsArePreserved.jsx]
+var Component = /** @class */ (function () {
+    function Component() {
+    }
+    Component.prototype.render = function () {
+        return <div>
+            {/* missing */}
+            {null /* preserved */}
+        </div>;
+    };
+    return Component;
+}());

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=commonjs).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=commonjs).symbols
@@ -1,24 +1,27 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 >JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
 
-    interface IntrsinsicElements { [index: string]: any }
->IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
->index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
-
-    type JSXElement = any;
->JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
-}
 class Component {
->Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 16))
 
     render() {
->render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 17))
 
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=commonjs).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=commonjs).symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+>JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
+
+    interface IntrsinsicElements { [index: string]: any }
+>IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
+>index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
+
+    type JSXElement = any;
+>JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
+}
+class Component {
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+
+    render() {
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=commonjs).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=commonjs).types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+>index : string
+
+    type JSXElement = any;
+>JSXElement : any
+}
+class Component {
+>Component : Component
+
+    render() {
+>render : () => any
+
+        return <div>
+><div>            {/* missing */}            {null/* preserved */}        </div> : error
+>div : any
+
+            {/* missing */}
+            {null/* preserved */}
+>null : null
+
+        </div>;
+>div : any
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=commonjs).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=commonjs).types
@@ -1,12 +1,6 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
->index : string
-
-    type JSXElement = any;
->JSXElement : any
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
 >Component : Component
 
@@ -14,13 +8,22 @@ class Component {
 >render : () => any
 
         return <div>
-><div>            {/* missing */}            {null/* preserved */}        </div> : error
+><div>            {/* missing */}            {null/* preserved */}            {                // ??? 1            }            { // ??? 2            }            {// ??? 3            }            {                // ??? 4            /* ??? 5 */}        </div> : error
 >div : any
 
             {/* missing */}
             {null/* preserved */}
 >null : null
-
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
 >div : any
     }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=system).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=system).js
@@ -1,14 +1,21 @@
 //// [commentsOnJSXExpressionsArePreserved.tsx]
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
-    type JSXElement = any;
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
     render() {
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }
@@ -21,6 +28,16 @@ var Component = /** @class */ (function () {
         return <div>
             {/* missing */}
             {null /* preserved */}
+            {
+            // ??? 1
+            }
+            {// ??? 2
+            }
+            {// ??? 3
+            }
+            {
+            // ??? 4
+            /* ??? 5 */ }
         </div>;
     };
     return Component;

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=system).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=system).js
@@ -1,0 +1,27 @@
+//// [commentsOnJSXExpressionsArePreserved.tsx]
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+    type JSXElement = any;
+}
+class Component {
+    render() {
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}
+
+//// [commentsOnJSXExpressionsArePreserved.jsx]
+var Component = /** @class */ (function () {
+    function Component() {
+    }
+    Component.prototype.render = function () {
+        return <div>
+            {/* missing */}
+            {null /* preserved */}
+        </div>;
+    };
+    return Component;
+}());

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=system).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=system).symbols
@@ -1,24 +1,27 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 >JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
 
-    interface IntrsinsicElements { [index: string]: any }
->IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
->index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
-
-    type JSXElement = any;
->JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
-}
 class Component {
->Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 16))
 
     render() {
->render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 17))
 
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=system).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=system).symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+>JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
+
+    interface IntrsinsicElements { [index: string]: any }
+>IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
+>index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
+
+    type JSXElement = any;
+>JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
+}
+class Component {
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+
+    render() {
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=system).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=system).types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+>index : string
+
+    type JSXElement = any;
+>JSXElement : any
+}
+class Component {
+>Component : Component
+
+    render() {
+>render : () => any
+
+        return <div>
+><div>            {/* missing */}            {null/* preserved */}        </div> : error
+>div : any
+
+            {/* missing */}
+            {null/* preserved */}
+>null : null
+
+        </div>;
+>div : any
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=system).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=preserve,module=system).types
@@ -1,12 +1,6 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
->index : string
-
-    type JSXElement = any;
->JSXElement : any
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
 >Component : Component
 
@@ -14,13 +8,22 @@ class Component {
 >render : () => any
 
         return <div>
-><div>            {/* missing */}            {null/* preserved */}        </div> : error
+><div>            {/* missing */}            {null/* preserved */}            {                // ??? 1            }            { // ??? 2            }            {// ??? 3            }            {                // ??? 4            /* ??? 5 */}        </div> : error
 >div : any
 
             {/* missing */}
             {null/* preserved */}
 >null : null
-
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
 >div : any
     }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).errors.txt
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).errors.txt
@@ -1,0 +1,19 @@
+tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,17): error TS2304: Cannot find name 'React'.
+
+
+==== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx (1 errors) ====
+    // file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+    namespace JSX {
+        interface IntrsinsicElements { [index: string]: any }
+        type JSXElement = any;
+    }
+    class Component {
+        render() {
+            return <div>
+                    ~~~
+!!! error TS2304: Cannot find name 'React'.
+                {/* missing */}
+                {null/* preserved */}
+            </div>;
+        }
+    }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).errors.txt
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).errors.txt
@@ -1,12 +1,9 @@
-tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,17): error TS2304: Cannot find name 'React'.
+tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(5,17): error TS2304: Cannot find name 'React'.
 
 
 ==== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx (1 errors) ====
-    // file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-    namespace JSX {
-        interface IntrsinsicElements { [index: string]: any }
-        type JSXElement = any;
-    }
+    // file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+    namespace JSX {}
     class Component {
         render() {
             return <div>
@@ -14,6 +11,16 @@ tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,17): error TS230
 !!! error TS2304: Cannot find name 'React'.
                 {/* missing */}
                 {null/* preserved */}
+                {
+                    // ??? 1
+                }
+                { // ??? 2
+                }
+                {// ??? 3
+                }
+                {
+                    // ??? 4
+                /* ??? 5 */}
             </div>;
         }
     }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).js
@@ -1,0 +1,24 @@
+//// [commentsOnJSXExpressionsArePreserved.tsx]
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+    type JSXElement = any;
+}
+class Component {
+    render() {
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}
+
+//// [commentsOnJSXExpressionsArePreserved.js]
+var Component = /** @class */ (function () {
+    function Component() {
+    }
+    Component.prototype.render = function () {
+        return React.createElement("div", null, null /* preserved */);
+    };
+    return Component;
+}());

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).js
@@ -1,14 +1,21 @@
 //// [commentsOnJSXExpressionsArePreserved.tsx]
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
-    type JSXElement = any;
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
     render() {
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).symbols
@@ -1,24 +1,27 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 >JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
 
-    interface IntrsinsicElements { [index: string]: any }
->IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
->index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
-
-    type JSXElement = any;
->JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
-}
 class Component {
->Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 16))
 
     render() {
->render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 17))
 
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+>JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
+
+    interface IntrsinsicElements { [index: string]: any }
+>IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
+>index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
+
+    type JSXElement = any;
+>JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
+}
+class Component {
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+
+    render() {
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).types
@@ -1,12 +1,6 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
->index : string
-
-    type JSXElement = any;
->JSXElement : any
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
 >Component : Component
 
@@ -14,13 +8,22 @@ class Component {
 >render : () => any
 
         return <div>
-><div>            {/* missing */}            {null/* preserved */}        </div> : any
+><div>            {/* missing */}            {null/* preserved */}            {                // ??? 1            }            { // ??? 2            }            {// ??? 3            }            {                // ??? 4            /* ??? 5 */}        </div> : any
 >div : any
 
             {/* missing */}
             {null/* preserved */}
 >null : null
-
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
 >div : any
     }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=commonjs).types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+>index : string
+
+    type JSXElement = any;
+>JSXElement : any
+}
+class Component {
+>Component : Component
+
+    render() {
+>render : () => any
+
+        return <div>
+><div>            {/* missing */}            {null/* preserved */}        </div> : any
+>div : any
+
+            {/* missing */}
+            {null/* preserved */}
+>null : null
+
+        </div>;
+>div : any
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).errors.txt
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).errors.txt
@@ -1,0 +1,19 @@
+tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,17): error TS2304: Cannot find name 'React'.
+
+
+==== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx (1 errors) ====
+    // file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+    namespace JSX {
+        interface IntrsinsicElements { [index: string]: any }
+        type JSXElement = any;
+    }
+    class Component {
+        render() {
+            return <div>
+                    ~~~
+!!! error TS2304: Cannot find name 'React'.
+                {/* missing */}
+                {null/* preserved */}
+            </div>;
+        }
+    }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).errors.txt
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).errors.txt
@@ -1,12 +1,9 @@
-tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,17): error TS2304: Cannot find name 'React'.
+tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(5,17): error TS2304: Cannot find name 'React'.
 
 
 ==== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx (1 errors) ====
-    // file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-    namespace JSX {
-        interface IntrsinsicElements { [index: string]: any }
-        type JSXElement = any;
-    }
+    // file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+    namespace JSX {}
     class Component {
         render() {
             return <div>
@@ -14,6 +11,16 @@ tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,17): error TS230
 !!! error TS2304: Cannot find name 'React'.
                 {/* missing */}
                 {null/* preserved */}
+                {
+                    // ??? 1
+                }
+                { // ??? 2
+                }
+                {// ??? 3
+                }
+                {
+                    // ??? 4
+                /* ??? 5 */}
             </div>;
         }
     }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).js
@@ -1,0 +1,24 @@
+//// [commentsOnJSXExpressionsArePreserved.tsx]
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+    type JSXElement = any;
+}
+class Component {
+    render() {
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}
+
+//// [commentsOnJSXExpressionsArePreserved.js]
+var Component = /** @class */ (function () {
+    function Component() {
+    }
+    Component.prototype.render = function () {
+        return React.createElement("div", null, null /* preserved */);
+    };
+    return Component;
+}());

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).js
@@ -1,14 +1,21 @@
 //// [commentsOnJSXExpressionsArePreserved.tsx]
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
-    type JSXElement = any;
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
     render() {
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).symbols
@@ -1,24 +1,27 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 >JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
 
-    interface IntrsinsicElements { [index: string]: any }
->IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
->index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
-
-    type JSXElement = any;
->JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
-}
 class Component {
->Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 16))
 
     render() {
->render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 17))
 
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+>JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
+
+    interface IntrsinsicElements { [index: string]: any }
+>IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
+>index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
+
+    type JSXElement = any;
+>JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
+}
+class Component {
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+
+    render() {
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).types
@@ -1,12 +1,6 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
->index : string
-
-    type JSXElement = any;
->JSXElement : any
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
 >Component : Component
 
@@ -14,13 +8,22 @@ class Component {
 >render : () => any
 
         return <div>
-><div>            {/* missing */}            {null/* preserved */}        </div> : any
+><div>            {/* missing */}            {null/* preserved */}            {                // ??? 1            }            { // ??? 2            }            {// ??? 3            }            {                // ??? 4            /* ??? 5 */}        </div> : any
 >div : any
 
             {/* missing */}
             {null/* preserved */}
 >null : null
-
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
 >div : any
     }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react,module=system).types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+>index : string
+
+    type JSXElement = any;
+>JSXElement : any
+}
+class Component {
+>Component : Component
+
+    render() {
+>render : () => any
+
+        return <div>
+><div>            {/* missing */}            {null/* preserved */}        </div> : any
+>div : any
+
+            {/* missing */}
+            {null/* preserved */}
+>null : null
+
+        </div>;
+>div : any
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).errors.txt
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).errors.txt
@@ -1,12 +1,9 @@
-tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,16): error TS2307: Cannot find module 'react/jsx-runtime' or its corresponding type declarations.
+tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(5,16): error TS2307: Cannot find module 'react/jsx-runtime' or its corresponding type declarations.
 
 
 ==== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx (1 errors) ====
-    // file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-    namespace JSX {
-        interface IntrsinsicElements { [index: string]: any }
-        type JSXElement = any;
-    }
+    // file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+    namespace JSX {}
     class Component {
         render() {
             return <div>
@@ -15,6 +12,26 @@ tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,16): error TS230
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 {null/* preserved */}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                {
+    ~~~~~~~~~~~~~
+                    // ??? 1
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+                }
+    ~~~~~~~~~~~~~
+                { // ??? 2
+    ~~~~~~~~~~~~~~~~~~~~~~
+                }
+    ~~~~~~~~~~~~~
+                {// ??? 3
+    ~~~~~~~~~~~~~~~~~~~~~
+                }
+    ~~~~~~~~~~~~~
+                {
+    ~~~~~~~~~~~~~
+                    // ??? 4
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+                /* ??? 5 */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~
             </div>;
     ~~~~~~~~~~~~~~
 !!! error TS2307: Cannot find module 'react/jsx-runtime' or its corresponding type declarations.

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).errors.txt
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).errors.txt
@@ -1,0 +1,22 @@
+tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,16): error TS2307: Cannot find module 'react/jsx-runtime' or its corresponding type declarations.
+
+
+==== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx (1 errors) ====
+    // file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+    namespace JSX {
+        interface IntrsinsicElements { [index: string]: any }
+        type JSXElement = any;
+    }
+    class Component {
+        render() {
+            return <div>
+                   ~~~~~
+                {/* missing */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                {null/* preserved */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            </div>;
+    ~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'react/jsx-runtime' or its corresponding type declarations.
+        }
+    }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).js
@@ -1,14 +1,21 @@
 //// [commentsOnJSXExpressionsArePreserved.tsx]
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
-    type JSXElement = any;
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
     render() {
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).js
@@ -1,0 +1,24 @@
+//// [commentsOnJSXExpressionsArePreserved.tsx]
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+    type JSXElement = any;
+}
+class Component {
+    render() {
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}
+
+//// [commentsOnJSXExpressionsArePreserved.js]
+var Component = /** @class */ (function () {
+    function Component() {
+    }
+    Component.prototype.render = function () {
+        return _a.jsx("div", { children: null /* preserved */ }, void 0);
+    };
+    return Component;
+}());

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).symbols
@@ -1,24 +1,27 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 >JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
 
-    interface IntrsinsicElements { [index: string]: any }
->IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
->index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
-
-    type JSXElement = any;
->JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
-}
 class Component {
->Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 16))
 
     render() {
->render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 17))
 
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+>JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
+
+    interface IntrsinsicElements { [index: string]: any }
+>IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
+>index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
+
+    type JSXElement = any;
+>JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
+}
+class Component {
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+
+    render() {
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).types
@@ -1,12 +1,6 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
->index : string
-
-    type JSXElement = any;
->JSXElement : any
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
 >Component : Component
 
@@ -14,13 +8,22 @@ class Component {
 >render : () => any
 
         return <div>
-><div>            {/* missing */}            {null/* preserved */}        </div> : any
+><div>            {/* missing */}            {null/* preserved */}            {                // ??? 1            }            { // ??? 2            }            {// ??? 3            }            {                // ??? 4            /* ??? 5 */}        </div> : any
 >div : any
 
             {/* missing */}
             {null/* preserved */}
 >null : null
-
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
 >div : any
     }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=commonjs).types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+>index : string
+
+    type JSXElement = any;
+>JSXElement : any
+}
+class Component {
+>Component : Component
+
+    render() {
+>render : () => any
+
+        return <div>
+><div>            {/* missing */}            {null/* preserved */}        </div> : any
+>div : any
+
+            {/* missing */}
+            {null/* preserved */}
+>null : null
+
+        </div>;
+>div : any
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).errors.txt
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).errors.txt
@@ -1,12 +1,9 @@
-tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,16): error TS2792: Cannot find module 'react/jsx-runtime'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?
+tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(5,16): error TS2792: Cannot find module 'react/jsx-runtime'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?
 
 
 ==== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx (1 errors) ====
-    // file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-    namespace JSX {
-        interface IntrsinsicElements { [index: string]: any }
-        type JSXElement = any;
-    }
+    // file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+    namespace JSX {}
     class Component {
         render() {
             return <div>
@@ -15,6 +12,26 @@ tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,16): error TS279
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 {null/* preserved */}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                {
+    ~~~~~~~~~~~~~
+                    // ??? 1
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+                }
+    ~~~~~~~~~~~~~
+                { // ??? 2
+    ~~~~~~~~~~~~~~~~~~~~~~
+                }
+    ~~~~~~~~~~~~~
+                {// ??? 3
+    ~~~~~~~~~~~~~~~~~~~~~
+                }
+    ~~~~~~~~~~~~~
+                {
+    ~~~~~~~~~~~~~
+                    // ??? 4
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+                /* ??? 5 */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~
             </div>;
     ~~~~~~~~~~~~~~
 !!! error TS2792: Cannot find module 'react/jsx-runtime'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).errors.txt
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).errors.txt
@@ -1,0 +1,22 @@
+tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,16): error TS2792: Cannot find module 'react/jsx-runtime'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?
+
+
+==== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx (1 errors) ====
+    // file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+    namespace JSX {
+        interface IntrsinsicElements { [index: string]: any }
+        type JSXElement = any;
+    }
+    class Component {
+        render() {
+            return <div>
+                   ~~~~~
+                {/* missing */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                {null/* preserved */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            </div>;
+    ~~~~~~~~~~~~~~
+!!! error TS2792: Cannot find module 'react/jsx-runtime'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?
+        }
+    }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).js
@@ -1,14 +1,21 @@
 //// [commentsOnJSXExpressionsArePreserved.tsx]
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
-    type JSXElement = any;
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
     render() {
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).js
@@ -1,0 +1,24 @@
+//// [commentsOnJSXExpressionsArePreserved.tsx]
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+    type JSXElement = any;
+}
+class Component {
+    render() {
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}
+
+//// [commentsOnJSXExpressionsArePreserved.js]
+var Component = /** @class */ (function () {
+    function Component() {
+    }
+    Component.prototype.render = function () {
+        return _jsx("div", { children: null /* preserved */ }, void 0);
+    };
+    return Component;
+}());

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).symbols
@@ -1,24 +1,27 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 >JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
 
-    interface IntrsinsicElements { [index: string]: any }
->IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
->index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
-
-    type JSXElement = any;
->JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
-}
 class Component {
->Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 16))
 
     render() {
->render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 17))
 
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+>JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
+
+    interface IntrsinsicElements { [index: string]: any }
+>IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
+>index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
+
+    type JSXElement = any;
+>JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
+}
+class Component {
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+
+    render() {
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).types
@@ -1,12 +1,6 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
->index : string
-
-    type JSXElement = any;
->JSXElement : any
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
 >Component : Component
 
@@ -14,13 +8,22 @@ class Component {
 >render : () => any
 
         return <div>
-><div>            {/* missing */}            {null/* preserved */}        </div> : any
+><div>            {/* missing */}            {null/* preserved */}            {                // ??? 1            }            { // ??? 2            }            {// ??? 3            }            {                // ??? 4            /* ??? 5 */}        </div> : any
 >div : any
 
             {/* missing */}
             {null/* preserved */}
 >null : null
-
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
 >div : any
     }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsx,module=system).types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+>index : string
+
+    type JSXElement = any;
+>JSXElement : any
+}
+class Component {
+>Component : Component
+
+    render() {
+>render : () => any
+
+        return <div>
+><div>            {/* missing */}            {null/* preserved */}        </div> : any
+>div : any
+
+            {/* missing */}
+            {null/* preserved */}
+>null : null
+
+        </div>;
+>div : any
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).errors.txt
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).errors.txt
@@ -1,0 +1,22 @@
+tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,16): error TS2307: Cannot find module 'react/jsx-dev-runtime' or its corresponding type declarations.
+
+
+==== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx (1 errors) ====
+    // file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+    namespace JSX {
+        interface IntrsinsicElements { [index: string]: any }
+        type JSXElement = any;
+    }
+    class Component {
+        render() {
+            return <div>
+                   ~~~~~
+                {/* missing */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                {null/* preserved */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            </div>;
+    ~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'react/jsx-dev-runtime' or its corresponding type declarations.
+        }
+    }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).errors.txt
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).errors.txt
@@ -1,12 +1,9 @@
-tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,16): error TS2307: Cannot find module 'react/jsx-dev-runtime' or its corresponding type declarations.
+tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(5,16): error TS2307: Cannot find module 'react/jsx-dev-runtime' or its corresponding type declarations.
 
 
 ==== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx (1 errors) ====
-    // file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-    namespace JSX {
-        interface IntrsinsicElements { [index: string]: any }
-        type JSXElement = any;
-    }
+    // file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+    namespace JSX {}
     class Component {
         render() {
             return <div>
@@ -15,6 +12,26 @@ tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,16): error TS230
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 {null/* preserved */}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                {
+    ~~~~~~~~~~~~~
+                    // ??? 1
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+                }
+    ~~~~~~~~~~~~~
+                { // ??? 2
+    ~~~~~~~~~~~~~~~~~~~~~~
+                }
+    ~~~~~~~~~~~~~
+                {// ??? 3
+    ~~~~~~~~~~~~~~~~~~~~~
+                }
+    ~~~~~~~~~~~~~
+                {
+    ~~~~~~~~~~~~~
+                    // ??? 4
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+                /* ??? 5 */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~
             </div>;
     ~~~~~~~~~~~~~~
 !!! error TS2307: Cannot find module 'react/jsx-dev-runtime' or its corresponding type declarations.

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).js
@@ -1,0 +1,25 @@
+//// [commentsOnJSXExpressionsArePreserved.tsx]
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+    type JSXElement = any;
+}
+class Component {
+    render() {
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}
+
+//// [commentsOnJSXExpressionsArePreserved.js]
+var _jsxFileName = "tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx";
+var Component = /** @class */ (function () {
+    function Component() {
+    }
+    Component.prototype.render = function () {
+        return _a.jsxDEV("div", { children: null /* preserved */ }, void 0, false, { fileName: _jsxFileName, lineNumber: 8, columnNumber: 15 }, this);
+    };
+    return Component;
+}());

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).js
@@ -1,14 +1,21 @@
 //// [commentsOnJSXExpressionsArePreserved.tsx]
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
-    type JSXElement = any;
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
     render() {
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }
@@ -19,7 +26,7 @@ var Component = /** @class */ (function () {
     function Component() {
     }
     Component.prototype.render = function () {
-        return _a.jsxDEV("div", { children: null /* preserved */ }, void 0, false, { fileName: _jsxFileName, lineNumber: 8, columnNumber: 15 }, this);
+        return _a.jsxDEV("div", { children: null /* preserved */ }, void 0, false, { fileName: _jsxFileName, lineNumber: 5, columnNumber: 15 }, this);
     };
     return Component;
 }());

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).symbols
@@ -1,24 +1,27 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 >JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
 
-    interface IntrsinsicElements { [index: string]: any }
->IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
->index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
-
-    type JSXElement = any;
->JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
-}
 class Component {
->Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 16))
 
     render() {
->render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 17))
 
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+>JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
+
+    interface IntrsinsicElements { [index: string]: any }
+>IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
+>index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
+
+    type JSXElement = any;
+>JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
+}
+class Component {
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+
+    render() {
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).types
@@ -1,12 +1,6 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
->index : string
-
-    type JSXElement = any;
->JSXElement : any
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
 >Component : Component
 
@@ -14,13 +8,22 @@ class Component {
 >render : () => any
 
         return <div>
-><div>            {/* missing */}            {null/* preserved */}        </div> : any
+><div>            {/* missing */}            {null/* preserved */}            {                // ??? 1            }            { // ??? 2            }            {// ??? 3            }            {                // ??? 4            /* ??? 5 */}        </div> : any
 >div : any
 
             {/* missing */}
             {null/* preserved */}
 >null : null
-
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
 >div : any
     }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=commonjs).types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+>index : string
+
+    type JSXElement = any;
+>JSXElement : any
+}
+class Component {
+>Component : Component
+
+    render() {
+>render : () => any
+
+        return <div>
+><div>            {/* missing */}            {null/* preserved */}        </div> : any
+>div : any
+
+            {/* missing */}
+            {null/* preserved */}
+>null : null
+
+        </div>;
+>div : any
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).errors.txt
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).errors.txt
@@ -1,12 +1,9 @@
-tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,16): error TS2792: Cannot find module 'react/jsx-dev-runtime'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?
+tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(5,16): error TS2792: Cannot find module 'react/jsx-dev-runtime'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?
 
 
 ==== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx (1 errors) ====
-    // file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-    namespace JSX {
-        interface IntrsinsicElements { [index: string]: any }
-        type JSXElement = any;
-    }
+    // file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+    namespace JSX {}
     class Component {
         render() {
             return <div>
@@ -15,6 +12,26 @@ tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,16): error TS279
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 {null/* preserved */}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                {
+    ~~~~~~~~~~~~~
+                    // ??? 1
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+                }
+    ~~~~~~~~~~~~~
+                { // ??? 2
+    ~~~~~~~~~~~~~~~~~~~~~~
+                }
+    ~~~~~~~~~~~~~
+                {// ??? 3
+    ~~~~~~~~~~~~~~~~~~~~~
+                }
+    ~~~~~~~~~~~~~
+                {
+    ~~~~~~~~~~~~~
+                    // ??? 4
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+                /* ??? 5 */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~
             </div>;
     ~~~~~~~~~~~~~~
 !!! error TS2792: Cannot find module 'react/jsx-dev-runtime'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).errors.txt
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).errors.txt
@@ -1,0 +1,22 @@
+tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx(8,16): error TS2792: Cannot find module 'react/jsx-dev-runtime'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?
+
+
+==== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx (1 errors) ====
+    // file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+    namespace JSX {
+        interface IntrsinsicElements { [index: string]: any }
+        type JSXElement = any;
+    }
+    class Component {
+        render() {
+            return <div>
+                   ~~~~~
+                {/* missing */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                {null/* preserved */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            </div>;
+    ~~~~~~~~~~~~~~
+!!! error TS2792: Cannot find module 'react/jsx-dev-runtime'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?
+        }
+    }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).js
@@ -1,0 +1,25 @@
+//// [commentsOnJSXExpressionsArePreserved.tsx]
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+    type JSXElement = any;
+}
+class Component {
+    render() {
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}
+
+//// [commentsOnJSXExpressionsArePreserved.js]
+var _jsxFileName = "tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx";
+var Component = /** @class */ (function () {
+    function Component() {
+    }
+    Component.prototype.render = function () {
+        return _jsxDEV("div", { children: null /* preserved */ }, void 0, false, { fileName: _jsxFileName, lineNumber: 8, columnNumber: 15 }, this);
+    };
+    return Component;
+}());

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).js
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).js
@@ -1,14 +1,21 @@
 //// [commentsOnJSXExpressionsArePreserved.tsx]
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
-    type JSXElement = any;
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
     render() {
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }
@@ -19,7 +26,7 @@ var Component = /** @class */ (function () {
     function Component() {
     }
     Component.prototype.render = function () {
-        return _jsxDEV("div", { children: null /* preserved */ }, void 0, false, { fileName: _jsxFileName, lineNumber: 8, columnNumber: 15 }, this);
+        return _jsxDEV("div", { children: null /* preserved */ }, void 0, false, { fileName: _jsxFileName, lineNumber: 5, columnNumber: 15 }, this);
     };
     return Component;
 }());

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).symbols
@@ -1,24 +1,27 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 >JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
 
-    interface IntrsinsicElements { [index: string]: any }
->IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
->index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
-
-    type JSXElement = any;
->JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
-}
 class Component {
->Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 16))
 
     render() {
->render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 17))
 
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).symbols
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+>JSX : Symbol(JSX, Decl(commentsOnJSXExpressionsArePreserved.tsx, 0, 0))
+
+    interface IntrsinsicElements { [index: string]: any }
+>IntrsinsicElements : Symbol(IntrsinsicElements, Decl(commentsOnJSXExpressionsArePreserved.tsx, 1, 15))
+>index : Symbol(index, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 36))
+
+    type JSXElement = any;
+>JSXElement : Symbol(JSXElement, Decl(commentsOnJSXExpressionsArePreserved.tsx, 2, 57))
+}
+class Component {
+>Component : Symbol(Component, Decl(commentsOnJSXExpressionsArePreserved.tsx, 4, 1))
+
+    render() {
+>render : Symbol(Component.render, Decl(commentsOnJSXExpressionsArePreserved.tsx, 5, 17))
+
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).types
@@ -1,12 +1,6 @@
 === tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
->index : string
-
-    type JSXElement = any;
->JSXElement : any
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
 >Component : Component
 
@@ -14,13 +8,22 @@ class Component {
 >render : () => any
 
         return <div>
-><div>            {/* missing */}            {null/* preserved */}        </div> : any
+><div>            {/* missing */}            {null/* preserved */}            {                // ??? 1            }            { // ??? 2            }            {// ??? 3            }            {                // ??? 4            /* ??? 5 */}        </div> : any
 >div : any
 
             {/* missing */}
             {null/* preserved */}
 >null : null
-
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
 >div : any
     }

--- a/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).types
+++ b/tests/baselines/reference/commentsOnJSXExpressionsArePreserved(jsx=react-jsxdev,module=system).types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx ===
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+>index : string
+
+    type JSXElement = any;
+>JSXElement : any
+}
+class Component {
+>Component : Component
+
+    render() {
+>render : () => any
+
+        return <div>
+><div>            {/* missing */}            {null/* preserved */}        </div> : any
+>div : any
+
+            {/* missing */}
+            {null/* preserved */}
+>null : null
+
+        </div>;
+>div : any
+    }
+}

--- a/tests/baselines/reference/jsxAndTypeAssertion.js
+++ b/tests/baselines/reference/jsxAndTypeAssertion.js
@@ -40,9 +40,9 @@ x = <foo test={<foo>}>hello{<foo>}</foo>};
 
 x = <foo>x</foo>, x = <foo />;
 
-<foo>{<foo><foo>{/foo/.test(x) ? <foo><foo></foo> : <foo><foo></foo>}</foo>}</foo>
-    :
-}
+    <foo>{<foo><foo>{/foo/.test(x) ? <foo><foo></foo> : <foo><foo></foo>}</foo>}</foo>
+            :
+        }
 
     
-</></>}</></>}/></></></>;
+        </></>}</></>}/></></></>;

--- a/tests/baselines/reference/jsxEsprimaFbTestSuite.js
+++ b/tests/baselines/reference/jsxEsprimaFbTestSuite.js
@@ -69,7 +69,7 @@ baz
 </AbC_def>;
 <a b={x ? <c /> : <d />}/>;
 <a></a>;
-<a></a>;
+<a>{/* this is a comment */}</a>;
 <div>@test content</div>;
 <div><br />7x invalid-js-identifier</div>;
 <LeftRight left/>, <a />;

--- a/tests/baselines/reference/jsxNestedWithinTernaryParsesCorrectly.js
+++ b/tests/baselines/reference/jsxNestedWithinTernaryParsesCorrectly.js
@@ -17,9 +17,9 @@ const a = (
 var emptyMessage = null;
 var a = (<div>
       {0 ? (emptyMessage // must be identifier?
-) : (
-// must be exactly two expression holes
-<span>
+    ) : (
+    // must be exactly two expression holes
+    <span>
           {0}{0}
         </span>)}
     </div>);

--- a/tests/baselines/reference/jsxReactTestSuite.js
+++ b/tests/baselines/reference/jsxReactTestSuite.js
@@ -137,15 +137,15 @@ var x = <div attr1={"foo" + "bar"} attr2={"foo" + "bar" +
     "baz" + "bug"} attr4="baz">
   </div>;
 (<div>
-    
-    
+    {/* A comment at the beginning */}
+    {/* A second comment at the beginning */}
     <span>
-      
+      {/* A nested comment */}
     </span>
-    
+    {/* A sandwiched comment */}
     <br />
-    
-    
+    {/* A comment at the end */}
+    {/* A second comment at the end */}
   </div>);
 (<div 
 /* a multi-line

--- a/tests/baselines/reference/jsxReactTestSuite.js
+++ b/tests/baselines/reference/jsxReactTestSuite.js
@@ -133,8 +133,10 @@ var x =
     <Composite2 />
 </Composite>;
 var x = <div attr1={"foo" + "bar"} attr2={"foo" + "bar" +
-    "baz" + "bug"} attr3={"foo" + "bar" +
-    "baz" + "bug"} attr4="baz">
+        "baz" + "bug"} attr3={"foo" + "bar" +
+        "baz" + "bug"
+    // Extra line here.
+    } attr4="baz">
   </div>;
 (<div>
     {/* A comment at the beginning */}

--- a/tests/baselines/reference/tsxTypeArgumentsJsxPreserveOutput.js
+++ b/tests/baselines/reference/tsxTypeArgumentsJsxPreserveOutput.js
@@ -43,7 +43,7 @@ function Foo() {
     return null;
 }
 <>
-    
+    {/* JsxSelfClosingElement */}
     <Foo />
     <Foo />
     <Foo />
@@ -55,7 +55,7 @@ function Foo() {
     <Foo />
     <Foo />
 
-    
+    {/* JsxOpeningElement */}
     <Foo></Foo>
     <Foo></Foo>
     <Foo></Foo>

--- a/tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx
+++ b/tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx
@@ -1,0 +1,15 @@
+// @module: system,commonjs
+// @jsx: react,react-jsx,react-jsxdev,preserve
+// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {
+    interface IntrsinsicElements { [index: string]: any }
+    type JSXElement = any;
+}
+class Component {
+    render() {
+        return <div>
+            {/* missing */}
+            {null/* preserved */}
+        </div>;
+    }
+}

--- a/tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx
+++ b/tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx
@@ -1,15 +1,22 @@
 // @module: system,commonjs
 // @jsx: react,react-jsx,react-jsxdev,preserve
-// file is interntionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
-namespace JSX {
-    interface IntrsinsicElements { [index: string]: any }
-    type JSXElement = any;
-}
+// file is intentionally not a module - this tests for a crash in the module/system transforms alongside the `react-jsx` and `react-jsxdev` outputs
+namespace JSX {}
 class Component {
     render() {
         return <div>
             {/* missing */}
             {null/* preserved */}
+            {
+                // ??? 1
+            }
+            { // ??? 2
+            }
+            {// ??? 3
+            }
+            {
+                // ??? 4
+            /* ??? 5 */}
         </div>;
     }
 }


### PR DESCRIPTION
And, perhaps more importantly, fixes a crash caused by the interaction of the `module` or `system` transformers and the new `jsx` transforms discovered along the way (in the same test case).

Fixes #41754
