### PR TITLE
addImplementationSuccessElaboration admits declarations with no symbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27483,9 +27483,9 @@ namespace ts {
                 const oldCandidateForArgumentArityError = candidateForArgumentArityError;
                 const oldCandidateForTypeArgumentError = candidateForTypeArgumentError;
 
-                const declCount = length(failed.declaration?.symbol.declarations);
-                const isOverload = declCount > 1;
-                const implDecl = isOverload ? find(failed.declaration?.symbol.declarations || emptyArray, d => isFunctionLikeDeclaration(d) && nodeIsPresent(d.body)) : undefined;
+                const failedSignatureDeclarations = failed.declaration?.symbol?.declarations || emptyArray;
+                const isOverload = failedSignatureDeclarations.length > 1;
+                const implDecl = isOverload ? find(failedSignatureDeclarations, d => isFunctionLikeDeclaration(d) && nodeIsPresent(d.body)) : undefined;
                 if (implDecl) {
                     const candidate = getSignatureFromDeclaration(implDecl as FunctionLikeDeclaration);
                     const isSingleNonGenericCandidate = !candidate.typeParameters;

--- a/tests/baselines/reference/jsxCallElaborationCheckNoCrash1.errors.txt
+++ b/tests/baselines/reference/jsxCallElaborationCheckNoCrash1.errors.txt
@@ -1,0 +1,19 @@
+tests/cases/compiler/jsxCallElaborationCheckNoCrash1.tsx(10,29): error TS2322: Type '{}' is not assignable to type 'LibraryManagedAttributes<Tag, DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>>'.
+
+
+==== tests/cases/compiler/jsxCallElaborationCheckNoCrash1.tsx (1 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    
+    import * as React from "react";
+    
+    type Tags = "span" | "div";
+    
+    export const Hoc = <Tag extends Tags>(
+       TagElement: Tag,
+    ): React.SFC => {
+       const Component = () => <TagElement />;
+                                ~~~~~~~~~~
+!!! error TS2322: Type '{}' is not assignable to type 'LibraryManagedAttributes<Tag, DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>>'.
+       return Component;
+    };
+    

--- a/tests/baselines/reference/jsxCallElaborationCheckNoCrash1.js
+++ b/tests/baselines/reference/jsxCallElaborationCheckNoCrash1.js
@@ -1,0 +1,26 @@
+//// [jsxCallElaborationCheckNoCrash1.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+
+import * as React from "react";
+
+type Tags = "span" | "div";
+
+export const Hoc = <Tag extends Tags>(
+   TagElement: Tag,
+): React.SFC => {
+   const Component = () => <TagElement />;
+   return Component;
+};
+
+
+//// [jsxCallElaborationCheckNoCrash1.js]
+"use strict";
+/// <reference path="react16.d.ts" />
+exports.__esModule = true;
+exports.Hoc = void 0;
+var React = require("react");
+var Hoc = function (TagElement) {
+    var Component = function () { return React.createElement(TagElement, null); };
+    return Component;
+};
+exports.Hoc = Hoc;

--- a/tests/baselines/reference/jsxCallElaborationCheckNoCrash1.symbols
+++ b/tests/baselines/reference/jsxCallElaborationCheckNoCrash1.symbols
@@ -1,0 +1,31 @@
+=== tests/cases/compiler/jsxCallElaborationCheckNoCrash1.tsx ===
+/// <reference path="react16.d.ts" />
+
+import * as React from "react";
+>React : Symbol(React, Decl(jsxCallElaborationCheckNoCrash1.tsx, 2, 6))
+
+type Tags = "span" | "div";
+>Tags : Symbol(Tags, Decl(jsxCallElaborationCheckNoCrash1.tsx, 2, 31))
+
+export const Hoc = <Tag extends Tags>(
+>Hoc : Symbol(Hoc, Decl(jsxCallElaborationCheckNoCrash1.tsx, 6, 12))
+>Tag : Symbol(Tag, Decl(jsxCallElaborationCheckNoCrash1.tsx, 6, 20))
+>Tags : Symbol(Tags, Decl(jsxCallElaborationCheckNoCrash1.tsx, 2, 31))
+
+   TagElement: Tag,
+>TagElement : Symbol(TagElement, Decl(jsxCallElaborationCheckNoCrash1.tsx, 6, 38))
+>Tag : Symbol(Tag, Decl(jsxCallElaborationCheckNoCrash1.tsx, 6, 20))
+
+): React.SFC => {
+>React : Symbol(React, Decl(jsxCallElaborationCheckNoCrash1.tsx, 2, 6))
+>SFC : Symbol(React.SFC, Decl(react16.d.ts, 400, 9))
+
+   const Component = () => <TagElement />;
+>Component : Symbol(Component, Decl(jsxCallElaborationCheckNoCrash1.tsx, 9, 8))
+>TagElement : Symbol(TagElement, Decl(jsxCallElaborationCheckNoCrash1.tsx, 6, 38))
+
+   return Component;
+>Component : Symbol(Component, Decl(jsxCallElaborationCheckNoCrash1.tsx, 9, 8))
+
+};
+

--- a/tests/baselines/reference/jsxCallElaborationCheckNoCrash1.types
+++ b/tests/baselines/reference/jsxCallElaborationCheckNoCrash1.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/jsxCallElaborationCheckNoCrash1.tsx ===
+/// <reference path="react16.d.ts" />
+
+import * as React from "react";
+>React : typeof React
+
+type Tags = "span" | "div";
+>Tags : Tags
+
+export const Hoc = <Tag extends Tags>(
+>Hoc : <Tag extends Tags>(TagElement: Tag) => React.SFC
+><Tag extends Tags>(   TagElement: Tag,): React.SFC => {   const Component = () => <TagElement />;   return Component;} : <Tag extends Tags>(TagElement: Tag) => React.SFC
+
+   TagElement: Tag,
+>TagElement : Tag
+
+): React.SFC => {
+>React : any
+
+   const Component = () => <TagElement />;
+>Component : () => JSX.Element
+>() => <TagElement /> : () => JSX.Element
+><TagElement /> : JSX.Element
+>TagElement : Tag
+
+   return Component;
+>Component : () => JSX.Element
+
+};
+

--- a/tests/cases/compiler/jsxCallElaborationCheckNoCrash1.tsx
+++ b/tests/cases/compiler/jsxCallElaborationCheckNoCrash1.tsx
@@ -1,0 +1,13 @@
+// @jsx: react
+/// <reference path="/.lib/react16.d.ts" />
+
+import * as React from "react";
+
+type Tags = "span" | "div";
+
+export const Hoc = <Tag extends Tags>(
+   TagElement: Tag,
+): React.SFC => {
+   const Component = () => <TagElement />;
+   return Component;
+};


### PR DESCRIPTION
*shakes fist* Our imprecise type of `Declaration.symbol` leads to a bug yet again!

Fixes #41616
