### PR TITLE
JSDoc declaration emit should reuse input nodes where possible when serializing typedefs

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5961,13 +5961,14 @@ namespace ts {
                         return setOriginalNode(typeToTypeNodeHelper(getTypeFromTypeNode(node), context), node);
                     }
                     if (isLiteralImportTypeNode(node)) {
+                        const nodeSymbol = getNodeLinks(node).resolvedSymbol;
                         if (isInJSDoc(node) &&
-                            getNodeLinks(node).resolvedSymbol &&
+                            nodeSymbol &&
                             (
                                 // The import type resolved using jsdoc fallback logic
-                                (!node.isTypeOf && !(getNodeLinks(node).resolvedSymbol!.flags & SymbolFlags.Type)) ||
+                                (!node.isTypeOf && !(nodeSymbol.flags & SymbolFlags.Type)) ||
                                 // The import type had type arguments autofilled by js fallback logic
-                                !(length(node.typeArguments) >= getMinTypeArgumentCount(getLocalTypeParametersOfClassOrInterfaceOrTypeAlias(getNodeLinks(node).resolvedSymbol!)))
+                                !(length(node.typeArguments) >= getMinTypeArgumentCount(getLocalTypeParametersOfClassOrInterfaceOrTypeAlias(nodeSymbol)))
                             )
                         ) {
                             return setOriginalNode(typeToTypeNodeHelper(getTypeFromTypeNode(node), context), node);
@@ -6547,7 +6548,10 @@ namespace ts {
                     const commentText = jsdocAliasDecl ? jsdocAliasDecl.comment || jsdocAliasDecl.parent.comment : undefined;
                     const oldFlags = context.flags;
                     context.flags |= NodeBuilderFlags.InTypeAlias;
-                    const typeNode = jsdocAliasDecl && jsdocAliasDecl.typeExpression && isJSDocTypeExpression(jsdocAliasDecl.typeExpression) && serializeExistingTypeNode(context, jsdocAliasDecl.typeExpression.type, includePrivateSymbol, bundled) || typeToTypeNodeHelper(aliasType, context);
+                    const typeNode = jsdocAliasDecl && jsdocAliasDecl.typeExpression
+                        && isJSDocTypeExpression(jsdocAliasDecl.typeExpression)
+                        && serializeExistingTypeNode(context, jsdocAliasDecl.typeExpression.type, includePrivateSymbol, bundled)
+                        || typeToTypeNodeHelper(aliasType, context);
                     addResult(setSyntheticLeadingComments(
                         factory.createTypeAliasDeclaration(/*decorators*/ undefined, /*modifiers*/ undefined, getInternalSymbolName(symbol, symbolName), typeParamDecls, typeNode),
                         !commentText ? [] : [{ kind: SyntaxKind.MultiLineCommentTrivia, text: "*\n * " + commentText.replace(/\n/g, "\n * ") + "\n ", pos: -1, end: -1, hasTrailingNewLine: true }]

--- a/tests/baselines/reference/jsDeclarationsFunctionClassesCjsExportAssignment.js
+++ b/tests/baselines/reference/jsDeclarationsFunctionClassesCjsExportAssignment.js
@@ -231,7 +231,7 @@ type Input = {
 /**
  * Imports
  */
-type HookHandler = (arg: Context) => void;
+type HookHandler = import("./hook").HookHandler;
 /**
  * State type definition
  */

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespace.js
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespace.js
@@ -55,7 +55,7 @@ export {testFn, testFnTypes};
 
 //// [file.d.ts]
 export namespace myTypes {
-    type typeA = string | RegExp | (string | RegExp)[];
+    type typeA = string | RegExp | Array<string | RegExp>;
     type typeB = {
         /**
          * - Prop 1.
@@ -66,19 +66,14 @@ export namespace myTypes {
          */
         prop2: string;
     };
-    type typeC = Function | typeB;
+    type typeC = myTypes.typeB | Function;
+    const myTypes: {
+        [x: string]: any;
+    };
 }
-/**
- * @namespace myTypes
- * @global
- * @type {Object<string,*>}
- */
-export const myTypes: {
-    [x: string]: any;
-};
 //// [file2.d.ts]
 export namespace testFnTypes {
-    type input = boolean | Function | myTypes.typeB;
+    type input = boolean | myTypes.typeC;
 }
 /** @typedef {boolean|myTypes.typeC} testFnTypes.input */
 /**

--- a/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.js
+++ b/tests/baselines/reference/jsDeclarationsImportAliasExposedWithinNamespaceCjs.js
@@ -63,7 +63,7 @@ export const myTypes: {
     [x: string]: any;
 };
 export namespace myTypes {
-    type typeA = string | RegExp | (string | RegExp)[];
+    type typeA = string | RegExp | Array<string | RegExp>;
     type typeB = {
         /**
          * - Prop 1.
@@ -74,7 +74,7 @@ export namespace myTypes {
          */
         prop2: string;
     };
-    type typeC = Function | typeB;
+    type typeC = myTypes.typeB | Function;
 }
 //// [file2.d.ts]
 /** @typedef {boolean|myTypes.typeC} testFnTypes.input */
@@ -94,6 +94,6 @@ export const testFnTypes: {
     [x: string]: any;
 };
 export namespace testFnTypes {
-    type input = boolean | Function | myTypes.typeB;
+    type input = boolean | myTypes.typeC;
 }
 import { myTypes } from "./file.js";

--- a/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit1.errors.txt
+++ b/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit1.errors.txt
@@ -1,0 +1,30 @@
+tests/cases/conformance/jsdoc/declarations/file.js(8,1): error TS9006: Declaration emit for this file requires using private name 'Base' from module '"tests/cases/conformance/jsdoc/declarations/base"'. An explicit type annotation may unblock declaration emit.
+
+
+==== tests/cases/conformance/jsdoc/declarations/base.js (0 errors) ====
+    class Base {
+        constructor() {}
+    }
+    
+    const BaseFactory = () => {
+        return new Base();
+    };
+    
+    BaseFactory.Base = Base;
+    
+    module.exports = BaseFactory;
+    
+==== tests/cases/conformance/jsdoc/declarations/file.js (1 errors) ====
+    /** @typedef {import('./base')} BaseFactory */
+    
+    /**
+     *
+     * @param {InstanceType<BaseFactory["Base"]>} base
+     * @returns {InstanceType<BaseFactory["Base"]>}
+     */
+    const test = (base) => {
+    ~~~~~
+!!! error TS9006: Declaration emit for this file requires using private name 'Base' from module '"tests/cases/conformance/jsdoc/declarations/base"'. An explicit type annotation may unblock declaration emit.
+        return base;
+    };
+    

--- a/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit1.js
+++ b/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit1.js
@@ -1,0 +1,57 @@
+//// [tests/cases/conformance/jsdoc/declarations/jsDeclarationsParameterTagReusesInputNodeInEmit1.ts] ////
+
+//// [base.js]
+class Base {
+    constructor() {}
+}
+
+const BaseFactory = () => {
+    return new Base();
+};
+
+BaseFactory.Base = Base;
+
+module.exports = BaseFactory;
+
+//// [file.js]
+/** @typedef {import('./base')} BaseFactory */
+
+/**
+ *
+ * @param {InstanceType<BaseFactory["Base"]>} base
+ * @returns {InstanceType<BaseFactory["Base"]>}
+ */
+const test = (base) => {
+    return base;
+};
+
+
+//// [base.js]
+class Base {
+    constructor() { }
+}
+const BaseFactory = () => {
+    return new Base();
+};
+BaseFactory.Base = Base;
+module.exports = BaseFactory;
+//// [file.js]
+/** @typedef {import('./base')} BaseFactory */
+/**
+ *
+ * @param {InstanceType<BaseFactory["Base"]>} base
+ * @returns {InstanceType<BaseFactory["Base"]>}
+ */
+const test = (base) => {
+    return base;
+};
+
+
+//// [base.d.ts]
+export = BaseFactory;
+declare function BaseFactory(): Base;
+declare namespace BaseFactory {
+    export { Base };
+}
+declare class Base {
+}

--- a/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit1.symbols
+++ b/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit1.symbols
@@ -1,0 +1,44 @@
+=== tests/cases/conformance/jsdoc/declarations/base.js ===
+class Base {
+>Base : Symbol(Base, Decl(base.js, 0, 0))
+
+    constructor() {}
+}
+
+const BaseFactory = () => {
+>BaseFactory : Symbol(BaseFactory, Decl(base.js, 4, 5), Decl(base.js, 6, 2))
+
+    return new Base();
+>Base : Symbol(Base, Decl(base.js, 0, 0))
+
+};
+
+BaseFactory.Base = Base;
+>BaseFactory.Base : Symbol(BaseFactory.Base, Decl(base.js, 6, 2))
+>BaseFactory : Symbol(BaseFactory, Decl(base.js, 4, 5), Decl(base.js, 6, 2))
+>Base : Symbol(BaseFactory.Base, Decl(base.js, 6, 2))
+>Base : Symbol(Base, Decl(base.js, 0, 0))
+
+module.exports = BaseFactory;
+>module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/base", Decl(base.js, 0, 0))
+>module : Symbol(export=, Decl(base.js, 8, 24))
+>exports : Symbol(export=, Decl(base.js, 8, 24))
+>BaseFactory : Symbol(BaseFactory, Decl(base.js, 4, 5), Decl(base.js, 6, 2))
+
+=== tests/cases/conformance/jsdoc/declarations/file.js ===
+/** @typedef {import('./base')} BaseFactory */
+
+/**
+ *
+ * @param {InstanceType<BaseFactory["Base"]>} base
+ * @returns {InstanceType<BaseFactory["Base"]>}
+ */
+const test = (base) => {
+>test : Symbol(test, Decl(file.js, 7, 5))
+>base : Symbol(base, Decl(file.js, 7, 14))
+
+    return base;
+>base : Symbol(base, Decl(file.js, 7, 14))
+
+};
+

--- a/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit1.types
+++ b/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit1.types
@@ -1,0 +1,49 @@
+=== tests/cases/conformance/jsdoc/declarations/base.js ===
+class Base {
+>Base : Base
+
+    constructor() {}
+}
+
+const BaseFactory = () => {
+>BaseFactory : { (): Base; Base: typeof Base; }
+>() => {    return new Base();} : { (): Base; Base: typeof Base; }
+
+    return new Base();
+>new Base() : Base
+>Base : typeof Base
+
+};
+
+BaseFactory.Base = Base;
+>BaseFactory.Base = Base : typeof Base
+>BaseFactory.Base : typeof Base
+>BaseFactory : { (): Base; Base: typeof Base; }
+>Base : typeof Base
+>Base : typeof Base
+
+module.exports = BaseFactory;
+>module.exports = BaseFactory : { (): Base; Base: typeof Base; }
+>module.exports : { (): Base; Base: typeof Base; }
+>module : { "\"tests/cases/conformance/jsdoc/declarations/base\"": { (): Base; Base: typeof Base; }; }
+>exports : { (): Base; Base: typeof Base; }
+>BaseFactory : { (): Base; Base: typeof Base; }
+
+=== tests/cases/conformance/jsdoc/declarations/file.js ===
+/** @typedef {import('./base')} BaseFactory */
+
+/**
+ *
+ * @param {InstanceType<BaseFactory["Base"]>} base
+ * @returns {InstanceType<BaseFactory["Base"]>}
+ */
+const test = (base) => {
+>test : (base: InstanceType<BaseFactory["Base"]>) => Base
+>(base) => {    return base;} : (base: InstanceType<BaseFactory["Base"]>) => Base
+>base : Base
+
+    return base;
+>base : Base
+
+};
+

--- a/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit2.js
+++ b/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit2.js
@@ -1,0 +1,66 @@
+//// [tests/cases/conformance/jsdoc/declarations/jsDeclarationsParameterTagReusesInputNodeInEmit2.ts] ////
+
+//// [base.js]
+class Base {
+    constructor() {}
+}
+
+const BaseFactory = () => {
+    return new Base();
+};
+
+BaseFactory.Base = Base;
+
+module.exports = BaseFactory;
+
+//// [file.js]
+/** @typedef {typeof import('./base')} BaseFactory */
+
+/**
+ *
+ * @param {InstanceType<BaseFactory["Base"]>} base
+ * @returns {InstanceType<BaseFactory["Base"]>}
+ */
+const test = (base) => {
+    return base;
+};
+
+
+//// [base.js]
+class Base {
+    constructor() { }
+}
+const BaseFactory = () => {
+    return new Base();
+};
+BaseFactory.Base = Base;
+module.exports = BaseFactory;
+//// [file.js]
+/** @typedef {typeof import('./base')} BaseFactory */
+/**
+ *
+ * @param {InstanceType<BaseFactory["Base"]>} base
+ * @returns {InstanceType<BaseFactory["Base"]>}
+ */
+const test = (base) => {
+    return base;
+};
+
+
+//// [base.d.ts]
+export = BaseFactory;
+declare function BaseFactory(): Base;
+declare namespace BaseFactory {
+    export { Base };
+}
+declare class Base {
+}
+//// [file.d.ts]
+/** @typedef {typeof import('./base')} BaseFactory */
+/**
+ *
+ * @param {InstanceType<BaseFactory["Base"]>} base
+ * @returns {InstanceType<BaseFactory["Base"]>}
+ */
+declare function test(base: InstanceType<BaseFactory["Base"]>): InstanceType<BaseFactory["Base"]>;
+type BaseFactory = typeof import('./base');

--- a/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit2.symbols
+++ b/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit2.symbols
@@ -1,0 +1,44 @@
+=== tests/cases/conformance/jsdoc/declarations/base.js ===
+class Base {
+>Base : Symbol(Base, Decl(base.js, 0, 0))
+
+    constructor() {}
+}
+
+const BaseFactory = () => {
+>BaseFactory : Symbol(BaseFactory, Decl(base.js, 4, 5), Decl(base.js, 6, 2))
+
+    return new Base();
+>Base : Symbol(Base, Decl(base.js, 0, 0))
+
+};
+
+BaseFactory.Base = Base;
+>BaseFactory.Base : Symbol(BaseFactory.Base, Decl(base.js, 6, 2))
+>BaseFactory : Symbol(BaseFactory, Decl(base.js, 4, 5), Decl(base.js, 6, 2))
+>Base : Symbol(BaseFactory.Base, Decl(base.js, 6, 2))
+>Base : Symbol(Base, Decl(base.js, 0, 0))
+
+module.exports = BaseFactory;
+>module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/base", Decl(base.js, 0, 0))
+>module : Symbol(export=, Decl(base.js, 8, 24))
+>exports : Symbol(export=, Decl(base.js, 8, 24))
+>BaseFactory : Symbol(BaseFactory, Decl(base.js, 4, 5), Decl(base.js, 6, 2))
+
+=== tests/cases/conformance/jsdoc/declarations/file.js ===
+/** @typedef {typeof import('./base')} BaseFactory */
+
+/**
+ *
+ * @param {InstanceType<BaseFactory["Base"]>} base
+ * @returns {InstanceType<BaseFactory["Base"]>}
+ */
+const test = (base) => {
+>test : Symbol(test, Decl(file.js, 7, 5))
+>base : Symbol(base, Decl(file.js, 7, 14))
+
+    return base;
+>base : Symbol(base, Decl(file.js, 7, 14))
+
+};
+

--- a/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit2.types
+++ b/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit2.types
@@ -1,0 +1,49 @@
+=== tests/cases/conformance/jsdoc/declarations/base.js ===
+class Base {
+>Base : Base
+
+    constructor() {}
+}
+
+const BaseFactory = () => {
+>BaseFactory : { (): Base; Base: typeof Base; }
+>() => {    return new Base();} : { (): Base; Base: typeof Base; }
+
+    return new Base();
+>new Base() : Base
+>Base : typeof Base
+
+};
+
+BaseFactory.Base = Base;
+>BaseFactory.Base = Base : typeof Base
+>BaseFactory.Base : typeof Base
+>BaseFactory : { (): Base; Base: typeof Base; }
+>Base : typeof Base
+>Base : typeof Base
+
+module.exports = BaseFactory;
+>module.exports = BaseFactory : { (): Base; Base: typeof Base; }
+>module.exports : { (): Base; Base: typeof Base; }
+>module : { "\"tests/cases/conformance/jsdoc/declarations/base\"": { (): Base; Base: typeof Base; }; }
+>exports : { (): Base; Base: typeof Base; }
+>BaseFactory : { (): Base; Base: typeof Base; }
+
+=== tests/cases/conformance/jsdoc/declarations/file.js ===
+/** @typedef {typeof import('./base')} BaseFactory */
+
+/**
+ *
+ * @param {InstanceType<BaseFactory["Base"]>} base
+ * @returns {InstanceType<BaseFactory["Base"]>}
+ */
+const test = (base) => {
+>test : (base: InstanceType<BaseFactory["Base"]>) => Base
+>(base) => {    return base;} : (base: InstanceType<BaseFactory["Base"]>) => Base
+>base : Base
+
+    return base;
+>base : Base
+
+};
+

--- a/tests/baselines/reference/jsDeclarationsTypeAliases.js
+++ b/tests/baselines/reference/jsDeclarationsTypeAliases.js
@@ -119,9 +119,9 @@ export type MixinName<T> = T & {
  */
 export type Identity<T> = (x: T) => T;
 //// [mixed.d.ts]
-export type SomeType = number | {
+export type SomeType = {
     x: string;
-} | LocalThing | ExportedThing;
+} | number | LocalThing | ExportedThing;
 /**
  * @typedef {{x: string} | number | LocalThing | ExportedThing} SomeType
  */

--- a/tests/baselines/reference/jsDeclarationsTypedefPropertyAndExportAssignment.js
+++ b/tests/baselines/reference/jsDeclarationsTypedefPropertyAndExportAssignment.js
@@ -104,7 +104,7 @@ module.exports = MainThreadTasks;
 
 
 //// [module.d.ts]
-export type TaskGroupIds = "parseHTML" | "styleLayout";
+export type TaskGroupIds = 'parseHTML' | 'styleLayout';
 export type TaskGroup = {
     id: TaskGroupIds;
     label: string;
@@ -154,11 +154,7 @@ declare class MainThreadTasks {
 declare namespace MainThreadTasks {
     export { TaskGroup, TaskNode, PriorTaskData };
 }
-type TaskGroup = {
-    id: import("./module.js").TaskGroupIds;
-    label: string;
-    traceEventNames: string[];
-};
+type TaskGroup = import('./module.js').TaskGroup;
 type TaskNode = {
     children: TaskNode[];
     parent: TaskNode | undefined;

--- a/tests/baselines/reference/jsdocImportTypeReferenceToCommonjsModule.types
+++ b/tests/baselines/reference/jsdocImportTypeReferenceToCommonjsModule.types
@@ -11,7 +11,7 @@ export = config;
 === tests/cases/conformance/jsdoc/test.js ===
 /** @param {import('./ex')} a */
 function demo(a) {
->demo : (a: import('./ex')) => void
+>demo : (a: { fix: boolean; }) => void
 >a : { fix: boolean; }
 
     a.fix

--- a/tests/baselines/reference/jsdocImportTypeReferenceToESModule.types
+++ b/tests/baselines/reference/jsdocImportTypeReferenceToESModule.types
@@ -5,7 +5,7 @@ export var config: {}
 === tests/cases/conformance/jsdoc/test.js ===
 /** @param {import('./ex')} a */
 function demo(a) {
->demo : (a: import('./ex')) => void
+>demo : (a: typeof import("tests/cases/conformance/jsdoc/ex")) => void
 >a : typeof import("tests/cases/conformance/jsdoc/ex")
 
     a.config

--- a/tests/baselines/reference/recursiveTypeReferences2.js
+++ b/tests/baselines/reference/recursiveTypeReferences2.js
@@ -78,11 +78,11 @@ var p = {};
 declare const p: XMLObject<{
     foo: string;
 }>;
-type JsonArray = readonly Json[];
+type JsonArray = ReadonlyArray<Json>;
 type JsonRecord = {
     readonly [key: string]: Json;
 };
-type Json = string | number | boolean | JsonRecord | JsonArray | readonly [];
+type Json = boolean | number | string | null | JsonRecord | readonly Json[] | readonly [];
 /**
  * <T>
  */

--- a/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-js-based-projects-and-emits-them-correctly.js
+++ b/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-js-based-projects-and-emits-them-correctly.js
@@ -168,9 +168,8 @@ module.exports = {};
 }
 
 //// [/lib/sub-project/index.d.ts]
-export type MyNominal = string & {
-    [Symbol.species]: "MyNominal";
-};
+export type MyNominal = Nominal<string, 'MyNominal'>;
+import { Nominal } from "../common/nominal";
 
 
 //// [/lib/sub-project/index.js]
@@ -197,7 +196,7 @@ exports.__esModule = true;
       },
       "../../src/sub-project/index.js": {
         "version": "-23375763082-import { Nominal } from '../common/nominal';\n\n/**\n * @typedef {Nominal<string, 'MyNominal'>} MyNominal\n */\n",
-        "signature": "-4500199036-export type MyNominal = string & {\r\n    [Symbol.species]: \"MyNominal\";\r\n};\r\n",
+        "signature": "-1163946571-export type MyNominal = Nominal<string, 'MyNominal'>;\r\nimport { Nominal } from \"../common/nominal\";\r\n",
         "affectsGlobalScope": false
       }
     },
@@ -263,9 +262,14 @@ exports.getVar = getVar;
         "signature": "-32082413277-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };\ninterface SymbolConstructor {\n    readonly species: symbol;\n    readonly toStringTag: symbol;\n}\ndeclare var Symbol: SymbolConstructor;\ninterface Symbol {\n    readonly [Symbol.toStringTag]: string;\n}\n",
         "affectsGlobalScope": true
       },
+      "../common/nominal.d.ts": {
+        "version": "-15964609857-export type Nominal<T, Name> = T & {\r\n    [Symbol.species]: Name;\r\n};\r\n",
+        "signature": "-15964609857-export type Nominal<T, Name> = T & {\r\n    [Symbol.species]: Name;\r\n};\r\n",
+        "affectsGlobalScope": false
+      },
       "../sub-project/index.d.ts": {
-        "version": "-4500199036-export type MyNominal = string & {\r\n    [Symbol.species]: \"MyNominal\";\r\n};\r\n",
-        "signature": "-4500199036-export type MyNominal = string & {\r\n    [Symbol.species]: \"MyNominal\";\r\n};\r\n",
+        "version": "-1163946571-export type MyNominal = Nominal<string, 'MyNominal'>;\r\nimport { Nominal } from \"../common/nominal\";\r\n",
+        "signature": "-1163946571-export type MyNominal = Nominal<string, 'MyNominal'>;\r\nimport { Nominal } from \"../common/nominal\";\r\n",
         "affectsGlobalScope": false
       },
       "../../src/sub-project-2/index.js": {
@@ -285,12 +289,20 @@ exports.getVar = getVar;
       "configFilePath": "../../src/sub-project-2/tsconfig.json"
     },
     "referencedMap": {
+      "../sub-project/index.d.ts": [
+        "../common/nominal.d.ts"
+      ],
       "../../src/sub-project-2/index.js": [
         "../sub-project/index.d.ts"
       ]
     },
-    "exportedModulesMap": {},
+    "exportedModulesMap": {
+      "../sub-project/index.d.ts": [
+        "../common/nominal.d.ts"
+      ]
+    },
     "semanticDiagnosticsPerFile": [
+      "../common/nominal.d.ts",
       "../lib.d.ts",
       "../sub-project/index.d.ts",
       "../../src/sub-project-2/index.js"

--- a/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-outfile-js-projects-and-concatenates-them-correctly.js
+++ b/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-outfile-js-projects-and-concatenates-them-correctly.js
@@ -191,9 +191,7 @@ type Nominal<T, Name> = T & {
  * @typedef {Nominal<string, 'MyNominal'>} MyNominal
  */
 declare const c: any;
-type MyNominal = string & {
-    [Symbol.species]: "MyNominal";
-};
+type MyNominal = Nominal<string, 'MyNominal'>;
 
 
 //// [/src/sub-project/sub-project.js]
@@ -253,7 +251,7 @@ var c = /** @type {*} */ (null);
         },
         {
           "pos": 64,
-          "end": 220,
+          "end": 199,
           "kind": "text"
         }
       ]
@@ -293,14 +291,12 @@ type Nominal<T, Name> = T & {
 };
 
 ----------------------------------------------------------------------
-text: (64-220)
+text: (64-199)
 /**
  * @typedef {Nominal<string, 'MyNominal'>} MyNominal
  */
 declare const c: any;
-type MyNominal = string & {
-    [Symbol.species]: "MyNominal";
-};
+type MyNominal = Nominal<string, 'MyNominal'>;
 
 ======================================================================
 
@@ -312,9 +308,7 @@ type Nominal<T, Name> = T & {
  * @typedef {Nominal<string, 'MyNominal'>} MyNominal
  */
 declare const c: any;
-type MyNominal = string & {
-    [Symbol.species]: "MyNominal";
-};
+type MyNominal = Nominal<string, 'MyNominal'>;
 /**
  * @return {keyof typeof variable}
  */
@@ -377,20 +371,20 @@ function getVar() {
       "sections": [
         {
           "pos": 0,
-          "end": 220,
+          "end": 199,
           "kind": "prepend",
           "data": "../sub-project/sub-project.d.ts",
           "texts": [
             {
               "pos": 0,
-              "end": 220,
+              "end": 199,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 220,
-          "end": 377,
+          "pos": 199,
+          "end": 356,
           "kind": "text"
         }
       ]
@@ -431,9 +425,9 @@ function getVar() {
 ======================================================================
 File:: /src/sub-project-2/sub-project-2.d.ts
 ----------------------------------------------------------------------
-prepend: (0-220):: ../sub-project/sub-project.d.ts texts:: 1
+prepend: (0-199):: ../sub-project/sub-project.d.ts texts:: 1
 >>--------------------------------------------------------------------
-text: (0-220)
+text: (0-199)
 type Nominal<T, Name> = T & {
     [Symbol.species]: Name;
 };
@@ -441,12 +435,10 @@ type Nominal<T, Name> = T & {
  * @typedef {Nominal<string, 'MyNominal'>} MyNominal
  */
 declare const c: any;
-type MyNominal = string & {
-    [Symbol.species]: "MyNominal";
-};
+type MyNominal = Nominal<string, 'MyNominal'>;
 
 ----------------------------------------------------------------------
-text: (220-377)
+text: (199-356)
 /**
  * @return {keyof typeof variable}
  */

--- a/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/modifies-outfile-js-projects-and-concatenates-them-correctly.js
+++ b/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/modifies-outfile-js-projects-and-concatenates-them-correctly.js
@@ -191,9 +191,7 @@ type Nominal<T, Name> = T & {
  * @typedef {Nominal<string, 'MyNominal'>} MyNominal
  */
 declare const c: any;
-type MyNominal = string & {
-    [Symbol.species]: "MyNominal";
-};
+type MyNominal = Nominal<string, 'MyNominal'>;
 
 
 //// [/src/sub-project/sub-project.js]
@@ -253,7 +251,7 @@ var c = /** @type {*} */ (null);
         },
         {
           "pos": 64,
-          "end": 220,
+          "end": 199,
           "kind": "text"
         }
       ]
@@ -293,14 +291,12 @@ type Nominal<T, Name> = T & {
 };
 
 ----------------------------------------------------------------------
-text: (64-220)
+text: (64-199)
 /**
  * @typedef {Nominal<string, 'MyNominal'>} MyNominal
  */
 declare const c: any;
-type MyNominal = string & {
-    [Symbol.species]: "MyNominal";
-};
+type MyNominal = Nominal<string, 'MyNominal'>;
 
 ======================================================================
 
@@ -312,9 +308,7 @@ type Nominal<T, Name> = T & {
  * @typedef {Nominal<string, 'MyNominal'>} MyNominal
  */
 declare const c: any;
-type MyNominal = string & {
-    [Symbol.species]: "MyNominal";
-};
+type MyNominal = Nominal<string, 'MyNominal'>;
 /**
  * @return {keyof typeof variable}
  */
@@ -377,20 +371,20 @@ function getVar() {
       "sections": [
         {
           "pos": 0,
-          "end": 220,
+          "end": 199,
           "kind": "prepend",
           "data": "../sub-project/sub-project.d.ts",
           "texts": [
             {
               "pos": 0,
-              "end": 220,
+              "end": 199,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 220,
-          "end": 377,
+          "pos": 199,
+          "end": 356,
           "kind": "text"
         }
       ]
@@ -431,9 +425,9 @@ function getVar() {
 ======================================================================
 File:: /src/sub-project-2/sub-project-2.d.ts
 ----------------------------------------------------------------------
-prepend: (0-220):: ../sub-project/sub-project.d.ts texts:: 1
+prepend: (0-199):: ../sub-project/sub-project.d.ts texts:: 1
 >>--------------------------------------------------------------------
-text: (0-220)
+text: (0-199)
 type Nominal<T, Name> = T & {
     [Symbol.species]: Name;
 };
@@ -441,12 +435,10 @@ type Nominal<T, Name> = T & {
  * @typedef {Nominal<string, 'MyNominal'>} MyNominal
  */
 declare const c: any;
-type MyNominal = string & {
-    [Symbol.species]: "MyNominal";
-};
+type MyNominal = Nominal<string, 'MyNominal'>;
 
 ----------------------------------------------------------------------
-text: (220-377)
+text: (199-356)
 /**
  * @return {keyof typeof variable}
  */
@@ -533,7 +525,7 @@ var c = /** @type {*} */ (undefined);
         },
         {
           "pos": 64,
-          "end": 220,
+          "end": 199,
           "kind": "text"
         }
       ]
@@ -573,14 +565,12 @@ type Nominal<T, Name> = T & {
 };
 
 ----------------------------------------------------------------------
-text: (64-220)
+text: (64-199)
 /**
  * @typedef {Nominal<string, 'MyNominal'>} MyNominal
  */
 declare const c: any;
-type MyNominal = string & {
-    [Symbol.species]: "MyNominal";
-};
+type MyNominal = Nominal<string, 'MyNominal'>;
 
 ======================================================================
 
@@ -637,20 +627,20 @@ function getVar() {
       "sections": [
         {
           "pos": 0,
-          "end": 220,
+          "end": 199,
           "kind": "prepend",
           "data": "../sub-project/sub-project.d.ts",
           "texts": [
             {
               "pos": 0,
-              "end": 220,
+              "end": 199,
               "kind": "text"
             }
           ]
         },
         {
-          "pos": 220,
-          "end": 377,
+          "pos": 199,
+          "end": 356,
           "kind": "text"
         }
       ]
@@ -691,9 +681,9 @@ function getVar() {
 ======================================================================
 File:: /src/sub-project-2/sub-project-2.d.ts
 ----------------------------------------------------------------------
-prepend: (0-220):: ../sub-project/sub-project.d.ts texts:: 1
+prepend: (0-199):: ../sub-project/sub-project.d.ts texts:: 1
 >>--------------------------------------------------------------------
-text: (0-220)
+text: (0-199)
 type Nominal<T, Name> = T & {
     [Symbol.species]: Name;
 };
@@ -701,12 +691,10 @@ type Nominal<T, Name> = T & {
  * @typedef {Nominal<string, 'MyNominal'>} MyNominal
  */
 declare const c: any;
-type MyNominal = string & {
-    [Symbol.species]: "MyNominal";
-};
+type MyNominal = Nominal<string, 'MyNominal'>;
 
 ----------------------------------------------------------------------
-text: (220-377)
+text: (199-356)
 /**
  * @return {keyof typeof variable}
  */

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsParameterTagReusesInputNodeInEmit1.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsParameterTagReusesInputNodeInEmit1.ts
@@ -1,0 +1,29 @@
+// @allowJs: true
+// @checkJs: true
+// @target: es6
+// @outDir: ./out
+// @declaration: true
+// @filename: base.js
+class Base {
+    constructor() {}
+}
+
+const BaseFactory = () => {
+    return new Base();
+};
+
+BaseFactory.Base = Base;
+
+module.exports = BaseFactory;
+
+// @filename: file.js
+/** @typedef {import('./base')} BaseFactory */
+
+/**
+ *
+ * @param {InstanceType<BaseFactory["Base"]>} base
+ * @returns {InstanceType<BaseFactory["Base"]>}
+ */
+const test = (base) => {
+    return base;
+};

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsParameterTagReusesInputNodeInEmit2.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsParameterTagReusesInputNodeInEmit2.ts
@@ -1,0 +1,29 @@
+// @allowJs: true
+// @checkJs: true
+// @target: es6
+// @outDir: ./out
+// @declaration: true
+// @filename: base.js
+class Base {
+    constructor() {}
+}
+
+const BaseFactory = () => {
+    return new Base();
+};
+
+BaseFactory.Base = Base;
+
+module.exports = BaseFactory;
+
+// @filename: file.js
+/** @typedef {typeof import('./base')} BaseFactory */
+
+/**
+ *
+ * @param {InstanceType<BaseFactory["Base"]>} base
+ * @returns {InstanceType<BaseFactory["Base"]>}
+ */
+const test = (base) => {
+    return base;
+};


### PR DESCRIPTION
Fixes part of #41672
