### PR TITLE
In JS Class serialization, read the base construct signature from the static base type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6772,7 +6772,7 @@ namespace ts {
                         !some(getSignaturesOfType(staticType, SignatureKind.Construct));
                     const constructors = isNonConstructableClassLikeInJsFile ?
                         [factory.createConstructorDeclaration(/*decorators*/ undefined, factory.createModifiersFromModifierFlags(ModifierFlags.Private), [], /*body*/ undefined)] :
-                        serializeSignatures(SignatureKind.Construct, staticType, baseTypes[0], SyntaxKind.Constructor) as ConstructorDeclaration[];
+                        serializeSignatures(SignatureKind.Construct, staticType, staticBaseType, SyntaxKind.Constructor) as ConstructorDeclaration[];
                     const indexSignatures = serializeIndexSignatures(classType, baseTypes[0]);
                     addResult(setTextRange(factory.createClassDeclaration(
                         /*decorators*/ undefined,

--- a/tests/baselines/reference/jsDeclarationsClasses.js
+++ b/tests/baselines/reference/jsDeclarationsClasses.js
@@ -577,10 +577,6 @@ export class N<T> extends L {
  * @extends {N<U>}
  */
 export class O<U> extends N<U> {
-    /**
-     * @param {U} param
-     */
-    constructor(param: U);
     another2: U;
 }
 declare const VariableBase_base: any;

--- a/tests/baselines/reference/jsDeclarationsSubclassWithExplicitNoArgumentConstructor.js
+++ b/tests/baselines/reference/jsDeclarationsSubclassWithExplicitNoArgumentConstructor.js
@@ -1,0 +1,63 @@
+//// [index.js]
+export class Super {
+    /**
+     * @param {string} firstArg
+     * @param {string} secondArg
+     */
+    constructor(firstArg, secondArg) { }
+}
+
+export class Sub extends Super {
+    constructor() {
+        super('first', 'second');
+    }
+}
+
+//// [index.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+exports.__esModule = true;
+exports.Sub = exports.Super = void 0;
+var Super = /** @class */ (function () {
+    /**
+     * @param {string} firstArg
+     * @param {string} secondArg
+     */
+    function Super(firstArg, secondArg) {
+    }
+    return Super;
+}());
+exports.Super = Super;
+var Sub = /** @class */ (function (_super) {
+    __extends(Sub, _super);
+    function Sub() {
+        return _super.call(this, 'first', 'second') || this;
+    }
+    return Sub;
+}(Super));
+exports.Sub = Sub;
+
+
+//// [index.d.ts]
+export class Super {
+    /**
+     * @param {string} firstArg
+     * @param {string} secondArg
+     */
+    constructor(firstArg: string, secondArg: string);
+}
+export class Sub extends Super {
+    constructor();
+}

--- a/tests/baselines/reference/jsDeclarationsSubclassWithExplicitNoArgumentConstructor.symbols
+++ b/tests/baselines/reference/jsDeclarationsSubclassWithExplicitNoArgumentConstructor.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/jsdoc/declarations/index.js ===
+export class Super {
+>Super : Symbol(Super, Decl(index.js, 0, 0))
+
+    /**
+     * @param {string} firstArg
+     * @param {string} secondArg
+     */
+    constructor(firstArg, secondArg) { }
+>firstArg : Symbol(firstArg, Decl(index.js, 5, 16))
+>secondArg : Symbol(secondArg, Decl(index.js, 5, 25))
+}
+
+export class Sub extends Super {
+>Sub : Symbol(Sub, Decl(index.js, 6, 1))
+>Super : Symbol(Super, Decl(index.js, 0, 0))
+
+    constructor() {
+        super('first', 'second');
+>super : Symbol(Super, Decl(index.js, 0, 0))
+    }
+}

--- a/tests/baselines/reference/jsDeclarationsSubclassWithExplicitNoArgumentConstructor.types
+++ b/tests/baselines/reference/jsDeclarationsSubclassWithExplicitNoArgumentConstructor.types
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/jsdoc/declarations/index.js ===
+export class Super {
+>Super : Super
+
+    /**
+     * @param {string} firstArg
+     * @param {string} secondArg
+     */
+    constructor(firstArg, secondArg) { }
+>firstArg : string
+>secondArg : string
+}
+
+export class Sub extends Super {
+>Sub : Sub
+>Super : Super
+
+    constructor() {
+        super('first', 'second');
+>super('first', 'second') : void
+>super : typeof Super
+>'first' : "first"
+>'second' : "second"
+    }
+}

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsSubclassWithExplicitNoArgumentConstructor.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsSubclassWithExplicitNoArgumentConstructor.ts
@@ -1,0 +1,19 @@
+// @allowJs: true
+// @checkJs: true
+// @outDir: /out
+// @lib: es6
+// @declaration: true
+// @filename: index.js
+export class Super {
+    /**
+     * @param {string} firstArg
+     * @param {string} secondArg
+     */
+    constructor(firstArg, secondArg) { }
+}
+
+export class Sub extends Super {
+    constructor() {
+        super('first', 'second');
+    }
+}


### PR DESCRIPTION
And not the _instance_ base type, where non-static members come from.


Fixes #41397
