### PR TITLE
Make sure document event listener will specify more specific type - readystatechange

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -4406,7 +4406,7 @@ interface DocumentEventMap extends GlobalEventHandlersEventMap, DocumentAndEleme
     "fullscreenerror": Event;
     "pointerlockchange": Event;
     "pointerlockerror": Event;
-    "readystatechange": Event;
+    "readystatechange": ProgressEvent<Document>;
     "visibilitychange": Event;
 }
 


### PR DESCRIPTION
Make sure document event listener will specify more specific type for readystatechange #41775

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #

https://github.com/microsoft/TypeScript/issues/41775
