### PR TITLE
Reuse temp variable scope for converted loop body

### DIFF
--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -3155,7 +3155,7 @@ namespace ts {
 
             const containsYield = (node.statement.transformFlags & TransformFlags.ContainsYield) !== 0;
 
-            let emitFlags: EmitFlags = 0;
+            let emitFlags: EmitFlags = EmitFlags.ReuseTempVariableScope;
             if (currentState.containsLexicalThis) emitFlags |= EmitFlags.CapturesThis;
             if (containsYield && (hierarchyFacts & HierarchyFacts.AsyncFunctionBody) !== 0) emitFlags |= EmitFlags.AsyncFunctionBody;
 

--- a/tests/baselines/reference/asyncAwaitWithCapturedBlockScopeVar.js
+++ b/tests/baselines/reference/asyncAwaitWithCapturedBlockScopeVar.js
@@ -44,11 +44,11 @@ function fn1() {
                 case 0:
                     ar = [];
                     _loop_1 = function (i) {
-                        return __generator(this, function (_a) {
-                            switch (_a.label) {
+                        return __generator(this, function (_b) {
+                            switch (_b.label) {
                                 case 0: return [4 /*yield*/, 1];
                                 case 1:
-                                    _a.sent();
+                                    _b.sent();
                                     ar.push(function () { return i; });
                                     return [2 /*return*/];
                             }
@@ -78,11 +78,11 @@ function fn2() {
                 case 0:
                     ar = [];
                     _loop_2 = function (i) {
-                        return __generator(this, function (_a) {
-                            switch (_a.label) {
+                        return __generator(this, function (_b) {
+                            switch (_b.label) {
                                 case 0: return [4 /*yield*/, 1];
                                 case 1:
-                                    _a.sent();
+                                    _b.sent();
                                     ar.push(function () { return i; });
                                     return [2 /*return*/, "break"];
                             }
@@ -114,11 +114,11 @@ function fn3() {
                 case 0:
                     ar = [];
                     _loop_3 = function (i) {
-                        return __generator(this, function (_a) {
-                            switch (_a.label) {
+                        return __generator(this, function (_b) {
+                            switch (_b.label) {
                                 case 0: return [4 /*yield*/, 1];
                                 case 1:
-                                    _a.sent();
+                                    _b.sent();
                                     ar.push(function () { return i; });
                                     return [2 /*return*/, "continue"];
                             }
@@ -148,11 +148,11 @@ function fn4() {
                 case 0:
                     ar = [];
                     _loop_4 = function (i) {
-                        return __generator(this, function (_a) {
-                            switch (_a.label) {
+                        return __generator(this, function (_b) {
+                            switch (_b.label) {
                                 case 0: return [4 /*yield*/, 1];
                                 case 1:
-                                    _a.sent();
+                                    _b.sent();
                                     ar.push(function () { return i; });
                                     return [2 /*return*/, { value: 1 }];
                             }

--- a/tests/baselines/reference/blockScopedBindingsInDownlevelGenerator.js
+++ b/tests/baselines/reference/blockScopedBindingsInDownlevelGenerator.js
@@ -52,13 +52,13 @@ function a() {
         switch (_d.label) {
             case 0:
                 _loop_1 = function (i) {
-                    return __generator(this, function (_a) {
-                        switch (_a.label) {
+                    return __generator(this, function (_e) {
+                        switch (_e.label) {
                             case 0:
                                 (function () { return i; })();
                                 return [4 /*yield*/, i];
                             case 1:
-                                _a.sent();
+                                _e.sent();
                                 return [2 /*return*/];
                         }
                     });

--- a/tests/baselines/reference/capturedLetConstInLoop10.js
+++ b/tests/baselines/reference/capturedLetConstInLoop10.js
@@ -69,8 +69,8 @@ var A = /** @class */ (function () {
                 var b = function () { return y; };
                 this_2.bar(b());
             };
-            for (var _i = 0, _a = [1]; _i < _a.length; _i++) {
-                var y = _a[_i];
+            for (var _b = 0, _c = [1]; _b < _c.length; _b++) {
+                var y = _c[_b];
                 _loop_3(y);
             }
             this_2.bar(a());
@@ -89,8 +89,8 @@ var A = /** @class */ (function () {
                 var b = function () { return y; };
                 this_3.bar(b());
             };
-            for (var _i = 0, _a = [1]; _i < _a.length; _i++) {
-                var y = _a[_i];
+            for (var _b = 0, _c = [1]; _b < _c.length; _b++) {
+                var y = _c[_b];
                 _loop_5(y);
             }
         };

--- a/tests/baselines/reference/capturedLetConstInLoop13.js
+++ b/tests/baselines/reference/capturedLetConstInLoop13.js
@@ -34,10 +34,10 @@ var Main = /** @class */ (function () {
             names[_i] = arguments[_i];
         }
         var _loop_1 = function (name_1) {
-            var _a;
-            this_1.bar((_a = {},
-                _a[name_1 + ".a"] = function () { _this.foo(name_1); },
-                _a));
+            var _b;
+            this_1.bar((_b = {},
+                _b[name_1 + ".a"] = function () { _this.foo(name_1); },
+                _b));
         };
         var this_1 = this;
         for (var _a = 0, names_1 = names; _a < names_1.length; _a++) {

--- a/tests/baselines/reference/capturedLetConstInLoop9.js
+++ b/tests/baselines/reference/capturedLetConstInLoop9.js
@@ -178,16 +178,16 @@ for (var x = 0; x < 1; ++x) {
 }
 function foo() {
     var _loop_3 = function (a) {
-        var _a;
+        var _b;
         if (a === 1) {
             return "break";
         }
         if (a === 2) {
             return "break-l0";
         }
-        for (var _i = 0, _b = []; _i < _b.length; _i++) {
-            var b = _b[_i];
-            _a = [{ x: 1, y: 2 }][0], x = _a.x, z = _a.y;
+        for (var _c = 0, _d = []; _c < _d.length; _c++) {
+            var b = _d[_c];
+            _b = [{ x: 1, y: 2 }][0], x = _b.x, z = _b.y;
             if (b === 1) {
                 break;
             }
@@ -200,8 +200,8 @@ function foo() {
             return { value: 50 };
         }
         var _loop_4 = function (b) {
-            var _a;
-            _a = [{ x1: 1, y: arguments_1.length }][0], x1 = _a.x1, z1 = _a.y;
+            var _g;
+            _g = [{ x1: 1, y: arguments_1.length }][0], x1 = _g.x1, z1 = _g.y;
             if (b === 1) {
                 return "break";
             }
@@ -211,8 +211,8 @@ function foo() {
             (function () { return b; });
             return { value: 100 };
         };
-        for (var _c = 0, _d = []; _c < _d.length; _c++) {
-            var b = _d[_c];
+        for (var _e = 0, _f = []; _e < _f.length; _e++) {
+            var b = _f[_e];
             var state_2 = _loop_4(b);
             if (typeof state_2 === "object")
                 return state_2;

--- a/tests/baselines/reference/jsDeclarationsSubclassWithExplicitNoArgumentConstructor.js
+++ b/tests/baselines/reference/jsDeclarationsSubclassWithExplicitNoArgumentConstructor.js
@@ -23,6 +23,8 @@ var __extends = (this && this.__extends) || (function () {
         return extendStatics(d, b);
     };
     return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());

--- a/tests/baselines/reference/nestedLoops.js
+++ b/tests/baselines/reference/nestedLoops.js
@@ -31,8 +31,8 @@ var Test = /** @class */ (function () {
                     var x = outer + inner + newValue;
                 });
             };
-            for (var _i = 0, innerArray_1 = innerArray; _i < innerArray_1.length; _i++) {
-                var inner = innerArray_1[_i];
+            for (var _a = 0, innerArray_1 = innerArray; _a < innerArray_1.length; _a++) {
+                var inner = innerArray_1[_a];
                 _loop_2(inner);
             }
         };

--- a/tests/baselines/reference/newLexicalEnvironmentForConvertedLoop.js
+++ b/tests/baselines/reference/newLexicalEnvironmentForConvertedLoop.js
@@ -18,10 +18,10 @@ function baz(x) {
 }
 function foo(set) {
     var _loop_1 = function (value, i) {
-        var _a;
+        var _c;
         var bar = [];
         (function () { return bar; });
-        (_a = set.values).push.apply(_a, []);
+        (_c = set.values).push.apply(_c, []);
     };
     for (var _i = 0, _a = baz(set.values); _i < _a.length; _i++) {
         var _b = _a[_i], value = _b[0], i = _b[1];

--- a/tests/baselines/reference/optionalChainingInLoop.js
+++ b/tests/baselines/reference/optionalChainingInLoop.js
@@ -1,0 +1,25 @@
+//// [optionalChainingInLoop.ts]
+// https://github.com/microsoft/TypeScript/issues/40643
+const list: any[] = []
+for (const comp of list) {
+    comp.sp.y = comp.sp.r.find((k: any) => k.c == (comp.xp ? '1' : '0'))
+    for (const item of comp.c) {
+        item.v = !!item.t?.length
+    }
+}
+
+//// [optionalChainingInLoop.js]
+var _a;
+// https://github.com/microsoft/TypeScript/issues/40643
+var list = [];
+var _loop_1 = function (comp) {
+    comp.sp.y = comp.sp.r.find(function (k) { return k.c == (comp.xp ? '1' : '0'); });
+    for (var _b = 0, _c = comp.c; _b < _c.length; _b++) {
+        var item = _c[_b];
+        item.v = !!((_a = item.t) === null || _a === void 0 ? void 0 : _a.length);
+    }
+};
+for (var _i = 0, list_1 = list; _i < list_1.length; _i++) {
+    var comp = list_1[_i];
+    _loop_1(comp);
+}

--- a/tests/cases/conformance/expressions/optionalChaining/optionalChainingInLoop.ts
+++ b/tests/cases/conformance/expressions/optionalChaining/optionalChainingInLoop.ts
@@ -1,0 +1,11 @@
+// @target: es5
+// @lib: es2015
+// @noTypesAndSymbols: true
+// https://github.com/microsoft/TypeScript/issues/40643
+const list: any[] = []
+for (const comp of list) {
+    comp.sp.y = comp.sp.r.find((k: any) => k.c == (comp.xp ? '1' : '0'))
+    for (const item of comp.c) {
+        item.v = !!item.t?.length
+    }
+}


### PR DESCRIPTION
This marks converted loop bodies with the `ReuseTempVariableScope` emit flag so that we don't introduce clashing temporary variables.

Fixes #40643
