### PR TITLE
Don't check computed name visibility results in declaration emit

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4997,7 +4997,7 @@ namespace ts {
                     anyType : getTypeOfSymbol(propertySymbol);
                 const saveEnclosingDeclaration = context.enclosingDeclaration;
                 context.enclosingDeclaration = undefined;
-                if (context.tracker.trackSymbol && getCheckFlags(propertySymbol) & CheckFlags.Late) {
+                if (context.tracker.trackSymbol && getCheckFlags(propertySymbol) & CheckFlags.Late && isLateBoundName(propertySymbol.escapedName)) {
                     const decl = first(propertySymbol.declarations);
                     if (hasLateBindableName(decl)) {
                         if (isBinaryExpression(decl)) {

--- a/tests/baselines/reference/declarationEmitStringEnumUsedInNonlocalSpread.js
+++ b/tests/baselines/reference/declarationEmitStringEnumUsedInNonlocalSpread.js
@@ -1,0 +1,115 @@
+//// [tests/cases/compiler/declarationEmitStringEnumUsedInNonlocalSpread.ts] ////
+
+//// [class.ts]
+export const enum TestEnum {
+    Test1 = '123123',
+    Test2 = '12312312312',
+}
+
+export interface ITest {
+    [TestEnum.Test1]: string;
+    [TestEnum.Test2]: string;
+}
+
+export class A {
+    getA(): ITest {
+        return {
+            [TestEnum.Test1]: '123',
+            [TestEnum.Test2]: '123',
+        };
+    }
+}
+//// [index.ts]
+import { A } from './class';
+
+export class B extends A {
+    getA() { // TS4053 error
+        return {
+            ...super.getA(),
+            a: '123',
+        };
+    }
+}
+
+//// [class.js]
+"use strict";
+exports.__esModule = true;
+exports.A = void 0;
+var A = /** @class */ (function () {
+    function A() {
+    }
+    A.prototype.getA = function () {
+        var _a;
+        return _a = {},
+            _a["123123" /* Test1 */] = '123',
+            _a["12312312312" /* Test2 */] = '123',
+            _a;
+    };
+    return A;
+}());
+exports.A = A;
+//// [index.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+exports.__esModule = true;
+exports.B = void 0;
+var class_1 = require("./class");
+var B = /** @class */ (function (_super) {
+    __extends(B, _super);
+    function B() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    B.prototype.getA = function () {
+        return __assign(__assign({}, _super.prototype.getA.call(this)), { a: '123' });
+    };
+    return B;
+}(class_1.A));
+exports.B = B;
+
+
+//// [class.d.ts]
+export declare const enum TestEnum {
+    Test1 = "123123",
+    Test2 = "12312312312"
+}
+export interface ITest {
+    [TestEnum.Test1]: string;
+    [TestEnum.Test2]: string;
+}
+export declare class A {
+    getA(): ITest;
+}
+//// [index.d.ts]
+import { A } from './class';
+export declare class B extends A {
+    getA(): {
+        a: string;
+        123123: string;
+        12312312312: string;
+    };
+}

--- a/tests/baselines/reference/declarationEmitStringEnumUsedInNonlocalSpread.symbols
+++ b/tests/baselines/reference/declarationEmitStringEnumUsedInNonlocalSpread.symbols
@@ -1,0 +1,73 @@
+=== tests/cases/compiler/class.ts ===
+export const enum TestEnum {
+>TestEnum : Symbol(TestEnum, Decl(class.ts, 0, 0))
+
+    Test1 = '123123',
+>Test1 : Symbol(TestEnum.Test1, Decl(class.ts, 0, 28))
+
+    Test2 = '12312312312',
+>Test2 : Symbol(TestEnum.Test2, Decl(class.ts, 1, 21))
+}
+
+export interface ITest {
+>ITest : Symbol(ITest, Decl(class.ts, 3, 1))
+
+    [TestEnum.Test1]: string;
+>[TestEnum.Test1] : Symbol(ITest[TestEnum.Test1], Decl(class.ts, 5, 24))
+>TestEnum.Test1 : Symbol(TestEnum.Test1, Decl(class.ts, 0, 28))
+>TestEnum : Symbol(TestEnum, Decl(class.ts, 0, 0))
+>Test1 : Symbol(TestEnum.Test1, Decl(class.ts, 0, 28))
+
+    [TestEnum.Test2]: string;
+>[TestEnum.Test2] : Symbol(ITest[TestEnum.Test2], Decl(class.ts, 6, 29))
+>TestEnum.Test2 : Symbol(TestEnum.Test2, Decl(class.ts, 1, 21))
+>TestEnum : Symbol(TestEnum, Decl(class.ts, 0, 0))
+>Test2 : Symbol(TestEnum.Test2, Decl(class.ts, 1, 21))
+}
+
+export class A {
+>A : Symbol(A, Decl(class.ts, 8, 1))
+
+    getA(): ITest {
+>getA : Symbol(A.getA, Decl(class.ts, 10, 16))
+>ITest : Symbol(ITest, Decl(class.ts, 3, 1))
+
+        return {
+            [TestEnum.Test1]: '123',
+>[TestEnum.Test1] : Symbol([TestEnum.Test1], Decl(class.ts, 12, 16))
+>TestEnum.Test1 : Symbol(TestEnum.Test1, Decl(class.ts, 0, 28))
+>TestEnum : Symbol(TestEnum, Decl(class.ts, 0, 0))
+>Test1 : Symbol(TestEnum.Test1, Decl(class.ts, 0, 28))
+
+            [TestEnum.Test2]: '123',
+>[TestEnum.Test2] : Symbol([TestEnum.Test2], Decl(class.ts, 13, 36))
+>TestEnum.Test2 : Symbol(TestEnum.Test2, Decl(class.ts, 1, 21))
+>TestEnum : Symbol(TestEnum, Decl(class.ts, 0, 0))
+>Test2 : Symbol(TestEnum.Test2, Decl(class.ts, 1, 21))
+
+        };
+    }
+}
+=== tests/cases/compiler/index.ts ===
+import { A } from './class';
+>A : Symbol(A, Decl(index.ts, 0, 8))
+
+export class B extends A {
+>B : Symbol(B, Decl(index.ts, 0, 28))
+>A : Symbol(A, Decl(index.ts, 0, 8))
+
+    getA() { // TS4053 error
+>getA : Symbol(B.getA, Decl(index.ts, 2, 26))
+
+        return {
+            ...super.getA(),
+>super.getA : Symbol(A.getA, Decl(class.ts, 10, 16))
+>super : Symbol(A, Decl(class.ts, 8, 1))
+>getA : Symbol(A.getA, Decl(class.ts, 10, 16))
+
+            a: '123',
+>a : Symbol(a, Decl(index.ts, 5, 28))
+
+        };
+    }
+}

--- a/tests/baselines/reference/declarationEmitStringEnumUsedInNonlocalSpread.types
+++ b/tests/baselines/reference/declarationEmitStringEnumUsedInNonlocalSpread.types
@@ -1,0 +1,80 @@
+=== tests/cases/compiler/class.ts ===
+export const enum TestEnum {
+>TestEnum : TestEnum
+
+    Test1 = '123123',
+>Test1 : TestEnum.Test1
+>'123123' : "123123"
+
+    Test2 = '12312312312',
+>Test2 : TestEnum.Test2
+>'12312312312' : "12312312312"
+}
+
+export interface ITest {
+    [TestEnum.Test1]: string;
+>[TestEnum.Test1] : string
+>TestEnum.Test1 : TestEnum.Test1
+>TestEnum : typeof TestEnum
+>Test1 : TestEnum.Test1
+
+    [TestEnum.Test2]: string;
+>[TestEnum.Test2] : string
+>TestEnum.Test2 : TestEnum.Test2
+>TestEnum : typeof TestEnum
+>Test2 : TestEnum.Test2
+}
+
+export class A {
+>A : A
+
+    getA(): ITest {
+>getA : () => ITest
+
+        return {
+>{            [TestEnum.Test1]: '123',            [TestEnum.Test2]: '123',        } : { 123123: string; 12312312312: string; }
+
+            [TestEnum.Test1]: '123',
+>[TestEnum.Test1] : string
+>TestEnum.Test1 : TestEnum.Test1
+>TestEnum : typeof TestEnum
+>Test1 : TestEnum.Test1
+>'123' : "123"
+
+            [TestEnum.Test2]: '123',
+>[TestEnum.Test2] : string
+>TestEnum.Test2 : TestEnum.Test2
+>TestEnum : typeof TestEnum
+>Test2 : TestEnum.Test2
+>'123' : "123"
+
+        };
+    }
+}
+=== tests/cases/compiler/index.ts ===
+import { A } from './class';
+>A : typeof A
+
+export class B extends A {
+>B : B
+>A : A
+
+    getA() { // TS4053 error
+>getA : () => { a: string; 123123: string; 12312312312: string; }
+
+        return {
+>{            ...super.getA(),            a: '123',        } : { a: string; 123123: string; 12312312312: string; }
+
+            ...super.getA(),
+>super.getA() : import("tests/cases/compiler/class").ITest
+>super.getA : () => import("tests/cases/compiler/class").ITest
+>super : A
+>getA : () => import("tests/cases/compiler/class").ITest
+
+            a: '123',
+>a : string
+>'123' : "123"
+
+        };
+    }
+}

--- a/tests/baselines/reference/declarationEmitWithDefaultAsComputedName.js
+++ b/tests/baselines/reference/declarationEmitWithDefaultAsComputedName.js
@@ -41,7 +41,6 @@ declare type Experiment<Name> = {
 declare const _default: Experiment<"foo">;
 export default _default;
 //// [main.d.ts]
-import other from "./other";
 export declare const obj: {
     foo: number;
 };

--- a/tests/baselines/reference/declarationEmitWithDefaultAsComputedName2.js
+++ b/tests/baselines/reference/declarationEmitWithDefaultAsComputedName2.js
@@ -41,7 +41,6 @@ declare type Experiment<Name> = {
 declare const _default: Experiment<"foo">;
 export default _default;
 //// [main.d.ts]
-import * as other2 from "./other";
 export declare const obj: {
     foo: number;
 };

--- a/tests/baselines/reference/objectLiteralComputedNameNoDeclarationError.js
+++ b/tests/baselines/reference/objectLiteralComputedNameNoDeclarationError.js
@@ -21,10 +21,6 @@ exports.Baa = (_a = {},
 
 
 //// [objectLiteralComputedNameNoDeclarationError.d.ts]
-declare const Foo: {
-    BANANA: "banana";
-};
 export declare const Baa: {
     banana: number;
 };
-export {};

--- a/tests/cases/compiler/declarationEmitStringEnumUsedInNonlocalSpread.ts
+++ b/tests/cases/compiler/declarationEmitStringEnumUsedInNonlocalSpread.ts
@@ -1,0 +1,31 @@
+// @declaration: true
+// @filename: class.ts
+export const enum TestEnum {
+    Test1 = '123123',
+    Test2 = '12312312312',
+}
+
+export interface ITest {
+    [TestEnum.Test1]: string;
+    [TestEnum.Test2]: string;
+}
+
+export class A {
+    getA(): ITest {
+        return {
+            [TestEnum.Test1]: '123',
+            [TestEnum.Test2]: '123',
+        };
+    }
+}
+// @filename: index.ts
+import { A } from './class';
+
+export class B extends A {
+    getA() { // TS4053 error
+        return {
+            ...super.getA(),
+            a: '123',
+        };
+    }
+}


### PR DESCRIPTION
In cases where the computed name representation is not actually in use in the output (we only use it for late bound unique symbol names, and inline the latebound name as a non-latebound one in all other cases). This happens to remove some extraneous statements in a handful of our existing tests, where latebound visibility checking was pulling in private declarations not *actually* required for declaration emit.

Fixes #40718
