### PR TITLE
Preserve substitution types in check position of conditional types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14374,10 +14374,9 @@ namespace ts {
                     }
                 }
                 // Return a deferred type for a check that is neither definitely true nor definitely false
-                const erasedCheckType = getActualTypeVariable(checkType);
                 result = <ConditionalType>createType(TypeFlags.Conditional);
                 result.root = root;
-                result.checkType = erasedCheckType;
+                result.checkType = checkType;
                 result.extendsType = extendsType;
                 result.mapper = mapper;
                 result.combinedMapper = combinedMapper;
@@ -20208,12 +20207,6 @@ namespace ts {
                     }
                     if (source.flags & (TypeFlags.Object | TypeFlags.Intersection)) {
                         invokeOnce(source, target, inferFromObjectTypes);
-                    }
-                }
-                if (source.flags & TypeFlags.Simplifiable) {
-                    const simplified = getSimplifiedType(source, contravariant);
-                    if (simplified !== source) {
-                        inferFromTypes(simplified, target);
                     }
                 }
             }

--- a/tests/baselines/reference/recursiveConditionalTypes.errors.txt
+++ b/tests/baselines/reference/recursiveConditionalTypes.errors.txt
@@ -190,3 +190,23 @@ tests/cases/compiler/recursiveConditionalTypes.ts(116,9): error TS2345: Argument
 !!! error TS2345:               Type 'string' is not assignable to type 'number'.
     }
     
+    // Repros from #41756
+    
+    type ParseSuccess<R extends string> = { rest: R };
+    
+    type ParseManyWhitespace<S extends string> =
+        S extends ` ${infer R0}` ?
+            ParseManyWhitespace<R0> extends ParseSuccess<infer R1> ? ParseSuccess<R1> : null :
+            ParseSuccess<S>;
+    
+    type TP1 = ParseManyWhitespace<" foo">;
+    
+    type ParseManyWhitespace2<S extends string> =
+        S extends ` ${infer R0}` ?
+            Helper<ParseManyWhitespace2<R0>> :
+            ParseSuccess<S>;
+    
+    type Helper<T> = T extends ParseSuccess<infer R> ? ParseSuccess<R> : null
+    
+    type TP2 = ParseManyWhitespace2<" foo">;
+    

--- a/tests/baselines/reference/recursiveConditionalTypes.js
+++ b/tests/baselines/reference/recursiveConditionalTypes.js
@@ -117,6 +117,26 @@ function f21<T extends number>(x: Grow1<[], T>, y: Grow2<[], T>) {
     f21(y, x);  // Error
 }
 
+// Repros from #41756
+
+type ParseSuccess<R extends string> = { rest: R };
+
+type ParseManyWhitespace<S extends string> =
+    S extends ` ${infer R0}` ?
+        ParseManyWhitespace<R0> extends ParseSuccess<infer R1> ? ParseSuccess<R1> : null :
+        ParseSuccess<S>;
+
+type TP1 = ParseManyWhitespace<" foo">;
+
+type ParseManyWhitespace2<S extends string> =
+    S extends ` ${infer R0}` ?
+        Helper<ParseManyWhitespace2<R0>> :
+        ParseSuccess<S>;
+
+type Helper<T> = T extends ParseSuccess<infer R> ? ParseSuccess<R> : null
+
+type TP2 = ParseManyWhitespace2<" foo">;
+
 
 //// [recursiveConditionalTypes.js]
 "use strict";
@@ -214,3 +234,11 @@ declare function f20<T, U extends T>(x: Unpack1<T>, y: Unpack2<T>): void;
 declare type Grow1<T extends unknown[], N extends number> = T['length'] extends N ? T : Grow1<[number, ...T], N>;
 declare type Grow2<T extends unknown[], N extends number> = T['length'] extends N ? T : Grow2<[string, ...T], N>;
 declare function f21<T extends number>(x: Grow1<[], T>, y: Grow2<[], T>): void;
+declare type ParseSuccess<R extends string> = {
+    rest: R;
+};
+declare type ParseManyWhitespace<S extends string> = S extends ` ${infer R0}` ? ParseManyWhitespace<R0> extends ParseSuccess<infer R1> ? ParseSuccess<R1> : null : ParseSuccess<S>;
+declare type TP1 = ParseManyWhitespace<" foo">;
+declare type ParseManyWhitespace2<S extends string> = S extends ` ${infer R0}` ? Helper<ParseManyWhitespace2<R0>> : ParseSuccess<S>;
+declare type Helper<T> = T extends ParseSuccess<infer R> ? ParseSuccess<R> : null;
+declare type TP2 = ParseManyWhitespace2<" foo">;

--- a/tests/baselines/reference/recursiveConditionalTypes.symbols
+++ b/tests/baselines/reference/recursiveConditionalTypes.symbols
@@ -465,3 +465,65 @@ function f21<T extends number>(x: Grow1<[], T>, y: Grow2<[], T>) {
 >x : Symbol(x, Decl(recursiveConditionalTypes.ts, 114, 31))
 }
 
+// Repros from #41756
+
+type ParseSuccess<R extends string> = { rest: R };
+>ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 116, 1))
+>R : Symbol(R, Decl(recursiveConditionalTypes.ts, 120, 18))
+>rest : Symbol(rest, Decl(recursiveConditionalTypes.ts, 120, 39))
+>R : Symbol(R, Decl(recursiveConditionalTypes.ts, 120, 18))
+
+type ParseManyWhitespace<S extends string> =
+>ParseManyWhitespace : Symbol(ParseManyWhitespace, Decl(recursiveConditionalTypes.ts, 120, 50))
+>S : Symbol(S, Decl(recursiveConditionalTypes.ts, 122, 25))
+
+    S extends ` ${infer R0}` ?
+>S : Symbol(S, Decl(recursiveConditionalTypes.ts, 122, 25))
+>R0 : Symbol(R0, Decl(recursiveConditionalTypes.ts, 123, 23))
+
+        ParseManyWhitespace<R0> extends ParseSuccess<infer R1> ? ParseSuccess<R1> : null :
+>ParseManyWhitespace : Symbol(ParseManyWhitespace, Decl(recursiveConditionalTypes.ts, 120, 50))
+>R0 : Symbol(R0, Decl(recursiveConditionalTypes.ts, 123, 23))
+>ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 116, 1))
+>R1 : Symbol(R1, Decl(recursiveConditionalTypes.ts, 124, 58))
+>ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 116, 1))
+>R1 : Symbol(R1, Decl(recursiveConditionalTypes.ts, 124, 58))
+
+        ParseSuccess<S>;
+>ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 116, 1))
+>S : Symbol(S, Decl(recursiveConditionalTypes.ts, 122, 25))
+
+type TP1 = ParseManyWhitespace<" foo">;
+>TP1 : Symbol(TP1, Decl(recursiveConditionalTypes.ts, 125, 24))
+>ParseManyWhitespace : Symbol(ParseManyWhitespace, Decl(recursiveConditionalTypes.ts, 120, 50))
+
+type ParseManyWhitespace2<S extends string> =
+>ParseManyWhitespace2 : Symbol(ParseManyWhitespace2, Decl(recursiveConditionalTypes.ts, 127, 39))
+>S : Symbol(S, Decl(recursiveConditionalTypes.ts, 129, 26))
+
+    S extends ` ${infer R0}` ?
+>S : Symbol(S, Decl(recursiveConditionalTypes.ts, 129, 26))
+>R0 : Symbol(R0, Decl(recursiveConditionalTypes.ts, 130, 23))
+
+        Helper<ParseManyWhitespace2<R0>> :
+>Helper : Symbol(Helper, Decl(recursiveConditionalTypes.ts, 132, 24))
+>ParseManyWhitespace2 : Symbol(ParseManyWhitespace2, Decl(recursiveConditionalTypes.ts, 127, 39))
+>R0 : Symbol(R0, Decl(recursiveConditionalTypes.ts, 130, 23))
+
+        ParseSuccess<S>;
+>ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 116, 1))
+>S : Symbol(S, Decl(recursiveConditionalTypes.ts, 129, 26))
+
+type Helper<T> = T extends ParseSuccess<infer R> ? ParseSuccess<R> : null
+>Helper : Symbol(Helper, Decl(recursiveConditionalTypes.ts, 132, 24))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 134, 12))
+>T : Symbol(T, Decl(recursiveConditionalTypes.ts, 134, 12))
+>ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 116, 1))
+>R : Symbol(R, Decl(recursiveConditionalTypes.ts, 134, 45))
+>ParseSuccess : Symbol(ParseSuccess, Decl(recursiveConditionalTypes.ts, 116, 1))
+>R : Symbol(R, Decl(recursiveConditionalTypes.ts, 134, 45))
+
+type TP2 = ParseManyWhitespace2<" foo">;
+>TP2 : Symbol(TP2, Decl(recursiveConditionalTypes.ts, 134, 73))
+>ParseManyWhitespace2 : Symbol(ParseManyWhitespace2, Decl(recursiveConditionalTypes.ts, 127, 39))
+

--- a/tests/baselines/reference/recursiveConditionalTypes.types
+++ b/tests/baselines/reference/recursiveConditionalTypes.types
@@ -310,3 +310,35 @@ function f21<T extends number>(x: Grow1<[], T>, y: Grow2<[], T>) {
 >x : Grow1<[], T>
 }
 
+// Repros from #41756
+
+type ParseSuccess<R extends string> = { rest: R };
+>ParseSuccess : ParseSuccess<R>
+>rest : R
+
+type ParseManyWhitespace<S extends string> =
+>ParseManyWhitespace : ParseManyWhitespace<S>
+
+    S extends ` ${infer R0}` ?
+        ParseManyWhitespace<R0> extends ParseSuccess<infer R1> ? ParseSuccess<R1> : null :
+>null : null
+
+        ParseSuccess<S>;
+
+type TP1 = ParseManyWhitespace<" foo">;
+>TP1 : ParseSuccess<"foo">
+
+type ParseManyWhitespace2<S extends string> =
+>ParseManyWhitespace2 : ParseManyWhitespace2<S>
+
+    S extends ` ${infer R0}` ?
+        Helper<ParseManyWhitespace2<R0>> :
+        ParseSuccess<S>;
+
+type Helper<T> = T extends ParseSuccess<infer R> ? ParseSuccess<R> : null
+>Helper : Helper<T>
+>null : null
+
+type TP2 = ParseManyWhitespace2<" foo">;
+>TP2 : ParseSuccess<"foo">
+

--- a/tests/cases/compiler/recursiveConditionalTypes.ts
+++ b/tests/cases/compiler/recursiveConditionalTypes.ts
@@ -119,3 +119,23 @@ type Grow2<T extends unknown[], N extends number> = T['length'] extends N ? T : 
 function f21<T extends number>(x: Grow1<[], T>, y: Grow2<[], T>) {
     f21(y, x);  // Error
 }
+
+// Repros from #41756
+
+type ParseSuccess<R extends string> = { rest: R };
+
+type ParseManyWhitespace<S extends string> =
+    S extends ` ${infer R0}` ?
+        ParseManyWhitespace<R0> extends ParseSuccess<infer R1> ? ParseSuccess<R1> : null :
+        ParseSuccess<S>;
+
+type TP1 = ParseManyWhitespace<" foo">;
+
+type ParseManyWhitespace2<S extends string> =
+    S extends ` ${infer R0}` ?
+        Helper<ParseManyWhitespace2<R0>> :
+        ParseSuccess<S>;
+
+type Helper<T> = T extends ParseSuccess<infer R> ? ParseSuccess<R> : null
+
+type TP2 = ParseManyWhitespace2<" foo">;


### PR DESCRIPTION
With this PR we properly preserve substitution types in the check type position of conditional types. Previously we'd erase substitution types, thus losing constraints implied by containing conditional types. In #32093 this was fixed by attempting to simplify types during inference, but that can lead to infinite recursion as seen in #41756. By fixing the root issue (the erasure of substitution types) we can do away with #32093 and the infinite recursion.

BTW, the reasons we erased substitution types appear to be historical. Properly preserving them appears to have no ill effects.

Fixes #41756.