### PR TITLE
fix(41818): Detached JSDoc class docstring using @extends crashes tsc

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2147,8 +2147,8 @@ namespace ts {
             const saveCurrentFlow = currentFlow;
             for (const typeAlias of delayedTypeAliases) {
                 const host = getJSDocHost(typeAlias);
-                container = findAncestor(host.parent, n => !!(getContainerFlags(n) & ContainerFlags.IsContainer)) || file;
-                blockScopeContainer = getEnclosingBlockScopeContainer(host) || file;
+                container = (host && findAncestor(host.parent, n => !!(getContainerFlags(n) & ContainerFlags.IsContainer))) || file;
+                blockScopeContainer = (host && getEnclosingBlockScopeContainer(host)) || file;
                 currentFlow = initFlowNode({ flags: FlowFlags.Start });
                 parent = typeAlias;
                 bind(typeAlias.typeExpression);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1949,7 +1949,10 @@ namespace ts {
                     case SyntaxKind.JSDocCallbackTag:
                     case SyntaxKind.JSDocEnumTag:
                         // js type aliases do not resolve names from their host, so skip past it
-                        location = getJSDocHost(location);
+                        const root = getJSDocRoot(location);
+                        if (root) {
+                            location = root.parent;
+                        }
                         break;
                     case SyntaxKind.Parameter:
                         if (lastLocation && (
@@ -3161,7 +3164,8 @@ namespace ts {
                 return;
             }
             const host = getJSDocHost(node);
-            if (isExpressionStatement(host) &&
+            if (host &&
+                isExpressionStatement(host) &&
                 isBinaryExpression(host.expression) &&
                 getAssignmentDeclarationKind(host.expression) === AssignmentDeclarationKind.PrototypeProperty) {
                 // X.prototype.m = /** @param {K} p */ function () { } <-- look for K on X's declaration
@@ -3170,7 +3174,7 @@ namespace ts {
                     return getDeclarationOfJSPrototypeContainer(symbol);
                 }
             }
-            if ((isObjectLiteralMethod(host) || isPropertyAssignment(host)) &&
+            if (host && (isObjectLiteralMethod(host) || isPropertyAssignment(host)) &&
                 isBinaryExpression(host.parent.parent) &&
                 getAssignmentDeclarationKind(host.parent.parent) === AssignmentDeclarationKind.Prototype) {
                 // X.prototype = { /** @param {K} p */m() { } } <-- look for K on X's declaration

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2600,18 +2600,31 @@ namespace ts {
 
     export function getEffectiveJSDocHost(node: Node): Node | undefined {
         const host = getJSDocHost(node);
-        const decl = getSourceOfDefaultedAssignment(host) ||
-            getSourceOfAssignment(host) ||
-            getSingleInitializerOfVariableStatementOrPropertyDeclaration(host) ||
-            getSingleVariableOfVariableStatement(host) ||
-            getNestedModuleDeclaration(host) ||
-            host;
-        return decl;
+        if (host) {
+            return getSourceOfDefaultedAssignment(host)
+                || getSourceOfAssignment(host)
+                || getSingleInitializerOfVariableStatementOrPropertyDeclaration(host)
+                || getSingleVariableOfVariableStatement(host)
+                || getNestedModuleDeclaration(host)
+                || host;
+        }
     }
 
-    /** Use getEffectiveJSDocHost if you additionally need to look for jsdoc on parent nodes, like assignments.  */
-    export function getJSDocHost(node: Node): HasJSDoc {
-        return Debug.checkDefined(findAncestor(node.parent, isJSDoc)).parent;
+    /** Use getEffectiveJSDocHost if you additionally need to look for jsdoc on parent nodes, like assignments. */
+    export function getJSDocHost(node: Node): HasJSDoc | undefined {
+        const jsDoc = getJSDocRoot(node);
+        if (!jsDoc) {
+            return undefined;
+        }
+
+        const host = jsDoc.parent;
+        if (host && host.jsDoc && jsDoc === lastOrUndefined(host.jsDoc)) {
+            return host;
+        }
+    }
+
+    export function getJSDocRoot(node: Node): JSDoc | undefined {
+        return findAncestor(node.parent, isJSDoc);
     }
 
     export function getTypeParameterFromJsDoc(node: TypeParameterDeclaration & { parent: JSDocTemplateTag }): TypeParameterDeclaration | undefined {

--- a/tests/baselines/reference/extendsTag2.errors.txt
+++ b/tests/baselines/reference/extendsTag2.errors.txt
@@ -1,0 +1,25 @@
+error TS8022: JSDoc '@extends' is not attached to a class.
+
+
+!!! error TS8022: JSDoc '@extends' is not attached to a class.
+==== tests/cases/conformance/jsdoc/foo.js (0 errors) ====
+    /**
+     * @constructor
+     */
+    class A {
+        constructor() {}
+    }
+    
+    /**
+     * @extends {A}
+     */
+    
+    /**
+     * @constructor
+     */
+    class B extends A {
+        constructor() {
+            super();
+        }
+    }
+    

--- a/tests/baselines/reference/extendsTag2.js
+++ b/tests/baselines/reference/extendsTag2.js
@@ -1,0 +1,40 @@
+//// [foo.js]
+/**
+ * @constructor
+ */
+class A {
+    constructor() {}
+}
+
+/**
+ * @extends {A}
+ */
+
+/**
+ * @constructor
+ */
+class B extends A {
+    constructor() {
+        super();
+    }
+}
+
+
+//// [foo.js]
+/**
+ * @constructor
+ */
+class A {
+    constructor() { }
+}
+/**
+ * @extends {A}
+ */
+/**
+ * @constructor
+ */
+class B extends A {
+    constructor() {
+        super();
+    }
+}

--- a/tests/baselines/reference/extendsTag2.symbols
+++ b/tests/baselines/reference/extendsTag2.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/jsdoc/foo.js ===
+/**
+ * @constructor
+ */
+class A {
+>A : Symbol(A, Decl(foo.js, 0, 0))
+
+    constructor() {}
+}
+
+/**
+ * @extends {A}
+ */
+
+/**
+ * @constructor
+ */
+class B extends A {
+>B : Symbol(B, Decl(foo.js, 5, 1))
+>A : Symbol(A, Decl(foo.js, 0, 0))
+
+    constructor() {
+        super();
+>super : Symbol(A, Decl(foo.js, 0, 0))
+    }
+}
+

--- a/tests/baselines/reference/extendsTag2.types
+++ b/tests/baselines/reference/extendsTag2.types
@@ -1,0 +1,28 @@
+=== tests/cases/conformance/jsdoc/foo.js ===
+/**
+ * @constructor
+ */
+class A {
+>A : A
+
+    constructor() {}
+}
+
+/**
+ * @extends {A}
+ */
+
+/**
+ * @constructor
+ */
+class B extends A {
+>B : B
+>A : A
+
+    constructor() {
+        super();
+>super() : void
+>super : typeof A
+    }
+}
+

--- a/tests/baselines/reference/extendsTag3.js
+++ b/tests/baselines/reference/extendsTag3.js
@@ -1,0 +1,35 @@
+//// [foo.js]
+/**
+ * @constructor
+ */
+class A {
+    constructor() {}
+}
+
+/**
+ * @extends {A}
+ * @constructor
+ */
+class B extends A {
+    constructor() {
+        super();
+    }
+}
+
+
+//// [foo.js]
+/**
+ * @constructor
+ */
+class A {
+    constructor() { }
+}
+/**
+ * @extends {A}
+ * @constructor
+ */
+class B extends A {
+    constructor() {
+        super();
+    }
+}

--- a/tests/baselines/reference/extendsTag3.symbols
+++ b/tests/baselines/reference/extendsTag3.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/conformance/jsdoc/foo.js ===
+/**
+ * @constructor
+ */
+class A {
+>A : Symbol(A, Decl(foo.js, 0, 0))
+
+    constructor() {}
+}
+
+/**
+ * @extends {A}
+ * @constructor
+ */
+class B extends A {
+>B : Symbol(B, Decl(foo.js, 5, 1))
+>A : Symbol(A, Decl(foo.js, 0, 0))
+
+    constructor() {
+        super();
+>super : Symbol(A, Decl(foo.js, 0, 0))
+    }
+}
+

--- a/tests/baselines/reference/extendsTag3.types
+++ b/tests/baselines/reference/extendsTag3.types
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/jsdoc/foo.js ===
+/**
+ * @constructor
+ */
+class A {
+>A : A
+
+    constructor() {}
+}
+
+/**
+ * @extends {A}
+ * @constructor
+ */
+class B extends A {
+>B : B
+>A : A
+
+    constructor() {
+        super();
+>super() : void
+>super : typeof A
+    }
+}
+

--- a/tests/baselines/reference/extendsTag4.errors.txt
+++ b/tests/baselines/reference/extendsTag4.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/conformance/jsdoc/foo.js(11,1): error TS8022: JSDoc '@extends' is not attached to a class.
+
+
+==== tests/cases/conformance/jsdoc/foo.js (1 errors) ====
+    /**
+     * @constructor
+     */
+    class A {
+        constructor() {}
+    }
+    
+    /**
+     * @extends {A}
+     */
+    
+    
+!!! error TS8022: JSDoc '@extends' is not attached to a class.

--- a/tests/baselines/reference/extendsTag4.js
+++ b/tests/baselines/reference/extendsTag4.js
@@ -1,0 +1,23 @@
+//// [foo.js]
+/**
+ * @constructor
+ */
+class A {
+    constructor() {}
+}
+
+/**
+ * @extends {A}
+ */
+
+
+//// [foo.js]
+/**
+ * @constructor
+ */
+class A {
+    constructor() { }
+}
+/**
+ * @extends {A}
+ */

--- a/tests/baselines/reference/extendsTag4.symbols
+++ b/tests/baselines/reference/extendsTag4.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/jsdoc/foo.js ===
+/**
+ * @constructor
+ */
+class A {
+>A : Symbol(A, Decl(foo.js, 0, 0))
+
+    constructor() {}
+}
+
+/**
+ * @extends {A}
+ */
+

--- a/tests/baselines/reference/extendsTag4.types
+++ b/tests/baselines/reference/extendsTag4.types
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/jsdoc/foo.js ===
+/**
+ * @constructor
+ */
+class A {
+>A : A
+
+    constructor() {}
+}
+
+/**
+ * @extends {A}
+ */
+

--- a/tests/cases/conformance/jsdoc/extendsTag2.ts
+++ b/tests/cases/conformance/jsdoc/extendsTag2.ts
@@ -1,0 +1,25 @@
+// @allowJs: true
+// @checkJs: true
+// @target: esnext
+// @outDir: out
+// @Filename: foo.js
+
+/**
+ * @constructor
+ */
+class A {
+    constructor() {}
+}
+
+/**
+ * @extends {A}
+ */
+
+/**
+ * @constructor
+ */
+class B extends A {
+    constructor() {
+        super();
+    }
+}

--- a/tests/cases/conformance/jsdoc/extendsTag3.ts
+++ b/tests/cases/conformance/jsdoc/extendsTag3.ts
@@ -1,0 +1,22 @@
+// @allowJs: true
+// @checkJs: true
+// @target: esnext
+// @outDir: out
+// @Filename: foo.js
+
+/**
+ * @constructor
+ */
+class A {
+    constructor() {}
+}
+
+/**
+ * @extends {A}
+ * @constructor
+ */
+class B extends A {
+    constructor() {
+        super();
+    }
+}

--- a/tests/cases/conformance/jsdoc/extendsTag4.ts
+++ b/tests/cases/conformance/jsdoc/extendsTag4.ts
@@ -1,0 +1,16 @@
+// @allowJs: true
+// @checkJs: true
+// @target: esnext
+// @outDir: out
+// @Filename: foo.js
+
+/**
+ * @constructor
+ */
+class A {
+    constructor() {}
+}
+
+/**
+ * @extends {A}
+ */


### PR DESCRIPTION
Fixes #41818

> In case of multiple documentation comments before a JavaScript symbol, JSDoc only associates the last comment with the symbol.


```ts
/**
 * @constructor
 */
class A {
    constructor() {}
}

/**
 * @extends {A}
 */

/**
 * @constructor
 */
class B extends A {
    constructor() {
        super();
    }
}
```

<details>
  <summary>checkJSDocAugmentsTag checks</summary>

  ```ts
  function checkJSDocAugmentsTag(node: JSDocAugmentsTag): void {
      const classLike = getEffectiveJSDocHost(node);
      if (!classLike || !isClassDeclaration(classLike) && !isClassExpression(classLike)) {
          error(classLike, Diagnostics.JSDoc_0_is_not_attached_to_a_class, idText(node.tagName));
          return;
      }
      const augmentsTags = getJSDocTags(classLike).filter(isJSDocAugmentsTag);
      Debug.assert(augmentsTags.length > 0);
  }
  ```
</details>

```ts
/**
 * @extends {A}
 */
```

`getEffectiveJSDocHost` returns node related to `class B extends A {}`. `getJSDocTags(classLike)` uses the comment associates with `class B extends A {}`
```ts
/**
 * @constructor
 */
```
that doesn't have `@extends`. For that reason TS throws `Debug.assert(augmentsTags.length > 0);`.

I suppose in this case `getEffectiveJSDocHost` should return `undefined`, to throw error  `JSDoc_0_is_not_attached_to_a_class`
```ts
/**
 * @extends {A}
 */
```

Or do we need to check `isJSDocAugmentsTag` in all JSDoc comments?

/cc @sandersn 

