### PR TITLE
fix(41868): Infer parameter from usage does not work on arrow functions that are a PropertyDeclaration of a Class

### DIFF
--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -447,7 +447,7 @@ namespace ts.codefix {
             case SyntaxKind.ArrowFunction:
             case SyntaxKind.FunctionExpression:
                 const parent = containingFunction.parent;
-                searchToken = isVariableDeclaration(parent) && isIdentifier(parent.name) ?
+                searchToken = (isVariableDeclaration(parent) || isPropertyDeclaration(parent)) && isIdentifier(parent.name) ?
                     parent.name :
                     containingFunction.name;
                 break;

--- a/tests/cases/fourslash/codeFixInferFromUsagePropertyDeclarationArrowFunction.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsagePropertyDeclarationArrowFunction.ts
@@ -1,0 +1,52 @@
+/// <reference path='fourslash.ts' />
+
+// @noImplicitAny: true
+// @Filename: test.ts
+////class MyClass {
+////    bar = (a, b, c, d, e, f) => {};
+////};
+////
+////interface I {
+////    x: number;
+////}
+////
+////enum E {
+////    X
+////}
+////
+////function foo(x: MyClass) {
+////    const a = 1;
+////    const b = "";
+////    const c = { x: 1, y: 1 };
+////    const d = [1, 2, 3];
+////    const e: I = { x: 1 };
+////    const f: E = E.X;
+////    x.bar(a, b, c, d, e, f);
+////}
+
+verify.codeFixAll({
+  fixId: "inferFromUsage",
+  fixAllDescription: "Infer all types from usage",
+  newFileContent:
+`class MyClass {
+    bar = (a: number, b: string, c: { x: number; y: number; }, d: number[], e: I, f: E) => {};
+};
+
+interface I {
+    x: number;
+}
+
+enum E {
+    X
+}
+
+function foo(x: MyClass) {
+    const a = 1;
+    const b = "";
+    const c = { x: 1, y: 1 };
+    const d = [1, 2, 3];
+    const e: I = { x: 1 };
+    const f: E = E.X;
+    x.bar(a, b, c, d, e, f);
+}`,
+});


### PR DESCRIPTION
Fixes #41868 
