### PR TITLE
fix(40806): Add missing options and possible values of DateTimeFormat

### DIFF
--- a/src/lib/es2020.intl.d.ts
+++ b/src/lib/es2020.intl.d.ts
@@ -277,4 +277,27 @@ declare namespace Intl {
         unit?: string;
         unitDisplay?: string;
     }
+
+    interface DateTimeFormatOptions {
+        dateStyle?: "full" | "long" | "medium" | "short";
+        timeStyle?: "full" | "long" | "medium" | "short";
+        calendar?: "buddhist" | "chinese" | " coptic" | "ethiopia" | "ethiopic" | "gregory" | " hebrew" | "indian" | "islamic" | "iso8601" | " japanese" | "persian" | "roc";
+        dayPeriod?: "narrow" | "short" | " long";
+        numberingSystem?: "arab" | "arabext" | " bali" | "beng" | "deva" | "fullwide" | " gujr" | "guru" | "hanidec" | "khmr" | " knda" | "laoo" | "latn" | "limb" | "mlym" | " mong" | "mymr" | "orya" | "tamldec" | " telu" | "thai" | "tibt";
+        localeMatcher?: "best fit" | "lookup";
+        timeZone?: string;
+        hour12?: boolean;
+        hourCycle?: "h11" | "h12" | "h23" | "h24";
+        formatMatcher?: "best fit" | "basic";
+        weekday?: "long" | "short" | "narrow";
+        era?: "long" | "short" | "narrow";
+        year?: "numeric" | "2-digit";
+        month?: "numeric" | "2-digit" | "long" | "short" | "narrow";
+        day?: "numeric" | "2-digit";
+        hour?: "numeric" | "2-digit";
+        minute?: "numeric" | "2-digit";
+        second?: "numeric" | "2-digit";
+        fractionalSecondDigits?: 0 | 1 | 2 | 3;
+        timeZoneName?: "long" | "short";
+    }
 }

--- a/tests/lib/lib.d.ts
+++ b/tests/lib/lib.d.ts
@@ -3938,19 +3938,26 @@ declare module Intl {
     }
 
     interface DateTimeFormatOptions {
-        localeMatcher?: string;
-        weekday?: string;
-        era?: string;
-        year?: string;
-        month?: string;
-        day?: string;
-        hour?: string;
-        minute?: string;
-        second?: string;
-        timeZoneName?: string;
-        formatMatcher?: string;
-        hour12?: boolean;
+        dateStyle?: "full" | "long" | "medium" | "short";
+        timeStyle?: "full" | "long" | "medium" | "short";
+        calendar?: "buddhist" | "chinese" | " coptic" | "ethiopia" | "ethiopic" | "gregory" | " hebrew" | "indian" | "islamic" | "iso8601" | " japanese" | "persian" | "roc";
+        dayPeriod?: "narrow" | "short" | " long";
+        numberingSystem?: "arab" | "arabext" | " bali" | "beng" | "deva" | "fullwide" | " gujr" | "guru" | "hanidec" | "khmr" | " knda" | "laoo" | "latn" | "limb" | "mlym" | " mong" | "mymr" | "orya" | "tamldec" | " telu" | "thai" | "tibt";
+        localeMatcher?: "best fit" | "lookup";
         timeZone?: string;
+        hour12?: boolean;
+        hourCycle?: "h11" | "h12" | "h23" | "h24";
+        formatMatcher?: "best fit" | "basic";
+        weekday?: "long" | "short" | "narrow";
+        era?: "long" | "short" | "narrow";
+        year?: "numeric" | "2-digit";
+        month?: "numeric" | "2-digit" |"long" | "short" | "narrow";
+        day?: "numeric" | "2-digit";
+        hour?: "numeric" | "2-digit";
+        minute?: "numeric" | "2-digit";
+        second?: "numeric" | "2-digit";
+        fractionalSecondDigits?: 0 | 1 | 2 | 3;
+        timeZoneName?: "long" | "short";
     }
 
     interface ResolvedDateTimeFormatOptions {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

# Fixes #40806 

Options of Intl DateTimeFormat and possible values taken from [MDN page Intl/DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat).

```typescript

interface DateTimeFormatOptions {
    dateStyle?: "full" | "long" | "medium" | "short";
    timeStyle?: "full" | "long" | "medium" | "short";
    calendar?: "buddhist" | "chinese" | " coptic" | "ethiopia" | "ethiopic" | "gregory" | " hebrew" | "indian" | "islamic" | "iso8601" | " japanese" | "persian" | "roc";
    dayPeriod?: "narrow" | "short" | " long";
    numberingSystem?: "arab" | "arabext" | " bali" | "beng" | "deva" | "fullwide" | " gujr" | "guru" | "hanidec" | "khmr" | " knda" | "laoo" | "latn" | "limb" | "mlym" | " mong" | "mymr" | "orya" | "tamldec" | " telu" | "thai" | "tibt";
    localeMatcher?: "best fit" | "lookup";
    timeZone?: string;
    hour12?: boolean;
    hourCycle?: "h11" | "h12" | "h23" | "h24";
    formatMatcher?: "best fit" | "basic";
    weekday?: "long" | "short" | "narrow";
    era?: "long" | "short" | "narrow";
    year?: "numeric" | "2-digit";
    month?: "numeric" | "2-digit" |"long" | "short" | "narrow";
    day?: "numeric" | "2-digit";
    hour?: "numeric" | "2-digit";
    minute?: "numeric" | "2-digit";
    second?: "numeric" | "2-digit";
    fractionalSecondDigits?: 0 | 1 | 2 | 3;
    timeZoneName?: "long" | "short";
}
```
