### PR TITLE
Generalize the fastpath for comparisons of unions which are correspondences

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17271,6 +17271,8 @@ namespace ts {
             function eachTypeRelatedToType(source: UnionOrIntersectionType, target: Type, reportErrors: boolean, intersectionState: IntersectionState): Ternary {
                 let result = Ternary.True;
                 const sourceTypes = source.types;
+                // We strip `undefined` from the target if the `source` trivially doesn't contain it for our correspondence-checking fastpath
+                // since `undefined` is frequently added by optionality and would otherwise spoil a potentially useful correspondence
                 const undefinedStrippedTarget = getUndefinedStrippedTargetIfNeeded(source, target as UnionType);
                 for (let i = 0; i < sourceTypes.length; i++) {
                     const sourceType = sourceTypes[i];


### PR DESCRIPTION
to include unions resulting from the application of intersections on unions.

This expands the fastpath we added in #37749 to handle structures like those produced in #41517 in linear time, bringing the typecheck time of https://github.com/NoPhaseNoKill/ts-slow-compilation-example/tree/main/src down on my machine to ~3s, down from ~30s.
