### PR TITLE
Ensure factory symbol remains unused in react-jsx mode when not referenced in user code

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26912,6 +26912,9 @@ namespace ts {
                 errorOutputContainer);
 
             function checkTagNameDoesNotExpectTooManyArguments(): boolean {
+                if (getJsxNamespaceContainerForImplicitImport(node)) {
+                    return true; // factory is implicitly jsx/jsxdev - assume it fits the bill, since we don't strongly look for the jsx/jsxs/jsxDEV factory APIs anywhere else (at least not yet)
+                }
                 const tagType = isJsxOpeningElement(node) || isJsxSelfClosingElement(node) && !isJsxIntrinsicIdentifier(node.tagName) ? checkExpression(node.tagName) : undefined;
                 if (!tagType) {
                     return true;

--- a/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsx).errors.txt
+++ b/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsx).errors.txt
@@ -1,0 +1,17 @@
+tests/cases/compiler/index.tsx(3,1): error TS6133: 'React' is declared but its value is never read.
+
+
+==== tests/cases/compiler/index.tsx (1 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    
+    import React from "react";
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS6133: 'React' is declared but its value is never read.
+    
+    function Bar() {
+      return <div />;
+    }
+    
+    export function Foo() {
+      return <Bar />;
+    }

--- a/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsx).js
+++ b/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsx).js
@@ -1,0 +1,25 @@
+//// [index.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+
+import React from "react";
+
+function Bar() {
+  return <div />;
+}
+
+export function Foo() {
+  return <Bar />;
+}
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+exports.Foo = void 0;
+var jsx_runtime_1 = require("react/jsx-runtime");
+function Bar() {
+    return jsx_runtime_1.jsx("div", {}, void 0);
+}
+function Foo() {
+    return jsx_runtime_1.jsx(Bar, {}, void 0);
+}
+exports.Foo = Foo;

--- a/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsx).symbols
+++ b/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsx).symbols
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/index.tsx ===
+/// <reference path="react16.d.ts" />
+
+import React from "react";
+>React : Symbol(React, Decl(index.tsx, 2, 6))
+
+function Bar() {
+>Bar : Symbol(Bar, Decl(index.tsx, 2, 26))
+
+  return <div />;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+}
+
+export function Foo() {
+>Foo : Symbol(Foo, Decl(index.tsx, 6, 1))
+
+  return <Bar />;
+>Bar : Symbol(Bar, Decl(index.tsx, 2, 26))
+}

--- a/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsx).types
+++ b/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsx).types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/index.tsx ===
+/// <reference path="react16.d.ts" />
+
+import React from "react";
+>React : typeof React
+
+function Bar() {
+>Bar : () => JSX.Element
+
+  return <div />;
+><div /> : JSX.Element
+>div : any
+}
+
+export function Foo() {
+>Foo : () => JSX.Element
+
+  return <Bar />;
+><Bar /> : JSX.Element
+>Bar : () => JSX.Element
+}

--- a/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsxdev).errors.txt
+++ b/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsxdev).errors.txt
@@ -1,0 +1,17 @@
+tests/cases/compiler/index.tsx(3,1): error TS6133: 'React' is declared but its value is never read.
+
+
+==== tests/cases/compiler/index.tsx (1 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    
+    import React from "react";
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS6133: 'React' is declared but its value is never read.
+    
+    function Bar() {
+      return <div />;
+    }
+    
+    export function Foo() {
+      return <Bar />;
+    }

--- a/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsxdev).js
+++ b/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsxdev).js
@@ -1,0 +1,26 @@
+//// [index.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+
+import React from "react";
+
+function Bar() {
+  return <div />;
+}
+
+export function Foo() {
+  return <Bar />;
+}
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+exports.Foo = void 0;
+var jsx_dev_runtime_1 = require("react/jsx-dev-runtime");
+var _jsxFileName = "tests/cases/compiler/index.tsx";
+function Bar() {
+    return jsx_dev_runtime_1.jsxDEV("div", {}, void 0, false, { fileName: _jsxFileName, lineNumber: 6, columnNumber: 9 }, this);
+}
+function Foo() {
+    return jsx_dev_runtime_1.jsxDEV(Bar, {}, void 0, false, { fileName: _jsxFileName, lineNumber: 10, columnNumber: 9 }, this);
+}
+exports.Foo = Foo;

--- a/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsxdev).symbols
+++ b/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsxdev).symbols
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/index.tsx ===
+/// <reference path="react16.d.ts" />
+
+import React from "react";
+>React : Symbol(React, Decl(index.tsx, 2, 6))
+
+function Bar() {
+>Bar : Symbol(Bar, Decl(index.tsx, 2, 26))
+
+  return <div />;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+}
+
+export function Foo() {
+>Foo : Symbol(Foo, Decl(index.tsx, 6, 1))
+
+  return <Bar />;
+>Bar : Symbol(Bar, Decl(index.tsx, 2, 26))
+}

--- a/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsxdev).types
+++ b/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsxdev).types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/index.tsx ===
+/// <reference path="react16.d.ts" />
+
+import React from "react";
+>React : typeof React
+
+function Bar() {
+>Bar : () => JSX.Element
+
+  return <div />;
+><div /> : JSX.Element
+>div : any
+}
+
+export function Foo() {
+>Foo : () => JSX.Element
+
+  return <Bar />;
+><Bar /> : JSX.Element
+>Bar : () => JSX.Element
+}

--- a/tests/cases/compiler/reactImportUnusedInNewJSXEmit.tsx
+++ b/tests/cases/compiler/reactImportUnusedInNewJSXEmit.tsx
@@ -1,0 +1,16 @@
+// @esModuleInterop: true
+// @noUnusedLocals: true
+// @jsx: react-jsx,react-jsxdev
+// @skipLibCheck: true
+// @filename: index.tsx
+/// <reference path="/.lib/react16.d.ts" />
+
+import React from "react";
+
+function Bar() {
+  return <div />;
+}
+
+export function Foo() {
+  return <Bar />;
+}


### PR DESCRIPTION
One of our checks was assuming the old-style jsx emit unconditionally and looking up the jsx factory entity name, which in turn would flag it as referenced.

Fixes #41882
