### PR TITLE
Properly cache types for shared control flow nodes (4.1 cherry-pick)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21702,6 +21702,7 @@ namespace ts {
                     return errorType;
                 }
                 flowDepth++;
+                let sharedFlow: FlowNode | undefined;
                 while (true) {
                     const flags = flow.flags;
                     if (flags & FlowFlags.Shared) {
@@ -21714,6 +21715,7 @@ namespace ts {
                                 return sharedFlowTypes[i];
                             }
                         }
+                        sharedFlow = flow;
                     }
                     let type: FlowType | undefined;
                     if (flags & FlowFlags.Assignment) {
@@ -21777,9 +21779,9 @@ namespace ts {
                         // simply return the non-auto declared type to reduce follow-on errors.
                         type = convertAutoToAny(declaredType);
                     }
-                    if (flags & FlowFlags.Shared) {
+                    if (sharedFlow) {
                         // Record visited node and the associated type in the cache.
-                        sharedFlowNodes[sharedFlowCount] = flow;
+                        sharedFlowNodes[sharedFlowCount] = sharedFlow;
                         sharedFlowTypes[sharedFlowCount] = type;
                         sharedFlowCount++;
                     }

--- a/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.js
+++ b/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.js
@@ -1,0 +1,127 @@
+//// [controlFlowManyCallExpressionStatementsPerf.ts]
+function test(x: boolean): boolean { return x; }
+
+let state = true;
+
+if (state) {
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+}
+
+
+//// [controlFlowManyCallExpressionStatementsPerf.js]
+"use strict";
+function test(x) { return x; }
+var state = true;
+if (state) {
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+    test(state && state);
+}

--- a/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.symbols
+++ b/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.symbols
@@ -1,0 +1,293 @@
+=== tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts ===
+function test(x: boolean): boolean { return x; }
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>x : Symbol(x, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 14))
+>x : Symbol(x, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 14))
+
+let state = true;
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+if (state) {
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+
+  test(state as any && state);
+>test : Symbol(test, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 0, 0))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+>state : Symbol(state, Decl(controlFlowManyCallExpressionStatementsPerf.ts, 2, 3))
+}
+

--- a/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.types
+++ b/tests/baselines/reference/controlFlowManyCallExpressionStatementsPerf.types
@@ -1,0 +1,462 @@
+=== tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts ===
+function test(x: boolean): boolean { return x; }
+>test : (x: boolean) => boolean
+>x : boolean
+>x : boolean
+
+let state = true;
+>state : boolean
+>true : true
+
+if (state) {
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+
+  test(state as any && state);
+>test(state as any && state) : boolean
+>test : (x: boolean) => boolean
+>state as any && state : any
+>state as any : any
+>state : true
+>state : true
+}
+

--- a/tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts
+++ b/tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts
@@ -1,0 +1,64 @@
+// @strict: true
+
+function test(x: boolean): boolean { return x; }
+
+let state = true;
+
+if (state) {
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+  test(state as any && state);
+}


### PR DESCRIPTION
Bleep blop I'm not @typescript-bot, but this is a manual cherry-pick of #41665 into 4.1 per the discussion in https://github.com/microsoft/TypeScript/pull/41665#issuecomment-733955060.