### PR TITLE
Make optional properties assignable to string index signatures

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18478,7 +18478,11 @@ namespace ts {
                         continue;
                     }
                     if (kind === IndexKind.String || isNumericLiteralName(prop.escapedName)) {
-                        const related = isRelatedTo(getTypeOfSymbol(prop), target, reportErrors);
+                        const propType = getTypeOfSymbol(prop);
+                        const type = propType.flags & TypeFlags.Undefined || !(kind === IndexKind.String && prop.flags & SymbolFlags.Optional)
+                            ? propType
+                            : getTypeWithFacts(propType, TypeFacts.NEUndefined);
+                        const related = isRelatedTo(type, target, reportErrors);
                         if (!related) {
                             if (reportErrors) {
                                 reportError(Diagnostics.Property_0_is_incompatible_with_index_signature, symbolToString(prop));

--- a/tests/baselines/reference/optionalPropertyAssignableToStringIndexSignature.errors.txt
+++ b/tests/baselines/reference/optionalPropertyAssignableToStringIndexSignature.errors.txt
@@ -1,0 +1,47 @@
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/optionalPropertyAssignableToStringIndexSignature.ts(6,1): error TS2322: Type '{ k1: string | undefined; }' is not assignable to type '{ [key: string]: string; }'.
+  Property 'k1' is incompatible with index signature.
+    Type 'string | undefined' is not assignable to type 'string'.
+      Type 'undefined' is not assignable to type 'string'.
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/optionalPropertyAssignableToStringIndexSignature.ts(10,1): error TS2322: Type '{ 1?: string | undefined; }' is not assignable to type '{ [key: number]: string; }'.
+  Property '1' is incompatible with index signature.
+    Type 'string | undefined' is not assignable to type 'string'.
+      Type 'undefined' is not assignable to type 'string'.
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/optionalPropertyAssignableToStringIndexSignature.ts(13,5): error TS2322: Type '{ k1?: undefined; }' is not assignable to type '{ [key: string]: string; }'.
+  Property 'k1' is incompatible with index signature.
+    Type 'undefined' is not assignable to type 'string'.
+
+
+==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/optionalPropertyAssignableToStringIndexSignature.ts (3 errors) ====
+    declare let optionalProperties: { k1?: string };
+    declare let undefinedProperties: { k1: string | undefined };
+    
+    declare let stringDictionary: { [key: string]: string };
+    stringDictionary = optionalProperties;  // ok
+    stringDictionary = undefinedProperties; // error
+    ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type '{ k1: string | undefined; }' is not assignable to type '{ [key: string]: string; }'.
+!!! error TS2322:   Property 'k1' is incompatible with index signature.
+!!! error TS2322:     Type 'string | undefined' is not assignable to type 'string'.
+!!! error TS2322:       Type 'undefined' is not assignable to type 'string'.
+    
+    declare let probablyArray: { [key: number]: string };
+    declare let numberLiteralKeys: { 1?: string };
+    probablyArray = numberLiteralKeys;  // error
+    ~~~~~~~~~~~~~
+!!! error TS2322: Type '{ 1?: string | undefined; }' is not assignable to type '{ [key: number]: string; }'.
+!!! error TS2322:   Property '1' is incompatible with index signature.
+!!! error TS2322:     Type 'string | undefined' is not assignable to type 'string'.
+!!! error TS2322:       Type 'undefined' is not assignable to type 'string'.
+    
+    declare let optionalUndefined: { k1?: undefined };
+    let dict: { [key: string]: string } = optionalUndefined; // error
+        ~~~~
+!!! error TS2322: Type '{ k1?: undefined; }' is not assignable to type '{ [key: string]: string; }'.
+!!! error TS2322:   Property 'k1' is incompatible with index signature.
+!!! error TS2322:     Type 'undefined' is not assignable to type 'string'.
+    
+    function f<T>() {
+    	let optional: { k1?: T } = undefined!;
+    	let dict: { [key: string]: T | number } = optional; // ok
+    }
+    

--- a/tests/baselines/reference/optionalPropertyAssignableToStringIndexSignature.js
+++ b/tests/baselines/reference/optionalPropertyAssignableToStringIndexSignature.js
@@ -1,0 +1,31 @@
+//// [optionalPropertyAssignableToStringIndexSignature.ts]
+declare let optionalProperties: { k1?: string };
+declare let undefinedProperties: { k1: string | undefined };
+
+declare let stringDictionary: { [key: string]: string };
+stringDictionary = optionalProperties;  // ok
+stringDictionary = undefinedProperties; // error
+
+declare let probablyArray: { [key: number]: string };
+declare let numberLiteralKeys: { 1?: string };
+probablyArray = numberLiteralKeys;  // error
+
+declare let optionalUndefined: { k1?: undefined };
+let dict: { [key: string]: string } = optionalUndefined; // error
+
+function f<T>() {
+	let optional: { k1?: T } = undefined!;
+	let dict: { [key: string]: T | number } = optional; // ok
+}
+
+
+//// [optionalPropertyAssignableToStringIndexSignature.js]
+"use strict";
+stringDictionary = optionalProperties; // ok
+stringDictionary = undefinedProperties; // error
+probablyArray = numberLiteralKeys; // error
+var dict = optionalUndefined; // error
+function f() {
+    var optional = undefined;
+    var dict = optional; // ok
+}

--- a/tests/baselines/reference/optionalPropertyAssignableToStringIndexSignature.symbols
+++ b/tests/baselines/reference/optionalPropertyAssignableToStringIndexSignature.symbols
@@ -1,0 +1,59 @@
+=== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/optionalPropertyAssignableToStringIndexSignature.ts ===
+declare let optionalProperties: { k1?: string };
+>optionalProperties : Symbol(optionalProperties, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 0, 11))
+>k1 : Symbol(k1, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 0, 33))
+
+declare let undefinedProperties: { k1: string | undefined };
+>undefinedProperties : Symbol(undefinedProperties, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 1, 11))
+>k1 : Symbol(k1, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 1, 34))
+
+declare let stringDictionary: { [key: string]: string };
+>stringDictionary : Symbol(stringDictionary, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 3, 11))
+>key : Symbol(key, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 3, 33))
+
+stringDictionary = optionalProperties;  // ok
+>stringDictionary : Symbol(stringDictionary, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 3, 11))
+>optionalProperties : Symbol(optionalProperties, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 0, 11))
+
+stringDictionary = undefinedProperties; // error
+>stringDictionary : Symbol(stringDictionary, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 3, 11))
+>undefinedProperties : Symbol(undefinedProperties, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 1, 11))
+
+declare let probablyArray: { [key: number]: string };
+>probablyArray : Symbol(probablyArray, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 7, 11))
+>key : Symbol(key, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 7, 30))
+
+declare let numberLiteralKeys: { 1?: string };
+>numberLiteralKeys : Symbol(numberLiteralKeys, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 8, 11))
+>1 : Symbol(1, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 8, 32))
+
+probablyArray = numberLiteralKeys;  // error
+>probablyArray : Symbol(probablyArray, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 7, 11))
+>numberLiteralKeys : Symbol(numberLiteralKeys, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 8, 11))
+
+declare let optionalUndefined: { k1?: undefined };
+>optionalUndefined : Symbol(optionalUndefined, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 11, 11))
+>k1 : Symbol(k1, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 11, 32))
+
+let dict: { [key: string]: string } = optionalUndefined; // error
+>dict : Symbol(dict, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 12, 3))
+>key : Symbol(key, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 12, 13))
+>optionalUndefined : Symbol(optionalUndefined, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 11, 11))
+
+function f<T>() {
+>f : Symbol(f, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 12, 56))
+>T : Symbol(T, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 14, 11))
+
+	let optional: { k1?: T } = undefined!;
+>optional : Symbol(optional, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 15, 4))
+>k1 : Symbol(k1, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 15, 16))
+>T : Symbol(T, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 14, 11))
+>undefined : Symbol(undefined)
+
+	let dict: { [key: string]: T | number } = optional; // ok
+>dict : Symbol(dict, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 16, 4))
+>key : Symbol(key, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 16, 14))
+>T : Symbol(T, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 14, 11))
+>optional : Symbol(optional, Decl(optionalPropertyAssignableToStringIndexSignature.ts, 15, 4))
+}
+

--- a/tests/baselines/reference/optionalPropertyAssignableToStringIndexSignature.types
+++ b/tests/baselines/reference/optionalPropertyAssignableToStringIndexSignature.types
@@ -1,0 +1,60 @@
+=== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/optionalPropertyAssignableToStringIndexSignature.ts ===
+declare let optionalProperties: { k1?: string };
+>optionalProperties : { k1?: string | undefined; }
+>k1 : string | undefined
+
+declare let undefinedProperties: { k1: string | undefined };
+>undefinedProperties : { k1: string | undefined; }
+>k1 : string | undefined
+
+declare let stringDictionary: { [key: string]: string };
+>stringDictionary : { [key: string]: string; }
+>key : string
+
+stringDictionary = optionalProperties;  // ok
+>stringDictionary = optionalProperties : { k1?: string | undefined; }
+>stringDictionary : { [key: string]: string; }
+>optionalProperties : { k1?: string | undefined; }
+
+stringDictionary = undefinedProperties; // error
+>stringDictionary = undefinedProperties : { k1: string | undefined; }
+>stringDictionary : { [key: string]: string; }
+>undefinedProperties : { k1: string | undefined; }
+
+declare let probablyArray: { [key: number]: string };
+>probablyArray : { [key: number]: string; }
+>key : number
+
+declare let numberLiteralKeys: { 1?: string };
+>numberLiteralKeys : { 1?: string | undefined; }
+>1 : string | undefined
+
+probablyArray = numberLiteralKeys;  // error
+>probablyArray = numberLiteralKeys : { 1?: string | undefined; }
+>probablyArray : { [key: number]: string; }
+>numberLiteralKeys : { 1?: string | undefined; }
+
+declare let optionalUndefined: { k1?: undefined };
+>optionalUndefined : { k1?: undefined; }
+>k1 : undefined
+
+let dict: { [key: string]: string } = optionalUndefined; // error
+>dict : { [key: string]: string; }
+>key : string
+>optionalUndefined : { k1?: undefined; }
+
+function f<T>() {
+>f : <T>() => void
+
+	let optional: { k1?: T } = undefined!;
+>optional : { k1?: T | undefined; }
+>k1 : T | undefined
+>undefined! : never
+>undefined : undefined
+
+	let dict: { [key: string]: T | number } = optional; // ok
+>dict : { [key: string]: number | T; }
+>key : string
+>optional : { k1?: T | undefined; }
+}
+

--- a/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/optionalPropertyAssignableToStringIndexSignature.ts
+++ b/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/optionalPropertyAssignableToStringIndexSignature.ts
@@ -1,0 +1,20 @@
+// @strict: true
+
+declare let optionalProperties: { k1?: string };
+declare let undefinedProperties: { k1: string | undefined };
+
+declare let stringDictionary: { [key: string]: string };
+stringDictionary = optionalProperties;  // ok
+stringDictionary = undefinedProperties; // error
+
+declare let probablyArray: { [key: number]: string };
+declare let numberLiteralKeys: { 1?: string };
+probablyArray = numberLiteralKeys;  // error
+
+declare let optionalUndefined: { k1?: undefined };
+let dict: { [key: string]: string } = optionalUndefined; // error
+
+function f<T>() {
+	let optional: { k1?: T } = undefined!;
+	let dict: { [key: string]: T | number } = optional; // ok
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Prerequisite of #41418, discussed in #41505 and #41907.

Attempted release-notes-quality description:

## Optional properties are assignable to string index signatures

String index signatures are a way of typing dictionary-like objects, where you want to allow access with arbitrary keys:

```ts
const movieWatchCount: { [key: string]: number } = {};

function watchMovie(title: string) {
  movieWatchCount[title] = (movieWatchCount[title] ?? 0) + 1;
}
```

Of course, for any movie title not yet in the dictionary, `movieWatchCount[title]` will be `undefined`. (TypeScript 4.1 added the option [`--noUncheckedIndexedAccess`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#checked-indexed-accesses---nouncheckedindexedaccess) to include `undefined` when reading from an index signature like this.) Even though it’s clear that there must be some strings not present in `movieWatchCount`, previous versions of TypeScript treated optional object properties as unassignable to otherwise compatible index signatures, due to the presence of `undefined`:

```ts
type WesAndersonWatchCount = {
  "Fantastic Mr. Fox"?: number;
  "The Royal Tenenbaums"?: number;
  "Moonrise Kingdom"?: number;
  "The Grand Budapest Hotel"?: number;
};

declare const wesAndersonWatchCount: WesAndersonWatchCount;
const movieWatchCount: { [key: string]: number } = wesAndersonWatchCount;
//    ^^^^^^^^^^^^^^^
//  Type 'WesAndersonWatchCount' is not assignable to type '{ [key: string]: number; }'.
//    Property '"Fantastic Mr. Fox"' is incompatible with index signature.
//      Type 'number | undefined' is not assignable to type 'number'.
//        Type 'undefined' is not assignable to type 'number'. (2322)
```

TypeScript 4.2 allows this assignment. However, it does _not_ allow the assignment of non-optional properties with `undefined` in their types, nor does it allow writing `undefined` to a specific key:

```ts
type BatmanWatchCount = {
  "Batman Begins": number | undefined;
  "The Dark Knight": number | undefined;
  "The Dark Knight Rises": number | undefined;
};

declare const batmanWatchCount: BatmanWatchCount;
const movieWatchCount: { [key: string]: number } = batmanWatchCount;
//    ^^^^^^^^^^^^^^^
//  Still an error in 4.2 - only optional properties can be assigned

movieWatchCount["It's the Great Pumpkin, Charlie Brown"] = undefined;
// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//  Still an error in 4.2
```

The new rule also does not apply to number index signatures, since they are assumed to be array-like and dense:

```ts
declare let sortOfArrayish: { [key: number]: string };
declare let numberKeys: { 42?: string };
sortOfArrayish = numberKeys;
// ^^^^^^^^^^^
// Type '{ 42?: string | undefined; }' is not assignable to type '{ [key: number]: string; }'.
//   Property '42' is incompatible with index signature.
//     Type 'string | undefined' is not assignable to type 'string'.
//       Type 'undefined' is not assignable to type 'string'.(2322)
```