### PR TITLE
Add text-based fastpaths into LS token matching

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1397,7 +1397,7 @@ namespace ts {
         const tokenFullStart = token.getFullStart();
         // Text-scan based fast path - can be bamboozled by comments and other trivia, but often provides
         // a good, fast approximation without too much extra work in the cases where it fails.
-        const bestGuessIndex = sourceFile.text.slice(0, tokenFullStart).lastIndexOf(matchingTokenText);
+        const bestGuessIndex = sourceFile.text.lastIndexOf(matchingTokenText, tokenFullStart);
         if (bestGuessIndex === -1) {
             return undefined; // if the token text doesn't appear in the file, there can't be a match - super fast bail
         }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1402,7 +1402,7 @@ namespace ts {
             return undefined; // if the token text doesn't appear in the file, there can't be a match - super fast bail
         }
         // we can only use the textual result directly if we didn't have to count any close tokens within the range
-        if (sourceFile.text.slice(bestGuessIndex, tokenFullStart - 1).indexOf(closeTokenText) === -1) {
+        if (sourceFile.text.lastIndexOf(closeTokenText, tokenFullStart - 1) < bestGuessIndex) {
             const nodeAtGuess = findPrecedingToken(bestGuessIndex + 1, sourceFile);
             if (nodeAtGuess && nodeAtGuess.kind === matchingTokenKind) {
                 return nodeAtGuess;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1463,11 +1463,11 @@ namespace ts {
     }
 
     // Get info for an expression like `f <` that may be the start of type arguments.
-    export function getPossibleTypeArgumentsInfo(tokenIn: Node, sourceFile: SourceFile): PossibleTypeArgumentInfo | undefined {
+    export function getPossibleTypeArgumentsInfo(tokenIn: Node | undefined, sourceFile: SourceFile): PossibleTypeArgumentInfo | undefined {
         // This is a rare case, but one that saves on a _lot_ of work if true - if the source file has _no_ `<` character,
         // then there obviously can't be any type arguments - no expensive brace-matching backwards scanning required
 
-        if (sourceFile.text.lastIndexOf("<", tokenIn.pos) === -1) {
+        if (sourceFile.text.lastIndexOf("<", tokenIn ? tokenIn.pos : sourceFile.text.length) === -1) {
             return undefined;
         }
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1467,7 +1467,7 @@ namespace ts {
         // This is a rare case, but one that saves on a _lot_ of work if true - if the source file has _no_ `<` character,
         // then there obviously can't be any type arguments - no expensive brace-matching backwards scanning required
 
-        if (sourceFile.text.indexOf("<") === -1) {
+        if (sourceFile.text.lastIndexOf("<", tokenIn.pos) === -1) {
             return undefined;
         }
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1391,7 +1391,23 @@ namespace ts {
         return isInsideJsxElementTraversal(getTokenAtPosition(sourceFile, position));
     }
 
-    export function findPrecedingMatchingToken(token: Node, matchingTokenKind: SyntaxKind, sourceFile: SourceFile) {
+    export function findPrecedingMatchingToken(token: Node, matchingTokenKind: SyntaxKind.OpenBraceToken | SyntaxKind.OpenParenToken | SyntaxKind.OpenBracketToken, sourceFile: SourceFile) {
+        const closeTokenText = tokenToString(token.kind)!;
+        const matchingTokenText = tokenToString(matchingTokenKind)!;
+        const tokenFullStart = token.getFullStart();
+        // Text-scan based fast path - can be bamboozled by comments and other trivia, but often provides
+        // a good, fast approximation without too much extra work in the cases where it fails.
+        const bestGuessIndex = sourceFile.text.slice(0, tokenFullStart).lastIndexOf(matchingTokenText);
+        if (bestGuessIndex === -1) {
+            return undefined; // if the token text doesn't appear in the file, there can't be a match - super fast bail
+        }
+        // we can only use the textual result directly if we didn't have to count any close tokens within the range
+        if (sourceFile.text.slice(bestGuessIndex, tokenFullStart - 1).indexOf(closeTokenText) === -1) {
+            const nodeAtGuess = findPrecedingToken(bestGuessIndex + 1, sourceFile);
+            if (nodeAtGuess && nodeAtGuess.kind === matchingTokenKind) {
+                return nodeAtGuess;
+            }
+        }
         const tokenKind = token.kind;
         let remainingMatchingTokens = 0;
         while (true) {
@@ -1448,6 +1464,12 @@ namespace ts {
 
     // Get info for an expression like `f <` that may be the start of type arguments.
     export function getPossibleTypeArgumentsInfo(tokenIn: Node, sourceFile: SourceFile): PossibleTypeArgumentInfo | undefined {
+        // This is a rare case, but one that saves on a _lot_ of work if true - if the sorce file has _no_ `<` character,
+        // then there obviously can't be any type arguments - no expensive bracematching backwards scanning required
+        if (sourceFile.text.indexOf("<") === -1) {
+            return undefined;
+        }
+
         let token: Node | undefined = tokenIn;
         // This function determines if the node could be type argument position
         // Since during editing, when type argument list is not complete,

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1464,8 +1464,9 @@ namespace ts {
 
     // Get info for an expression like `f <` that may be the start of type arguments.
     export function getPossibleTypeArgumentsInfo(tokenIn: Node, sourceFile: SourceFile): PossibleTypeArgumentInfo | undefined {
-        // This is a rare case, but one that saves on a _lot_ of work if true - if the sorce file has _no_ `<` character,
-        // then there obviously can't be any type arguments - no expensive bracematching backwards scanning required
+        // This is a rare case, but one that saves on a _lot_ of work if true - if the source file has _no_ `<` character,
+        // then there obviously can't be any type arguments - no expensive brace-matching backwards scanning required
+
         if (sourceFile.text.indexOf("<") === -1) {
             return undefined;
         }


### PR DESCRIPTION
This takes the runtime of the `excessivelyLargeArrayLiteralCompletions.ts` `fourslash` test down from ~36s on my machine (near the timeout limit) to 1s.

A bit of history: The test in question was added recently, in #40953, as a perf-monitoring test. The initial fix did make the perf much better (going from "spin forever" to 11s is pretty good), however its perf has been creeping back up over the last two months, to the point where on @andrewbranch 's machine it started timing out. So I took a look again to see what was going on. The low-level operation that we spend all the time doing is matching tokens, and that's what I'd algorithmically optimized in #40953. In this PR, I took a look from the top down - the reason we're matching tokens, _at all_, is to determine if the location we're looking for completions at is a type argument position (which in turn filters the completion list) - to do so, we match all braces backwards from the cursor until we run into a `<` which isn't contained within a set of matched braces. Unfortunately, in the test given, there are _thousands_ of braces to match, so even though the token finding within the source file is pretty efficient(tm), we have a lot of work to do, still, since we essentially are forced to find almost every other token in the file. And that's where this PR comes in: in two phases, we use textual heuristics to quickly stop or speed up that token matching process.