### PR TITLE
[Experiment] Use hash of source file text as version for the source file in tsserver

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -655,12 +655,6 @@ namespace ts.server {
         /*@internal*/
         readonly filenameToScriptInfo = new Map<string, ScriptInfo>();
         private readonly scriptInfoInNodeModulesWatchers = new Map<string, ScriptInfoInNodeModulesWatcher>();
-        /**
-         * Contains all the deleted script info's version information so that
-         * it does not reset when creating script info again
-         * (and could have potentially collided with version where contents mismatch)
-         */
-        private readonly filenameToScriptInfoVersion = new Map<string, ScriptInfoVersion>();
         // Set of all '.js' files ever opened.
         private readonly allJsFilesForOpenFileTelemetry = new Map<string, true>();
 
@@ -1599,7 +1593,6 @@ namespace ts.server {
 
         private deleteScriptInfo(info: ScriptInfo) {
             this.filenameToScriptInfo.delete(info.path);
-            this.filenameToScriptInfoVersion.set(info.path, info.getVersion());
             const realpath = info.getRealpathIfDifferent();
             if (realpath) {
                 this.realpathToScriptInfos!.remove(realpath, info); // TODO: GH#18217
@@ -2636,9 +2629,8 @@ namespace ts.server {
                 if (!openedByClient && !isDynamic && !(hostToQueryFileExistsOn || this.host).fileExists(fileName)) {
                     return;
                 }
-                info = new ScriptInfo(this.host, fileName, scriptKind!, !!hasMixedContent, path, this.filenameToScriptInfoVersion.get(path)); // TODO: GH#18217
+                info = new ScriptInfo(this.host, fileName, scriptKind!, !!hasMixedContent, path); // TODO: GH#18217
                 this.filenameToScriptInfo.set(info.path, info);
-                this.filenameToScriptInfoVersion.delete(info.path);
                 if (!openedByClient) {
                     this.watchClosedScriptInfo(info);
                 }

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -1,12 +1,7 @@
 namespace ts.server {
-    export interface ScriptInfoVersion {
-        svc: number;
-        text: number;
-    }
-
     /* @internal */
     export class TextStorage {
-        version: ScriptInfoVersion;
+        version: string | undefined;
 
         /**
          * Generated only on demand (based on edits, or information requested)
@@ -46,14 +41,7 @@ namespace ts.server {
          */
         private pendingReloadFromDisk = false;
 
-        constructor(private readonly host: ServerHost, private readonly info: ScriptInfo, initialVersion?: ScriptInfoVersion) {
-            this.version = initialVersion || { svc: 0, text: 0 };
-        }
-
-        public getVersion() {
-            return this.svc
-                ? `SVC-${this.version.svc}-${this.svc.getSnapshotVersion()}`
-                : `Text-${this.version.text}`;
+        constructor(private readonly host: ServerHost, private readonly info: ScriptInfo) {
         }
 
         public hasScriptVersionCache_TestOnly() {
@@ -77,16 +65,17 @@ namespace ts.server {
         public useText(newText?: string) {
             this.svc = undefined;
             this.text = newText;
+            this.version = undefined;
             this.lineMap = undefined;
             this.fileSize = undefined;
             this.resetSourceMapInfo();
-            this.version.text++;
         }
 
         public edit(start: number, end: number, newText: string) {
             this.switchToScriptVersionCache().edit(start, end - start, newText);
             this.ownFileText = false;
             this.text = undefined;
+            this.version = undefined;
             this.lineMap = undefined;
             this.fileSize = undefined;
             this.resetSourceMapInfo();
@@ -142,6 +131,7 @@ namespace ts.server {
 
         public delayReloadFromFileIntoText() {
             this.pendingReloadFromDisk = true;
+            this.version = undefined;
         }
 
         /**
@@ -225,7 +215,6 @@ namespace ts.server {
         private switchToScriptVersionCache(): ScriptVersionCache {
             if (!this.svc || this.pendingReloadFromDisk) {
                 this.svc = ScriptVersionCache.fromString(this.getOrLoadText());
-                this.version.svc++;
             }
             return this.svc;
         }
@@ -334,10 +323,10 @@ namespace ts.server {
             readonly scriptKind: ScriptKind,
             public readonly hasMixedContent: boolean,
             readonly path: Path,
-            initialVersion?: ScriptInfoVersion) {
+        ) {
             this.isDynamic = isDynamicFileName(fileName);
 
-            this.textStorage = new TextStorage(host, this, initialVersion);
+            this.textStorage = new TextStorage(host, this);
             if (hasMixedContent || this.isDynamic) {
                 this.textStorage.reload("");
                 this.realpath = this.path;
@@ -345,11 +334,6 @@ namespace ts.server {
             this.scriptKind = scriptKind
                 ? scriptKind
                 : getScriptKindFromFileName(fileName);
-        }
-
-        /*@internal*/
-        getVersion() {
-            return this.textStorage.version;
         }
 
         /*@internal*/
@@ -560,9 +544,12 @@ namespace ts.server {
         }
 
         getLatestVersion() {
-            // Ensure we have updated snapshot to give back latest version
-            this.textStorage.getSnapshot();
-            return this.textStorage.getVersion();
+            if (this.textStorage.version === undefined) {
+                // Ensure we have updated snapshot to give back latest version
+                const text = getSnapshotText(this.textStorage.getSnapshot());
+                this.textStorage.version = this.host.createHash ? this.host.createHash(text) : generateDjb2Hash(text);
+            }
+            return this.textStorage.version;
         }
 
         saveTo(fileName: string) {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9139,10 +9139,6 @@ declare namespace ts.server.protocol {
     }
 }
 declare namespace ts.server {
-    interface ScriptInfoVersion {
-        svc: number;
-        text: number;
-    }
     function isDynamicFileName(fileName: NormalizedPath): boolean;
     class ScriptInfo {
         private readonly host;
@@ -9157,7 +9153,7 @@ declare namespace ts.server {
         private formatSettings;
         private preferences;
         private textStorage;
-        constructor(host: ServerHost, fileName: NormalizedPath, scriptKind: ScriptKind, hasMixedContent: boolean, path: Path, initialVersion?: ScriptInfoVersion);
+        constructor(host: ServerHost, fileName: NormalizedPath, scriptKind: ScriptKind, hasMixedContent: boolean, path: Path);
         isScriptOpen(): boolean;
         open(newText: string): void;
         close(fileExists?: boolean): void;
@@ -9624,12 +9620,6 @@ declare namespace ts.server {
     }
     export class ProjectService {
         private readonly scriptInfoInNodeModulesWatchers;
-        /**
-         * Contains all the deleted script info's version information so that
-         * it does not reset when creating script info again
-         * (and could have potentially collided with version where contents mismatch)
-         */
-        private readonly filenameToScriptInfoVersion;
         private readonly allJsFilesForOpenFileTelemetry;
         /**
          * maps external project file name to list of config files that were the part of this project


### PR DESCRIPTION
This ensures that we can use tsbuildinfo that tsc emits since versions are used for file upto date ness checks.
Eg this will be needed for #41004 to work.
