### PR TITLE
Simplify expression type to fix build break

### DIFF
--- a/src/testRunner/unittests/tsbuild/outFile.ts
+++ b/src/testRunner/unittests/tsbuild/outFile.ts
@@ -465,7 +465,7 @@ namespace ts {
                 }
 
                 function stripInternalScenario(fs: vfs.FileSystem, removeCommentsDisabled?: boolean, jsDocStyle?: boolean) {
-                    const internal = jsDocStyle ? `/**@internal*/` : `/*@internal*/`;
+                    const internal: string = jsDocStyle ? `/**@internal*/` : `/*@internal*/`;
                     if (removeCommentsDisabled) {
                         diableRemoveCommentsInAll(fs);
                     }


### PR DESCRIPTION
Fixes the post-LKG build break introduced by the changes in #41891 by simplifying the expression type in use by widening the type of a ternary to `string`, rather than a union of literal types.
