### PR TITLE
fix(41740): TypeScript server crashes when renaming function parameter erroneously named as reserved word "default"

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -921,7 +921,7 @@ namespace ts.FindAllReferences {
                 // When renaming at an export specifier, rename the export and not the thing being exported.
                 getReferencesAtExportSpecifier(exportSpecifier.name, symbol, exportSpecifier, state.createSearch(node, originalSymbol, /*comingFrom*/ undefined), state, /*addReferencesHere*/ true, /*alwaysGetReferences*/ true);
             }
-            else if (node && node.kind === SyntaxKind.DefaultKeyword) {
+            else if (node && node.kind === SyntaxKind.DefaultKeyword && symbol.escapedName === InternalSymbolName.Default) {
                 addReference(node, symbol, state);
                 searchForImportsOfExport(node, symbol, { exportingModuleSymbol: Debug.checkDefined(symbol.parent, "Expected export symbol to have a parent"), exportKind: ExportKind.Default }, state);
             }

--- a/tests/baselines/reference/findAllRefsForDefaultKeyword.baseline.jsonc
+++ b/tests/baselines/reference/findAllRefsForDefaultKeyword.baseline.jsonc
@@ -1,0 +1,89 @@
+undefined
+
+undefined
+
+undefined
+
+undefined
+
+// === /tests/cases/fourslash/findAllRefsForDefaultKeyword.ts ===
+// function f(value: string, default: string) {}
+// 
+// const default = 1;
+// 
+// function default() {}
+// 
+// class default {}
+// 
+// const foo = {
+//     /*FIND ALL REFS*/[|default|]: 1
+// }
+
+[
+  {
+    "definition": {
+      "containerKind": "",
+      "containerName": "",
+      "fileName": "/tests/cases/fourslash/findAllRefsForDefaultKeyword.ts",
+      "kind": "property",
+      "name": "(property) default: number",
+      "textSpan": {
+        "start": 126,
+        "length": 7
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "default",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "contextSpan": {
+        "start": 126,
+        "length": 10
+      }
+    },
+    "references": [
+      {
+        "textSpan": {
+          "start": 126,
+          "length": 7
+        },
+        "fileName": "/tests/cases/fourslash/findAllRefsForDefaultKeyword.ts",
+        "contextSpan": {
+          "start": 126,
+          "length": 10
+        },
+        "isWriteAccess": true,
+        "isDefinition": true
+      }
+    ]
+  }
+]

--- a/tests/cases/fourslash/findAllRefsForDefaultKeyword.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultKeyword.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts" />
+
+// @noLib: true
+////function f(value: string, /*1*/default: string) {}
+////
+////const /*2*/default = 1;
+////
+////function /*3*/default() {}
+////
+////class /*4*/default {}
+////
+////const foo = {
+////    /*5*/default: 1
+////}
+
+verify.baselineFindAllReferences("1", "2", "3", "4", "5");

--- a/tests/cases/fourslash/renameDefaultKeyword.ts
+++ b/tests/cases/fourslash/renameDefaultKeyword.ts
@@ -1,0 +1,22 @@
+/// <reference path="fourslash.ts" />
+
+// @noLib: true
+////function f(value: string, /*1*/default: string) {}
+////
+////const /*2*/default = 1;
+////
+////function /*3*/default() {}
+////
+////class /*4*/default {}
+////
+////const foo = {
+////    /*5*/[|default|]: 1
+////}
+
+for (const marker of ["1", "2", "3", "4"]) {
+    goTo.marker(marker);
+    verify.renameInfoFailed(ts.Diagnostics.You_cannot_rename_this_element.message);
+}
+
+goTo.marker("5");
+verify.renameInfoSucceeded("default");


### PR DESCRIPTION
Fixes #41740