### PR TITLE
Display correct message for iterrable string for missing downlevel iterator flag

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -34448,7 +34448,9 @@ namespace ts {
                         ? downlevelIteration
                             ? [Diagnostics.Type_0_is_not_an_array_type_or_does_not_have_a_Symbol_iterator_method_that_returns_an_iterator, true]
                             : yieldType
-                                ? [Diagnostics.Type_0_is_not_an_array_type_or_a_string_type_Use_compiler_option_downlevelIteration_to_allow_iterating_of_iterators, false]
+                                ? (<IntrinsicType>yieldType).intrinsicName === "string"
+                                    ? [Diagnostics.Type_0_is_not_an_array_type_Use_compiler_option_downlevelIteration_to_allow_iterating_of_iterators, false]
+                                    : [Diagnostics.Type_0_is_not_an_array_type_or_a_string_type_Use_compiler_option_downlevelIteration_to_allow_iterating_of_iterators, false]
                                 : [Diagnostics.Type_0_is_not_an_array_type, true]
                         : downlevelIteration
                             ? [Diagnostics.Type_0_is_not_an_array_type_or_a_string_type_or_does_not_have_a_Symbol_iterator_method_that_returns_an_iterator, true]

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2425,6 +2425,10 @@
         "category": "Error",
         "code": 2569
     },
+    "Type '{0}' is not an array type. Use compiler option '--downlevelIteration' to allow iterating of iterators.": {
+        "category": "Error",
+        "code": 2570
+    },
     "Object is of type 'unknown'.": {
         "category": "Error",
         "code": 2571

--- a/tests/baselines/reference/downlevelIterableString.errors.txt
+++ b/tests/baselines/reference/downlevelIterableString.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/downlevelIterableString.ts(2,29): error TS2461: Type 'string' is not an array type.
+
+
+==== tests/cases/compiler/downlevelIterableString.ts (1 errors) ====
+    function testString(name: string) {
+        for (const _char of [...name]) {
+                                ~~~~
+!!! error TS2461: Type 'string' is not an array type.
+        }
+    }
+    

--- a/tests/baselines/reference/downlevelIterableString.js
+++ b/tests/baselines/reference/downlevelIterableString.js
@@ -1,0 +1,20 @@
+//// [downlevelIterableString.ts]
+function testString(name: string) {
+    for (const _char of [...name]) {
+    }
+}
+
+
+//// [downlevelIterableString.js]
+var __spreadArrays = (this && this.__spreadArrays) || function () {
+    for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+    for (var r = Array(s), k = 0, i = 0; i < il; i++)
+        for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+            r[k] = a[j];
+    return r;
+};
+function testString(name) {
+    for (var _i = 0, _a = __spreadArrays(name); _i < _a.length; _i++) {
+        var _char = _a[_i];
+    }
+}

--- a/tests/baselines/reference/downlevelIterableString.symbols
+++ b/tests/baselines/reference/downlevelIterableString.symbols
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/downlevelIterableString.ts ===
+function testString(name: string) {
+>testString : Symbol(testString, Decl(downlevelIterableString.ts, 0, 0))
+>name : Symbol(name, Decl(downlevelIterableString.ts, 0, 20))
+
+    for (const _char of [...name]) {
+>_char : Symbol(_char, Decl(downlevelIterableString.ts, 1, 14))
+>name : Symbol(name, Decl(downlevelIterableString.ts, 0, 20))
+    }
+}
+

--- a/tests/baselines/reference/downlevelIterableString.types
+++ b/tests/baselines/reference/downlevelIterableString.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/downlevelIterableString.ts ===
+function testString(name: string) {
+>testString : (name: string) => void
+>name : string
+
+    for (const _char of [...name]) {
+>_char : any
+>[...name] : any[]
+>...name : any
+>name : string
+    }
+}
+

--- a/tests/cases/compiler/downlevelIterableString.ts
+++ b/tests/cases/compiler/downlevelIterableString.ts
@@ -1,0 +1,4 @@
+function testString(name: string) {
+    for (const _char of [...name]) {
+    }
+}


### PR DESCRIPTION
Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Fixes #41918
