### PR TITLE
Fix auto import completion inserting wrong module specifier

### DIFF
--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -2794,7 +2794,12 @@ namespace FourSlash {
 
             const details = this.getCompletionEntryDetails(options.name, options.source, options.preferences);
             if (!details) {
-                return this.raiseError(`No completions were found for the given name, source, and preferences.`);
+                const completions = this.getCompletionListAtCaret(options.preferences)?.entries;
+                const matchingName = completions?.filter(e => e.name === options.name);
+                const detailMessage = matchingName?.length
+                    ? `\n  Found ${matchingName.length} with name '${options.name}' from source(s) ${matchingName.map(e => `'${e.source}'`).join(", ")}.`
+                    : "";
+                return this.raiseError(`No completions were found for the given name, source, and preferences.` + detailMessage);
             }
             const codeActions = details.codeActions;
             if (codeActions?.length !== 1) {

--- a/tests/cases/fourslash/completionsImport_ambient.ts
+++ b/tests/cases/fourslash/completionsImport_ambient.ts
@@ -1,0 +1,28 @@
+/// <reference path="fourslash.ts" />
+
+// @module: commonjs
+
+// @Filename: a.d.ts
+//// declare namespace foo { class Bar {} }
+//// declare module 'path1' {
+////   import Bar = foo.Bar;
+////   export default Bar;
+//// }
+//// declare module 'path2longer' {
+////   import Bar = foo.Bar;
+////   export {Bar};
+//// }
+////
+
+// @Filename: b.ts
+//// Ba/**/
+
+verify.applyCodeActionFromCompletion("", {
+  name: "Bar",
+  source: "path2longer",
+  description: `Import 'Bar' from module "path2longer"`,
+  newFileContent: `import { Bar } from "path2longer";\n\nBa`,
+  preferences: {
+    includeCompletionsForModuleExports: true
+  }
+});

--- a/tests/cases/fourslash/completionsImport_ambient.ts
+++ b/tests/cases/fourslash/completionsImport_ambient.ts
@@ -17,6 +17,35 @@
 // @Filename: b.ts
 //// Ba/**/
 
+verify.completions({
+  marker: "",
+  exact: [
+    completion.globalThisEntry,
+    ...completion.globalsVars,
+    {
+      name: "foo",
+      sortText: completion.SortText.GlobalsOrKeywords
+    },
+    completion.undefinedVarEntry,
+    {
+      name: "Bar",
+      source: "path1",
+      hasAction: true,
+      sortText: completion.SortText.AutoImportSuggestions
+    },
+    {
+      name: "Bar",
+      source: "path2longer",
+      hasAction: true,
+      sortText: completion.SortText.AutoImportSuggestions
+    },
+    ...completion.statementKeywordsWithTypes
+  ],
+  preferences: {
+    includeCompletionsForModuleExports: true
+  }
+});
+
 verify.applyCodeActionFromCompletion("", {
   name: "Bar",
   source: "path2longer",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #41010

If the `source` of a completion item is a bare specifier (which I believe can only arise from ambient modules), there’s really no reason to consider other module specifiers. When `source` is a path to a module, we look at symlinks, `paths`, reëxports, etc. to find the best module specifier for that symbol. None of that is relevant for ambient modules, so we should just use exactly what the completion entry showed. 
