### PR TITLE
Avoid rewriting bare module specifiers on rename when fix is not verifiably correct

### DIFF
--- a/src/services/getEditsForFileRename.ts
+++ b/src/services/getEditsForFileRename.ts
@@ -151,7 +151,7 @@ namespace ts {
                     const toImport = oldFromNew !== undefined
                         // If we're at the new location (file was already renamed), need to redo module resolution starting from the old location.
                         // TODO:GH#18217
-                        ? getSourceFileToImportFromResolved(resolveModuleName(importLiteral.text, oldImportFromPath, program.getCompilerOptions(), host as ModuleResolutionHost),
+                        ? getSourceFileToImportFromResolved(importLiteral, resolveModuleName(importLiteral.text, oldImportFromPath, program.getCompilerOptions(), host as ModuleResolutionHost),
                                                             oldToNew, allFiles)
                         : getSourceFileToImport(importedModuleSymbol, importLiteral, sourceFile, program, host, oldToNew);
 
@@ -193,11 +193,11 @@ namespace ts {
             const resolved = host.resolveModuleNames
                 ? host.getResolvedModuleWithFailedLookupLocationsFromCache && host.getResolvedModuleWithFailedLookupLocationsFromCache(importLiteral.text, importingSourceFile.fileName)
                 : program.getResolvedModuleWithFailedLookupLocationsFromCache(importLiteral.text, importingSourceFile.fileName);
-            return getSourceFileToImportFromResolved(resolved, oldToNew, program.getSourceFiles());
+            return getSourceFileToImportFromResolved(importLiteral, resolved, oldToNew, program.getSourceFiles());
         }
     }
 
-    function getSourceFileToImportFromResolved(resolved: ResolvedModuleWithFailedLookupLocations | undefined, oldToNew: PathUpdater, sourceFiles: readonly SourceFile[]): ToImport | undefined {
+    function getSourceFileToImportFromResolved(importLiteral: StringLiteralLike, resolved: ResolvedModuleWithFailedLookupLocations | undefined, oldToNew: PathUpdater, sourceFiles: readonly SourceFile[]): ToImport | undefined {
         // Search through all locations looking for a moved file, and only then test already existing files.
         // This is because if `a.ts` is compiled to `a.js` and `a.ts` is moved, we don't want to resolve anything to `a.js`, but to `a.ts`'s new location.
         if (!resolved) return undefined;
@@ -210,8 +210,9 @@ namespace ts {
 
         // Then failed lookups that are in the list of sources
         const result = forEach(resolved.failedLookupLocations, tryChangeWithIgnoringPackageJsonExisting)
-            // Then failed lookups except package.json since we dont want to touch them (only included ts/js files)
-            || forEach(resolved.failedLookupLocations, tryChangeWithIgnoringPackageJson);
+            // Then failed lookups except package.json since we dont want to touch them (only included ts/js files).
+            // At this point, the confidence level of this fix being correct is too low to change bare specifiers or absolute paths.
+            || pathIsRelative(importLiteral.text) && forEach(resolved.failedLookupLocations, tryChangeWithIgnoringPackageJson);
         if (result) return result;
 
         // If nothing changed, then result is resolved module file thats not updated

--- a/tests/cases/fourslash/getEditsForFileRename_unresolvableImport.ts
+++ b/tests/cases/fourslash/getEditsForFileRename_unresolvableImport.ts
@@ -1,0 +1,27 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "allowJs": true,
+////     "paths": {
+////       "*": ["./next/src/*"],
+////       "@app": ["./modules/@app/*"],
+////       "@app/*": ["./modules/@app/*"],
+////       "@local": ["./modules/@local/*"],
+////       "@local/*": ["./modules/@local/*"]
+////     }
+////   }
+//// }
+
+// @Filename: /modules/@app/something/index.js
+//// import "@local/some-other-import";
+
+// @Filename: /modules/@local/index.js
+//// import "@local/some-other-import";
+
+verify.getEditsForFileRename({
+  oldPath: "/modules/@app/something",
+  newPath: "/modules/@app/something-2",
+  newFileContents: {}
+});

--- a/tests/cases/fourslash/getEditsForFileRename_unresolvableNodeModule.ts
+++ b/tests/cases/fourslash/getEditsForFileRename_unresolvableNodeModule.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: /modules/@app/something/index.js
+//// import "doesnt-exist";
+
+// @Filename: /modules/@local/foo.js
+//// import "doesnt-exist"; 
+
+verify.getEditsForFileRename({
+  oldPath: "/modules/@app/something",
+  newPath: "/modules/@app/something-2",
+  newFileContents: {}
+});


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #40560

Rewriting module specifiers based on `failedLookupLocations` seems very sketchy to begin with, but there is like, literally no reason to do that if the module specifier is not relative. The bug here was basically operating an an assumption that some random `node_modules` directory that _definitely didn’t exist_ maybe was supposed to exist, and so we’ll rewrite you a path to that set of node_modules, even though we know for sure they don’t exist. I would be tempted to take this fix farther and never look at `failedLookupLocations` at all—my instinct would be, if you can’t resolve a module specifier, don’t rewrite it—but I’m not familiar with this part of the codebase.
