### PR TITLE
Fix references to generated factory imports in system+react-jsx[dev] emit

### DIFF
--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -1732,7 +1732,7 @@ namespace ts {
             //
             // - We do not substitute generated identifiers for any reason.
             // - We do not substitute identifiers tagged with the LocalName flag.
-            if (!isGeneratedIdentifier(node) && !isLocalName(node)) {
+            if (!(isGeneratedIdentifier(node) && !(node.autoGenerateFlags & GeneratedIdentifierFlags.AllowNameSubstitution)) && !isLocalName(node)) {
                 const importDeclaration = resolver.getReferencedImportDeclaration(node);
                 if (importDeclaration) {
                     if (isImportClause(importDeclaration)) {

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsx,module=commonjs).js
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsx,module=commonjs).js
@@ -1,10 +1,10 @@
-//// [jsxJsxsCjsTransformSubstitutesNames.tsx]
+//// [jsxJsxsTransformSubstitutesNames.tsx]
 /// <reference path="/.lib/react16.d.ts" />
 const a = <div></div>
 
 export {};
 
-//// [jsxJsxsCjsTransformSubstitutesNames.js]
+//// [jsxJsxsTransformSubstitutesNames.js]
 "use strict";
 exports.__esModule = true;
 var jsx_runtime_1 = require("react/jsx-runtime");

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsx,module=commonjs).symbols
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsx,module=commonjs).symbols
@@ -1,7 +1,7 @@
-=== tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNames.tsx ===
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNames.tsx ===
 /// <reference path="react16.d.ts" />
 const a = <div></div>
->a : Symbol(a, Decl(jsxJsxsCjsTransformSubstitutesNames.tsx, 1, 5))
+>a : Symbol(a, Decl(jsxJsxsTransformSubstitutesNames.tsx, 1, 5))
 >div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
 >div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
 

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsx,module=commonjs).types
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsx,module=commonjs).types
@@ -1,4 +1,4 @@
-=== tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNames.tsx ===
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNames.tsx ===
 /// <reference path="react16.d.ts" />
 const a = <div></div>
 >a : JSX.Element

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsx,module=system).js
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsx,module=system).js
@@ -1,0 +1,23 @@
+//// [jsxJsxsTransformSubstitutesNames.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+const a = <div></div>
+
+export {};
+
+//// [jsxJsxsTransformSubstitutesNames.js]
+System.register(["react/jsx-runtime"], function (exports_1, context_1) {
+    "use strict";
+    var jsx_runtime_1, a;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [
+            function (jsx_runtime_1_1) {
+                jsx_runtime_1 = jsx_runtime_1_1;
+            }
+        ],
+        execute: function () {
+            /// <reference path="react16.d.ts" />
+            a = jsx_runtime_1.jsx("div", {}, void 0);
+        }
+    };
+});

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsx,module=system).symbols
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsx,module=system).symbols
@@ -1,7 +1,7 @@
-=== tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNames.tsx ===
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNames.tsx ===
 /// <reference path="react16.d.ts" />
 const a = <div></div>
->a : Symbol(a, Decl(jsxJsxsCjsTransformSubstitutesNames.tsx, 1, 5))
+>a : Symbol(a, Decl(jsxJsxsTransformSubstitutesNames.tsx, 1, 5))
 >div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
 >div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
 

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsx,module=system).types
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsx,module=system).types
@@ -1,4 +1,4 @@
-=== tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNames.tsx ===
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNames.tsx ===
 /// <reference path="react16.d.ts" />
 const a = <div></div>
 >a : JSX.Element

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsxdev,module=commonjs).js
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsxdev,module=commonjs).js
@@ -1,13 +1,13 @@
-//// [jsxJsxsCjsTransformSubstitutesNames.tsx]
+//// [jsxJsxsTransformSubstitutesNames.tsx]
 /// <reference path="/.lib/react16.d.ts" />
 const a = <div></div>
 
 export {};
 
-//// [jsxJsxsCjsTransformSubstitutesNames.js]
+//// [jsxJsxsTransformSubstitutesNames.js]
 "use strict";
 exports.__esModule = true;
 var jsx_dev_runtime_1 = require("react/jsx-dev-runtime");
-var _jsxFileName = "tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNames.tsx";
+var _jsxFileName = "tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNames.tsx";
 /// <reference path="react16.d.ts" />
 var a = jsx_dev_runtime_1.jsxDEV("div", {}, void 0, false, { fileName: _jsxFileName, lineNumber: 2, columnNumber: 10 }, this);

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsxdev,module=commonjs).symbols
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsxdev,module=commonjs).symbols
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNames.tsx ===
+/// <reference path="react16.d.ts" />
+const a = <div></div>
+>a : Symbol(a, Decl(jsxJsxsTransformSubstitutesNames.tsx, 1, 5))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+
+export {};

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsxdev,module=commonjs).types
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsxdev,module=commonjs).types
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNames.tsx ===
+/// <reference path="react16.d.ts" />
+const a = <div></div>
+>a : JSX.Element
+><div></div> : JSX.Element
+>div : any
+>div : any
+
+export {};

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsxdev,module=system).js
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsxdev,module=system).js
@@ -1,0 +1,24 @@
+//// [jsxJsxsTransformSubstitutesNames.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+const a = <div></div>
+
+export {};
+
+//// [jsxJsxsTransformSubstitutesNames.js]
+System.register(["react/jsx-dev-runtime"], function (exports_1, context_1) {
+    "use strict";
+    var jsx_dev_runtime_1, _jsxFileName, a;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [
+            function (jsx_dev_runtime_1_1) {
+                jsx_dev_runtime_1 = jsx_dev_runtime_1_1;
+            }
+        ],
+        execute: function () {
+            _jsxFileName = "tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNames.tsx";
+            /// <reference path="react16.d.ts" />
+            a = jsx_dev_runtime_1.jsxDEV("div", {}, void 0, false, { fileName: _jsxFileName, lineNumber: 2, columnNumber: 10 }, this);
+        }
+    };
+});

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsxdev,module=system).symbols
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsxdev,module=system).symbols
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNames.tsx ===
+/// <reference path="react16.d.ts" />
+const a = <div></div>
+>a : Symbol(a, Decl(jsxJsxsTransformSubstitutesNames.tsx, 1, 5))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+
+export {};

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsxdev,module=system).types
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNames(jsx=react-jsxdev,module=system).types
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNames.tsx ===
+/// <reference path="react16.d.ts" />
+const a = <div></div>
+>a : JSX.Element
+><div></div> : JSX.Element
+>div : any
+>div : any
+
+export {};

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsx,module=commonjs).js
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsx,module=commonjs).js
@@ -1,4 +1,4 @@
-//// [jsxJsxsCjsTransformSubstitutesNamesFragment.tsx]
+//// [jsxJsxsTransformSubstitutesNamesFragment.tsx]
 /// <reference path="/.lib/react16.d.ts" />
 const a = <>
   <p></p>
@@ -8,7 +8,7 @@ const a = <>
 
 export {};
 
-//// [jsxJsxsCjsTransformSubstitutesNamesFragment.js]
+//// [jsxJsxsTransformSubstitutesNamesFragment.js]
 "use strict";
 exports.__esModule = true;
 var jsx_runtime_1 = require("react/jsx-runtime");

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsx,module=commonjs).symbols
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsx,module=commonjs).symbols
@@ -1,7 +1,7 @@
-=== tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNamesFragment.tsx ===
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNamesFragment.tsx ===
 /// <reference path="react16.d.ts" />
 const a = <>
->a : Symbol(a, Decl(jsxJsxsCjsTransformSubstitutesNamesFragment.tsx, 1, 5))
+>a : Symbol(a, Decl(jsxJsxsTransformSubstitutesNamesFragment.tsx, 1, 5))
 
   <p></p>
 >p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsx,module=commonjs).types
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsx,module=commonjs).types
@@ -1,4 +1,4 @@
-=== tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNamesFragment.tsx ===
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNamesFragment.tsx ===
 /// <reference path="react16.d.ts" />
 const a = <>
 >a : JSX.Element

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsx,module=system).js
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsx,module=system).js
@@ -1,0 +1,27 @@
+//// [jsxJsxsTransformSubstitutesNamesFragment.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+const a = <>
+  <p></p>
+  text
+  <div></div>
+</>
+
+export {};
+
+//// [jsxJsxsTransformSubstitutesNamesFragment.js]
+System.register(["react/jsx-runtime"], function (exports_1, context_1) {
+    "use strict";
+    var jsx_runtime_1, a;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [
+            function (jsx_runtime_1_1) {
+                jsx_runtime_1 = jsx_runtime_1_1;
+            }
+        ],
+        execute: function () {
+            /// <reference path="react16.d.ts" />
+            a = jsx_runtime_1.jsxs(jsx_runtime_1.Fragment, { children: [jsx_runtime_1.jsx("p", {}, void 0), "text", jsx_runtime_1.jsx("div", {}, void 0)] }, void 0);
+        }
+    };
+});

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsx,module=system).symbols
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsx,module=system).symbols
@@ -1,7 +1,7 @@
-=== tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNamesFragment.tsx ===
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNamesFragment.tsx ===
 /// <reference path="react16.d.ts" />
 const a = <>
->a : Symbol(a, Decl(jsxJsxsCjsTransformSubstitutesNamesFragment.tsx, 1, 5))
+>a : Symbol(a, Decl(jsxJsxsTransformSubstitutesNamesFragment.tsx, 1, 5))
 
   <p></p>
 >p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsx,module=system).types
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsx,module=system).types
@@ -1,4 +1,4 @@
-=== tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNamesFragment.tsx ===
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNamesFragment.tsx ===
 /// <reference path="react16.d.ts" />
 const a = <>
 >a : JSX.Element

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsxdev,module=commonjs).js
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsxdev,module=commonjs).js
@@ -1,4 +1,4 @@
-//// [jsxJsxsCjsTransformSubstitutesNamesFragment.tsx]
+//// [jsxJsxsTransformSubstitutesNamesFragment.tsx]
 /// <reference path="/.lib/react16.d.ts" />
 const a = <>
   <p></p>
@@ -8,10 +8,10 @@ const a = <>
 
 export {};
 
-//// [jsxJsxsCjsTransformSubstitutesNamesFragment.js]
+//// [jsxJsxsTransformSubstitutesNamesFragment.js]
 "use strict";
 exports.__esModule = true;
 var jsx_dev_runtime_1 = require("react/jsx-dev-runtime");
-var _jsxFileName = "tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNamesFragment.tsx";
+var _jsxFileName = "tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNamesFragment.tsx";
 /// <reference path="react16.d.ts" />
 var a = jsx_dev_runtime_1.jsxDEV(jsx_dev_runtime_1.Fragment, { children: [jsx_dev_runtime_1.jsxDEV("p", {}, void 0, false, { fileName: _jsxFileName, lineNumber: 3, columnNumber: 3 }, this), "text", jsx_dev_runtime_1.jsxDEV("div", {}, void 0, false, { fileName: _jsxFileName, lineNumber: 5, columnNumber: 3 }, this)] }, void 0, true, { fileName: _jsxFileName, lineNumber: 2, columnNumber: 10 }, this);

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsxdev,module=commonjs).symbols
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsxdev,module=commonjs).symbols
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNamesFragment.tsx ===
+/// <reference path="react16.d.ts" />
+const a = <>
+>a : Symbol(a, Decl(jsxJsxsTransformSubstitutesNamesFragment.tsx, 1, 5))
+
+  <p></p>
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+
+  text
+  <div></div>
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+
+</>
+
+export {};

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsxdev,module=commonjs).types
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsxdev,module=commonjs).types
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNamesFragment.tsx ===
+/// <reference path="react16.d.ts" />
+const a = <>
+>a : JSX.Element
+><>  <p></p>  text  <div></div></> : JSX.Element
+
+  <p></p>
+><p></p> : JSX.Element
+>p : any
+>p : any
+
+  text
+  <div></div>
+><div></div> : JSX.Element
+>div : any
+>div : any
+
+</>
+
+export {};

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsxdev,module=system).js
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsxdev,module=system).js
@@ -1,0 +1,28 @@
+//// [jsxJsxsTransformSubstitutesNamesFragment.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+const a = <>
+  <p></p>
+  text
+  <div></div>
+</>
+
+export {};
+
+//// [jsxJsxsTransformSubstitutesNamesFragment.js]
+System.register(["react/jsx-dev-runtime"], function (exports_1, context_1) {
+    "use strict";
+    var jsx_dev_runtime_1, _jsxFileName, a;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [
+            function (jsx_dev_runtime_1_1) {
+                jsx_dev_runtime_1 = jsx_dev_runtime_1_1;
+            }
+        ],
+        execute: function () {
+            _jsxFileName = "tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNamesFragment.tsx";
+            /// <reference path="react16.d.ts" />
+            a = jsx_dev_runtime_1.jsxDEV(jsx_dev_runtime_1.Fragment, { children: [jsx_dev_runtime_1.jsxDEV("p", {}, void 0, false, { fileName: _jsxFileName, lineNumber: 3, columnNumber: 3 }, this), "text", jsx_dev_runtime_1.jsxDEV("div", {}, void 0, false, { fileName: _jsxFileName, lineNumber: 5, columnNumber: 3 }, this)] }, void 0, true, { fileName: _jsxFileName, lineNumber: 2, columnNumber: 10 }, this);
+        }
+    };
+});

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsxdev,module=system).symbols
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsxdev,module=system).symbols
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNamesFragment.tsx ===
+/// <reference path="react16.d.ts" />
+const a = <>
+>a : Symbol(a, Decl(jsxJsxsTransformSubstitutesNamesFragment.tsx, 1, 5))
+
+  <p></p>
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+
+  text
+  <div></div>
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+
+</>
+
+export {};

--- a/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsxdev,module=system).types
+++ b/tests/baselines/reference/jsxJsxsTransformSubstitutesNamesFragment(jsx=react-jsxdev,module=system).types
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNamesFragment.tsx ===
+/// <reference path="react16.d.ts" />
+const a = <>
+>a : JSX.Element
+><>  <p></p>  text  <div></div></> : JSX.Element
+
+  <p></p>
+><p></p> : JSX.Element
+>p : any
+>p : any
+
+  text
+  <div></div>
+><div></div> : JSX.Element
+>div : any
+>div : any
+
+</>
+
+export {};

--- a/tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNames.tsx
+++ b/tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNames.tsx
@@ -1,11 +1,7 @@
 // @jsx: react-jsx,react-jsxdev
 // @strict: true
-// @module: commonjs
+// @module: commonjs,system
 /// <reference path="/.lib/react16.d.ts" />
-const a = <>
-  <p></p>
-  text
-  <div></div>
-</>
+const a = <div></div>
 
 export {};

--- a/tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNamesFragment.tsx
+++ b/tests/cases/conformance/jsx/jsxs/jsxJsxsTransformSubstitutesNamesFragment.tsx
@@ -1,7 +1,11 @@
 // @jsx: react-jsx,react-jsxdev
 // @strict: true
-// @module: commonjs
+// @module: commonjs,system
 /// <reference path="/.lib/react16.d.ts" />
-const a = <div></div>
+const a = <>
+  <p></p>
+  text
+  <div></div>
+</>
 
 export {};


### PR DESCRIPTION
Fixing this was pretty simple - the `module` transform already does the right thing, the `system` transform just never got updated.

Fixes #41914
