### PR TITLE
fix(41965): Wrong error text for definite-assignment-assertion on ambient variable declaration

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40078,7 +40078,9 @@ namespace ts {
             if (node.exclamationToken && (node.parent.parent.kind !== SyntaxKind.VariableStatement || !node.type || node.initializer || node.flags & NodeFlags.Ambient)) {
                 const message = node.initializer
                     ? Diagnostics.Declarations_with_initializers_cannot_also_have_definite_assignment_assertions
-                    : Diagnostics.Declarations_with_definite_assignment_assertions_must_also_have_type_annotations;
+                    : !node.type
+                        ? Diagnostics.Declarations_with_definite_assignment_assertions_must_also_have_type_annotations
+                        : Diagnostics.A_definite_assignment_assertion_is_not_permitted_in_this_context;
                 return grammarErrorOnNode(node.exclamationToken, message);
             }
 

--- a/tests/baselines/reference/definiteAssignmentAssertions.errors.txt
+++ b/tests/baselines/reference/definiteAssignmentAssertions.errors.txt
@@ -9,11 +9,12 @@ tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(35,15): erro
 tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(69,10): error TS1264: Declarations with definite assignment assertions must also have type annotations.
 tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(70,10): error TS1263: Declarations with initializers cannot also have definite assignment assertions.
 tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(71,10): error TS1263: Declarations with initializers cannot also have definite assignment assertions.
-tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(76,15): error TS1264: Declarations with definite assignment assertions must also have type annotations.
-tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(77,15): error TS1264: Declarations with definite assignment assertions must also have type annotations.
+tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(76,15): error TS1255: A definite assignment assertion '!' is not permitted in this context.
+tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(77,15): error TS1255: A definite assignment assertion '!' is not permitted in this context.
+tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(80,7): error TS1255: A definite assignment assertion '!' is not permitted in this context.
 
 
-==== tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts (13 errors) ====
+==== tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts (14 errors) ====
     // Suppress strict property initialization check
     
     class C1 {
@@ -113,8 +114,14 @@ tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(77,15): erro
     
     declare let v1!: number;
                   ~
-!!! error TS1264: Declarations with definite assignment assertions must also have type annotations.
+!!! error TS1255: A definite assignment assertion '!' is not permitted in this context.
     declare var v2!: number;
                   ~
-!!! error TS1264: Declarations with definite assignment assertions must also have type annotations.
+!!! error TS1255: A definite assignment assertion '!' is not permitted in this context.
+    
+    declare namespace foo {
+    	var v!: number;
+    	     ~
+!!! error TS1255: A definite assignment assertion '!' is not permitted in this context.
+    }
     

--- a/tests/baselines/reference/definiteAssignmentAssertions.js
+++ b/tests/baselines/reference/definiteAssignmentAssertions.js
@@ -77,6 +77,10 @@ function f4() {
 declare let v1!: number;
 declare var v2!: number;
 
+declare namespace foo {
+	var v!: number;
+}
+
 
 //// [definiteAssignmentAssertions.js]
 "use strict";
@@ -166,3 +170,6 @@ declare function f3(): void;
 declare function f4(): void;
 declare let v1: number;
 declare var v2: number;
+declare namespace foo {
+    var v: number;
+}

--- a/tests/baselines/reference/definiteAssignmentAssertions.symbols
+++ b/tests/baselines/reference/definiteAssignmentAssertions.symbols
@@ -147,3 +147,10 @@ declare let v1!: number;
 declare var v2!: number;
 >v2 : Symbol(v2, Decl(definiteAssignmentAssertions.ts, 76, 11))
 
+declare namespace foo {
+>foo : Symbol(foo, Decl(definiteAssignmentAssertions.ts, 76, 24))
+
+	var v!: number;
+>v : Symbol(v, Decl(definiteAssignmentAssertions.ts, 79, 4))
+}
+

--- a/tests/baselines/reference/definiteAssignmentAssertions.types
+++ b/tests/baselines/reference/definiteAssignmentAssertions.types
@@ -158,3 +158,10 @@ declare let v1!: number;
 declare var v2!: number;
 >v2 : number
 
+declare namespace foo {
+>foo : typeof foo
+
+	var v!: number;
+>v : number
+}
+

--- a/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts
+++ b/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts
@@ -78,3 +78,7 @@ function f4() {
 
 declare let v1!: number;
 declare var v2!: number;
+
+declare namespace foo {
+	var v!: number;
+}


### PR DESCRIPTION
Fixes #41965