### PR TITLE
Strict subtype relation uses strict variance for all signatures in SFT mode

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16231,7 +16231,7 @@ namespace ts {
                 return Ternary.False;
             }
 
-            const strictVariance = !(checkMode & SignatureCheckMode.Callback) && strictFunctionTypes && (isStrictSignature(target) || isStrictSignature(source));
+            const strictVariance = !(checkMode & SignatureCheckMode.Callback) && strictFunctionTypes && (checkMode & SignatureCheckMode.StrictArity || isStrictSignature(target));
             let result = Ternary.True;
 
             const sourceThisType = getThisTypeOfSignature(source);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13154,7 +13154,7 @@ namespace ts {
                             }
                         }
                         count++;
-                        if (isTypeRelatedTo(source, target, strictSubtypeRelation) && (
+                        if (isTypeSubtypeOf(source, target) && (!isTypeSubtypeOf(target, source) || isTypeRelatedTo(source, target, strictSubtypeRelation)) && (
                             !(getObjectFlags(getTargetType(source)) & ObjectFlags.Class) ||
                             !(getObjectFlags(getTargetType(target)) & ObjectFlags.Class) ||
                             isTypeDerivedFrom(source, target))) {
@@ -16231,7 +16231,7 @@ namespace ts {
                 return Ternary.False;
             }
 
-            const strictVariance = !(checkMode & SignatureCheckMode.Callback) && strictFunctionTypes && (checkMode & SignatureCheckMode.StrictArity || isStrictSignature(target));
+            const strictVariance = !(checkMode & SignatureCheckMode.Callback) && (checkMode & SignatureCheckMode.StrictArity || strictFunctionTypes && isStrictSignature(target));
             let result = Ternary.True;
 
             const sourceThisType = getThisTypeOfSignature(source);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16183,6 +16183,11 @@ namespace ts {
                 isTypeAny(getReturnTypeOfSignature(s));
         }
 
+        function isStrictSignature(sig: Signature) {
+            const kind = sig.declaration ? sig.declaration.kind : SyntaxKind.Unknown;
+            return kind !== SyntaxKind.MethodDeclaration && kind !== SyntaxKind.MethodSignature && kind !== SyntaxKind.Constructor;
+        }
+
         /**
          * See signatureRelatedTo, compareSignaturesIdentical
          */
@@ -16226,9 +16231,7 @@ namespace ts {
                 return Ternary.False;
             }
 
-            const kind = target.declaration ? target.declaration.kind : SyntaxKind.Unknown;
-            const strictVariance = !(checkMode & SignatureCheckMode.Callback) && strictFunctionTypes && kind !== SyntaxKind.MethodDeclaration &&
-                kind !== SyntaxKind.MethodSignature && kind !== SyntaxKind.Constructor;
+            const strictVariance = !(checkMode & SignatureCheckMode.Callback) && strictFunctionTypes && (isStrictSignature(target) || isStrictSignature(source));
             let result = Ternary.True;
 
             const sourceThisType = getThisTypeOfSignature(source);

--- a/tests/baselines/reference/arrayLiteralWithMultipleBestCommonTypes.types
+++ b/tests/baselines/reference/arrayLiteralWithMultipleBestCommonTypes.types
@@ -36,8 +36,8 @@ var cs = [a, b, c]; // { x: number; y?: number };[]
 >c : { x: number; a?: number; }
 
 var ds = [(x: Object) => 1, (x: string) => 2]; // { (x:Object) => number }[]
->ds : ((x: Object) => number)[]
->[(x: Object) => 1, (x: string) => 2] : ((x: Object) => number)[]
+>ds : ((x: string) => number)[]
+>[(x: Object) => 1, (x: string) => 2] : ((x: string) => number)[]
 >(x: Object) => 1 : (x: Object) => number
 >x : Object
 >1 : 1

--- a/tests/baselines/reference/contextualTypingArrayOfLambdas.types
+++ b/tests/baselines/reference/contextualTypingArrayOfLambdas.types
@@ -23,8 +23,8 @@ class C extends A {
 }
 
 var xs = [(x: A) => { }, (x: B) => { }, (x: C) => { }];
->xs : ((x: A) => void)[]
->[(x: A) => { }, (x: B) => { }, (x: C) => { }] : ((x: A) => void)[]
+>xs : (((x: B) => void) | ((x: C) => void))[]
+>[(x: A) => { }, (x: B) => { }, (x: C) => { }] : (((x: B) => void) | ((x: C) => void))[]
 >(x: A) => { } : (x: A) => void
 >x : A
 >(x: B) => { } : (x: B) => void

--- a/tests/baselines/reference/functionWithMultipleReturnStatements2.types
+++ b/tests/baselines/reference/functionWithMultipleReturnStatements2.types
@@ -58,7 +58,7 @@ function f4() {
 }
 
 function f5() {
->f5 : () => Object | 1
+>f5 : () => Object
 
     return 1;
 >1 : 1

--- a/tests/baselines/reference/strictSubtypeReduction.errors.txt
+++ b/tests/baselines/reference/strictSubtypeReduction.errors.txt
@@ -1,0 +1,80 @@
+tests/cases/compiler/strictSubtypeReduction.ts(29,7): error TS2322: Type '((a: number) => void)[]' is not assignable to type '((ctrl: string | number) => void)[]'.
+  Type '(a: number) => void' is not assignable to type '(ctrl: string | number) => void'.
+    Types of parameters 'a' and 'ctrl' are incompatible.
+      Type 'string | number' is not assignable to type 'number'.
+        Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/strictSubtypeReduction.ts(30,7): error TS2322: Type '((a: number) => void)[]' is not assignable to type '((ctrl: string | number) => void)[]'.
+  Type '(a: number) => void' is not assignable to type '(ctrl: string | number) => void'.
+    Types of parameters 'a' and 'ctrl' are incompatible.
+      Type 'string | number' is not assignable to type 'number'.
+        Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/strictSubtypeReduction.ts(31,7): error TS2322: Type '((a: number) => void)[]' is not assignable to type '((ctrl: string | number) => void)[]'.
+  Type '(a: number) => void' is not assignable to type '(ctrl: string | number) => void'.
+    Types of parameters 'a' and 'ctrl' are incompatible.
+      Type 'string | number' is not assignable to type 'number'.
+        Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/strictSubtypeReduction.ts(32,7): error TS2322: Type '((a: number) => void)[]' is not assignable to type '((ctrl: string | number) => void)[]'.
+  Type '(a: number) => void' is not assignable to type '(ctrl: string | number) => void'.
+    Types of parameters 'a' and 'ctrl' are incompatible.
+      Type 'string | number' is not assignable to type 'number'.
+        Type 'string' is not assignable to type 'number'.
+
+
+==== tests/cases/compiler/strictSubtypeReduction.ts (4 errors) ====
+    // Repro from #41977
+    
+    class S1 {
+      static f(a: number | string): void {}
+    }
+    
+    class S2 {
+      static f(a: number): void {}
+      static g(a: number): void {}
+    }
+    
+    function f(a: number): void {}
+    function g(a: number): void {}
+    
+    // Declaring the following type aliases should have no effect
+    
+    type T1 = typeof S2.g;
+    type T2 = typeof g;
+    
+    // All should have type ((a: number) => void)[]
+    
+    const y1 = [S1.f, f];
+    const y2 = [S1.f, g];
+    const y3 = [S1.f, S2.f];
+    const y4 = [S1.f, S2.g];
+    
+    // All assignments should be errors
+    
+    const x1: ((ctrl: number | string) => void)[] = y1;
+          ~~
+!!! error TS2322: Type '((a: number) => void)[]' is not assignable to type '((ctrl: string | number) => void)[]'.
+!!! error TS2322:   Type '(a: number) => void' is not assignable to type '(ctrl: string | number) => void'.
+!!! error TS2322:     Types of parameters 'a' and 'ctrl' are incompatible.
+!!! error TS2322:       Type 'string | number' is not assignable to type 'number'.
+!!! error TS2322:         Type 'string' is not assignable to type 'number'.
+    const x2: ((ctrl: number | string) => void)[] = y2;
+          ~~
+!!! error TS2322: Type '((a: number) => void)[]' is not assignable to type '((ctrl: string | number) => void)[]'.
+!!! error TS2322:   Type '(a: number) => void' is not assignable to type '(ctrl: string | number) => void'.
+!!! error TS2322:     Types of parameters 'a' and 'ctrl' are incompatible.
+!!! error TS2322:       Type 'string | number' is not assignable to type 'number'.
+!!! error TS2322:         Type 'string' is not assignable to type 'number'.
+    const x3: ((ctrl: number | string) => void)[] = y3;
+          ~~
+!!! error TS2322: Type '((a: number) => void)[]' is not assignable to type '((ctrl: string | number) => void)[]'.
+!!! error TS2322:   Type '(a: number) => void' is not assignable to type '(ctrl: string | number) => void'.
+!!! error TS2322:     Types of parameters 'a' and 'ctrl' are incompatible.
+!!! error TS2322:       Type 'string | number' is not assignable to type 'number'.
+!!! error TS2322:         Type 'string' is not assignable to type 'number'.
+    const x4: ((ctrl: number | string) => void)[] = y4;
+          ~~
+!!! error TS2322: Type '((a: number) => void)[]' is not assignable to type '((ctrl: string | number) => void)[]'.
+!!! error TS2322:   Type '(a: number) => void' is not assignable to type '(ctrl: string | number) => void'.
+!!! error TS2322:     Types of parameters 'a' and 'ctrl' are incompatible.
+!!! error TS2322:       Type 'string | number' is not assignable to type 'number'.
+!!! error TS2322:         Type 'string' is not assignable to type 'number'.
+    

--- a/tests/baselines/reference/strictSubtypeReduction.js
+++ b/tests/baselines/reference/strictSubtypeReduction.js
@@ -1,0 +1,63 @@
+//// [strictSubtypeReduction.ts]
+// Repro from #41977
+
+class S1 {
+  static f(a: number | string): void {}
+}
+
+class S2 {
+  static f(a: number): void {}
+  static g(a: number): void {}
+}
+
+function f(a: number): void {}
+function g(a: number): void {}
+
+// Declaring the following type aliases should have no effect
+
+type T1 = typeof S2.g;
+type T2 = typeof g;
+
+// All should have type ((a: number) => void)[]
+
+const y1 = [S1.f, f];
+const y2 = [S1.f, g];
+const y3 = [S1.f, S2.f];
+const y4 = [S1.f, S2.g];
+
+// All assignments should be errors
+
+const x1: ((ctrl: number | string) => void)[] = y1;
+const x2: ((ctrl: number | string) => void)[] = y2;
+const x3: ((ctrl: number | string) => void)[] = y3;
+const x4: ((ctrl: number | string) => void)[] = y4;
+
+
+//// [strictSubtypeReduction.js]
+"use strict";
+// Repro from #41977
+var S1 = /** @class */ (function () {
+    function S1() {
+    }
+    S1.f = function (a) { };
+    return S1;
+}());
+var S2 = /** @class */ (function () {
+    function S2() {
+    }
+    S2.f = function (a) { };
+    S2.g = function (a) { };
+    return S2;
+}());
+function f(a) { }
+function g(a) { }
+// All should have type ((a: number) => void)[]
+var y1 = [S1.f, f];
+var y2 = [S1.f, g];
+var y3 = [S1.f, S2.f];
+var y4 = [S1.f, S2.g];
+// All assignments should be errors
+var x1 = y1;
+var x2 = y2;
+var x3 = y3;
+var x4 = y4;

--- a/tests/baselines/reference/strictSubtypeReduction.symbols
+++ b/tests/baselines/reference/strictSubtypeReduction.symbols
@@ -1,0 +1,99 @@
+=== tests/cases/compiler/strictSubtypeReduction.ts ===
+// Repro from #41977
+
+class S1 {
+>S1 : Symbol(S1, Decl(strictSubtypeReduction.ts, 0, 0))
+
+  static f(a: number | string): void {}
+>f : Symbol(S1.f, Decl(strictSubtypeReduction.ts, 2, 10))
+>a : Symbol(a, Decl(strictSubtypeReduction.ts, 3, 11))
+}
+
+class S2 {
+>S2 : Symbol(S2, Decl(strictSubtypeReduction.ts, 4, 1))
+
+  static f(a: number): void {}
+>f : Symbol(S2.f, Decl(strictSubtypeReduction.ts, 6, 10))
+>a : Symbol(a, Decl(strictSubtypeReduction.ts, 7, 11))
+
+  static g(a: number): void {}
+>g : Symbol(S2.g, Decl(strictSubtypeReduction.ts, 7, 30))
+>a : Symbol(a, Decl(strictSubtypeReduction.ts, 8, 11))
+}
+
+function f(a: number): void {}
+>f : Symbol(f, Decl(strictSubtypeReduction.ts, 9, 1))
+>a : Symbol(a, Decl(strictSubtypeReduction.ts, 11, 11))
+
+function g(a: number): void {}
+>g : Symbol(g, Decl(strictSubtypeReduction.ts, 11, 30))
+>a : Symbol(a, Decl(strictSubtypeReduction.ts, 12, 11))
+
+// Declaring the following type aliases should have no effect
+
+type T1 = typeof S2.g;
+>T1 : Symbol(T1, Decl(strictSubtypeReduction.ts, 12, 30))
+>S2.g : Symbol(S2.g, Decl(strictSubtypeReduction.ts, 7, 30))
+>S2 : Symbol(S2, Decl(strictSubtypeReduction.ts, 4, 1))
+>g : Symbol(S2.g, Decl(strictSubtypeReduction.ts, 7, 30))
+
+type T2 = typeof g;
+>T2 : Symbol(T2, Decl(strictSubtypeReduction.ts, 16, 22))
+>g : Symbol(g, Decl(strictSubtypeReduction.ts, 11, 30))
+
+// All should have type ((a: number) => void)[]
+
+const y1 = [S1.f, f];
+>y1 : Symbol(y1, Decl(strictSubtypeReduction.ts, 21, 5))
+>S1.f : Symbol(S1.f, Decl(strictSubtypeReduction.ts, 2, 10))
+>S1 : Symbol(S1, Decl(strictSubtypeReduction.ts, 0, 0))
+>f : Symbol(S1.f, Decl(strictSubtypeReduction.ts, 2, 10))
+>f : Symbol(f, Decl(strictSubtypeReduction.ts, 9, 1))
+
+const y2 = [S1.f, g];
+>y2 : Symbol(y2, Decl(strictSubtypeReduction.ts, 22, 5))
+>S1.f : Symbol(S1.f, Decl(strictSubtypeReduction.ts, 2, 10))
+>S1 : Symbol(S1, Decl(strictSubtypeReduction.ts, 0, 0))
+>f : Symbol(S1.f, Decl(strictSubtypeReduction.ts, 2, 10))
+>g : Symbol(g, Decl(strictSubtypeReduction.ts, 11, 30))
+
+const y3 = [S1.f, S2.f];
+>y3 : Symbol(y3, Decl(strictSubtypeReduction.ts, 23, 5))
+>S1.f : Symbol(S1.f, Decl(strictSubtypeReduction.ts, 2, 10))
+>S1 : Symbol(S1, Decl(strictSubtypeReduction.ts, 0, 0))
+>f : Symbol(S1.f, Decl(strictSubtypeReduction.ts, 2, 10))
+>S2.f : Symbol(S2.f, Decl(strictSubtypeReduction.ts, 6, 10))
+>S2 : Symbol(S2, Decl(strictSubtypeReduction.ts, 4, 1))
+>f : Symbol(S2.f, Decl(strictSubtypeReduction.ts, 6, 10))
+
+const y4 = [S1.f, S2.g];
+>y4 : Symbol(y4, Decl(strictSubtypeReduction.ts, 24, 5))
+>S1.f : Symbol(S1.f, Decl(strictSubtypeReduction.ts, 2, 10))
+>S1 : Symbol(S1, Decl(strictSubtypeReduction.ts, 0, 0))
+>f : Symbol(S1.f, Decl(strictSubtypeReduction.ts, 2, 10))
+>S2.g : Symbol(S2.g, Decl(strictSubtypeReduction.ts, 7, 30))
+>S2 : Symbol(S2, Decl(strictSubtypeReduction.ts, 4, 1))
+>g : Symbol(S2.g, Decl(strictSubtypeReduction.ts, 7, 30))
+
+// All assignments should be errors
+
+const x1: ((ctrl: number | string) => void)[] = y1;
+>x1 : Symbol(x1, Decl(strictSubtypeReduction.ts, 28, 5))
+>ctrl : Symbol(ctrl, Decl(strictSubtypeReduction.ts, 28, 12))
+>y1 : Symbol(y1, Decl(strictSubtypeReduction.ts, 21, 5))
+
+const x2: ((ctrl: number | string) => void)[] = y2;
+>x2 : Symbol(x2, Decl(strictSubtypeReduction.ts, 29, 5))
+>ctrl : Symbol(ctrl, Decl(strictSubtypeReduction.ts, 29, 12))
+>y2 : Symbol(y2, Decl(strictSubtypeReduction.ts, 22, 5))
+
+const x3: ((ctrl: number | string) => void)[] = y3;
+>x3 : Symbol(x3, Decl(strictSubtypeReduction.ts, 30, 5))
+>ctrl : Symbol(ctrl, Decl(strictSubtypeReduction.ts, 30, 12))
+>y3 : Symbol(y3, Decl(strictSubtypeReduction.ts, 23, 5))
+
+const x4: ((ctrl: number | string) => void)[] = y4;
+>x4 : Symbol(x4, Decl(strictSubtypeReduction.ts, 31, 5))
+>ctrl : Symbol(ctrl, Decl(strictSubtypeReduction.ts, 31, 12))
+>y4 : Symbol(y4, Decl(strictSubtypeReduction.ts, 24, 5))
+

--- a/tests/baselines/reference/strictSubtypeReduction.types
+++ b/tests/baselines/reference/strictSubtypeReduction.types
@@ -1,0 +1,103 @@
+=== tests/cases/compiler/strictSubtypeReduction.ts ===
+// Repro from #41977
+
+class S1 {
+>S1 : S1
+
+  static f(a: number | string): void {}
+>f : (a: number | string) => void
+>a : string | number
+}
+
+class S2 {
+>S2 : S2
+
+  static f(a: number): void {}
+>f : (a: number) => void
+>a : number
+
+  static g(a: number): void {}
+>g : (a: number) => void
+>a : number
+}
+
+function f(a: number): void {}
+>f : (a: number) => void
+>a : number
+
+function g(a: number): void {}
+>g : (a: number) => void
+>a : number
+
+// Declaring the following type aliases should have no effect
+
+type T1 = typeof S2.g;
+>T1 : (a: number) => void
+>S2.g : (a: number) => void
+>S2 : typeof S2
+>g : (a: number) => void
+
+type T2 = typeof g;
+>T2 : (a: number) => void
+>g : (a: number) => void
+
+// All should have type ((a: number) => void)[]
+
+const y1 = [S1.f, f];
+>y1 : ((a: number) => void)[]
+>[S1.f, f] : ((a: number) => void)[]
+>S1.f : (a: string | number) => void
+>S1 : typeof S1
+>f : (a: string | number) => void
+>f : (a: number) => void
+
+const y2 = [S1.f, g];
+>y2 : ((a: number) => void)[]
+>[S1.f, g] : ((a: number) => void)[]
+>S1.f : (a: string | number) => void
+>S1 : typeof S1
+>f : (a: string | number) => void
+>g : (a: number) => void
+
+const y3 = [S1.f, S2.f];
+>y3 : ((a: number) => void)[]
+>[S1.f, S2.f] : ((a: number) => void)[]
+>S1.f : (a: string | number) => void
+>S1 : typeof S1
+>f : (a: string | number) => void
+>S2.f : (a: number) => void
+>S2 : typeof S2
+>f : (a: number) => void
+
+const y4 = [S1.f, S2.g];
+>y4 : ((a: number) => void)[]
+>[S1.f, S2.g] : ((a: number) => void)[]
+>S1.f : (a: string | number) => void
+>S1 : typeof S1
+>f : (a: string | number) => void
+>S2.g : (a: number) => void
+>S2 : typeof S2
+>g : (a: number) => void
+
+// All assignments should be errors
+
+const x1: ((ctrl: number | string) => void)[] = y1;
+>x1 : ((ctrl: number | string) => void)[]
+>ctrl : string | number
+>y1 : ((a: number) => void)[]
+
+const x2: ((ctrl: number | string) => void)[] = y2;
+>x2 : ((ctrl: number | string) => void)[]
+>ctrl : string | number
+>y2 : ((a: number) => void)[]
+
+const x3: ((ctrl: number | string) => void)[] = y3;
+>x3 : ((ctrl: number | string) => void)[]
+>ctrl : string | number
+>y3 : ((a: number) => void)[]
+
+const x4: ((ctrl: number | string) => void)[] = y4;
+>x4 : ((ctrl: number | string) => void)[]
+>ctrl : string | number
+>y4 : ((a: number) => void)[]
+

--- a/tests/baselines/reference/subtypesOfTypeParameterWithConstraints2.types
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithConstraints2.types
@@ -566,16 +566,16 @@ function f20<T extends Number>(x: T) {
 >x : T
 
     var r19 = true ? new Object() : x; // ok
->r19 : Object | T
->true ? new Object() : x : Object | T
+>r19 : Object
+>true ? new Object() : x : Object
 >true : true
 >new Object() : Object
 >Object : ObjectConstructor
 >x : T
 
     var r19 = true ? x : new Object(); // ok
->r19 : Object | T
->true ? x : new Object() : Object | T
+>r19 : Object
+>true ? x : new Object() : Object
 >true : true
 >x : T
 >new Object() : Object

--- a/tests/baselines/reference/unionTypeReduction2.errors.txt
+++ b/tests/baselines/reference/unionTypeReduction2.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/types/union/unionTypeReduction2.ts(33,5): error TS2554: Expected 1 arguments, but got 0.
+tests/cases/conformance/types/union/unionTypeReduction2.ts(49,9): error TS2554: Expected 0 arguments, but got 1.
 
 
-==== tests/cases/conformance/types/union/unionTypeReduction2.ts (1 errors) ====
+==== tests/cases/conformance/types/union/unionTypeReduction2.ts (2 errors) ====
     function f1(x: { f(): void }, y: { f(x?: string): void }) {
         let z = !!true ? x : y;  // { f(x?: string): void }
         z.f();
@@ -54,6 +55,8 @@ tests/cases/conformance/types/union/unionTypeReduction2.ts(33,5): error TS2554: 
         let z = !!true ? a : b;  // A | B
         z.f();
         z.f('hello');
+            ~~~~~~~
+!!! error TS2554: Expected 0 arguments, but got 1.
     }
     
     // Repro from #35414

--- a/tests/baselines/reference/unionTypeReduction2.symbols
+++ b/tests/baselines/reference/unionTypeReduction2.symbols
@@ -154,14 +154,14 @@ function f11(a: A, b: B) {
 >b : Symbol(b, Decl(unionTypeReduction2.ts, 45, 18))
 
     z.f();
->z.f : Symbol(f, Decl(unionTypeReduction2.ts, 36, 10), Decl(unionTypeReduction2.ts, 40, 10))
+>z.f : Symbol(f, Decl(unionTypeReduction2.ts, 36, 10))
 >z : Symbol(z, Decl(unionTypeReduction2.ts, 46, 7))
->f : Symbol(f, Decl(unionTypeReduction2.ts, 36, 10), Decl(unionTypeReduction2.ts, 40, 10))
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 36, 10))
 
     z.f('hello');
->z.f : Symbol(f, Decl(unionTypeReduction2.ts, 36, 10), Decl(unionTypeReduction2.ts, 40, 10))
+>z.f : Symbol(f, Decl(unionTypeReduction2.ts, 36, 10))
 >z : Symbol(z, Decl(unionTypeReduction2.ts, 46, 7))
->f : Symbol(f, Decl(unionTypeReduction2.ts, 36, 10), Decl(unionTypeReduction2.ts, 40, 10))
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 36, 10))
 }
 
 // Repro from #35414

--- a/tests/baselines/reference/unionTypeReduction2.types
+++ b/tests/baselines/reference/unionTypeReduction2.types
@@ -189,8 +189,8 @@ function f11(a: A, b: B) {
 >b : B
 
     let z = !!true ? a : b;  // A | B
->z : A | B
->!!true ? a : b : A | B
+>z : A
+>!!true ? a : b : A
 >!!true : true
 >!true : false
 >true : true
@@ -199,15 +199,15 @@ function f11(a: A, b: B) {
 
     z.f();
 >z.f() : void
->z.f : ((x?: string | undefined) => void) | (() => void)
->z : A | B
->f : ((x?: string | undefined) => void) | (() => void)
+>z.f : () => void
+>z : A
+>f : () => void
 
     z.f('hello');
 >z.f('hello') : void
->z.f : ((x?: string | undefined) => void) | (() => void)
->z : A | B
->f : ((x?: string | undefined) => void) | (() => void)
+>z.f : () => void
+>z : A
+>f : () => void
 >'hello' : "hello"
 }
 

--- a/tests/cases/compiler/strictSubtypeReduction.ts
+++ b/tests/cases/compiler/strictSubtypeReduction.ts
@@ -1,0 +1,34 @@
+// @strict: true
+
+// Repro from #41977
+
+class S1 {
+  static f(a: number | string): void {}
+}
+
+class S2 {
+  static f(a: number): void {}
+  static g(a: number): void {}
+}
+
+function f(a: number): void {}
+function g(a: number): void {}
+
+// Declaring the following type aliases should have no effect
+
+type T1 = typeof S2.g;
+type T2 = typeof g;
+
+// All should have type ((a: number) => void)[]
+
+const y1 = [S1.f, f];
+const y2 = [S1.f, g];
+const y3 = [S1.f, S2.f];
+const y4 = [S1.f, S2.g];
+
+// All assignments should be errors
+
+const x1: ((ctrl: number | string) => void)[] = y1;
+const x2: ((ctrl: number | string) => void)[] = y2;
+const x3: ((ctrl: number | string) => void)[] = y3;
+const x4: ((ctrl: number | string) => void)[] = y4;


### PR DESCRIPTION
This PR makes `--strictFunctionTypes` (SFT) mode slightly stricter. With the PR, the strict subtype relation consistently uses strict variance for all signatures when in SFT mode, regardless of whether the signatures originated in methods. Thus, in SFT mode there should be no "butterfly effects" caused by bi-variance.

~This PR makes `--strictFunctionTypes` slightly stricter. Currently, we check function types bi-variantly when the target is a method or constructor. With this PR we check bi-variantly only when both source and target are a method or constructor.~

Fixes #41977.