### PR TITLE
Don’t require fourslash completions tests to specify replacementSpan when it’s zero-length

### DIFF
--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -907,11 +907,13 @@ namespace FourSlash {
                 this.raiseError(`Expected completion insert text to be ${expected.insertText}, got ${actual.insertText}`);
             }
             const convertedReplacementSpan = expected.replacementSpan && ts.createTextSpanFromRange(expected.replacementSpan);
-            try {
-                assert.deepEqual(actual.replacementSpan, convertedReplacementSpan);
-            }
-            catch {
-                this.raiseError(`Expected completion replacementSpan to be ${stringify(convertedReplacementSpan)}, got ${stringify(actual.replacementSpan)}`);
+            if (convertedReplacementSpan?.length) {
+                try {
+                    assert.deepEqual(actual.replacementSpan, convertedReplacementSpan);
+                }
+                catch {
+                    this.raiseError(`Expected completion replacementSpan to be ${stringify(convertedReplacementSpan)}, got ${stringify(actual.replacementSpan)}`);
+                }
             }
 
             if (expected.kind !== undefined || expected.kindModifiers !== undefined) {

--- a/tests/cases/fourslash/completionsWithGenericStringLiteral.ts
+++ b/tests/cases/fourslash/completionsWithGenericStringLiteral.ts
@@ -2,12 +2,9 @@
 // @strict: true
 
 //// declare function get<T, K extends keyof T>(obj: T, key: K): T[K];
-//// get({ hello: 123, world: 456 }, "[|/**/|]");
+//// get({ hello: 123, world: 456 }, "/**/");
 
 verify.completions({
   marker: "",
-  includes: [
-    { name: 'hello', replacementSpan: test.ranges()[0] },
-    { name: 'world', replacementSpan: test.ranges()[0] }
-  ]
+  includes: ["hello", "world"]
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

