### PR TITLE
Fix string literal object member completions with union contextual type

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2676,7 +2676,7 @@ namespace ts.Completions {
         return jsdoc && jsdoc.tags && (rangeContainsPosition(jsdoc, position) ? findLast(jsdoc.tags, tag => tag.pos < position) : undefined);
     }
 
-    function getPropertiesForObjectExpression(contextualType: Type, completionsType: Type | undefined, obj: ObjectLiteralExpression | JsxAttributes, checker: TypeChecker): Symbol[] {
+    export function getPropertiesForObjectExpression(contextualType: Type, completionsType: Type | undefined, obj: ObjectLiteralExpression | JsxAttributes, checker: TypeChecker): Symbol[] {
         const hasCompletionsType = completionsType && completionsType !== contextualType;
         const type = hasCompletionsType && !(completionsType!.flags & TypeFlags.AnyOrUnknown)
             ? checker.getUnionType([contextualType, completionsType!])

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -163,7 +163,7 @@ namespace ts.Completions.StringCompletions {
                     //      foo({
                     //          '/*completion position*/'
                     //      });
-                    return stringLiteralCompletionsFromProperties(typeChecker.getContextualType(parent.parent));
+                    return stringLiteralCompletionsForObjectLiteral(typeChecker, parent.parent);
                 }
                 return fromContextualType();
 
@@ -251,6 +251,25 @@ namespace ts.Completions.StringCompletions {
             kind: StringLiteralCompletionKind.Properties,
             symbols: filter(type.getApparentProperties(), prop => !(prop.valueDeclaration && isPrivateIdentifierPropertyDeclaration(prop.valueDeclaration))),
             hasIndexSignature: hasIndexSignature(type)
+        };
+    }
+
+    function stringLiteralCompletionsForObjectLiteral(checker: TypeChecker, objectLiteralExpression: ObjectLiteralExpression): StringLiteralCompletionsFromProperties | undefined {
+        const contextualType = checker.getContextualType(objectLiteralExpression);
+        if (!contextualType) return undefined;
+
+        const completionsType = checker.getContextualType(objectLiteralExpression, ContextFlags.Completions);
+        const symbols = getPropertiesForObjectExpression(
+            contextualType,
+            completionsType,
+            objectLiteralExpression,
+            checker
+        );
+
+        return {
+            kind: StringLiteralCompletionKind.Properties,
+            symbols,
+            hasIndexSignature: hasIndexSignature(contextualType)
         };
     }
 

--- a/tests/cases/fourslash/completionsQuotedObjectLiteralUnion.ts
+++ b/tests/cases/fourslash/completionsQuotedObjectLiteralUnion.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+//// interface A {
+////   "a-prop": string;
+//// }
+//// 
+//// interface B {
+////   "b-prop": string;
+//// }
+//// 
+//// const obj: A | B = {
+////   "/*1*/"
+//// }
+
+verify.completions({
+  marker: "1",
+  exact: ["a-prop", "b-prop"]
+});


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #40568

Done as part of the Pursuit Fellowship workshop 🥳 

Thanks @jenama and @kwong0419!
