### PR TITLE
Shrink error span on @type errors for signatures

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33372,7 +33372,7 @@ namespace ts {
             if (isInJSFile(node)) {
                 const typeTag = getJSDocTypeTag(node);
                 if (typeTag && typeTag.typeExpression && !getContextualCallSignature(getTypeFromTypeNode(typeTag.typeExpression), node)) {
-                    error(typeTag, Diagnostics.The_type_of_a_function_declaration_must_match_the_function_s_signature);
+                    error(typeTag.typeExpression.type, Diagnostics.The_type_of_a_function_declaration_must_match_the_function_s_signature);
                 }
             }
         }

--- a/tests/baselines/reference/checkJsdocTypeTag5.errors.txt
+++ b/tests/baselines/reference/checkJsdocTypeTag5.errors.txt
@@ -4,7 +4,7 @@ tests/cases/conformance/jsdoc/test.js(7,24): error TS2322: Type 'number' is not 
 tests/cases/conformance/jsdoc/test.js(10,17): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsdoc/test.js(12,14): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsdoc/test.js(14,24): error TS2322: Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsdoc/test.js(28,5): error TS8030: The type of a function declaration must match the function's signature.
+tests/cases/conformance/jsdoc/test.js(28,12): error TS8030: The type of a function declaration must match the function's signature.
 tests/cases/conformance/jsdoc/test.js(34,5): error TS2322: Type '1 | 2' is not assignable to type '2 | 3'.
   Type '1' is not assignable to type '2 | 3'.
 
@@ -50,7 +50,7 @@ tests/cases/conformance/jsdoc/test.js(34,5): error TS2322: Type '1 | 2' is not a
     /** @typedef {{(s: string): 0 | 1; (b: boolean): 2 | 3 }} Gioconda */
     
     /** @type {Gioconda} */
-        ~~~~~~~~~~~~~~~~
+               ~~~~~~~~
 !!! error TS8030: The type of a function declaration must match the function's signature.
     function monaLisa(sb) {
         return typeof sb === 'string' ? 1 : 2;

--- a/tests/baselines/reference/checkJsdocTypeTag6.errors.txt
+++ b/tests/baselines/reference/checkJsdocTypeTag6.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/conformance/jsdoc/test.js(1,5): error TS8030: The type of a function declaration must match the function's signature.
+tests/cases/conformance/jsdoc/test.js(1,12): error TS8030: The type of a function declaration must match the function's signature.
 tests/cases/conformance/jsdoc/test.js(7,5): error TS2741: Property 'prop' is missing in type '(prop: any) => void' but required in type '{ prop: string; }'.
-tests/cases/conformance/jsdoc/test.js(10,5): error TS8030: The type of a function declaration must match the function's signature.
+tests/cases/conformance/jsdoc/test.js(10,12): error TS8030: The type of a function declaration must match the function's signature.
 
 
 ==== tests/cases/conformance/jsdoc/test.js (3 errors) ====
     /** @type {number} */
-        ~~~~~~~~~~~~~~
+               ~~~~~~
 !!! error TS8030: The type of a function declaration must match the function's signature.
     function f() {
         return 1
@@ -19,7 +19,7 @@ tests/cases/conformance/jsdoc/test.js(10,5): error TS8030: The type of a functio
     }
     
     /** @type {(a: number) => number} */
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+               ~~~~~~~~~~~~~~~~~~~~~
 !!! error TS8030: The type of a function declaration must match the function's signature.
     function add1(a, b) { return a + b; }
     

--- a/tests/baselines/reference/typeTagCircularReferenceOnConstructorFunction.errors.txt
+++ b/tests/baselines/reference/typeTagCircularReferenceOnConstructorFunction.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/conformance/jsdoc/bug27346.js(2,4): error TS8030: The type of a function declaration must match the function's signature.
+tests/cases/conformance/jsdoc/bug27346.js(2,11): error TS8030: The type of a function declaration must match the function's signature.
 
 
 ==== tests/cases/conformance/jsdoc/bug27346.js (1 errors) ====
     /**
      * @type {MyClass}
-       ~~~~~~~~~~~~~~~
+              ~~~~~~~
 !!! error TS8030: The type of a function declaration must match the function's signature.
      */
     function MyClass() { }


### PR DESCRIPTION
Previously, the error span was too large on @type errors on functions
when the type was not a function. The span covered the entire tag. This
PR changes the error node just to be the type of the type tag. In other words,
the error span was previously this:

```
@type {IncorrectType}
```

But is now just this:

```
IncorrectType
```

Fixes the first error from #41974, but not the other two.

Thanks @ashyamanning and @neuhelos!