### PR TITLE
Fix find-all-refs crashing in some project references scenarios

### DIFF
--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -343,9 +343,11 @@ namespace ts.server {
             }));
         }
 
-        findReferences(_fileName: string, _position: number): ReferencedSymbol[] {
-            // Not yet implemented.
-            return [];
+        findReferences(fileName: string, position: number): ReferencedSymbol[] {
+            const args = this.createFileLocationRequestArgs(fileName, position);
+            const request = this.processRequest<protocol.ReferencesRequest>(CommandNames.ReferencesFull, args);
+            const response = this.processResponse(request);
+            return response.body;
         }
 
         getReferencesAtPosition(fileName: string, position: number): ReferenceEntry[] {

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -1117,7 +1117,9 @@ namespace FourSlash {
         }
 
         public verifyBaselineFindAllReferences(...markerNames: string[]) {
+            ts.Debug.assert(markerNames.length > 0, "Must pass at least one marker name to `baselineFindAllReferences()`");
             const baseline = markerNames.map(markerName => {
+                this.goToMarker(markerName);
                 const marker = this.getMarkerByName(markerName);
                 const references = this.languageService.findReferences(marker.fileName, marker.position);
                 const refsByFile = references
@@ -1200,7 +1202,7 @@ namespace FourSlash {
             }
         }
 
-        // Necessary to have this function since `findReferences` isn't implemented in `client.ts`
+        /** @deprecated - use `verify.baselineFindAllReferences()` instead. */
         public verifyGetReferencesForServerTest(expected: readonly ts.ReferenceEntry[]): void {
             const refs = this.getReferencesAtCaret();
             assert.deepEqual<readonly ts.ReferenceEntry[] | undefined>(refs, expected);

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -568,7 +568,7 @@ namespace ts.server {
     }
 
     function addToTodo<TLocation extends DocumentPosition | undefined>(project: Project, location: TLocation, toDo: Push<ProjectAndLocation<TLocation>>, seenProjects: Set<string>): void {
-        if (addToSeen(seenProjects, project)) toDo.push({ project, location });
+        if (!project.isOrphan() && addToSeen(seenProjects, project)) toDo.push({ project, location });
     }
 
     function addToSeen(seenProjects: Set<string>, project: Project) {

--- a/tests/baselines/reference/autoImportProvider_referencesCrash.baseline.jsonc
+++ b/tests/baselines/reference/autoImportProvider_referencesCrash.baseline.jsonc
@@ -1,0 +1,48 @@
+// === /b/b.ts ===
+// /// <reference path="../a/index.d.ts" />
+// new [|A|]/*FIND ALL REFS*/();
+
+[
+  {
+    "definition": {
+      "containerKind": "",
+      "containerName": "",
+      "fileName": "/a/index.ts",
+      "kind": "class",
+      "name": "class A",
+      "textSpan": {
+        "start": 10,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "class",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "A",
+          "kind": "className"
+        }
+      ],
+      "contextSpan": {
+        "start": 0,
+        "length": 10
+      }
+    },
+    "references": [
+      {
+        "textSpan": {
+          "start": 45,
+          "length": 1
+        },
+        "fileName": "/b/b.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      }
+    ]
+  }
+]

--- a/tests/cases/fourslash/server/autoImportProvider_referencesCrash.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_referencesCrash.ts
@@ -1,0 +1,43 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /a/package.json
+//// {}
+
+// @Filename: /a/tsconfig.json
+//// {}
+
+// @Filename: /a/index.ts
+//// class A {}
+
+// @Filename: /a/index.d.ts
+//// declare class A {
+//// }
+//// //# sourceMappingURL=index.d.ts.map
+
+// @Filename: /a/index.d.ts.map
+//// {"version":3,"file":"index.d.ts","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AAAA,OAAO,OAAO,CAAC;CAAG"}
+
+// @Filename: /b/tsconfig.json
+//// {
+////   "compilerOptions": { "disableSourceOfProjectReferenceRedirect": true },
+////   "references": [{ "path": "../a" }]
+//// }
+
+// @Filename: /b/b.ts
+//// /// <reference path="../a/index.d.ts" />
+//// new A/**/();
+
+// @Filename: /c/package.json
+//// { "dependencies": { "a": "*" } }
+
+// @Filename: /c/tsconfig.json
+//// { "references" [{ "path": "../a" }] }
+
+// @Filename: /c/index.ts
+//// export {};
+
+// @link: /a -> /c/node_modules/a
+
+// Test asserts lack of crash
+goTo.file("/c/index.ts"); // Create AutoImportProviderProject that has /a/index.d.ts in it
+verify.baselineFindAllReferences("");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #41971 

Thanks @amcasey for the repro help. This is one of those bugs that took 3 minutes to diagnose and fix, and 3 hours to come up with a failing test.
