### PR TITLE
Fix single-line comment disrupting return w/optional chain

### DIFF
--- a/src/compiler/transformers/es2020.ts
+++ b/src/compiler/transformers/es2020.ts
@@ -77,7 +77,6 @@ namespace ts {
                 if (!isSimpleCopiableExpression(expression)) {
                     thisArg = factory.createTempVariable(hoistVariableDeclaration);
                     expression = factory.createAssignment(thisArg, expression);
-                    // if (inParameterInitializer) tempVariableInParameter = true;
                 }
                 else {
                     thisArg = expression;
@@ -117,7 +116,6 @@ namespace ts {
             if (!isSimpleCopiableExpression(leftExpression)) {
                 capturedLeft = factory.createTempVariable(hoistVariableDeclaration);
                 leftExpression = factory.createAssignment(capturedLeft, leftExpression);
-                // if (inParameterInitializer) tempVariableInParameter = true;
             }
             let rightExpression = capturedLeft;
             let thisArg: Expression | undefined;
@@ -130,7 +128,6 @@ namespace ts {
                             if (!isSimpleCopiableExpression(rightExpression)) {
                                 thisArg = factory.createTempVariable(hoistVariableDeclaration);
                                 rightExpression = factory.createAssignment(thisArg, rightExpression);
-                                // if (inParameterInitializer) tempVariableInParameter = true;
                             }
                             else {
                                 thisArg = rightExpression;
@@ -163,6 +160,7 @@ namespace ts {
             const target = isDelete
                 ? factory.createConditionalExpression(createNotNullCondition(leftExpression, capturedLeft, /*invert*/ true), /*questionToken*/ undefined, factory.createTrue(), /*colonToken*/ undefined, factory.createDeleteExpression(rightExpression))
                 : factory.createConditionalExpression(createNotNullCondition(leftExpression, capturedLeft, /*invert*/ true), /*questionToken*/ undefined, factory.createVoidZero(), /*colonToken*/ undefined, rightExpression);
+            setTextRange(target, node);
             return thisArg ? factory.createSyntheticReferenceExpression(target, thisArg) : target;
         }
 
@@ -188,15 +186,14 @@ namespace ts {
             if (!isSimpleCopiableExpression(left)) {
                 right = factory.createTempVariable(hoistVariableDeclaration);
                 left = factory.createAssignment(right, left);
-                // if (inParameterInitializer) tempVariableInParameter = true;
             }
-            return factory.createConditionalExpression(
+            return setTextRange(factory.createConditionalExpression(
                 createNotNullCondition(left, right),
                 /*questionToken*/ undefined,
                 right,
                 /*colonToken*/ undefined,
                 visitNode(node.right, visitor, isExpression),
-            );
+            ), node);
         }
 
         function visitDeleteExpression(node: DeleteExpression) {

--- a/tests/baselines/reference/optionalChainingInArrow.js
+++ b/tests/baselines/reference/optionalChainingInArrow.js
@@ -1,0 +1,13 @@
+//// [optionalChainingInArrow.ts]
+// https://github.com/microsoft/TypeScript/issues/41814
+const test = (names: string[]) =>
+    // single-line comment
+    names?.filter(x => x);
+
+
+//// [optionalChainingInArrow.js]
+// https://github.com/microsoft/TypeScript/issues/41814
+var test = function (names) {
+    // single-line comment
+    return names === null || names === void 0 ? void 0 : names.filter(function (x) { return x; });
+};

--- a/tests/cases/conformance/expressions/optionalChaining/optionalChainingInArrow.ts
+++ b/tests/cases/conformance/expressions/optionalChaining/optionalChainingInArrow.ts
@@ -1,0 +1,6 @@
+// @target: es5
+// @noTypesAndSymbols: true
+// https://github.com/microsoft/TypeScript/issues/41814
+const test = (names: string[]) =>
+    // single-line comment
+    names?.filter(x => x);


### PR DESCRIPTION
This copies the text range of the optional chaining argument to the synthetic outer expression so we can correctly "move" the comments to the `return` statement (by copying the text range from the resulting expression to the `return` in `convertToFunctionBlock`).

This also removes some unnecessary commented code from the es2020 transform.

Fixes #41814
