### PR TITLE
Less verbose transform of nullish coalescing and optional chaining

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7912,9 +7912,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.12.2",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.2.tgz",
-            "integrity": "sha512-rWYleAvfJPjduYCt+ELvzybNah/zIkRteGXIBO8X0lteRZPGladF61hFi8tU7qKTsF7u6DUQCtT9k00VlFOgkg==",
+            "version": "3.12.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.3.tgz",
+            "integrity": "sha512-feZzR+kIcSVuLi3s/0x0b2Tx4Iokwqt+8PJM7yRHKuldg4MLdam4TCFeICv+lgDtuYiCtdmrtIP+uN9LWvDasw==",
             "dev": true,
             "optional": true
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -585,9 +585,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.14.14",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
-            "integrity": "sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==",
+            "version": "14.14.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.16.tgz",
+            "integrity": "sha512-naXYePhweTi+BMv11TgioE2/FXU4fSl29HAH1ffxVciNsH3rYXjNP2yM8wqmSm7jS20gM8TIklKiTen+1iVncw==",
             "dev": true
         },
         "@types/node-fetch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -324,9 +324,9 @@
             }
         },
         "@octokit/openapi-types": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-2.0.0.tgz",
-            "integrity": "sha512-J4bfM7lf8oZvEAdpS71oTvC1ofKxfEZgU5vKVwzZKi4QPiL82udjpseJwxPid9Pu2FNmyRQOX4iEj6W1iOSnPw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-2.0.1.tgz",
+            "integrity": "sha512-9AuC04PUnZrjoLiw3uPtwGh9FE4Q3rTqs51oNlQ0rkwgE8ftYsOC+lsrQyvCvWm85smBbSc0FNRKKumvGyb44Q==",
             "dev": true
         },
         "@octokit/plugin-paginate-rest": {
@@ -402,12 +402,12 @@
             }
         },
         "@octokit/types": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.1.1.tgz",
-            "integrity": "sha512-btm3D6S7VkRrgyYF31etUtVY/eQ1KzrNRqhFt25KSe2mKlXuLXJilglRC6eDA2P6ou94BUnk/Kz5MPEolXgoiw==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.1.2.tgz",
+            "integrity": "sha512-LPCpcLbcky7fWfHCTuc7tMiSHFpFlrThJqVdaHgowBTMS0ijlZFfonQC/C1PrZOjD4xRCYgBqH9yttEATGE/nw==",
             "dev": true,
             "requires": {
-                "@octokit/openapi-types": "^2.0.0",
+                "@octokit/openapi-types": "^2.0.1",
                 "@types/node": ">= 8"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3757,9 +3757,9 @@
             "dev": true
         },
         "get-intrinsic": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-            "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+            "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
             "dev": true,
             "requires": {
                 "function-bind": "^1.1.1",

--- a/src/compiler/transformers/es2020.ts
+++ b/src/compiler/transformers/es2020.ts
@@ -158,25 +158,17 @@ namespace ts {
             }
 
             const target = isDelete
-                ? factory.createConditionalExpression(createNotNullCondition(leftExpression, capturedLeft, /*invert*/ true), /*questionToken*/ undefined, factory.createTrue(), /*colonToken*/ undefined, factory.createDeleteExpression(rightExpression))
-                : factory.createConditionalExpression(createNotNullCondition(leftExpression, capturedLeft, /*invert*/ true), /*questionToken*/ undefined, factory.createVoidZero(), /*colonToken*/ undefined, rightExpression);
+                ? factory.createConditionalExpression(createNotNullishCondition(leftExpression, /*invert*/ true), /*questionToken*/ undefined, factory.createTrue(), /*colonToken*/ undefined, factory.createDeleteExpression(rightExpression))
+                : factory.createConditionalExpression(createNotNullishCondition(leftExpression, /*invert*/ true), /*questionToken*/ undefined, factory.createVoidZero(), /*colonToken*/ undefined, rightExpression);
             setTextRange(target, node);
             return thisArg ? factory.createSyntheticReferenceExpression(target, thisArg) : target;
         }
 
-        function createNotNullCondition(left: Expression, right: Expression, invert?: boolean) {
+        function createNotNullishCondition(expr: Expression, invert?: boolean) {
             return factory.createBinaryExpression(
-                factory.createBinaryExpression(
-                    left,
-                    factory.createToken(invert ? SyntaxKind.EqualsEqualsEqualsToken : SyntaxKind.ExclamationEqualsEqualsToken),
-                    factory.createNull()
-                ),
-                factory.createToken(invert ? SyntaxKind.BarBarToken : SyntaxKind.AmpersandAmpersandToken),
-                factory.createBinaryExpression(
-                    right,
-                    factory.createToken(invert ? SyntaxKind.EqualsEqualsEqualsToken : SyntaxKind.ExclamationEqualsEqualsToken),
-                    factory.createVoidZero()
-                )
+                expr,
+                factory.createToken(invert ? SyntaxKind.EqualsEqualsToken : SyntaxKind.ExclamationEqualsToken),
+                factory.createNull()
             );
         }
 
@@ -188,7 +180,7 @@ namespace ts {
                 left = factory.createAssignment(right, left);
             }
             return setTextRange(factory.createConditionalExpression(
-                createNotNullCondition(left, right),
+                createNotNullishCondition(left),
                 /*questionToken*/ undefined,
                 right,
                 /*colonToken*/ undefined,


### PR DESCRIPTION
Less verbose transform of nullish coalescing and optional chaining.

The expression:

    (a !== null && a !== void 0)

is equivalent to:

    (a != null)

This PR takes into account that fact and uses that in order to produce less code in the transformed files.

See http://adripofjavascript.com/blog/drips/equals-equals-null-in-javascript.html

Linked issue #42047 
