### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -33,10 +33,10 @@ Note: The TypeScript Playground can be used to try older verions of TypeScript.
 
 Please keep and fill in the line that best applies:
 -->
- - This is a crash
- - This changed between versions ______ and _______
- - This is the behavior in every version I tried, and I reviewed the FAQ for entries about _________
- - I was unable to test this on prior versions because _______
+- This is a crash
+- This changed between versions ______ and _______
+- This is the behavior in every version I tried, and I reviewed the FAQ for entries about _________
+- I was unable to test this on prior versions because _______
 
 ### ⏯ Playground Link
 

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -4,41 +4,70 @@ about: Create a report to help us improve TypeScript
 title: ''
 labels: ''
 assignees: ''
-
 ---
-
-<!-- 🚨 STOP 🚨 STOP 🚨 STOP 🚨
-
-Half of all issues filed here are duplicates, answered in the FAQ, or not appropriate for the bug tracker. Even if you think you've found a *bug*, please read the FAQ first, especially the Common "Bugs" That Aren't Bugs section!
-
-Please help us by doing the following steps before logging an issue:
-  * Search: https://github.com/Microsoft/TypeScript/search?type=Issues
-  * Read the FAQ: https://github.com/Microsoft/TypeScript/wiki/FAQ
-
-Please fill in the *entire* template below.
--->
+# Bug Report
 
 <!--
-Please try to reproduce the issue with the latest published version. It may have already been fixed.
+  Please fill in each section completely. Thank you!
+-->
+
+### 🔎 Search Terms
+
+<!--
+  What search terms did you use when trying to find an existing bug report?
+  List them here so people in the future can find this one more easily.
+-->
+
+### 🕗 Version & Regression Information
+
+<!-- When did you start seeing this bug occur?
+
+"Bugs" that have existed in TS for a long time are very likely to be FAQs; refer to
+  https://github.com/Microsoft/TypeScript/wiki/FAQ#common-bugs-that-arent-bugs
+
+If possible, please try testing the nightly version of TS to see if it's already been fixed.
 For npm: `typescript@next`
 This is also the 'Nightly' version in the playground: http://www.typescriptlang.org/play/?ts=Nightly
+
+Note: The TypeScript Playground can be used to try older verions of TypeScript.
+
+Please keep and fill in the line that best applies:
 -->
-**TypeScript Version:**  3.7.x-dev.201xxxxx
+ - This is a crash
+ - This changed between versions ______ and _______
+ - This is the behavior in every version I tried, and I reviewed the FAQ for entries about _________
+ - I was unable to test this on prior versions because _______
 
-<!-- Search terms you tried before logging this (so others can find this issue more easily) -->
-**Search Terms:**
+### ⏯ Playground Link
 
-**Code**
+<!--
+  A link to a TypeScript Playground "Share" link which shows this behavior
 
+  The TypeScript Workbench can be used for more complex setups, try
+  https://www.typescriptlang.org/dev/bug-workbench/
+
+  As a last resort, you can link to a repo, but these will be slower for us to investigate.
+-->
+[Playground link with relevant code](https://www.typescriptlang.org/play?#code/PTAEFkE9QYwewCYFNQHM5IM6gBZIE5JA)
+
+### 💻 Code
+
+<!-- Please post the relevant code sample here as well-->
 ```ts
-// A *self-contained* demonstration of the problem follows...
-// Test this by running `tsc` on the command-line, rather than through another build tool such as Gulp, Webpack, etc.
+// We can quickly address your report if:
+//  - The code sample is short. Nearly all TypeScript bugs can be demonstrated in 20-30 lines of code!
+//  - It doesn't use external libraries. These are often issues with the type definitions rather than TypeScript bugs.
+//  - The incorrectness of the behavior is readily apparent from reading the sample.
+// Reports are slower to investigate if:
+//  - We have to pare too much extraneous code.
+//  - We have to clone a large repo and validate that the problem isn't elsewhere.
+//  - The sample is confusing or doesn't clearly demonstrate what's wrong.
 ```
 
-**Expected behavior:**
+### 🙂 Expected behavior
 
-**Actual behavior:**
+<!-- What you expected to happen, and why -->
 
-**Playground Link:** <!-- A link to a TypeScript Playground "Share" link which demonstrates this behavior -->
+### 🙁 Actual behavior
 
-**Related Issues:** <!-- Did you find other bugs that looked similar? -->
+<!-- What actually happened instead, and why it was wrong -->

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -64,10 +64,10 @@ Please keep and fill in the line that best applies:
 //  - The sample is confusing or doesn't clearly demonstrate what's wrong.
 ```
 
-### 🙂 Expected behavior
-
-<!-- What you expected to happen, and why -->
-
 ### 🙁 Actual behavior
 
-<!-- What actually happened instead, and why it was wrong -->
+<!-- What happened, and why it was wrong -->
+
+### 🙂 Expected behavior
+
+<!-- What you expected to happen instead, and why -->

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -4,44 +4,56 @@ about: Suggest an idea
 title: ''
 labels: ''
 assignees: ''
-
 ---
-
-<!-- 🚨 STOP 🚨 𝗦𝗧𝗢𝗣 🚨 𝑺𝑻𝑶𝑷 🚨
-
-Half of all issues filed here are duplicates, answered in the FAQ, or not appropriate for the bug tracker.
-
-Please help us by doing the following steps before logging an issue:
-  * Search: https://github.com/Microsoft/TypeScript/search?type=Issues
-  * Read the FAQ, especially the "Common Feature Requests" section: https://github.com/Microsoft/TypeScript/wiki/FAQ
-
--->
-
-## Search Terms
-
-<!-- List of keywords you searched for before creating this issue. Write them down here so that others can find this suggestion more easily -->
-
-## Suggestion
-
-<!-- A summary of what you'd like to see added or changed -->
-
-## Use Cases
+# Suggestion
 
 <!--
-What do you want to use this for?
-What shortcomings exist with current approaches?
+  Please fill in each section completely. Thank you!
 -->
 
-## Examples
+## 🔍 Search Terms
 
-<!-- Show how this would be used and what the behavior would be -->
+<!--
+  💡 Did you know? TypeScript has over 2,000 open suggestions!
+  🔎 Please search thoroughly before logging new feature requests as most common ideas already have a proposal in progress.
+  The "Common Feature Requests" section of the FAQ lists many popular requests: https://github.com/Microsoft/TypeScript/wiki/FAQ#common-feature-requests
 
-## Checklist
+  Replace the text below:
+-->
 
+List of keywords you searched for before creating this issue. Write them down here so that others can find this suggestion more easily and help provide feedback.
+
+## ✅ Viability Checklist
+
+<!--
+   Suggestions that don't meet all these criteria are very, very unlikely to be accepted.
+   We always recommend reviewing the TypeScript design goals before investing time writing
+   a proposal for ideas outside the scope of the project.
+-->
 My suggestion meets these guidelines:
 
 * [ ] This wouldn't be a breaking change in existing TypeScript/JavaScript code
 * [ ] This wouldn't change the runtime behavior of existing JavaScript code
 * [ ] This could be implemented without emitting different JS based on the types of the expressions
-* [ ] This isn't a runtime feature (e.g. library functionality, non-ECMAScript syntax with JavaScript output, etc.)
+* [ ] This isn't a runtime feature (e.g. library functionality, non-ECMAScript syntax with JavaScript output, new syntax sugar for JS, etc.)
 * [ ] This feature would agree with the rest of [TypeScript's Design Goals](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Design-Goals).
+
+
+## ⭐ Suggestion
+
+<!-- A summary of what you'd like to see added or changed -->
+
+## 💻 Use Cases
+
+<!--
+  What do you want to use this for?
+  What shortcomings exist with current approaches?
+  What workarounds are you using in the meantime?
+-->
+
+## 📃 Motivating Example
+
+<!--
+  If you were announcing this feature in a blog post, what's a short explanation that shows
+  a developer why this feature improves the language?
+-->

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -43,17 +43,17 @@ My suggestion meets these guidelines:
 
 <!-- A summary of what you'd like to see added or changed -->
 
+## 📃 Motivating Example
+
+<!--
+  If you were announcing this feature in a blog post, what's a short explanation that shows
+  a developer why this feature improves the language?
+-->
+
 ## 💻 Use Cases
 
 <!--
   What do you want to use this for?
   What shortcomings exist with current approaches?
   What workarounds are you using in the meantime?
--->
-
-## 📃 Motivating Example
-
-<!--
-  If you were announcing this feature in a blog post, what's a short explanation that shows
-  a developer why this feature improves the language?
 -->

--- a/.github/ISSUE_TEMPLATE/lib_change.md
+++ b/.github/ISSUE_TEMPLATE/lib_change.md
@@ -1,0 +1,54 @@
+---
+name: Library change
+about: Fix or improve issues with built-in type definitions like `lib.dom.d.ts`, `lib.es6.d.ts`, etc.
+title: ''
+labels: ''
+assignees: ''
+---
+# lib Update Request
+
+<!--
+  Please fill in each section completely. Thank you!
+
+  Are you here for one of these commonly-requested lib changes?
+    * Object.keys - see https://stackoverflow.com/questions/55012174/
+    * Array methods - see https://github.com/microsoft/TypeScript/issues/36554
+    * parseInt, parseFloat, isFinite, isNan, etc. - see https://github.com/microsoft/TypeScript/issues/4002
+
+  The DOM lib is maintained elsewhere and you can skip a step by filing issues/PRs for the DOM at that repo.
+  See https://github.com/microsoft/TypeScript-DOM-lib-generator
+-->
+
+## Configuration Check
+
+<!--
+  If you're missing common new methods like Array.includes, you have a misconfigured project.
+  Try setting lib: "es2020" and checking whether the type you want is present.
+
+  Conversely, if you are seeing built-in methods you expect to *not* see, check your 'lib' setting
+  or review your dependencies for lib/reference directives that might be polluting
+  your global scope. This is common when using the 'node' type library; see https://github.com/microsoft/TypeScript/issues/40184
+
+  Replace the text below:
+-->
+My compilation *target* is `ES2015` and my *lib* is `the default`.
+
+## Missing / Incorrect Definition
+
+<!--
+  What property, method, function, etc is missing or incorrect?
+-->
+
+## Sample Code
+
+<!--
+  What's some code using this that should work, but doesn't?
+-->
+
+## Documentation Link
+
+<!--
+  Link to relevant documentation (e.g. MDN, W3C, ECMAScript Spec) to consult for this property.
+  Note that lib.dom.d.ts intentionally does not include browser-specific extensions
+   or early experimental features.
+-->

--- a/.github/ISSUE_TEMPLATE/lib_change.md
+++ b/.github/ISSUE_TEMPLATE/lib_change.md
@@ -23,7 +23,8 @@ assignees: ''
 
 <!--
   If you're missing common new methods like Array.includes, you may have a misconfigured project.
-  Try setting lib: "es2020" and checking whether the type you want is present.
+  Try setting `lib: "es2020"` and checking whether the type you want is present.
+  You can diagnose further by running `tsc` with `--listFilesOnly` or `--showConfig`.
 
   Conversely, if you are seeing built-in methods you expect to *not* see, check your 'lib' setting
   or review your dependencies for lib/reference directives that might be polluting

--- a/.github/ISSUE_TEMPLATE/lib_change.md
+++ b/.github/ISSUE_TEMPLATE/lib_change.md
@@ -13,7 +13,7 @@ assignees: ''
   Are you here for one of these commonly-requested lib changes?
     * Object.keys - see https://stackoverflow.com/questions/55012174/
     * Array methods - see https://github.com/microsoft/TypeScript/issues/36554
-    * parseInt, parseFloat, isFinite, isNan, etc. - see https://github.com/microsoft/TypeScript/issues/4002
+    * parseInt, parseFloat, isFinite, isNaN, etc. - see https://github.com/microsoft/TypeScript/issues/4002
 
   The DOM lib is maintained elsewhere and you can skip a step by filing issues/PRs for the DOM at that repo.
   See https://github.com/microsoft/TypeScript-DOM-lib-generator

--- a/.github/ISSUE_TEMPLATE/lib_change.md
+++ b/.github/ISSUE_TEMPLATE/lib_change.md
@@ -22,7 +22,7 @@ assignees: ''
 ## Configuration Check
 
 <!--
-  If you're missing common new methods like Array.includes, you have a misconfigured project.
+  If you're missing common new methods like Array.includes, you may have a misconfigured project.
   Try setting lib: "es2020" and checking whether the type you want is present.
 
   Conversely, if you are seeing built-in methods you expect to *not* see, check your 'lib' setting

--- a/.github/ISSUE_TEMPLATE/lib_change.md
+++ b/.github/ISSUE_TEMPLATE/lib_change.md
@@ -27,7 +27,7 @@ assignees: ''
 
   Conversely, if you are seeing built-in methods you expect to *not* see, check your 'lib' setting
   or review your dependencies for lib/reference directives that might be polluting
-  your global scope. This is common when using the 'node' type library; see https://github.com/microsoft/TypeScript/issues/40184
+  your global scope. This is common when using the 'node' type library. See https://github.com/microsoft/TypeScript/issues/40184
 
   Replace the text below:
 -->


### PR DESCRIPTION
Goals of this PR:
 * Make the repo more "welcoming" - yelling at people in the template isn't friendly, and doesn't seem to have affected behavior in any measurable sense
 * Make the templates less "wall-of-text"y by using markdown header sections and emoji to more clearly visually break apart each section
 * Reorder the sections to create a "funnel" that encourages people to do things in the right order (search, **regress**, *then* describe)
 * Add a new template for the common case of DOM/lib updates
 * Encourage filers to explicitly identify regressions, since we care a lot about these, and also funnels "has always been this way" bugs into the FAQ more explicitly rather than upfront

I removed the "related issues" since I have rarely found it to be useful.