### PR TITLE
Add missing NumberFormatPartTypes types

### DIFF
--- a/src/lib/esnext.intl.d.ts
+++ b/src/lib/esnext.intl.d.ts
@@ -1,5 +1,5 @@
 declare namespace Intl {
-    type NumberFormatPartTypes = "currency" | "decimal" | "fraction" | "group" | "infinity" | "integer" | "literal" | "minusSign" | "nan" | "plusSign" | "percentSign";
+    type NumberFormatPartTypes = "compact" | "currency" | "decimal" | "exponentInteger" | "exponentMinusSign" | "exponentSeparator" | "fraction" | "group" | "infinity" | "integer" | "literal" | "minusSign" | "nan" | "plusSign" | "percentSign" | "unit" | "unknown";
 
     interface NumberFormatPart {
         type: NumberFormatPartTypes;


### PR DESCRIPTION
Adds 7 additional types found in ECMA-402, 7th ed. June 2020, https://www.ecma-international.org/ecma-402/#numberformat-objects (17 in total)

Fixes #42004, #42063
