### PR TITLE
Stricter type for ES5 Intl, redefine ES2020 intl

### DIFF
--- a/src/lib/es2020.intl.d.ts
+++ b/src/lib/es2020.intl.d.ts
@@ -55,6 +55,239 @@ declare namespace Intl {
     type RelativeTimeFormatStyle = "long" | "short" | "narrow";
 
     /**
+     * Unicode Calendar Identifier
+     *
+     * [Reference](http://unicode.org/reports/tr35/#UnicodeCalendarIdentifier)
+     *
+     * [Source](https://github.com/unicode-org/cldr/blob/b805d0b/common/bcp47/calendar.xml)
+     */
+    type Calendar =
+        // Thai Buddhist calendar
+        | "buddhist"
+        // Traditional Chinese calendar
+        | "chinese"
+        // Coptic calendar
+        | "coptic"
+        // Traditional Korean calendar
+        | "dangi"
+        // Ethiopic calendar, Amete Alem (epoch approx. 5493 B.C.E)
+        | "ethiopic-amete-alem" | "ethioaa"
+        // Ethiopic calendar, Amete Mihret (epoch approx, 8 C.E.)
+        | "ethiopic"
+        // Gregorian calendar
+        | "gregorian"
+        // Gregorian calendar (alias)
+        | "gregory"
+        // Traditional Hebrew calendar
+        | "hebrew"
+        // Indian calendar
+        | "indian"
+        // Islamic calendar
+        | "islamic"
+        // Islamic calendar, Umm al-Qura
+        | "islamic-umalqura"
+        // Islamic calendar, tabular (intercalary years [2,5,7,10,13,16,18,21,24,26,29] - astronomical epoch)
+        | "islamic-tbla"
+        // Islamic calendar, tabular (intercalary years [2,5,7,10,13,16,18,21,24,26,29] - civil epoch)
+        | "islamic-civil"
+        | "islamicc"  // Deprecated alias
+        // Islamic calendar, Saudi Arabia sighting
+        | "islamic-rgsa"
+        // ISO calendar (Gregorian calendar using the ISO 8601 calendar week rules)
+        | "iso8601"
+        // Japanese Imperial calendar
+        | "japanese"
+        // Persian calendar
+        | "persian"
+        // Republic of China calendar
+        | "roc"
+        ;
+
+    /**
+     * Unicode Number System Identifier
+     *
+     * [Reference](http://unicode.org/reports/tr35/#UnicodeNumberSystemIdentifier)
+     *
+     * [Source](https://github.com/unicode-org/cldr/blob/be7a953/common/bcp47/number.xml)
+     */
+    type NumberingSystem =
+        // Adlam digits
+        | "adlm"
+        // Ahom digits
+        | "ahom"
+        // Arabic-Indic digits
+        | "arab"
+        // Extended Arabic-Indic digits
+        | "arabext"
+        // Armenian upper case numerals — algorithmic
+        | "armn"
+        // Armenian lower case numerals — algorithmic
+        | "armnlow"
+        // Balinese digits
+        | "bali"
+        // Bengali digits
+        | "beng"
+        // Bhaiksuki digits
+        | "bhks"
+        // Brahmi digits
+        | "brah"
+        // Chakma digits
+        | "cakm"
+        // Cham digits
+        | "cham"
+        // Cyrillic numerals — algorithmic
+        | "cyrl"
+        // Devanagari digits
+        | "deva"
+        // Dives Akuru digits
+        | "diak"
+        // Ethiopic numerals — algorithmic
+        | "ethi"
+        // Financial numerals — may be algorithmic
+        | "finance"
+        // Full width digits
+        | "fullwide"
+        // Georgian numerals — algorithmic
+        | "geor"
+        // Gunjala Gondi digits
+        | "gong"
+        // Masaram Gondi digits
+        | "gonm"
+        // Greek upper case numerals — algorithmic
+        | "grek"
+        // Greek lower case numerals — algorithmic
+        | "greklow"
+        // Gujarati digits
+        | "gujr"
+        // Gurmukhi digits
+        | "guru"
+        // Han-character day-of-month numbering for lunar/other traditional calendars"
+        | "hanidays"
+        // Positional decimal system using Chinese number ideographs as digits
+        | "hanidec"
+        // Simplified Chinese numerals — algorithmic
+        | "hans"
+        // Simplified Chinese financial numerals — algorithmic
+        | "hansfin"
+        // Traditional Chinese numerals — algorithmic
+        | "hant"
+        // Traditional Chinese financial numerals — algorithmic
+        | "hantfin"
+        // Hebrew numerals — algorithmic
+        | "hebr"
+        // Pahawh Hmong digits
+        | "hmng"
+        // Nyiakeng Puachue Hmong digits
+        | "hmnp"
+        // Javanese digits
+        | "java"
+        // Japanese numerals — algorithmic
+        | "jpan"
+        // Japanese financial numerals — algorithmic
+        | "jpanfin"
+        // Japanese first-year Gannen numbering for Japanese calendar
+        | "jpanyear"
+        // Kayah Li digits
+        | "kali"
+        // Khmer digits
+        | "khmr"
+        // Kannada digits
+        | "knda"
+        // Tai Tham Hora (secular) digits
+        | "lana"
+        // Tai Tham Tham (ecclesiastical) digits
+        | "lanatham"
+        // Lao digits
+        | "laoo"
+        // Latin digits
+        | "latn"
+        // Lepcha digits
+        | "lepc"
+        // Limbu digits
+        | "limb"
+        // Mathematical bold digits
+        | "mathbold"
+        // Mathematical double-struck digits
+        | "mathdbl"
+        // Mathematical monospace digits
+        | "mathmono"
+        // Mathematical sans-serif bold digits
+        | "mathsanb"
+        // Mathematical sans-serif digits
+        | "mathsans"
+        // Malayalam digits
+        | "mlym"
+        // Modi digits
+        | "modi"
+        // Mongolian digits
+        | "mong"
+        // Mro digits
+        | "mroo"
+        // Meetei Mayek digits
+        | "mtei"
+        // Myanmar digits
+        | "mymr"
+        // Myanmar Shan digits
+        | "mymrshan"
+        // Myanmar Tai Laing digits
+        | "mymrtlng"
+        // Native digits
+        | "native"
+        // Newa digits
+        | "newa"
+        // N'Ko digits
+        | "nkoo"
+        // Ol Chiki digits
+        | "olck"
+        // Oriya digits
+        | "orya"
+        // Osmanya digits
+        | "osma"
+        // Hanifi Rohingya digits
+        | "rohg"
+        // Roman upper case numerals — algorithmic
+        | "roman"
+        // Roman lowercase numerals — algorithmic
+        | "romanlow"
+        // Saurashtra digits
+        | "saur"
+        // Sharada digits
+        | "shrd"
+        // Khudawadi digits
+        | "sind"
+        // Sinhala Lith digits
+        | "sinh"
+        // Sora_Sompeng digits
+        | "sora"
+        // Sundanese digits
+        | "sund"
+        // Takri digits
+        | "takr"
+        // New Tai Lue digits
+        | "talu"
+        // Tamil numerals — algorithmic
+        | "taml"
+        // Modern Tamil decimal digits
+        | "tamldec"
+        // Telugu digits
+        | "telu"
+        // Thai digits
+        | "thai"
+        // Tirhuta digits
+        | "tirh"
+        // Tibetan digits
+        | "tibt"
+        // Traditional numerals — may be algorithmic
+        | "traditional" | "traditio"
+        // Vai digits
+        | "vaii"
+        // Warang Citi digits
+        | "wara"
+        // Wancho digits
+        | "wcho"
+        ;
+
+    /**
      * An object with some or all of properties of `options` parameter
      * of `Intl.RelativeTimeFormat` constructor.
      *
@@ -281,23 +514,10 @@ declare namespace Intl {
     interface DateTimeFormatOptions {
         dateStyle?: "full" | "long" | "medium" | "short";
         timeStyle?: "full" | "long" | "medium" | "short";
-        calendar?: "buddhist" | "chinese" | " coptic" | "ethiopia" | "ethiopic" | "gregory" | " hebrew" | "indian" | "islamic" | "iso8601" | " japanese" | "persian" | "roc";
-        dayPeriod?: "narrow" | "short" | " long";
-        numberingSystem?: "arab" | "arabext" | " bali" | "beng" | "deva" | "fullwide" | " gujr" | "guru" | "hanidec" | "khmr" | " knda" | "laoo" | "latn" | "limb" | "mlym" | " mong" | "mymr" | "orya" | "tamldec" | " telu" | "thai" | "tibt";
-        localeMatcher?: "best fit" | "lookup";
-        timeZone?: string;
-        hour12?: boolean;
+        calendar?: Calendar;
+        dayPeriod?: "narrow" | "short" | "long";
+        numberingSystem?: NumberingSystem;
         hourCycle?: "h11" | "h12" | "h23" | "h24";
-        formatMatcher?: "best fit" | "basic";
-        weekday?: "long" | "short" | "narrow";
-        era?: "long" | "short" | "narrow";
-        year?: "numeric" | "2-digit";
-        month?: "numeric" | "2-digit" | "long" | "short" | "narrow";
-        day?: "numeric" | "2-digit";
-        hour?: "numeric" | "2-digit";
-        minute?: "numeric" | "2-digit";
-        second?: "numeric" | "2-digit";
         fractionalSecondDigits?: 0 | 1 | 2 | 3;
-        timeZoneName?: "long" | "short";
     }
 }

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4318,17 +4318,17 @@ declare namespace Intl {
     };
 
     interface DateTimeFormatOptions {
-        localeMatcher?: string;
-        weekday?: string;
-        era?: string;
-        year?: string;
-        month?: string;
-        day?: string;
-        hour?: string;
-        minute?: string;
-        second?: string;
-        timeZoneName?: string;
-        formatMatcher?: string;
+        localeMatcher?: "best fit" | "lookup";
+        weekday?: "long" | "short" | "narrow";
+        era?: "long" | "short" | "narrow";
+        year?: "numeric" | "2-digit";
+        month?: "numeric" | "2-digit" | "long" | "short" | "narrow";
+        day?: "numeric" | "2-digit";
+        hour?: "numeric" | "2-digit";
+        minute?: "numeric" | "2-digit";
+        second?: "numeric" | "2-digit";
+        timeZoneName?: "long" | "short";
+        formatMatcher?: "best fit" | "basic";
         hour12?: boolean;
         timeZone?: string;
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #42128
