### PR TITLE
support type inference of object non-literal keys

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26387,6 +26387,12 @@ namespace ts {
                 }
                 if (element.name) {
                     const nameType = getLiteralTypeFromPropertyName(element.name);
+                    if (nameType.flags & (TypeFlags.StringLiteral | TypeFlags.NumberLiteral)) {
+                        const propType = getTypeOfPropertyOfContextualType(type, escapeLeadingUnderscores((nameType as LiteralType).value.toString()), nameType);
+                        if (propType) {
+                            return propType;
+                        }
+                    }
                     // We avoid calling getApplicableIndexInfo here because it performs potentially expensive intersection reduction.
                     return mapType(type, t => findApplicableIndexInfo(getIndexInfosOfStructuredType(t), nameType)?.type, /*noReductions*/ true);
                 }

--- a/tests/baselines/reference/contextualTypeInObjectProperty.errors.txt
+++ b/tests/baselines/reference/contextualTypeInObjectProperty.errors.txt
@@ -1,0 +1,71 @@
+tests/cases/compiler/contextualTypeInObjectProperty.ts(19,17): error TS7006: Parameter 'keyC' implicitly has an 'any' type.
+tests/cases/compiler/contextualTypeInObjectProperty.ts(24,3): error TS2464: A computed property name must be of type 'string', 'number', 'symbol', or 'any'.
+tests/cases/compiler/contextualTypeInObjectProperty.ts(24,11): error TS7006: Parameter 'keyC' implicitly has an 'any' type.
+
+
+==== tests/cases/compiler/contextualTypeInObjectProperty.ts (3 errors) ====
+    type Shape = { 
+        "a"?: (a: "a") => "a";
+        "b"?: (b: "b") => "b";
+        "c"?: (c: "c") => "c";
+    };
+    
+    const getC = () => "c" as const;
+    
+    export const obj: Shape = {
+      ["a"]: keyA => keyA,
+      ["b" as "b"]: keyB => keyB,
+      [getC()]: keyC => keyC,
+    };
+    
+    
+    const getUnion = () => "b" as "b" | "c";
+    
+    export const unionType: Shape = {
+      [getUnion()]: keyC => keyC,      // Error
+                    ~~~~
+!!! error TS7006: Parameter 'keyC' implicitly has an 'any' type.
+    };
+    
+    
+    export const func: Shape = {
+      [getC]: keyC => keyC,     // Error
+      ~~~~~~
+!!! error TS2464: A computed property name must be of type 'string', 'number', 'symbol', or 'any'.
+              ~~~~
+!!! error TS7006: Parameter 'keyC' implicitly has an 'any' type.
+    };
+    
+    const generic: {
+      c: <T>(arg: T) => T;
+    } = {
+      [getC()]: keyC => keyC,
+    };
+    
+    const thisType = {
+      [getC()]: function() {
+        this.c();
+      }
+    };
+    
+    
+    declare function f<T extends object>(data: T, handlers: { [P in keyof T]: (value: T[P], prop: P) => void; }): void;
+    f({ data: 0 }, {
+      [(() => 'data' as const)()](value, key) {
+    
+      },
+    });
+    
+    
+    enum Keys {
+      FIRST,
+      SECOND
+    }
+    
+    const obj2: {
+      [key in Keys]: [string, string] 
+    } = {
+      [Keys.FIRST]: ['1', '2'], 
+      [Keys['SECOND']]: ['3', '4']
+    }
+    

--- a/tests/baselines/reference/contextualTypeInObjectProperty.js
+++ b/tests/baselines/reference/contextualTypeInObjectProperty.js
@@ -1,0 +1,100 @@
+//// [contextualTypeInObjectProperty.ts]
+type Shape = { 
+    "a"?: (a: "a") => "a";
+    "b"?: (b: "b") => "b";
+    "c"?: (c: "c") => "c";
+};
+
+const getC = () => "c" as const;
+
+export const obj: Shape = {
+  ["a"]: keyA => keyA,
+  ["b" as "b"]: keyB => keyB,
+  [getC()]: keyC => keyC,
+};
+
+
+const getUnion = () => "b" as "b" | "c";
+
+export const unionType: Shape = {
+  [getUnion()]: keyC => keyC,      // Error
+};
+
+
+export const func: Shape = {
+  [getC]: keyC => keyC,     // Error
+};
+
+const generic: {
+  c: <T>(arg: T) => T;
+} = {
+  [getC()]: keyC => keyC,
+};
+
+const thisType = {
+  [getC()]: function() {
+    this.c();
+  }
+};
+
+
+declare function f<T extends object>(data: T, handlers: { [P in keyof T]: (value: T[P], prop: P) => void; }): void;
+f({ data: 0 }, {
+  [(() => 'data' as const)()](value, key) {
+
+  },
+});
+
+
+enum Keys {
+  FIRST,
+  SECOND
+}
+
+const obj2: {
+  [key in Keys]: [string, string] 
+} = {
+  [Keys.FIRST]: ['1', '2'], 
+  [Keys['SECOND']]: ['3', '4']
+}
+
+
+//// [contextualTypeInObjectProperty.js]
+"use strict";
+var _a, _b, _c, _d, _e, _f, _g;
+exports.__esModule = true;
+exports.func = exports.unionType = exports.obj = void 0;
+var getC = function () { return "c"; };
+exports.obj = (_a = {},
+    _a["a"] = function (keyA) { return keyA; },
+    _a["b"] = function (keyB) { return keyB; },
+    _a[getC()] = function (keyC) { return keyC; },
+    _a);
+var getUnion = function () { return "b"; };
+exports.unionType = (_b = {},
+    _b[getUnion()] = function (keyC) { return keyC; },
+    _b);
+exports.func = (_c = {},
+    _c[getC] = function (keyC) { return keyC; },
+    _c);
+var generic = (_d = {},
+    _d[getC()] = function (keyC) { return keyC; },
+    _d);
+var thisType = (_e = {},
+    _e[getC()] = function () {
+        this.c();
+    },
+    _e);
+f({ data: 0 }, (_f = {},
+    _f[(function () { return 'data'; })()] = function (value, key) {
+    },
+    _f));
+var Keys;
+(function (Keys) {
+    Keys[Keys["FIRST"] = 0] = "FIRST";
+    Keys[Keys["SECOND"] = 1] = "SECOND";
+})(Keys || (Keys = {}));
+var obj2 = (_g = {},
+    _g[Keys.FIRST] = ['1', '2'],
+    _g[Keys['SECOND']] = ['3', '4'],
+    _g);

--- a/tests/baselines/reference/contextualTypeInObjectProperty.symbols
+++ b/tests/baselines/reference/contextualTypeInObjectProperty.symbols
@@ -1,0 +1,166 @@
+=== tests/cases/compiler/contextualTypeInObjectProperty.ts ===
+type Shape = { 
+>Shape : Symbol(Shape, Decl(contextualTypeInObjectProperty.ts, 0, 0))
+
+    "a"?: (a: "a") => "a";
+>"a" : Symbol("a", Decl(contextualTypeInObjectProperty.ts, 0, 14))
+>a : Symbol(a, Decl(contextualTypeInObjectProperty.ts, 1, 11))
+
+    "b"?: (b: "b") => "b";
+>"b" : Symbol("b", Decl(contextualTypeInObjectProperty.ts, 1, 26))
+>b : Symbol(b, Decl(contextualTypeInObjectProperty.ts, 2, 11))
+
+    "c"?: (c: "c") => "c";
+>"c" : Symbol("c", Decl(contextualTypeInObjectProperty.ts, 2, 26))
+>c : Symbol(c, Decl(contextualTypeInObjectProperty.ts, 3, 11))
+
+};
+
+const getC = () => "c" as const;
+>getC : Symbol(getC, Decl(contextualTypeInObjectProperty.ts, 6, 5))
+>const : Symbol(const)
+
+export const obj: Shape = {
+>obj : Symbol(obj, Decl(contextualTypeInObjectProperty.ts, 8, 12))
+>Shape : Symbol(Shape, Decl(contextualTypeInObjectProperty.ts, 0, 0))
+
+  ["a"]: keyA => keyA,
+>["a"] : Symbol(["a"], Decl(contextualTypeInObjectProperty.ts, 8, 27))
+>"a" : Symbol(["a"], Decl(contextualTypeInObjectProperty.ts, 8, 27))
+>keyA : Symbol(keyA, Decl(contextualTypeInObjectProperty.ts, 9, 8))
+>keyA : Symbol(keyA, Decl(contextualTypeInObjectProperty.ts, 9, 8))
+
+  ["b" as "b"]: keyB => keyB,
+>["b" as "b"] : Symbol(["b" as "b"], Decl(contextualTypeInObjectProperty.ts, 9, 22))
+>keyB : Symbol(keyB, Decl(contextualTypeInObjectProperty.ts, 10, 15))
+>keyB : Symbol(keyB, Decl(contextualTypeInObjectProperty.ts, 10, 15))
+
+  [getC()]: keyC => keyC,
+>[getC()] : Symbol([getC()], Decl(contextualTypeInObjectProperty.ts, 10, 29))
+>getC : Symbol(getC, Decl(contextualTypeInObjectProperty.ts, 6, 5))
+>keyC : Symbol(keyC, Decl(contextualTypeInObjectProperty.ts, 11, 11))
+>keyC : Symbol(keyC, Decl(contextualTypeInObjectProperty.ts, 11, 11))
+
+};
+
+
+const getUnion = () => "b" as "b" | "c";
+>getUnion : Symbol(getUnion, Decl(contextualTypeInObjectProperty.ts, 15, 5))
+
+export const unionType: Shape = {
+>unionType : Symbol(unionType, Decl(contextualTypeInObjectProperty.ts, 17, 12))
+>Shape : Symbol(Shape, Decl(contextualTypeInObjectProperty.ts, 0, 0))
+
+  [getUnion()]: keyC => keyC,      // Error
+>[getUnion()] : Symbol([getUnion()], Decl(contextualTypeInObjectProperty.ts, 17, 33))
+>getUnion : Symbol(getUnion, Decl(contextualTypeInObjectProperty.ts, 15, 5))
+>keyC : Symbol(keyC, Decl(contextualTypeInObjectProperty.ts, 18, 15))
+>keyC : Symbol(keyC, Decl(contextualTypeInObjectProperty.ts, 18, 15))
+
+};
+
+
+export const func: Shape = {
+>func : Symbol(func, Decl(contextualTypeInObjectProperty.ts, 22, 12))
+>Shape : Symbol(Shape, Decl(contextualTypeInObjectProperty.ts, 0, 0))
+
+  [getC]: keyC => keyC,     // Error
+>[getC] : Symbol([getC], Decl(contextualTypeInObjectProperty.ts, 22, 28))
+>getC : Symbol(getC, Decl(contextualTypeInObjectProperty.ts, 6, 5))
+>keyC : Symbol(keyC, Decl(contextualTypeInObjectProperty.ts, 23, 9))
+>keyC : Symbol(keyC, Decl(contextualTypeInObjectProperty.ts, 23, 9))
+
+};
+
+const generic: {
+>generic : Symbol(generic, Decl(contextualTypeInObjectProperty.ts, 26, 5))
+
+  c: <T>(arg: T) => T;
+>c : Symbol(c, Decl(contextualTypeInObjectProperty.ts, 26, 16))
+>T : Symbol(T, Decl(contextualTypeInObjectProperty.ts, 27, 6))
+>arg : Symbol(arg, Decl(contextualTypeInObjectProperty.ts, 27, 9))
+>T : Symbol(T, Decl(contextualTypeInObjectProperty.ts, 27, 6))
+>T : Symbol(T, Decl(contextualTypeInObjectProperty.ts, 27, 6))
+
+} = {
+  [getC()]: keyC => keyC,
+>[getC()] : Symbol([getC()], Decl(contextualTypeInObjectProperty.ts, 28, 5))
+>getC : Symbol(getC, Decl(contextualTypeInObjectProperty.ts, 6, 5))
+>keyC : Symbol(keyC, Decl(contextualTypeInObjectProperty.ts, 29, 11))
+>keyC : Symbol(keyC, Decl(contextualTypeInObjectProperty.ts, 29, 11))
+
+};
+
+const thisType = {
+>thisType : Symbol(thisType, Decl(contextualTypeInObjectProperty.ts, 32, 5))
+
+  [getC()]: function() {
+>[getC()] : Symbol([getC()], Decl(contextualTypeInObjectProperty.ts, 32, 18))
+>getC : Symbol(getC, Decl(contextualTypeInObjectProperty.ts, 6, 5))
+
+    this.c();
+>this.c : Symbol([getC()], Decl(contextualTypeInObjectProperty.ts, 32, 18))
+>this : Symbol(thisType, Decl(contextualTypeInObjectProperty.ts, 32, 16))
+>c : Symbol([getC()], Decl(contextualTypeInObjectProperty.ts, 32, 18))
+  }
+};
+
+
+declare function f<T extends object>(data: T, handlers: { [P in keyof T]: (value: T[P], prop: P) => void; }): void;
+>f : Symbol(f, Decl(contextualTypeInObjectProperty.ts, 36, 2))
+>T : Symbol(T, Decl(contextualTypeInObjectProperty.ts, 39, 19))
+>data : Symbol(data, Decl(contextualTypeInObjectProperty.ts, 39, 37))
+>T : Symbol(T, Decl(contextualTypeInObjectProperty.ts, 39, 19))
+>handlers : Symbol(handlers, Decl(contextualTypeInObjectProperty.ts, 39, 45))
+>P : Symbol(P, Decl(contextualTypeInObjectProperty.ts, 39, 59))
+>T : Symbol(T, Decl(contextualTypeInObjectProperty.ts, 39, 19))
+>value : Symbol(value, Decl(contextualTypeInObjectProperty.ts, 39, 75))
+>T : Symbol(T, Decl(contextualTypeInObjectProperty.ts, 39, 19))
+>P : Symbol(P, Decl(contextualTypeInObjectProperty.ts, 39, 59))
+>prop : Symbol(prop, Decl(contextualTypeInObjectProperty.ts, 39, 87))
+>P : Symbol(P, Decl(contextualTypeInObjectProperty.ts, 39, 59))
+
+f({ data: 0 }, {
+>f : Symbol(f, Decl(contextualTypeInObjectProperty.ts, 36, 2))
+>data : Symbol(data, Decl(contextualTypeInObjectProperty.ts, 40, 3))
+
+  [(() => 'data' as const)()](value, key) {
+>[(() => 'data' as const)()] : Symbol([(() => 'data' as const)()], Decl(contextualTypeInObjectProperty.ts, 40, 16))
+>const : Symbol(const)
+>value : Symbol(value, Decl(contextualTypeInObjectProperty.ts, 41, 30))
+>key : Symbol(key, Decl(contextualTypeInObjectProperty.ts, 41, 36))
+
+  },
+});
+
+
+enum Keys {
+>Keys : Symbol(Keys, Decl(contextualTypeInObjectProperty.ts, 44, 3))
+
+  FIRST,
+>FIRST : Symbol(Keys.FIRST, Decl(contextualTypeInObjectProperty.ts, 47, 11))
+
+  SECOND
+>SECOND : Symbol(Keys.SECOND, Decl(contextualTypeInObjectProperty.ts, 48, 8))
+}
+
+const obj2: {
+>obj2 : Symbol(obj2, Decl(contextualTypeInObjectProperty.ts, 52, 5))
+
+  [key in Keys]: [string, string] 
+>key : Symbol(key, Decl(contextualTypeInObjectProperty.ts, 53, 3))
+>Keys : Symbol(Keys, Decl(contextualTypeInObjectProperty.ts, 44, 3))
+
+} = {
+  [Keys.FIRST]: ['1', '2'], 
+>[Keys.FIRST] : Symbol([Keys.FIRST], Decl(contextualTypeInObjectProperty.ts, 54, 5))
+>Keys.FIRST : Symbol(Keys.FIRST, Decl(contextualTypeInObjectProperty.ts, 47, 11))
+>Keys : Symbol(Keys, Decl(contextualTypeInObjectProperty.ts, 44, 3))
+>FIRST : Symbol(Keys.FIRST, Decl(contextualTypeInObjectProperty.ts, 47, 11))
+
+  [Keys['SECOND']]: ['3', '4']
+>[Keys['SECOND']] : Symbol([Keys['SECOND']], Decl(contextualTypeInObjectProperty.ts, 55, 27))
+>Keys : Symbol(Keys, Decl(contextualTypeInObjectProperty.ts, 44, 3))
+>'SECOND' : Symbol(Keys.SECOND, Decl(contextualTypeInObjectProperty.ts, 48, 8))
+}
+

--- a/tests/baselines/reference/contextualTypeInObjectProperty.types
+++ b/tests/baselines/reference/contextualTypeInObjectProperty.types
@@ -1,0 +1,192 @@
+=== tests/cases/compiler/contextualTypeInObjectProperty.ts ===
+type Shape = { 
+>Shape : Shape
+
+    "a"?: (a: "a") => "a";
+>"a" : (a: "a") => "a"
+>a : "a"
+
+    "b"?: (b: "b") => "b";
+>"b" : (b: "b") => "b"
+>b : "b"
+
+    "c"?: (c: "c") => "c";
+>"c" : (c: "c") => "c"
+>c : "c"
+
+};
+
+const getC = () => "c" as const;
+>getC : () => "c"
+>() => "c" as const : () => "c"
+>"c" as const : "c"
+>"c" : "c"
+
+export const obj: Shape = {
+>obj : Shape
+>{  ["a"]: keyA => keyA,  ["b" as "b"]: keyB => keyB,  [getC()]: keyC => keyC,} : { a: (keyA: "a") => "a"; b: (keyB: "b") => "b"; c: (keyC: "c") => "c"; }
+
+  ["a"]: keyA => keyA,
+>["a"] : (keyA: "a") => "a"
+>"a" : "a"
+>keyA => keyA : (keyA: "a") => "a"
+>keyA : "a"
+>keyA : "a"
+
+  ["b" as "b"]: keyB => keyB,
+>["b" as "b"] : (keyB: "b") => "b"
+>"b" as "b" : "b"
+>"b" : "b"
+>keyB => keyB : (keyB: "b") => "b"
+>keyB : "b"
+>keyB : "b"
+
+  [getC()]: keyC => keyC,
+>[getC()] : (keyC: "c") => "c"
+>getC() : "c"
+>getC : () => "c"
+>keyC => keyC : (keyC: "c") => "c"
+>keyC : "c"
+>keyC : "c"
+
+};
+
+
+const getUnion = () => "b" as "b" | "c";
+>getUnion : () => "b" | "c"
+>() => "b" as "b" | "c" : () => "b" | "c"
+>"b" as "b" | "c" : "b" | "c"
+>"b" : "b"
+
+export const unionType: Shape = {
+>unionType : Shape
+>{  [getUnion()]: keyC => keyC,      // Error} : { [x: string]: (keyC: any) => any; }
+
+  [getUnion()]: keyC => keyC,      // Error
+>[getUnion()] : (keyC: any) => any
+>getUnion() : "b" | "c"
+>getUnion : () => "b" | "c"
+>keyC => keyC : (keyC: any) => any
+>keyC : any
+>keyC : any
+
+};
+
+
+export const func: Shape = {
+>func : Shape
+>{  [getC]: keyC => keyC,     // Error} : {}
+
+  [getC]: keyC => keyC,     // Error
+>[getC] : (keyC: any) => any
+>getC : () => "c"
+>keyC => keyC : (keyC: any) => any
+>keyC : any
+>keyC : any
+
+};
+
+const generic: {
+>generic : { c: <T>(arg: T) => T; }
+
+  c: <T>(arg: T) => T;
+>c : <T>(arg: T) => T
+>arg : T
+
+} = {
+>{  [getC()]: keyC => keyC,} : { c: <T>(keyC: T) => T; }
+
+  [getC()]: keyC => keyC,
+>[getC()] : <T>(keyC: T) => T
+>getC() : "c"
+>getC : () => "c"
+>keyC => keyC : <T>(keyC: T) => T
+>keyC : T
+>keyC : T
+
+};
+
+const thisType = {
+>thisType : { c: () => void; }
+>{  [getC()]: function() {    this.c();  }} : { c: () => void; }
+
+  [getC()]: function() {
+>[getC()] : () => void
+>getC() : "c"
+>getC : () => "c"
+>function() {    this.c();  } : () => void
+
+    this.c();
+>this.c() : void
+>this.c : () => void
+>this : { c: () => void; }
+>c : () => void
+  }
+};
+
+
+declare function f<T extends object>(data: T, handlers: { [P in keyof T]: (value: T[P], prop: P) => void; }): void;
+>f : <T extends object>(data: T, handlers: { [P in keyof T]: (value: T[P], prop: P) => void; }) => void
+>data : T
+>handlers : { [P in keyof T]: (value: T[P], prop: P) => void; }
+>value : T[P]
+>prop : P
+
+f({ data: 0 }, {
+>f({ data: 0 }, {  [(() => 'data' as const)()](value, key) {  },}) : void
+>f : <T extends object>(data: T, handlers: { [P in keyof T]: (value: T[P], prop: P) => void; }) => void
+>{ data: 0 } : { data: number; }
+>data : number
+>0 : 0
+>{  [(() => 'data' as const)()](value, key) {  },} : { data(value: number, key: "data"): void; }
+
+  [(() => 'data' as const)()](value, key) {
+>[(() => 'data' as const)()] : (value: number, key: "data") => void
+>(() => 'data' as const)() : "data"
+>(() => 'data' as const) : () => "data"
+>() => 'data' as const : () => "data"
+>'data' as const : "data"
+>'data' : "data"
+>value : number
+>key : "data"
+
+  },
+});
+
+
+enum Keys {
+>Keys : Keys
+
+  FIRST,
+>FIRST : Keys.FIRST
+
+  SECOND
+>SECOND : Keys.SECOND
+}
+
+const obj2: {
+>obj2 : { 0: [string, string]; 1: [string, string]; }
+
+  [key in Keys]: [string, string] 
+} = {
+>{  [Keys.FIRST]: ['1', '2'],   [Keys['SECOND']]: ['3', '4']} : { 0: [string, string]; 1: [string, string]; }
+
+  [Keys.FIRST]: ['1', '2'], 
+>[Keys.FIRST] : [string, string]
+>Keys.FIRST : Keys.FIRST
+>Keys : typeof Keys
+>FIRST : Keys.FIRST
+>['1', '2'] : [string, string]
+>'1' : "1"
+>'2' : "2"
+
+  [Keys['SECOND']]: ['3', '4']
+>[Keys['SECOND']] : [string, string]
+>Keys['SECOND'] : Keys.SECOND
+>Keys : typeof Keys
+>'SECOND' : "SECOND"
+>['3', '4'] : [string, string]
+>'3' : "3"
+>'4' : "4"
+}
+

--- a/tests/cases/compiler/contextualTypeInObjectProperty.ts
+++ b/tests/cases/compiler/contextualTypeInObjectProperty.ts
@@ -1,0 +1,61 @@
+// @noImplicitAny: true
+// @noImplicitThis: true
+
+type Shape = { 
+    "a"?: (a: "a") => "a";
+    "b"?: (b: "b") => "b";
+    "c"?: (c: "c") => "c";
+};
+
+const getC = () => "c" as const;
+
+export const obj: Shape = {
+  ["a"]: keyA => keyA,
+  ["b" as "b"]: keyB => keyB,
+  [getC()]: keyC => keyC,
+};
+
+
+const getUnion = () => "b" as "b" | "c";
+
+export const unionType: Shape = {
+  [getUnion()]: keyC => keyC,      // Error
+};
+
+
+export const func: Shape = {
+  [getC]: keyC => keyC,     // Error
+};
+
+const generic: {
+  c: <T>(arg: T) => T;
+} = {
+  [getC()]: keyC => keyC,
+};
+
+const thisType = {
+  [getC()]: function() {
+    this.c();
+  }
+};
+
+
+declare function f<T extends object>(data: T, handlers: { [P in keyof T]: (value: T[P], prop: P) => void; }): void;
+f({ data: 0 }, {
+  [(() => 'data' as const)()](value, key) {
+
+  },
+});
+
+
+enum Keys {
+  FIRST,
+  SECOND
+}
+
+const obj2: {
+  [key in Keys]: [string, string] 
+} = {
+  [Keys.FIRST]: ['1', '2'], 
+  [Keys['SECOND']]: ['3', '4']
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #29718, Fixes #47737
