### PR TITLE
fix(42160): Extract to Constant Adds Unnecessary Parentheses around Assertions

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3580,7 +3580,8 @@ namespace ts {
                 }
 
             // TODO: Should prefix `++` and `--` be moved to the `Update` precedence?
-            // TODO: We are missing `TypeAssertionExpression`
+            case SyntaxKind.TypeAssertionExpression:
+            case SyntaxKind.NonNullExpression:
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.TypeOfExpression:
             case SyntaxKind.VoidExpression:
@@ -3601,6 +3602,9 @@ namespace ts {
             case SyntaxKind.PropertyAccessExpression:
             case SyntaxKind.ElementAccessExpression:
                 return OperatorPrecedence.Member;
+
+            case SyntaxKind.AsExpression:
+                return OperatorPrecedence.Relational;
 
             case SyntaxKind.ThisKeyword:
             case SyntaxKind.SuperKeyword:

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_thenTypeArgument1.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_thenTypeArgument1.ts
@@ -19,7 +19,7 @@ function wrapResponse<T>(response: T): APIResponse<T> {
 }
 
 async function get() {
-    const response = await Promise.resolve((undefined!));
+    const response = await Promise.resolve(undefined!);
     const result: APIResponse<{ email: string; }> = wrapResponse(response);
     return result;
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_thenTypeArgument2.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_thenTypeArgument2.ts
@@ -19,7 +19,7 @@ function wrapResponse<T>(response: T): APIResponse<T> {
 }
 
 async function get() {
-    const d = await Promise.resolve((undefined!));
+    const d = await Promise.resolve(undefined!);
     const result: APIResponse<{ email: string; }> = wrapResponse(d);
     return result;
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_thenTypeArgument3.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_thenTypeArgument3.ts
@@ -22,7 +22,7 @@ function wrapResponse<T>(response: T): APIResponse<T> {
 }
 
 async function get() {
-    const d = await Promise.resolve((undefined!));
+    const d = await Promise.resolve(undefined!);
     console.log(d);
     const result: APIResponse<{ email: string; }> = wrapResponse(d);
     return result;

--- a/tests/cases/fourslash/extract-const5.ts
+++ b/tests/cases/fourslash/extract-const5.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: foo.ts
+////const foo = /*a*/1!/*b*/;
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_0",
+    actionDescription: "Extract to constant in enclosing scope",
+    newContent:
+`const newLocal = 1!;
+const foo = /*RENAME*/newLocal;`
+});

--- a/tests/cases/fourslash/extract-const6.ts
+++ b/tests/cases/fourslash/extract-const6.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: foo.ts
+////const foo = /*a*/1 as number/*b*/;
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_0",
+    actionDescription: "Extract to constant in enclosing scope",
+    newContent:
+`const newLocal = 1 as number;
+const foo = /*RENAME*/newLocal;`
+});

--- a/tests/cases/fourslash/extract-const7.ts
+++ b/tests/cases/fourslash/extract-const7.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: foo.ts
+////const foo = /*a*/<number>1/*b*/;
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_0",
+    actionDescription: "Extract to constant in enclosing scope",
+    newContent:
+`const newLocal = <number>1;
+const foo = /*RENAME*/newLocal;`
+});


### PR DESCRIPTION
Fixes #42160