### PR TITLE
Adjust TS2691 message for .ts import sources

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3315,9 +3315,8 @@ namespace ts {
                          * Direct users to import source with .js extension if outputting an ES module.
                          * @see https://github.com/microsoft/TypeScript/issues/42151
                          */
-                        const target = getEmitScriptTarget(compilerOptions);
                         const moduleKind = getEmitModuleKind(compilerOptions);
-                        if (target >= ScriptTarget.ES2015 && moduleKind >= ModuleKind.ES2015) {
+                        if (moduleKind >= ModuleKind.ES2015) {
                             replacedImportSource += ".js";
                         }
                         error(errorNode, diag, tsExtension, replacedImportSource);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3309,7 +3309,18 @@ namespace ts {
                     const tsExtension = tryExtractTSExtension(moduleReference);
                     if (tsExtension) {
                         const diag = Diagnostics.An_import_path_cannot_end_with_a_0_extension_Consider_importing_1_instead;
-                        error(errorNode, diag, tsExtension, removeExtension(moduleReference, tsExtension));
+                        const importSourceWithoutExtension = removeExtension(moduleReference, tsExtension);
+                        let replacedImportSource = importSourceWithoutExtension;
+                        /**
+                         * Direct users to import source with .js extension if outputting an ES module.
+                         * @see https://github.com/microsoft/TypeScript/issues/42151
+                         */
+                        const target = getEmitScriptTarget(compilerOptions);
+                        const moduleKind = getEmitModuleKind(compilerOptions);
+                        if (target >= ScriptTarget.ES2015 && moduleKind >= ModuleKind.ES2015) {
+                            replacedImportSource += ".js";
+                        }
+                        error(errorNode, diag, tsExtension, replacedImportSource);
                     }
                     else if (!compilerOptions.resolveJsonModule &&
                         fileExtensionIs(moduleReference, Extension.Json) &&

--- a/tests/baselines/reference/moduleResolutionNoTsCJS.errors.txt
+++ b/tests/baselines/reference/moduleResolutionNoTsCJS.errors.txt
@@ -1,0 +1,33 @@
+tests/cases/compiler/user.ts(1,15): error TS2691: An import path cannot end with a '.ts' extension. Consider importing './x' instead.
+tests/cases/compiler/user.ts(2,15): error TS2691: An import path cannot end with a '.tsx' extension. Consider importing './y' instead.
+tests/cases/compiler/user.ts(3,15): error TS2691: An import path cannot end with a '.d.ts' extension. Consider importing './z' instead.
+
+
+==== tests/cases/compiler/x.ts (0 errors) ====
+    // CommonJS output
+    
+    export default 0;
+    
+==== tests/cases/compiler/y.tsx (0 errors) ====
+    export default 0;
+    
+==== tests/cases/compiler/z.d.ts (0 errors) ====
+    declare const x: number;
+    export default x;
+    
+==== tests/cases/compiler/user.ts (3 errors) ====
+    import x from "./x.ts";
+                  ~~~~~~~~
+!!! error TS2691: An import path cannot end with a '.ts' extension. Consider importing './x' instead.
+    import y from "./y.tsx";
+                  ~~~~~~~~~
+!!! error TS2691: An import path cannot end with a '.tsx' extension. Consider importing './y' instead.
+    import z from "./z.d.ts";
+                  ~~~~~~~~~~
+!!! error TS2691: An import path cannot end with a '.d.ts' extension. Consider importing './z' instead.
+    
+    // Making sure the suggested fixes are valid:
+    import x2 from "./x";
+    import y2 from "./y";
+    import z2 from "./z";
+    

--- a/tests/baselines/reference/moduleResolutionNoTsCJS.js
+++ b/tests/baselines/reference/moduleResolutionNoTsCJS.js
@@ -1,0 +1,37 @@
+//// [tests/cases/compiler/moduleResolutionNoTsCJS.ts] ////
+
+//// [x.ts]
+// CommonJS output
+
+export default 0;
+
+//// [y.tsx]
+export default 0;
+
+//// [z.d.ts]
+declare const x: number;
+export default x;
+
+//// [user.ts]
+import x from "./x.ts";
+import y from "./y.tsx";
+import z from "./z.d.ts";
+
+// Making sure the suggested fixes are valid:
+import x2 from "./x";
+import y2 from "./y";
+import z2 from "./z";
+
+
+//// [x.js]
+"use strict";
+// CommonJS output
+exports.__esModule = true;
+exports["default"] = 0;
+//// [y.jsx]
+"use strict";
+exports.__esModule = true;
+exports["default"] = 0;
+//// [user.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/moduleResolutionNoTsCJS.symbols
+++ b/tests/baselines/reference/moduleResolutionNoTsCJS.symbols
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/x.ts ===
+// CommonJS output
+No type information for this code.
+No type information for this code.export default 0;
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/y.tsx ===
+export default 0;
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/z.d.ts ===
+declare const x: number;
+>x : Symbol(x, Decl(z.d.ts, 0, 13))
+
+export default x;
+>x : Symbol(x, Decl(z.d.ts, 0, 13))
+
+=== tests/cases/compiler/user.ts ===
+import x from "./x.ts";
+>x : Symbol(x, Decl(user.ts, 0, 6))
+
+import y from "./y.tsx";
+>y : Symbol(y, Decl(user.ts, 1, 6))
+
+import z from "./z.d.ts";
+>z : Symbol(z, Decl(user.ts, 2, 6))
+
+// Making sure the suggested fixes are valid:
+import x2 from "./x";
+>x2 : Symbol(x2, Decl(user.ts, 5, 6))
+
+import y2 from "./y";
+>y2 : Symbol(y2, Decl(user.ts, 6, 6))
+
+import z2 from "./z";
+>z2 : Symbol(z2, Decl(user.ts, 7, 6))
+

--- a/tests/baselines/reference/moduleResolutionNoTsCJS.types
+++ b/tests/baselines/reference/moduleResolutionNoTsCJS.types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/x.ts ===
+// CommonJS output
+No type information for this code.
+No type information for this code.export default 0;
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/y.tsx ===
+export default 0;
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/z.d.ts ===
+declare const x: number;
+>x : number
+
+export default x;
+>x : number
+
+=== tests/cases/compiler/user.ts ===
+import x from "./x.ts";
+>x : any
+
+import y from "./y.tsx";
+>y : any
+
+import z from "./z.d.ts";
+>z : any
+
+// Making sure the suggested fixes are valid:
+import x2 from "./x";
+>x2 : 0
+
+import y2 from "./y";
+>y2 : 0
+
+import z2 from "./z";
+>z2 : number
+

--- a/tests/baselines/reference/moduleResolutionNoTsESM.errors.txt
+++ b/tests/baselines/reference/moduleResolutionNoTsESM.errors.txt
@@ -1,0 +1,33 @@
+tests/cases/compiler/user.ts(1,15): error TS2691: An import path cannot end with a '.ts' extension. Consider importing './x.js' instead.
+tests/cases/compiler/user.ts(2,15): error TS2691: An import path cannot end with a '.tsx' extension. Consider importing './y.js' instead.
+tests/cases/compiler/user.ts(3,15): error TS2691: An import path cannot end with a '.d.ts' extension. Consider importing './z.js' instead.
+
+
+==== tests/cases/compiler/x.ts (0 errors) ====
+    // ESM output
+    
+    export default 0;
+    
+==== tests/cases/compiler/y.tsx (0 errors) ====
+    export default 0;
+    
+==== tests/cases/compiler/z.d.ts (0 errors) ====
+    declare const x: number;
+    export default x;
+    
+==== tests/cases/compiler/user.ts (3 errors) ====
+    import x from "./x.ts";
+                  ~~~~~~~~
+!!! error TS2691: An import path cannot end with a '.ts' extension. Consider importing './x.js' instead.
+    import y from "./y.tsx";
+                  ~~~~~~~~~
+!!! error TS2691: An import path cannot end with a '.tsx' extension. Consider importing './y.js' instead.
+    import z from "./z.d.ts";
+                  ~~~~~~~~~~
+!!! error TS2691: An import path cannot end with a '.d.ts' extension. Consider importing './z.js' instead.
+    
+    // Making sure the suggested fixes are valid:
+    import x2 from "./x";
+    import y2 from "./y";
+    import z2 from "./z";
+    

--- a/tests/baselines/reference/moduleResolutionNoTsESM.js
+++ b/tests/baselines/reference/moduleResolutionNoTsESM.js
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/moduleResolutionNoTsESM.ts] ////
+
+//// [x.ts]
+// ESM output
+
+export default 0;
+
+//// [y.tsx]
+export default 0;
+
+//// [z.d.ts]
+declare const x: number;
+export default x;
+
+//// [user.ts]
+import x from "./x.ts";
+import y from "./y.tsx";
+import z from "./z.d.ts";
+
+// Making sure the suggested fixes are valid:
+import x2 from "./x";
+import y2 from "./y";
+import z2 from "./z";
+
+
+//// [x.js]
+// ESM output
+export default 0;
+//// [y.jsx]
+export default 0;
+//// [user.js]
+export {};

--- a/tests/baselines/reference/moduleResolutionNoTsESM.symbols
+++ b/tests/baselines/reference/moduleResolutionNoTsESM.symbols
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/x.ts ===
+// ESM output
+No type information for this code.
+No type information for this code.export default 0;
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/y.tsx ===
+export default 0;
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/z.d.ts ===
+declare const x: number;
+>x : Symbol(x, Decl(z.d.ts, 0, 13))
+
+export default x;
+>x : Symbol(x, Decl(z.d.ts, 0, 13))
+
+=== tests/cases/compiler/user.ts ===
+import x from "./x.ts";
+>x : Symbol(x, Decl(user.ts, 0, 6))
+
+import y from "./y.tsx";
+>y : Symbol(y, Decl(user.ts, 1, 6))
+
+import z from "./z.d.ts";
+>z : Symbol(z, Decl(user.ts, 2, 6))
+
+// Making sure the suggested fixes are valid:
+import x2 from "./x";
+>x2 : Symbol(x2, Decl(user.ts, 5, 6))
+
+import y2 from "./y";
+>y2 : Symbol(y2, Decl(user.ts, 6, 6))
+
+import z2 from "./z";
+>z2 : Symbol(z2, Decl(user.ts, 7, 6))
+

--- a/tests/baselines/reference/moduleResolutionNoTsESM.types
+++ b/tests/baselines/reference/moduleResolutionNoTsESM.types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/x.ts ===
+// ESM output
+No type information for this code.
+No type information for this code.export default 0;
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/y.tsx ===
+export default 0;
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/z.d.ts ===
+declare const x: number;
+>x : number
+
+export default x;
+>x : number
+
+=== tests/cases/compiler/user.ts ===
+import x from "./x.ts";
+>x : any
+
+import y from "./y.tsx";
+>y : any
+
+import z from "./z.d.ts";
+>z : any
+
+// Making sure the suggested fixes are valid:
+import x2 from "./x";
+>x2 : 0
+
+import y2 from "./y";
+>y2 : 0
+
+import z2 from "./z";
+>z2 : number
+

--- a/tests/cases/compiler/moduleResolutionNoTsCJS.ts
+++ b/tests/cases/compiler/moduleResolutionNoTsCJS.ts
@@ -1,0 +1,23 @@
+// CommonJS output
+// @module: commonjs
+
+// @jsx: Preserve
+// @filename: x.ts
+export default 0;
+
+// @filename: y.tsx
+export default 0;
+
+// @filename: z.d.ts
+declare const x: number;
+export default x;
+
+// @filename: user.ts
+import x from "./x.ts";
+import y from "./y.tsx";
+import z from "./z.d.ts";
+
+// Making sure the suggested fixes are valid:
+import x2 from "./x";
+import y2 from "./y";
+import z2 from "./z";

--- a/tests/cases/compiler/moduleResolutionNoTsESM.ts
+++ b/tests/cases/compiler/moduleResolutionNoTsESM.ts
@@ -1,3 +1,6 @@
+// ESM output
+// @module: es2015
+
 // @jsx: Preserve
 // @filename: x.ts
 export default 0;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

The advice given by error `TS2691` is confusing, and following its instructions produces output which throws `ERR_MODULE_NOT_FOUND` at runtime when outputting an ES module, i.e. when `moduleKind >= ModuleKind.ES2015`.

An import for a module located at `./test.ts` must be specified as `import ... from './test.js'` in order to get a valid ES module out, but users are directed to rename it to `./test`. This error message should be updated so users are given the correct advice based on their use case, and are not confused why their output throws despite the source being perfectly valid TS. (The `./test` format can be used to generate valid CommonJS modules, just not ES modules.)

Closes #42151.

### Current behavior
```typescript
import { test } from './test.ts'
```

Currently throws `TS2691` which says:

```none
An import path cannot end with a '.ts' extension. Consider importing './test' instead.ts(2691)
```

This adjustment does silence the compiler, but the compiled JS looks like:

```javascript
import { test } from './test';
console.log(test);
```

Which is not a valid ES module, as the import source is located at `./test.js`. Executing the output throws `ERR_MODULE_NOT_FOUND`.

### Suggested changes
This PR adjusts `checker.ts` to detect if the output is an ES module, and if so advises the user to replace `./import.ts` with `./import.js` instead of `./import`.

After these changes, trying to import `./test.js` while outputting an ES module throws:

```none
An import path cannot end with a '.ts' extension. Consider importing './test.js' instead.ts(2691)
```

Which will compile to a valid ES module that behaves as expected.