### PR TITLE
[Experiment] feat(7342): Decorators not allowed classes expressions

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1803,23 +1803,23 @@ namespace ts {
                 return true;
 
             case SyntaxKind.PropertyDeclaration:
-                // property declarations are valid if their parent is a class declaration.
-                return parent!.kind === SyntaxKind.ClassDeclaration;
+                // property declarations are valid if their parent is a class declaration/expression.
+                return isClassLike(parent!);
 
             case SyntaxKind.GetAccessor:
             case SyntaxKind.SetAccessor:
             case SyntaxKind.MethodDeclaration:
-                // if this method has a body and its parent is a class declaration, this is a valid target.
+                // if this method has a body and its parent is a class declaration/expression, this is a valid target.
                 return (node as FunctionLikeDeclaration).body !== undefined
-                    && parent!.kind === SyntaxKind.ClassDeclaration;
+                    && isClassLike(parent!);
 
             case SyntaxKind.Parameter:
-                // if the parameter's parent has a body and its grandparent is a class declaration, this is a valid target;
+                // if the parameter's parent has a body and its grandparent is a class declaration/expression, this is a valid target;
                 return (parent as FunctionLikeDeclaration).body !== undefined
                     && (parent!.kind === SyntaxKind.Constructor
                         || parent!.kind === SyntaxKind.MethodDeclaration
                         || parent!.kind === SyntaxKind.SetAccessor)
-                    && grandparent!.kind === SyntaxKind.ClassDeclaration;
+                    && isClassLike(grandparent!);
         }
 
         return false;
@@ -1840,12 +1840,13 @@ namespace ts {
         return nodeIsDecorated(node, parent!, grandparent!) || childIsDecorated(node, parent!); // TODO: GH#18217
     }
 
-    export function childIsDecorated(node: ClassDeclaration): boolean;
+    export function childIsDecorated(node: ClassLikeDeclaration): boolean;
     export function childIsDecorated(node: Node, parent: Node): boolean;
     export function childIsDecorated(node: Node, parent?: Node): boolean {
         switch (node.kind) {
+            case SyntaxKind.ClassExpression:
             case SyntaxKind.ClassDeclaration:
-                return some((node as ClassDeclaration).members, m => nodeOrChildIsDecorated(m, node, parent!)); // TODO: GH#18217
+                return some((node as ClassDeclaration | ClassExpression).members, m => nodeOrChildIsDecorated(m, node, parent!)); // TODO: GH#18217
             case SyntaxKind.MethodDeclaration:
             case SyntaxKind.SetAccessor:
                 return some((node as FunctionLikeDeclaration).parameters, p => nodeIsDecorated(p, node, parent!)); // TODO: GH#18217

--- a/tests/baselines/reference/decoratorChecksFunctionBodies.errors.txt
+++ b/tests/baselines/reference/decoratorChecksFunctionBodies.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/decorators/class/decoratorChecksFunctionBodies.ts(8,14): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+tests/cases/conformance/decorators/class/decoratorChecksFunctionBodies.ts(19,14): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
 
 
-==== tests/cases/conformance/decorators/class/decoratorChecksFunctionBodies.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/decoratorChecksFunctionBodies.ts (2 errors) ====
     // from #2971
     function func(s: string): void {
     }
@@ -18,3 +19,17 @@ tests/cases/conformance/decorators/class/decoratorChecksFunctionBodies.ts(8,14):
     
         }
     }
+    
+    const A1 = class {
+        @((x, p) => {
+            var a = 3;
+            func(a);
+                 ~
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+            return x; 
+        })
+        m() {
+    
+        }
+    }
+    

--- a/tests/baselines/reference/decoratorChecksFunctionBodies.js
+++ b/tests/baselines/reference/decoratorChecksFunctionBodies.js
@@ -14,6 +14,18 @@ class A {
     }
 }
 
+const A1 = class {
+    @((x, p) => {
+        var a = 3;
+        func(a);
+        return x; 
+    })
+    m() {
+
+    }
+}
+
+
 //// [decoratorChecksFunctionBodies.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -21,6 +33,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 // from #2971
 function func(s) {
 }
@@ -38,3 +51,16 @@ var A = /** @class */ (function () {
     ], A.prototype, "m", null);
     return A;
 }());
+var A1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    class_1.prototype.m = function () {
+    };
+    return class_1;
+}()), __decorate([
+    (function (x, p) {
+        var a = 3;
+        func(a);
+        return x;
+    })
+], _a.prototype, "m", null), _a);

--- a/tests/baselines/reference/decoratorChecksFunctionBodies.symbols
+++ b/tests/baselines/reference/decoratorChecksFunctionBodies.symbols
@@ -28,3 +28,28 @@ class A {
 
     }
 }
+
+const A1 = class {
+>A1 : Symbol(A1, Decl(decoratorChecksFunctionBodies.ts, 15, 5))
+
+    @((x, p) => {
+>x : Symbol(x, Decl(decoratorChecksFunctionBodies.ts, 16, 7))
+>p : Symbol(p, Decl(decoratorChecksFunctionBodies.ts, 16, 9))
+
+        var a = 3;
+>a : Symbol(a, Decl(decoratorChecksFunctionBodies.ts, 17, 11))
+
+        func(a);
+>func : Symbol(func, Decl(decoratorChecksFunctionBodies.ts, 0, 0))
+>a : Symbol(a, Decl(decoratorChecksFunctionBodies.ts, 17, 11))
+
+        return x; 
+>x : Symbol(x, Decl(decoratorChecksFunctionBodies.ts, 16, 7))
+
+    })
+    m() {
+>m : Symbol(A1.m, Decl(decoratorChecksFunctionBodies.ts, 15, 18))
+
+    }
+}
+

--- a/tests/baselines/reference/decoratorChecksFunctionBodies.types
+++ b/tests/baselines/reference/decoratorChecksFunctionBodies.types
@@ -32,3 +32,33 @@ class A {
 
     }
 }
+
+const A1 = class {
+>A1 : typeof A1
+>class {    @((x, p) => {        var a = 3;        func(a);        return x;     })    m() {    }} : typeof A1
+
+    @((x, p) => {
+>((x, p) => {        var a = 3;        func(a);        return x;     }) : (x: any, p: any) => any
+>(x, p) => {        var a = 3;        func(a);        return x;     } : (x: any, p: any) => any
+>x : any
+>p : any
+
+        var a = 3;
+>a : number
+>3 : 3
+
+        func(a);
+>func(a) : void
+>func : (s: string) => void
+>a : number
+
+        return x; 
+>x : any
+
+    })
+    m() {
+>m : () => void
+
+    }
+}
+

--- a/tests/baselines/reference/decoratorInstantiateModulesInFunctionBodies.js
+++ b/tests/baselines/reference/decoratorInstantiateModulesInFunctionBodies.js
@@ -13,12 +13,20 @@ function filter(handler: any) {
     };
 }
 
-class Wat {
+class A {
     @filter(() => test == 'abc')
     static whatever() {
         // ...
     }
 }
+
+const A1 = class {
+    @filter(() => test == 'abc')
+    static whatever() {
+        // ...
+    }
+}
+
 
 //// [a.js]
 "use strict";
@@ -34,6 +42,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 Object.defineProperty(exports, "__esModule", { value: true });
 var a_1 = require("./a");
 function filter(handler) {
@@ -41,14 +50,24 @@ function filter(handler) {
         // ...
     };
 }
-var Wat = /** @class */ (function () {
-    function Wat() {
+var A = /** @class */ (function () {
+    function A() {
     }
-    Wat.whatever = function () {
+    A.whatever = function () {
         // ...
     };
     __decorate([
         filter(function () { return a_1.test == 'abc'; })
-    ], Wat, "whatever", null);
-    return Wat;
+    ], A, "whatever", null);
+    return A;
 }());
+var A1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    class_1.whatever = function () {
+        // ...
+    };
+    return class_1;
+}()), __decorate([
+    filter(function () { return a_1.test == 'abc'; })
+], _a, "whatever", null), _a);

--- a/tests/baselines/reference/decoratorInstantiateModulesInFunctionBodies.symbols
+++ b/tests/baselines/reference/decoratorInstantiateModulesInFunctionBodies.symbols
@@ -19,16 +19,31 @@ function filter(handler: any) {
     };
 }
 
-class Wat {
->Wat : Symbol(Wat, Decl(b.ts, 6, 1))
+class A {
+>A : Symbol(A, Decl(b.ts, 6, 1))
 
     @filter(() => test == 'abc')
 >filter : Symbol(filter, Decl(b.ts, 0, 27))
 >test : Symbol(test, Decl(b.ts, 0, 8))
 
     static whatever() {
->whatever : Symbol(Wat.whatever, Decl(b.ts, 8, 11))
+>whatever : Symbol(A.whatever, Decl(b.ts, 8, 9))
 
         // ...
     }
 }
+
+const A1 = class {
+>A1 : Symbol(A1, Decl(b.ts, 15, 5))
+
+    @filter(() => test == 'abc')
+>filter : Symbol(filter, Decl(b.ts, 0, 27))
+>test : Symbol(test, Decl(b.ts, 0, 8))
+
+    static whatever() {
+>whatever : Symbol(A1.whatever, Decl(b.ts, 15, 18))
+
+        // ...
+    }
+}
+

--- a/tests/baselines/reference/decoratorInstantiateModulesInFunctionBodies.types
+++ b/tests/baselines/reference/decoratorInstantiateModulesInFunctionBodies.types
@@ -21,8 +21,8 @@ function filter(handler: any) {
     };
 }
 
-class Wat {
->Wat : Wat
+class A {
+>A : A
 
     @filter(() => test == 'abc')
 >filter(() => test == 'abc') : (target: any, propertyKey: string) => void
@@ -38,3 +38,23 @@ class Wat {
         // ...
     }
 }
+
+const A1 = class {
+>A1 : typeof A1
+>class {    @filter(() => test == 'abc')    static whatever() {        // ...    }} : typeof A1
+
+    @filter(() => test == 'abc')
+>filter(() => test == 'abc') : (target: any, propertyKey: string) => void
+>filter : (handler: any) => (target: any, propertyKey: string) => void
+>() => test == 'abc' : () => boolean
+>test == 'abc' : boolean
+>test : string
+>'abc' : "abc"
+
+    static whatever() {
+>whatever : () => void
+
+        // ...
+    }
+}
+

--- a/tests/baselines/reference/decoratorMetadata-jsdoc.errors.txt
+++ b/tests/baselines/reference/decoratorMetadata-jsdoc.errors.txt
@@ -1,9 +1,12 @@
 tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts(5,9): error TS8020: JSDoc types can only be used inside documentation comments.
 tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts(7,9): error TS8020: JSDoc types can only be used inside documentation comments.
 tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts(9,9): error TS8020: JSDoc types can only be used inside documentation comments.
+tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts(14,9): error TS8020: JSDoc types can only be used inside documentation comments.
+tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts(16,9): error TS8020: JSDoc types can only be used inside documentation comments.
+tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts(18,9): error TS8020: JSDoc types can only be used inside documentation comments.
 
 
-==== tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts (3 errors) ====
+==== tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts (6 errors) ====
     declare var decorator: any;
     
     class X {
@@ -20,3 +23,19 @@ tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts(9,9): error TS8020
             ~
 !!! error TS8020: JSDoc types can only be used inside documentation comments.
     }
+    
+    const X1 = class {
+        @decorator()
+        a?: string?;
+            ~~~~~~~
+!!! error TS8020: JSDoc types can only be used inside documentation comments.
+        @decorator()
+        b?: string!;
+            ~~~~~~~
+!!! error TS8020: JSDoc types can only be used inside documentation comments.
+        @decorator()
+        c?: *;
+            ~
+!!! error TS8020: JSDoc types can only be used inside documentation comments.
+    }
+    

--- a/tests/baselines/reference/decoratorMetadata-jsdoc.js
+++ b/tests/baselines/reference/decoratorMetadata-jsdoc.js
@@ -10,6 +10,16 @@ class X {
     c?: *;
 }
 
+const X1 = class {
+    @decorator()
+    a?: string?;
+    @decorator()
+    b?: string!;
+    @decorator()
+    c?: *;
+}
+
+
 //// [decoratorMetadata-jsdoc.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -20,6 +30,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 var __metadata = (this && this.__metadata) || function (k, v) {
     if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
 };
+var _a;
 var X = /** @class */ (function () {
     function X() {
     }
@@ -37,3 +48,17 @@ var X = /** @class */ (function () {
     ], X.prototype, "c", void 0);
     return X;
 }());
+var X1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    return class_1;
+}()), __decorate([
+    decorator(),
+    __metadata("design:type", String)
+], _a.prototype, "a", void 0), __decorate([
+    decorator(),
+    __metadata("design:type", String)
+], _a.prototype, "b", void 0), __decorate([
+    decorator(),
+    __metadata("design:type", Object)
+], _a.prototype, "c", void 0), _a);

--- a/tests/baselines/reference/decoratorMetadata-jsdoc.symbols
+++ b/tests/baselines/reference/decoratorMetadata-jsdoc.symbols
@@ -23,3 +23,26 @@ class X {
     c?: *;
 >c : Symbol(X.c, Decl(decoratorMetadata-jsdoc.ts, 6, 16))
 }
+
+const X1 = class {
+>X1 : Symbol(X1, Decl(decoratorMetadata-jsdoc.ts, 11, 5))
+
+    @decorator()
+>decorator : Symbol(decorator, Decl(decoratorMetadata-jsdoc.ts, 0, 11))
+
+    a?: string?;
+>a : Symbol(X1.a, Decl(decoratorMetadata-jsdoc.ts, 11, 18))
+
+    @decorator()
+>decorator : Symbol(decorator, Decl(decoratorMetadata-jsdoc.ts, 0, 11))
+
+    b?: string!;
+>b : Symbol(X1.b, Decl(decoratorMetadata-jsdoc.ts, 13, 16))
+
+    @decorator()
+>decorator : Symbol(decorator, Decl(decoratorMetadata-jsdoc.ts, 0, 11))
+
+    c?: *;
+>c : Symbol(X1.c, Decl(decoratorMetadata-jsdoc.ts, 15, 16))
+}
+

--- a/tests/baselines/reference/decoratorMetadata-jsdoc.types
+++ b/tests/baselines/reference/decoratorMetadata-jsdoc.types
@@ -26,3 +26,30 @@ class X {
     c?: *;
 >c : any
 }
+
+const X1 = class {
+>X1 : typeof X1
+>class {    @decorator()    a?: string?;    @decorator()    b?: string!;    @decorator()    c?: *;} : typeof X1
+
+    @decorator()
+>decorator() : any
+>decorator : any
+
+    a?: string?;
+>a : string
+
+    @decorator()
+>decorator() : any
+>decorator : any
+
+    b?: string!;
+>b : string
+
+    @decorator()
+>decorator() : any
+>decorator : any
+
+    c?: *;
+>c : any
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor1.js
+++ b/tests/baselines/reference/decoratorOnClassAccessor1.js
@@ -5,6 +5,11 @@ class C {
     @dec get accessor() { return 1; }
 }
 
+const C1 = class {
+    @dec get accessor() { return 1; }
+}
+
+
 //// [decoratorOnClassAccessor1.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -25,3 +31,15 @@ var C = /** @class */ (function () {
     ], C.prototype, "accessor", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    Object.defineProperty(class_1.prototype, "accessor", {
+        get: function () { return 1; },
+        enumerable: false,
+        configurable: true
+    });
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "accessor", null), _a);

--- a/tests/baselines/reference/decoratorOnClassAccessor1.symbols
+++ b/tests/baselines/reference/decoratorOnClassAccessor1.symbols
@@ -17,3 +17,12 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassAccessor1.ts, 0, 0))
 >accessor : Symbol(C.accessor, Decl(decoratorOnClassAccessor1.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassAccessor1.ts, 6, 5))
+
+    @dec get accessor() { return 1; }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor1.ts, 0, 0))
+>accessor : Symbol(C1.accessor, Decl(decoratorOnClassAccessor1.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor1.types
+++ b/tests/baselines/reference/decoratorOnClassAccessor1.types
@@ -13,3 +13,14 @@ class C {
 >accessor : number
 >1 : 1
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec get accessor() { return 1; }} : typeof C1
+
+    @dec get accessor() { return 1; }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>accessor : number
+>1 : 1
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor2.js
+++ b/tests/baselines/reference/decoratorOnClassAccessor2.js
@@ -5,6 +5,11 @@ class C {
     @dec public get accessor() { return 1; }
 }
 
+const C1 = class {
+    @dec public get accessor() { return 1; }
+}
+
+
 //// [decoratorOnClassAccessor2.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -25,3 +31,15 @@ var C = /** @class */ (function () {
     ], C.prototype, "accessor", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    Object.defineProperty(class_1.prototype, "accessor", {
+        get: function () { return 1; },
+        enumerable: false,
+        configurable: true
+    });
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "accessor", null), _a);

--- a/tests/baselines/reference/decoratorOnClassAccessor2.symbols
+++ b/tests/baselines/reference/decoratorOnClassAccessor2.symbols
@@ -17,3 +17,12 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassAccessor2.ts, 0, 0))
 >accessor : Symbol(C.accessor, Decl(decoratorOnClassAccessor2.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassAccessor2.ts, 6, 5))
+
+    @dec public get accessor() { return 1; }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor2.ts, 0, 0))
+>accessor : Symbol(C1.accessor, Decl(decoratorOnClassAccessor2.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor2.types
+++ b/tests/baselines/reference/decoratorOnClassAccessor2.types
@@ -13,3 +13,14 @@ class C {
 >accessor : number
 >1 : 1
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec public get accessor() { return 1; }} : typeof C1
+
+    @dec public get accessor() { return 1; }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>accessor : number
+>1 : 1
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor3.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassAccessor3.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor3.ts(4,12): error TS1005: ';' expected.
+tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor3.ts(8,12): error TS1005: ';' expected.
 
 
-==== tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor3.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor3.ts (2 errors) ====
     declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
     
     class C {
@@ -9,3 +10,10 @@ tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor3.ts(4
                ~
 !!! error TS1005: ';' expected.
     }
+    
+    const C1 = class {
+        public @dec get accessor() { return 1; }
+               ~
+!!! error TS1005: ';' expected.
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassAccessor3.js
+++ b/tests/baselines/reference/decoratorOnClassAccessor3.js
@@ -5,6 +5,11 @@ class C {
     public @dec get accessor() { return 1; }
 }
 
+const C1 = class {
+    public @dec get accessor() { return 1; }
+}
+
+
 //// [decoratorOnClassAccessor3.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -25,3 +31,15 @@ var C = /** @class */ (function () {
     ], C.prototype, "accessor", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    Object.defineProperty(class_1.prototype, "accessor", {
+        get: function () { return 1; },
+        enumerable: false,
+        configurable: true
+    });
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "accessor", null), _a);

--- a/tests/baselines/reference/decoratorOnClassAccessor3.symbols
+++ b/tests/baselines/reference/decoratorOnClassAccessor3.symbols
@@ -18,3 +18,13 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassAccessor3.ts, 0, 0))
 >accessor : Symbol(C.accessor, Decl(decoratorOnClassAccessor3.ts, 3, 10))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassAccessor3.ts, 6, 5))
+
+    public @dec get accessor() { return 1; }
+>public : Symbol(C1.public, Decl(decoratorOnClassAccessor3.ts, 6, 18))
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor3.ts, 0, 0))
+>accessor : Symbol(C1.accessor, Decl(decoratorOnClassAccessor3.ts, 7, 10))
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor3.types
+++ b/tests/baselines/reference/decoratorOnClassAccessor3.types
@@ -14,3 +14,15 @@ class C {
 >accessor : number
 >1 : 1
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    public @dec get accessor() { return 1; }} : typeof C1
+
+    public @dec get accessor() { return 1; }
+>public : any
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>accessor : number
+>1 : 1
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor4.js
+++ b/tests/baselines/reference/decoratorOnClassAccessor4.js
@@ -5,6 +5,11 @@ class C {
     @dec set accessor(value: number) { }
 }
 
+const C1 = class {
+    @dec set accessor(value: number) { }
+}
+
+
 //// [decoratorOnClassAccessor4.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -25,3 +31,15 @@ var C = /** @class */ (function () {
     ], C.prototype, "accessor", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    Object.defineProperty(class_1.prototype, "accessor", {
+        set: function (value) { },
+        enumerable: false,
+        configurable: true
+    });
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "accessor", null), _a);

--- a/tests/baselines/reference/decoratorOnClassAccessor4.symbols
+++ b/tests/baselines/reference/decoratorOnClassAccessor4.symbols
@@ -18,3 +18,13 @@ class C {
 >accessor : Symbol(C.accessor, Decl(decoratorOnClassAccessor4.ts, 2, 9))
 >value : Symbol(value, Decl(decoratorOnClassAccessor4.ts, 3, 22))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassAccessor4.ts, 6, 5))
+
+    @dec set accessor(value: number) { }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor4.ts, 0, 0))
+>accessor : Symbol(C1.accessor, Decl(decoratorOnClassAccessor4.ts, 6, 18))
+>value : Symbol(value, Decl(decoratorOnClassAccessor4.ts, 7, 22))
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor4.types
+++ b/tests/baselines/reference/decoratorOnClassAccessor4.types
@@ -13,3 +13,14 @@ class C {
 >accessor : number
 >value : number
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec set accessor(value: number) { }} : typeof C1
+
+    @dec set accessor(value: number) { }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>accessor : number
+>value : number
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor5.js
+++ b/tests/baselines/reference/decoratorOnClassAccessor5.js
@@ -5,6 +5,11 @@ class C {
     @dec public set accessor(value: number) { }
 }
 
+const C1 = class {
+    @dec public set accessor(value: number) { }
+}
+
+
 //// [decoratorOnClassAccessor5.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -25,3 +31,15 @@ var C = /** @class */ (function () {
     ], C.prototype, "accessor", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    Object.defineProperty(class_1.prototype, "accessor", {
+        set: function (value) { },
+        enumerable: false,
+        configurable: true
+    });
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "accessor", null), _a);

--- a/tests/baselines/reference/decoratorOnClassAccessor5.symbols
+++ b/tests/baselines/reference/decoratorOnClassAccessor5.symbols
@@ -18,3 +18,13 @@ class C {
 >accessor : Symbol(C.accessor, Decl(decoratorOnClassAccessor5.ts, 2, 9))
 >value : Symbol(value, Decl(decoratorOnClassAccessor5.ts, 3, 29))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassAccessor5.ts, 6, 5))
+
+    @dec public set accessor(value: number) { }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor5.ts, 0, 0))
+>accessor : Symbol(C1.accessor, Decl(decoratorOnClassAccessor5.ts, 6, 18))
+>value : Symbol(value, Decl(decoratorOnClassAccessor5.ts, 7, 29))
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor5.types
+++ b/tests/baselines/reference/decoratorOnClassAccessor5.types
@@ -13,3 +13,14 @@ class C {
 >accessor : number
 >value : number
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec public set accessor(value: number) { }} : typeof C1
+
+    @dec public set accessor(value: number) { }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>accessor : number
+>value : number
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor6.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassAccessor6.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor6.ts(4,12): error TS1005: ';' expected.
+tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor6.ts(8,12): error TS1005: ';' expected.
 
 
-==== tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor6.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor6.ts (2 errors) ====
     declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
     
     class C {
@@ -9,3 +10,10 @@ tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor6.ts(4
                ~
 !!! error TS1005: ';' expected.
     }
+    
+    const C1 = class {
+        public @dec set accessor(value: number) { }
+               ~
+!!! error TS1005: ';' expected.
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassAccessor6.js
+++ b/tests/baselines/reference/decoratorOnClassAccessor6.js
@@ -5,6 +5,11 @@ class C {
     public @dec set accessor(value: number) { }
 }
 
+const C1 = class {
+    public @dec set accessor(value: number) { }
+}
+
+
 //// [decoratorOnClassAccessor6.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -25,3 +31,15 @@ var C = /** @class */ (function () {
     ], C.prototype, "accessor", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    Object.defineProperty(class_1.prototype, "accessor", {
+        set: function (value) { },
+        enumerable: false,
+        configurable: true
+    });
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "accessor", null), _a);

--- a/tests/baselines/reference/decoratorOnClassAccessor6.symbols
+++ b/tests/baselines/reference/decoratorOnClassAccessor6.symbols
@@ -19,3 +19,14 @@ class C {
 >accessor : Symbol(C.accessor, Decl(decoratorOnClassAccessor6.ts, 3, 10))
 >value : Symbol(value, Decl(decoratorOnClassAccessor6.ts, 3, 29))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassAccessor6.ts, 6, 5))
+
+    public @dec set accessor(value: number) { }
+>public : Symbol(C1.public, Decl(decoratorOnClassAccessor6.ts, 6, 18))
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor6.ts, 0, 0))
+>accessor : Symbol(C1.accessor, Decl(decoratorOnClassAccessor6.ts, 7, 10))
+>value : Symbol(value, Decl(decoratorOnClassAccessor6.ts, 7, 29))
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor6.types
+++ b/tests/baselines/reference/decoratorOnClassAccessor6.types
@@ -14,3 +14,15 @@ class C {
 >accessor : number
 >value : number
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    public @dec set accessor(value: number) { }} : typeof C1
+
+    public @dec set accessor(value: number) { }
+>public : any
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>accessor : number
+>value : number
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor7.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassAccessor7.errors.txt
@@ -1,8 +1,10 @@
 tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts(26,5): error TS1207: Decorators cannot be applied to multiple get/set accessors of the same name.
 tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts(31,5): error TS1207: Decorators cannot be applied to multiple get/set accessors of the same name.
+tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts(56,5): error TS1207: Decorators cannot be applied to multiple get/set accessors of the same name.
+tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts(61,5): error TS1207: Decorators cannot be applied to multiple get/set accessors of the same name.
 
 
-==== tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts (2 errors) ====
+==== tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts (4 errors) ====
     declare function dec1<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
     declare function dec2<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
     
@@ -39,3 +41,38 @@ tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts(3
         ~
 !!! error TS1207: Decorators cannot be applied to multiple get/set accessors of the same name.
     }
+    
+    const A1 = class {
+        @dec1 get x() { return 0; }
+        set x(value: number) { }
+    }
+    
+    const B1 = class {
+        get x() { return 0; }
+        @dec2 set x(value: number) { }
+    }
+    
+    const C1 = class {
+        @dec1 set x(value: number) { }
+        get x() { return 0; }
+    }
+    
+    const D1 = class {
+        set x(value: number) { }
+        @dec2 get x() { return 0; }
+    }
+    
+    const E1 = class {
+        @dec1 get x() { return 0; }
+        @dec2 set x(value: number) { }
+        ~
+!!! error TS1207: Decorators cannot be applied to multiple get/set accessors of the same name.
+    }
+    
+    const F1 = class {
+        @dec1 set x(value: number) { }
+        @dec2 get x() { return 0; }
+        ~
+!!! error TS1207: Decorators cannot be applied to multiple get/set accessors of the same name.
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassAccessor7.js
+++ b/tests/baselines/reference/decoratorOnClassAccessor7.js
@@ -32,6 +32,37 @@ class F {
     @dec2 get x() { return 0; }
 }
 
+const A1 = class {
+    @dec1 get x() { return 0; }
+    set x(value: number) { }
+}
+
+const B1 = class {
+    get x() { return 0; }
+    @dec2 set x(value: number) { }
+}
+
+const C1 = class {
+    @dec1 set x(value: number) { }
+    get x() { return 0; }
+}
+
+const D1 = class {
+    set x(value: number) { }
+    @dec2 get x() { return 0; }
+}
+
+const E1 = class {
+    @dec1 get x() { return 0; }
+    @dec2 set x(value: number) { }
+}
+
+const F1 = class {
+    @dec1 set x(value: number) { }
+    @dec2 get x() { return 0; }
+}
+
+
 //// [decoratorOnClassAccessor7.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -39,6 +70,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a, _b, _c, _d, _e, _f;
 var A = /** @class */ (function () {
     function A() {
     }
@@ -123,3 +155,81 @@ var F = /** @class */ (function () {
     ], F.prototype, "x", null);
     return F;
 }());
+var A1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    Object.defineProperty(class_1.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: false,
+        configurable: true
+    });
+    return class_1;
+}()), __decorate([
+    dec1
+], _a.prototype, "x", null), _a);
+var B1 = (_b = /** @class */ (function () {
+    function class_2() {
+    }
+    Object.defineProperty(class_2.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: false,
+        configurable: true
+    });
+    return class_2;
+}()), __decorate([
+    dec2
+], _b.prototype, "x", null), _b);
+var C1 = (_c = /** @class */ (function () {
+    function class_3() {
+    }
+    Object.defineProperty(class_3.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: false,
+        configurable: true
+    });
+    return class_3;
+}()), __decorate([
+    dec1
+], _c.prototype, "x", null), _c);
+var D1 = (_d = /** @class */ (function () {
+    function class_4() {
+    }
+    Object.defineProperty(class_4.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: false,
+        configurable: true
+    });
+    return class_4;
+}()), __decorate([
+    dec2
+], _d.prototype, "x", null), _d);
+var E1 = (_e = /** @class */ (function () {
+    function class_5() {
+    }
+    Object.defineProperty(class_5.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: false,
+        configurable: true
+    });
+    return class_5;
+}()), __decorate([
+    dec1
+], _e.prototype, "x", null), _e);
+var F1 = (_f = /** @class */ (function () {
+    function class_6() {
+    }
+    Object.defineProperty(class_6.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: false,
+        configurable: true
+    });
+    return class_6;
+}()), __decorate([
+    dec1
+], _f.prototype, "x", null), _f);

--- a/tests/baselines/reference/decoratorOnClassAccessor7.symbols
+++ b/tests/baselines/reference/decoratorOnClassAccessor7.symbols
@@ -94,3 +94,78 @@ class F {
 >dec2 : Symbol(dec2, Decl(decoratorOnClassAccessor7.ts, 0, 127))
 >x : Symbol(F.x, Decl(decoratorOnClassAccessor7.ts, 28, 9), Decl(decoratorOnClassAccessor7.ts, 29, 34))
 }
+
+const A1 = class {
+>A1 : Symbol(A1, Decl(decoratorOnClassAccessor7.ts, 33, 5))
+
+    @dec1 get x() { return 0; }
+>dec1 : Symbol(dec1, Decl(decoratorOnClassAccessor7.ts, 0, 0))
+>x : Symbol(A1.x, Decl(decoratorOnClassAccessor7.ts, 33, 18), Decl(decoratorOnClassAccessor7.ts, 34, 31))
+
+    set x(value: number) { }
+>x : Symbol(A1.x, Decl(decoratorOnClassAccessor7.ts, 33, 18), Decl(decoratorOnClassAccessor7.ts, 34, 31))
+>value : Symbol(value, Decl(decoratorOnClassAccessor7.ts, 35, 10))
+}
+
+const B1 = class {
+>B1 : Symbol(B1, Decl(decoratorOnClassAccessor7.ts, 38, 5))
+
+    get x() { return 0; }
+>x : Symbol(B1.x, Decl(decoratorOnClassAccessor7.ts, 38, 18), Decl(decoratorOnClassAccessor7.ts, 39, 25))
+
+    @dec2 set x(value: number) { }
+>dec2 : Symbol(dec2, Decl(decoratorOnClassAccessor7.ts, 0, 127))
+>x : Symbol(B1.x, Decl(decoratorOnClassAccessor7.ts, 38, 18), Decl(decoratorOnClassAccessor7.ts, 39, 25))
+>value : Symbol(value, Decl(decoratorOnClassAccessor7.ts, 40, 16))
+}
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassAccessor7.ts, 43, 5))
+
+    @dec1 set x(value: number) { }
+>dec1 : Symbol(dec1, Decl(decoratorOnClassAccessor7.ts, 0, 0))
+>x : Symbol(C1.x, Decl(decoratorOnClassAccessor7.ts, 43, 18), Decl(decoratorOnClassAccessor7.ts, 44, 34))
+>value : Symbol(value, Decl(decoratorOnClassAccessor7.ts, 44, 16))
+
+    get x() { return 0; }
+>x : Symbol(C1.x, Decl(decoratorOnClassAccessor7.ts, 43, 18), Decl(decoratorOnClassAccessor7.ts, 44, 34))
+}
+
+const D1 = class {
+>D1 : Symbol(D1, Decl(decoratorOnClassAccessor7.ts, 48, 5))
+
+    set x(value: number) { }
+>x : Symbol(D1.x, Decl(decoratorOnClassAccessor7.ts, 48, 18), Decl(decoratorOnClassAccessor7.ts, 49, 28))
+>value : Symbol(value, Decl(decoratorOnClassAccessor7.ts, 49, 10))
+
+    @dec2 get x() { return 0; }
+>dec2 : Symbol(dec2, Decl(decoratorOnClassAccessor7.ts, 0, 127))
+>x : Symbol(D1.x, Decl(decoratorOnClassAccessor7.ts, 48, 18), Decl(decoratorOnClassAccessor7.ts, 49, 28))
+}
+
+const E1 = class {
+>E1 : Symbol(E1, Decl(decoratorOnClassAccessor7.ts, 53, 5))
+
+    @dec1 get x() { return 0; }
+>dec1 : Symbol(dec1, Decl(decoratorOnClassAccessor7.ts, 0, 0))
+>x : Symbol(E1.x, Decl(decoratorOnClassAccessor7.ts, 53, 18), Decl(decoratorOnClassAccessor7.ts, 54, 31))
+
+    @dec2 set x(value: number) { }
+>dec2 : Symbol(dec2, Decl(decoratorOnClassAccessor7.ts, 0, 127))
+>x : Symbol(E1.x, Decl(decoratorOnClassAccessor7.ts, 53, 18), Decl(decoratorOnClassAccessor7.ts, 54, 31))
+>value : Symbol(value, Decl(decoratorOnClassAccessor7.ts, 55, 16))
+}
+
+const F1 = class {
+>F1 : Symbol(F1, Decl(decoratorOnClassAccessor7.ts, 58, 5))
+
+    @dec1 set x(value: number) { }
+>dec1 : Symbol(dec1, Decl(decoratorOnClassAccessor7.ts, 0, 0))
+>x : Symbol(F1.x, Decl(decoratorOnClassAccessor7.ts, 58, 18), Decl(decoratorOnClassAccessor7.ts, 59, 34))
+>value : Symbol(value, Decl(decoratorOnClassAccessor7.ts, 59, 16))
+
+    @dec2 get x() { return 0; }
+>dec2 : Symbol(dec2, Decl(decoratorOnClassAccessor7.ts, 0, 127))
+>x : Symbol(F1.x, Decl(decoratorOnClassAccessor7.ts, 58, 18), Decl(decoratorOnClassAccessor7.ts, 59, 34))
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor7.types
+++ b/tests/baselines/reference/decoratorOnClassAccessor7.types
@@ -90,3 +90,90 @@ class F {
 >x : number
 >0 : 0
 }
+
+const A1 = class {
+>A1 : typeof A1
+>class {    @dec1 get x() { return 0; }    set x(value: number) { }} : typeof A1
+
+    @dec1 get x() { return 0; }
+>dec1 : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>0 : 0
+
+    set x(value: number) { }
+>x : number
+>value : number
+}
+
+const B1 = class {
+>B1 : typeof B1
+>class {    get x() { return 0; }    @dec2 set x(value: number) { }} : typeof B1
+
+    get x() { return 0; }
+>x : number
+>0 : 0
+
+    @dec2 set x(value: number) { }
+>dec2 : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>value : number
+}
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec1 set x(value: number) { }    get x() { return 0; }} : typeof C1
+
+    @dec1 set x(value: number) { }
+>dec1 : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>value : number
+
+    get x() { return 0; }
+>x : number
+>0 : 0
+}
+
+const D1 = class {
+>D1 : typeof D1
+>class {    set x(value: number) { }    @dec2 get x() { return 0; }} : typeof D1
+
+    set x(value: number) { }
+>x : number
+>value : number
+
+    @dec2 get x() { return 0; }
+>dec2 : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>0 : 0
+}
+
+const E1 = class {
+>E1 : typeof E1
+>class {    @dec1 get x() { return 0; }    @dec2 set x(value: number) { }} : typeof E1
+
+    @dec1 get x() { return 0; }
+>dec1 : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>0 : 0
+
+    @dec2 set x(value: number) { }
+>dec2 : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>value : number
+}
+
+const F1 = class {
+>F1 : typeof F1
+>class {    @dec1 set x(value: number) { }    @dec2 get x() { return 0; }} : typeof F1
+
+    @dec1 set x(value: number) { }
+>dec1 : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>value : number
+
+    @dec2 get x() { return 0; }
+>dec2 : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>0 : 0
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor8.js
+++ b/tests/baselines/reference/decoratorOnClassAccessor8.js
@@ -29,6 +29,35 @@ class F {
     @dec set x(value: number) { }
 }
 
+const A1 = class {
+    @dec get x() { return 0; }
+    set x(value: number) { }
+}
+
+const B1 = class {
+    get x() { return 0; }
+    @dec set x(value: number) { }
+}
+
+const C1 = class {
+    @dec set x(value: number) { }
+    get x() { return 0; }
+}
+
+const D1 = class {
+    set x(value: number) { }
+    @dec get x() { return 0; }
+}
+
+const E1 = class {
+    @dec get x() { return 0; }
+}
+
+const F1 = class {
+    @dec set x(value: number) { }
+}
+
+
 //// [decoratorOnClassAccessor8.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -39,6 +68,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 var __metadata = (this && this.__metadata) || function (k, v) {
     if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
 };
+var _a, _b, _c, _d, _e, _f;
 var A = /** @class */ (function () {
     function A() {
     }
@@ -133,3 +163,91 @@ var F = /** @class */ (function () {
     ], F.prototype, "x", null);
     return F;
 }());
+var A1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    Object.defineProperty(class_1.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: false,
+        configurable: true
+    });
+    return class_1;
+}()), __decorate([
+    dec,
+    __metadata("design:type", Number),
+    __metadata("design:paramtypes", [Number])
+], _a.prototype, "x", null), _a);
+var B1 = (_b = /** @class */ (function () {
+    function class_2() {
+    }
+    Object.defineProperty(class_2.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: false,
+        configurable: true
+    });
+    return class_2;
+}()), __decorate([
+    dec,
+    __metadata("design:type", Number),
+    __metadata("design:paramtypes", [Number])
+], _b.prototype, "x", null), _b);
+var C1 = (_c = /** @class */ (function () {
+    function class_3() {
+    }
+    Object.defineProperty(class_3.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: false,
+        configurable: true
+    });
+    return class_3;
+}()), __decorate([
+    dec,
+    __metadata("design:type", Number),
+    __metadata("design:paramtypes", [Number])
+], _c.prototype, "x", null), _c);
+var D1 = (_d = /** @class */ (function () {
+    function class_4() {
+    }
+    Object.defineProperty(class_4.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: false,
+        configurable: true
+    });
+    return class_4;
+}()), __decorate([
+    dec,
+    __metadata("design:type", Number),
+    __metadata("design:paramtypes", [Number])
+], _d.prototype, "x", null), _d);
+var E1 = (_e = /** @class */ (function () {
+    function class_5() {
+    }
+    Object.defineProperty(class_5.prototype, "x", {
+        get: function () { return 0; },
+        enumerable: false,
+        configurable: true
+    });
+    return class_5;
+}()), __decorate([
+    dec,
+    __metadata("design:type", Object),
+    __metadata("design:paramtypes", [])
+], _e.prototype, "x", null), _e);
+var F1 = (_f = /** @class */ (function () {
+    function class_6() {
+    }
+    Object.defineProperty(class_6.prototype, "x", {
+        set: function (value) { },
+        enumerable: false,
+        configurable: true
+    });
+    return class_6;
+}()), __decorate([
+    dec,
+    __metadata("design:type", Number),
+    __metadata("design:paramtypes", [Number])
+], _f.prototype, "x", null), _f);

--- a/tests/baselines/reference/decoratorOnClassAccessor8.symbols
+++ b/tests/baselines/reference/decoratorOnClassAccessor8.symbols
@@ -74,3 +74,69 @@ class F {
 >x : Symbol(F.x, Decl(decoratorOnClassAccessor8.ts, 26, 9))
 >value : Symbol(value, Decl(decoratorOnClassAccessor8.ts, 27, 15))
 }
+
+const A1 = class {
+>A1 : Symbol(A1, Decl(decoratorOnClassAccessor8.ts, 30, 5))
+
+    @dec get x() { return 0; }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor8.ts, 0, 0))
+>x : Symbol(A1.x, Decl(decoratorOnClassAccessor8.ts, 30, 18), Decl(decoratorOnClassAccessor8.ts, 31, 30))
+
+    set x(value: number) { }
+>x : Symbol(A1.x, Decl(decoratorOnClassAccessor8.ts, 30, 18), Decl(decoratorOnClassAccessor8.ts, 31, 30))
+>value : Symbol(value, Decl(decoratorOnClassAccessor8.ts, 32, 10))
+}
+
+const B1 = class {
+>B1 : Symbol(B1, Decl(decoratorOnClassAccessor8.ts, 35, 5))
+
+    get x() { return 0; }
+>x : Symbol(B1.x, Decl(decoratorOnClassAccessor8.ts, 35, 18), Decl(decoratorOnClassAccessor8.ts, 36, 25))
+
+    @dec set x(value: number) { }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor8.ts, 0, 0))
+>x : Symbol(B1.x, Decl(decoratorOnClassAccessor8.ts, 35, 18), Decl(decoratorOnClassAccessor8.ts, 36, 25))
+>value : Symbol(value, Decl(decoratorOnClassAccessor8.ts, 37, 15))
+}
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassAccessor8.ts, 40, 5))
+
+    @dec set x(value: number) { }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor8.ts, 0, 0))
+>x : Symbol(C1.x, Decl(decoratorOnClassAccessor8.ts, 40, 18), Decl(decoratorOnClassAccessor8.ts, 41, 33))
+>value : Symbol(value, Decl(decoratorOnClassAccessor8.ts, 41, 15))
+
+    get x() { return 0; }
+>x : Symbol(C1.x, Decl(decoratorOnClassAccessor8.ts, 40, 18), Decl(decoratorOnClassAccessor8.ts, 41, 33))
+}
+
+const D1 = class {
+>D1 : Symbol(D1, Decl(decoratorOnClassAccessor8.ts, 45, 5))
+
+    set x(value: number) { }
+>x : Symbol(D1.x, Decl(decoratorOnClassAccessor8.ts, 45, 18), Decl(decoratorOnClassAccessor8.ts, 46, 28))
+>value : Symbol(value, Decl(decoratorOnClassAccessor8.ts, 46, 10))
+
+    @dec get x() { return 0; }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor8.ts, 0, 0))
+>x : Symbol(D1.x, Decl(decoratorOnClassAccessor8.ts, 45, 18), Decl(decoratorOnClassAccessor8.ts, 46, 28))
+}
+
+const E1 = class {
+>E1 : Symbol(E1, Decl(decoratorOnClassAccessor8.ts, 50, 5))
+
+    @dec get x() { return 0; }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor8.ts, 0, 0))
+>x : Symbol(E1.x, Decl(decoratorOnClassAccessor8.ts, 50, 18))
+}
+
+const F1 = class {
+>F1 : Symbol(F1, Decl(decoratorOnClassAccessor8.ts, 54, 5))
+
+    @dec set x(value: number) { }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor8.ts, 0, 0))
+>x : Symbol(F1.x, Decl(decoratorOnClassAccessor8.ts, 54, 18))
+>value : Symbol(value, Decl(decoratorOnClassAccessor8.ts, 55, 15))
+}
+

--- a/tests/baselines/reference/decoratorOnClassAccessor8.types
+++ b/tests/baselines/reference/decoratorOnClassAccessor8.types
@@ -74,3 +74,80 @@ class F {
 >x : number
 >value : number
 }
+
+const A1 = class {
+>A1 : typeof A1
+>class {    @dec get x() { return 0; }    set x(value: number) { }} : typeof A1
+
+    @dec get x() { return 0; }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>0 : 0
+
+    set x(value: number) { }
+>x : number
+>value : number
+}
+
+const B1 = class {
+>B1 : typeof B1
+>class {    get x() { return 0; }    @dec set x(value: number) { }} : typeof B1
+
+    get x() { return 0; }
+>x : number
+>0 : 0
+
+    @dec set x(value: number) { }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>value : number
+}
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec set x(value: number) { }    get x() { return 0; }} : typeof C1
+
+    @dec set x(value: number) { }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>value : number
+
+    get x() { return 0; }
+>x : number
+>0 : 0
+}
+
+const D1 = class {
+>D1 : typeof D1
+>class {    set x(value: number) { }    @dec get x() { return 0; }} : typeof D1
+
+    set x(value: number) { }
+>x : number
+>value : number
+
+    @dec get x() { return 0; }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>0 : 0
+}
+
+const E1 = class {
+>E1 : typeof E1
+>class {    @dec get x() { return 0; }} : typeof E1
+
+    @dec get x() { return 0; }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>0 : 0
+}
+
+const F1 = class {
+>F1 : typeof F1
+>class {    @dec set x(value: number) { }} : typeof F1
+
+    @dec set x(value: number) { }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>value : number
+}
+

--- a/tests/baselines/reference/decoratorOnClassConstructor1.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassConstructor1.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor1.ts(4,5): error TS1206: Decorators are not valid here.
+tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor1.ts(8,5): error TS1206: Decorators are not valid here.
 
 
-==== tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor1.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor1.ts (2 errors) ====
     declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
     
     class C {
@@ -9,3 +10,10 @@ tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor
         ~
 !!! error TS1206: Decorators are not valid here.
     }
+    
+    const C1 = class {
+        @dec constructor() {}
+        ~
+!!! error TS1206: Decorators are not valid here.
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassConstructor1.js
+++ b/tests/baselines/reference/decoratorOnClassConstructor1.js
@@ -5,9 +5,19 @@ class C {
     @dec constructor() {}
 }
 
+const C1 = class {
+    @dec constructor() {}
+}
+
+
 //// [decoratorOnClassConstructor1.js]
 var C = /** @class */ (function () {
     function C() {
     }
     return C;
+}());
+var C1 = /** @class */ (function () {
+    function class_1() {
+    }
+    return class_1;
 }());

--- a/tests/baselines/reference/decoratorOnClassConstructor1.symbols
+++ b/tests/baselines/reference/decoratorOnClassConstructor1.symbols
@@ -16,3 +16,11 @@ class C {
     @dec constructor() {}
 >dec : Symbol(dec, Decl(decoratorOnClassConstructor1.ts, 0, 0))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassConstructor1.ts, 6, 5))
+
+    @dec constructor() {}
+>dec : Symbol(dec, Decl(decoratorOnClassConstructor1.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/decoratorOnClassConstructor1.types
+++ b/tests/baselines/reference/decoratorOnClassConstructor1.types
@@ -11,3 +11,12 @@ class C {
     @dec constructor() {}
 >dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec constructor() {}} : typeof C1
+
+    @dec constructor() {}
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+}
+

--- a/tests/baselines/reference/decoratorOnClassConstructor2.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassConstructor2.errors.txt
@@ -13,8 +13,16 @@ tests/cases/conformance/decorators/class/constructor/2.ts(2,19): error TS2691: A
     import {foo} from "./0.ts"
                       ~~~~~~~~
 !!! error TS2691: An import path cannot end with a '.ts' extension. Consider importing './0' instead.
-    export class C  extends base{
+    
+    export class C  extends base {
         constructor(@foo prop: any) {
             super();
         }
     }
+    
+    export const C1 = class extends base {
+        constructor(@foo prop: any) {
+            super();
+        }
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassConstructor2.js
+++ b/tests/baselines/reference/decoratorOnClassConstructor2.js
@@ -7,11 +7,19 @@ export function foo(target: Object, propertyKey: string | symbol, parameterIndex
 //// [2.ts]
 import {base} from "./0.ts"
 import {foo} from "./0.ts"
-export class C  extends base{
+
+export class C  extends base {
     constructor(@foo prop: any) {
         super();
     }
 }
+
+export const C1 = class extends base {
+    constructor(@foo prop: any) {
+        super();
+    }
+}
+
 
 //// [0.js]
 "use strict";
@@ -52,7 +60,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
     return function (target, key) { decorator(target, key, paramIndex); }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.C = void 0;
+exports.C1 = exports.C = void 0;
 var _0_ts_1 = require("./0.ts");
 var _0_ts_2 = require("./0.ts");
 var C = /** @class */ (function (_super) {
@@ -66,3 +74,10 @@ var C = /** @class */ (function (_super) {
     return C;
 }(_0_ts_1.base));
 exports.C = C;
+exports.C1 = /** @class */ (function (_super) {
+    __extends(class_1, _super);
+    function class_1(prop) {
+        return _super.call(this) || this;
+    }
+    return class_1;
+}(_0_ts_1.base));

--- a/tests/baselines/reference/decoratorOnClassConstructor2.symbols
+++ b/tests/baselines/reference/decoratorOnClassConstructor2.symbols
@@ -16,14 +16,27 @@ import {base} from "./0.ts"
 import {foo} from "./0.ts"
 >foo : Symbol(foo, Decl(2.ts, 1, 8))
 
-export class C  extends base{
+export class C  extends base {
 >C : Symbol(C, Decl(2.ts, 1, 26))
 >base : Symbol(base, Decl(2.ts, 0, 8))
 
     constructor(@foo prop: any) {
 >foo : Symbol(foo, Decl(2.ts, 1, 8))
->prop : Symbol(prop, Decl(2.ts, 3, 16))
+>prop : Symbol(prop, Decl(2.ts, 4, 16))
 
         super();
     }
 }
+
+export const C1 = class extends base {
+>C1 : Symbol(C1, Decl(2.ts, 9, 12))
+>base : Symbol(base, Decl(2.ts, 0, 8))
+
+    constructor(@foo prop: any) {
+>foo : Symbol(foo, Decl(2.ts, 1, 8))
+>prop : Symbol(prop, Decl(2.ts, 10, 16))
+
+        super();
+    }
+}
+

--- a/tests/baselines/reference/decoratorOnClassConstructor2.types
+++ b/tests/baselines/reference/decoratorOnClassConstructor2.types
@@ -15,7 +15,7 @@ import {base} from "./0.ts"
 import {foo} from "./0.ts"
 >foo : any
 
-export class C  extends base{
+export class C  extends base {
 >C : C
 >base : any
 
@@ -28,3 +28,19 @@ export class C  extends base{
 >super : any
     }
 }
+
+export const C1 = class extends base {
+>C1 : typeof C1
+>class extends base {    constructor(@foo prop: any) {        super();    }} : typeof C1
+>base : any
+
+    constructor(@foo prop: any) {
+>foo : any
+>prop : any
+
+        super();
+>super() : void
+>super : any
+    }
+}
+

--- a/tests/baselines/reference/decoratorOnClassConstructor3.js
+++ b/tests/baselines/reference/decoratorOnClassConstructor3.js
@@ -9,11 +9,18 @@ import {base} from "./0"
 import {foo} from "./0"
 
 /* Comment on the Class Declaration */
-export class C  extends base{
+export class C  extends base {
     constructor(@foo prop: any) {
         super();
     }
 }
+
+export const C1 = class extends base {
+    constructor(@foo prop: any) {
+        super();
+    }
+}
+
 
 //// [0.js]
 "use strict";
@@ -54,7 +61,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
     return function (target, key) { decorator(target, key, paramIndex); }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.C = void 0;
+exports.C1 = exports.C = void 0;
 var _0_1 = require("./0");
 var _0_2 = require("./0");
 /* Comment on the Class Declaration */
@@ -69,3 +76,10 @@ var C = /** @class */ (function (_super) {
     return C;
 }(_0_1.base));
 exports.C = C;
+exports.C1 = /** @class */ (function (_super) {
+    __extends(class_1, _super);
+    function class_1(prop) {
+        return _super.call(this) || this;
+    }
+    return class_1;
+}(_0_1.base));

--- a/tests/baselines/reference/decoratorOnClassConstructor3.symbols
+++ b/tests/baselines/reference/decoratorOnClassConstructor3.symbols
@@ -17,7 +17,7 @@ import {foo} from "./0"
 >foo : Symbol(foo, Decl(2.ts, 1, 8))
 
 /* Comment on the Class Declaration */
-export class C  extends base{
+export class C  extends base {
 >C : Symbol(C, Decl(2.ts, 1, 23))
 >base : Symbol(base, Decl(2.ts, 0, 8))
 
@@ -29,3 +29,17 @@ export class C  extends base{
 >super : Symbol(base, Decl(0.ts, 0, 0))
     }
 }
+
+export const C1 = class extends base {
+>C1 : Symbol(C1, Decl(2.ts, 10, 12))
+>base : Symbol(base, Decl(2.ts, 0, 8))
+
+    constructor(@foo prop: any) {
+>foo : Symbol(foo, Decl(2.ts, 1, 8))
+>prop : Symbol(prop, Decl(2.ts, 11, 16))
+
+        super();
+>super : Symbol(base, Decl(0.ts, 0, 0))
+    }
+}
+

--- a/tests/baselines/reference/decoratorOnClassConstructor3.types
+++ b/tests/baselines/reference/decoratorOnClassConstructor3.types
@@ -16,7 +16,7 @@ import {foo} from "./0"
 >foo : (target: Object, propertyKey: string | symbol, parameterIndex: number) => void
 
 /* Comment on the Class Declaration */
-export class C  extends base{
+export class C  extends base {
 >C : C
 >base : base
 
@@ -29,3 +29,19 @@ export class C  extends base{
 >super : typeof base
     }
 }
+
+export const C1 = class extends base {
+>C1 : typeof C1
+>class extends base {    constructor(@foo prop: any) {        super();    }} : typeof C1
+>base : base
+
+    constructor(@foo prop: any) {
+>foo : (target: Object, propertyKey: string | symbol, parameterIndex: number) => void
+>prop : any
+
+        super();
+>super() : void
+>super : typeof base
+    }
+}
+

--- a/tests/baselines/reference/decoratorOnClassConstructorParameter1.js
+++ b/tests/baselines/reference/decoratorOnClassConstructorParameter1.js
@@ -5,6 +5,11 @@ class C {
     constructor(@dec p: number) {}
 }
 
+const C1 = class {
+    constructor(@dec p: number) {}
+}
+
+
 //// [decoratorOnClassConstructorParameter1.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -22,4 +27,9 @@ var C = /** @class */ (function () {
         __param(0, dec)
     ], C);
     return C;
+}());
+var C1 = /** @class */ (function () {
+    function class_1(p) {
+    }
+    return class_1;
 }());

--- a/tests/baselines/reference/decoratorOnClassConstructorParameter1.symbols
+++ b/tests/baselines/reference/decoratorOnClassConstructorParameter1.symbols
@@ -13,3 +13,12 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassConstructorParameter1.ts, 0, 0))
 >p : Symbol(p, Decl(decoratorOnClassConstructorParameter1.ts, 3, 16))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassConstructorParameter1.ts, 6, 5))
+
+    constructor(@dec p: number) {}
+>dec : Symbol(dec, Decl(decoratorOnClassConstructorParameter1.ts, 0, 0))
+>p : Symbol(p, Decl(decoratorOnClassConstructorParameter1.ts, 7, 16))
+}
+

--- a/tests/baselines/reference/decoratorOnClassConstructorParameter1.types
+++ b/tests/baselines/reference/decoratorOnClassConstructorParameter1.types
@@ -12,3 +12,13 @@ class C {
 >dec : (target: Function, propertyKey: string | symbol, parameterIndex: number) => void
 >p : number
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    constructor(@dec p: number) {}} : typeof C1
+
+    constructor(@dec p: number) {}
+>dec : (target: Function, propertyKey: string | symbol, parameterIndex: number) => void
+>p : number
+}
+

--- a/tests/baselines/reference/decoratorOnClassConstructorParameter4.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassConstructorParameter4.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter4.ts(4,24): error TS1005: ',' expected.
+tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter4.ts(8,24): error TS1005: ',' expected.
 
 
-==== tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter4.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter4.ts (2 errors) ====
     declare function dec(target: Function, propertyKey: string | symbol, parameterIndex: number): void;
     
     class C {
@@ -9,3 +10,10 @@ tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassC
                            ~
 !!! error TS1005: ',' expected.
     }
+    
+    const C1 = class {
+        constructor(public @dec p: number) {}
+                           ~
+!!! error TS1005: ',' expected.
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassConstructorParameter4.js
+++ b/tests/baselines/reference/decoratorOnClassConstructorParameter4.js
@@ -5,6 +5,11 @@ class C {
     constructor(public @dec p: number) {}
 }
 
+const C1 = class {
+    constructor(public @dec p: number) {}
+}
+
+
 //// [decoratorOnClassConstructorParameter4.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -22,4 +27,9 @@ var C = /** @class */ (function () {
         __param(1, dec)
     ], C);
     return C;
+}());
+var C1 = /** @class */ (function () {
+    function class_1(public, p) {
+    }
+    return class_1;
 }());

--- a/tests/baselines/reference/decoratorOnClassConstructorParameter4.symbols
+++ b/tests/baselines/reference/decoratorOnClassConstructorParameter4.symbols
@@ -14,3 +14,13 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassConstructorParameter4.ts, 0, 0))
 >p : Symbol(p, Decl(decoratorOnClassConstructorParameter4.ts, 3, 22))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassConstructorParameter4.ts, 6, 5))
+
+    constructor(public @dec p: number) {}
+>public : Symbol(public, Decl(decoratorOnClassConstructorParameter4.ts, 7, 16))
+>dec : Symbol(dec, Decl(decoratorOnClassConstructorParameter4.ts, 0, 0))
+>p : Symbol(p, Decl(decoratorOnClassConstructorParameter4.ts, 7, 22))
+}
+

--- a/tests/baselines/reference/decoratorOnClassConstructorParameter4.types
+++ b/tests/baselines/reference/decoratorOnClassConstructorParameter4.types
@@ -13,3 +13,14 @@ class C {
 >dec : (target: Function, propertyKey: string | symbol, parameterIndex: number) => void
 >p : number
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    constructor(public @dec p: number) {}} : typeof C1
+
+    constructor(public @dec p: number) {}
+>public : any
+>dec : (target: Function, propertyKey: string | symbol, parameterIndex: number) => void
+>p : number
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod1.js
+++ b/tests/baselines/reference/decoratorOnClassMethod1.js
@@ -5,6 +5,11 @@ class C {
     @dec method() {}
 }
 
+const C1 = class {
+    @dec method() {}
+}
+
+
 //// [decoratorOnClassMethod1.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -21,3 +27,11 @@ var C = /** @class */ (function () {
     ], C.prototype, "method", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    class_1.prototype.method = function () { };
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "method", null), _a);

--- a/tests/baselines/reference/decoratorOnClassMethod1.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethod1.symbols
@@ -17,3 +17,12 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassMethod1.ts, 0, 0))
 >method : Symbol(C.method, Decl(decoratorOnClassMethod1.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethod1.ts, 6, 5))
+
+    @dec method() {}
+>dec : Symbol(dec, Decl(decoratorOnClassMethod1.ts, 0, 0))
+>method : Symbol(C1.method, Decl(decoratorOnClassMethod1.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod1.types
+++ b/tests/baselines/reference/decoratorOnClassMethod1.types
@@ -12,3 +12,13 @@ class C {
 >dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
 >method : () => void
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec method() {}} : typeof C1
+
+    @dec method() {}
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>method : () => void
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod10.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassMethod10.errors.txt
@@ -1,8 +1,10 @@
 tests/cases/conformance/decorators/class/method/decoratorOnClassMethod10.ts(4,6): error TS2345: Argument of type 'C' is not assignable to parameter of type 'Function'.
   Type 'C' is missing the following properties from type 'Function': apply, call, bind, prototype, and 3 more.
+tests/cases/conformance/decorators/class/method/decoratorOnClassMethod10.ts(8,6): error TS2345: Argument of type 'C1' is not assignable to parameter of type 'Function'.
+  Type 'C1' is missing the following properties from type 'Function': apply, call, bind, prototype, and 3 more.
 
 
-==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethod10.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethod10.ts (2 errors) ====
     declare function dec(target: Function, paramIndex: number): void;
     
     class C {
@@ -11,3 +13,11 @@ tests/cases/conformance/decorators/class/method/decoratorOnClassMethod10.ts(4,6)
 !!! error TS2345: Argument of type 'C' is not assignable to parameter of type 'Function'.
 !!! error TS2345:   Type 'C' is missing the following properties from type 'Function': apply, call, bind, prototype, and 3 more.
     }
+    
+    const C1 = class {
+        @dec method() {}
+         ~~~
+!!! error TS2345: Argument of type 'C1' is not assignable to parameter of type 'Function'.
+!!! error TS2345:   Type 'C1' is missing the following properties from type 'Function': apply, call, bind, prototype, and 3 more.
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassMethod10.js
+++ b/tests/baselines/reference/decoratorOnClassMethod10.js
@@ -5,6 +5,11 @@ class C {
     @dec method() {}
 }
 
+const C1 = class {
+    @dec method() {}
+}
+
+
 //// [decoratorOnClassMethod10.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -21,3 +27,11 @@ var C = /** @class */ (function () {
     ], C.prototype, "method", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    class_1.prototype.method = function () { };
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "method", null), _a);

--- a/tests/baselines/reference/decoratorOnClassMethod10.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethod10.symbols
@@ -12,3 +12,12 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassMethod10.ts, 0, 0))
 >method : Symbol(C.method, Decl(decoratorOnClassMethod10.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethod10.ts, 6, 5))
+
+    @dec method() {}
+>dec : Symbol(dec, Decl(decoratorOnClassMethod10.ts, 0, 0))
+>method : Symbol(C1.method, Decl(decoratorOnClassMethod10.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod10.types
+++ b/tests/baselines/reference/decoratorOnClassMethod10.types
@@ -11,3 +11,13 @@ class C {
 >dec : (target: Function, paramIndex: number) => void
 >method : () => void
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec method() {}} : typeof C1
+
+    @dec method() {}
+>dec : (target: Function, paramIndex: number) => void
+>method : () => void
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod11.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassMethod11.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/decorators/class/method/decoratorOnClassMethod11.ts(5,10): error TS2331: 'this' cannot be referenced in a module or namespace body.
+tests/cases/conformance/decorators/class/method/decoratorOnClassMethod11.ts(12,10): error TS2331: 'this' cannot be referenced in a module or namespace body.
 
 
-==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethod11.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethod11.ts (2 errors) ====
     module M {
         class C {
             decorator(target: Object, key: string): void { }
@@ -11,4 +12,14 @@ tests/cases/conformance/decorators/class/method/decoratorOnClassMethod11.ts(5,10
 !!! error TS2331: 'this' cannot be referenced in a module or namespace body.
             method() { }
         }
+    
+        const C1 = class {
+            decorator(target: Object, key: string): void { }
+    
+            @this.decorator
+             ~~~~
+!!! error TS2331: 'this' cannot be referenced in a module or namespace body.
+            method() { }
+        }
     }
+    

--- a/tests/baselines/reference/decoratorOnClassMethod11.js
+++ b/tests/baselines/reference/decoratorOnClassMethod11.js
@@ -6,7 +6,15 @@ module M {
         @this.decorator
         method() { }
     }
+
+    const C1 = class {
+        decorator(target: Object, key: string): void { }
+
+        @this.decorator
+        method() { }
+    }
 }
+
 
 //// [decoratorOnClassMethod11.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
@@ -17,6 +25,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 };
 var M;
 (function (M) {
+    var _a;
     var C = /** @class */ (function () {
         function C() {
         }
@@ -27,4 +36,13 @@ var M;
         ], C.prototype, "method", null);
         return C;
     }());
+    var C1 = (_a = /** @class */ (function () {
+        function class_1() {
+        }
+        class_1.prototype.decorator = function (target, key) { };
+        class_1.prototype.method = function () { };
+        return class_1;
+    }()), __decorate([
+        this.decorator
+    ], _a.prototype, "method", null), _a);
 })(M || (M = {}));

--- a/tests/baselines/reference/decoratorOnClassMethod11.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethod11.symbols
@@ -15,4 +15,19 @@ module M {
         method() { }
 >method : Symbol(C.method, Decl(decoratorOnClassMethod11.ts, 2, 56))
     }
+
+    const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethod11.ts, 8, 9))
+
+        decorator(target: Object, key: string): void { }
+>decorator : Symbol(C1.decorator, Decl(decoratorOnClassMethod11.ts, 8, 22))
+>target : Symbol(target, Decl(decoratorOnClassMethod11.ts, 9, 18))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>key : Symbol(key, Decl(decoratorOnClassMethod11.ts, 9, 33))
+
+        @this.decorator
+        method() { }
+>method : Symbol(C1.method, Decl(decoratorOnClassMethod11.ts, 9, 56))
+    }
 }
+

--- a/tests/baselines/reference/decoratorOnClassMethod11.types
+++ b/tests/baselines/reference/decoratorOnClassMethod11.types
@@ -18,4 +18,23 @@ module M {
         method() { }
 >method : () => void
     }
+
+    const C1 = class {
+>C1 : typeof C1
+>class {        decorator(target: Object, key: string): void { }        @this.decorator        method() { }    } : typeof C1
+
+        decorator(target: Object, key: string): void { }
+>decorator : (target: Object, key: string) => void
+>target : Object
+>key : string
+
+        @this.decorator
+>this.decorator : any
+>this : any
+>decorator : any
+
+        method() { }
+>method : () => void
+    }
 }
+

--- a/tests/baselines/reference/decoratorOnClassMethod12.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassMethod12.errors.txt
@@ -1,15 +1,25 @@
-tests/cases/conformance/decorators/class/method/decoratorOnClassMethod12.ts(6,10): error TS2660: 'super' can only be referenced in members of derived classes or object literal expressions.
+tests/cases/conformance/decorators/class/method/decoratorOnClassMethod12.ts(7,10): error TS2660: 'super' can only be referenced in members of derived classes or object literal expressions.
+tests/cases/conformance/decorators/class/method/decoratorOnClassMethod12.ts(12,10): error TS2660: 'super' can only be referenced in members of derived classes or object literal expressions.
 
 
-==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethod12.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethod12.ts (2 errors) ====
     module M {
         class S {
             decorator(target: Object, key: string): void { }
         }
+    
         class C extends S {
             @super.decorator
              ~~~~~
 !!! error TS2660: 'super' can only be referenced in members of derived classes or object literal expressions.
             method() { }
         }
+    
+        const C1 = class extends S {
+            @super.decorator
+             ~~~~~
+!!! error TS2660: 'super' can only be referenced in members of derived classes or object literal expressions.
+            method() { }
+        }
     }
+    

--- a/tests/baselines/reference/decoratorOnClassMethod12.js
+++ b/tests/baselines/reference/decoratorOnClassMethod12.js
@@ -3,11 +3,18 @@ module M {
     class S {
         decorator(target: Object, key: string): void { }
     }
+
     class C extends S {
         @super.decorator
         method() { }
     }
+
+    const C1 = class extends S {
+        @super.decorator
+        method() { }
+    }
 }
+
 
 //// [decoratorOnClassMethod12.js]
 var __extends = (this && this.__extends) || (function () {
@@ -33,6 +40,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 };
 var M;
 (function (M) {
+    var _a;
     var S = /** @class */ (function () {
         function S() {
         }
@@ -50,4 +58,14 @@ var M;
         ], C.prototype, "method", null);
         return C;
     }(S));
+    var C1 = (_a = /** @class */ (function (_super) {
+        __extends(class_1, _super);
+        function class_1() {
+            return _super !== null && _super.apply(this, arguments) || this;
+        }
+        class_1.prototype.method = function () { };
+        return class_1;
+    }(S)), __decorate([
+        _super.decorator
+    ], _a.prototype, "method", null), _a);
 })(M || (M = {}));

--- a/tests/baselines/reference/decoratorOnClassMethod12.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethod12.symbols
@@ -11,12 +11,23 @@ module M {
 >Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >key : Symbol(key, Decl(decoratorOnClassMethod12.ts, 2, 33))
     }
+
     class C extends S {
 >C : Symbol(C, Decl(decoratorOnClassMethod12.ts, 3, 5))
 >S : Symbol(S, Decl(decoratorOnClassMethod12.ts, 0, 10))
 
         @super.decorator
         method() { }
->method : Symbol(C.method, Decl(decoratorOnClassMethod12.ts, 4, 23))
+>method : Symbol(C.method, Decl(decoratorOnClassMethod12.ts, 5, 23))
+    }
+
+    const C1 = class extends S {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethod12.ts, 10, 9))
+>S : Symbol(S, Decl(decoratorOnClassMethod12.ts, 0, 10))
+
+        @super.decorator
+        method() { }
+>method : Symbol(C1.method, Decl(decoratorOnClassMethod12.ts, 10, 32))
     }
 }
+

--- a/tests/baselines/reference/decoratorOnClassMethod12.types
+++ b/tests/baselines/reference/decoratorOnClassMethod12.types
@@ -10,6 +10,7 @@ module M {
 >target : Object
 >key : string
     }
+
     class C extends S {
 >C : C
 >S : S
@@ -22,4 +23,19 @@ module M {
         method() { }
 >method : () => void
     }
+
+    const C1 = class extends S {
+>C1 : typeof C1
+>class extends S {        @super.decorator        method() { }    } : typeof C1
+>S : S
+
+        @super.decorator
+>super.decorator : any
+>super : any
+>decorator : any
+
+        method() { }
+>method : () => void
+    }
 }
+

--- a/tests/baselines/reference/decoratorOnClassMethod13.js
+++ b/tests/baselines/reference/decoratorOnClassMethod13.js
@@ -6,6 +6,12 @@ class C {
     @dec ["b"]() { }
 }
 
+const C1 = class {
+    @dec ["1"]() { }
+    @dec ["b"]() { }
+}
+
+
 //// [decoratorOnClassMethod13.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -13,6 +19,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 class C {
     ["1"]() { }
     ["b"]() { }
@@ -23,3 +30,11 @@ __decorate([
 __decorate([
     dec
 ], C.prototype, "b", null);
+const C1 = (_a = class {
+    ["1"]() { }
+    ["b"]() { }
+}, __decorate([
+    dec
+], _a.prototype, "1", null), __decorate([
+    dec
+], _a.prototype, "b", null), _a);

--- a/tests/baselines/reference/decoratorOnClassMethod13.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethod13.symbols
@@ -23,3 +23,18 @@ class C {
 >["b"] : Symbol(C["b"], Decl(decoratorOnClassMethod13.ts, 3, 20))
 >"b" : Symbol(C["b"], Decl(decoratorOnClassMethod13.ts, 3, 20))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethod13.ts, 7, 5))
+
+    @dec ["1"]() { }
+>dec : Symbol(dec, Decl(decoratorOnClassMethod13.ts, 0, 0))
+>["1"] : Symbol(C1["1"], Decl(decoratorOnClassMethod13.ts, 7, 18))
+>"1" : Symbol(C1["1"], Decl(decoratorOnClassMethod13.ts, 7, 18))
+
+    @dec ["b"]() { }
+>dec : Symbol(dec, Decl(decoratorOnClassMethod13.ts, 0, 0))
+>["b"] : Symbol(C1["b"], Decl(decoratorOnClassMethod13.ts, 8, 20))
+>"b" : Symbol(C1["b"], Decl(decoratorOnClassMethod13.ts, 8, 20))
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod13.types
+++ b/tests/baselines/reference/decoratorOnClassMethod13.types
@@ -18,3 +18,19 @@ class C {
 >["b"] : () => void
 >"b" : "b"
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec ["1"]() { }    @dec ["b"]() { }} : typeof C1
+
+    @dec ["1"]() { }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>["1"] : () => void
+>"1" : "1"
+
+    @dec ["b"]() { }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>["b"] : () => void
+>"b" : "b"
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod2.js
+++ b/tests/baselines/reference/decoratorOnClassMethod2.js
@@ -5,6 +5,11 @@ class C {
     @dec public method() {}
 }
 
+const C1 = class {
+    @dec public method() {}
+}
+
+
 //// [decoratorOnClassMethod2.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -21,3 +27,11 @@ var C = /** @class */ (function () {
     ], C.prototype, "method", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    class_1.prototype.method = function () { };
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "method", null), _a);

--- a/tests/baselines/reference/decoratorOnClassMethod2.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethod2.symbols
@@ -17,3 +17,12 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassMethod2.ts, 0, 0))
 >method : Symbol(C.method, Decl(decoratorOnClassMethod2.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethod2.ts, 6, 5))
+
+    @dec public method() {}
+>dec : Symbol(dec, Decl(decoratorOnClassMethod2.ts, 0, 0))
+>method : Symbol(C1.method, Decl(decoratorOnClassMethod2.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod2.types
+++ b/tests/baselines/reference/decoratorOnClassMethod2.types
@@ -12,3 +12,13 @@ class C {
 >dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
 >method : () => void
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec public method() {}} : typeof C1
+
+    @dec public method() {}
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>method : () => void
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod3.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassMethod3.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/decorators/class/method/decoratorOnClassMethod3.ts(4,12): error TS1005: ';' expected.
+tests/cases/conformance/decorators/class/method/decoratorOnClassMethod3.ts(8,12): error TS1005: ';' expected.
 
 
-==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethod3.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethod3.ts (2 errors) ====
     declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
     
     class C {
@@ -9,3 +10,10 @@ tests/cases/conformance/decorators/class/method/decoratorOnClassMethod3.ts(4,12)
                ~
 !!! error TS1005: ';' expected.
     }
+    
+    const C1 = class {
+        public @dec method() {}
+               ~
+!!! error TS1005: ';' expected.
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassMethod3.js
+++ b/tests/baselines/reference/decoratorOnClassMethod3.js
@@ -5,6 +5,11 @@ class C {
     public @dec method() {}
 }
 
+const C1 = class {
+    public @dec method() {}
+}
+
+
 //// [decoratorOnClassMethod3.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -21,3 +27,11 @@ var C = /** @class */ (function () {
     ], C.prototype, "method", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    class_1.prototype.method = function () { };
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "method", null), _a);

--- a/tests/baselines/reference/decoratorOnClassMethod3.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethod3.symbols
@@ -18,3 +18,13 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassMethod3.ts, 0, 0))
 >method : Symbol(C.method, Decl(decoratorOnClassMethod3.ts, 3, 10))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethod3.ts, 6, 5))
+
+    public @dec method() {}
+>public : Symbol(C1.public, Decl(decoratorOnClassMethod3.ts, 6, 18))
+>dec : Symbol(dec, Decl(decoratorOnClassMethod3.ts, 0, 0))
+>method : Symbol(C1.method, Decl(decoratorOnClassMethod3.ts, 7, 10))
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod3.types
+++ b/tests/baselines/reference/decoratorOnClassMethod3.types
@@ -13,3 +13,14 @@ class C {
 >dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
 >method : () => void
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    public @dec method() {}} : typeof C1
+
+    public @dec method() {}
+>public : any
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>method : () => void
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod4.js
+++ b/tests/baselines/reference/decoratorOnClassMethod4.js
@@ -5,6 +5,11 @@ class C {
     @dec ["method"]() {}
 }
 
+const C1 = class {
+    @dec ["method"]() {}
+}
+
+
 //// [decoratorOnClassMethod4.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,9 +17,15 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 class C {
     ["method"]() { }
 }
 __decorate([
     dec
 ], C.prototype, "method", null);
+const C1 = (_a = class {
+    ["method"]() { }
+}, __decorate([
+    dec
+], _a.prototype, "method", null), _a);

--- a/tests/baselines/reference/decoratorOnClassMethod4.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethod4.symbols
@@ -18,3 +18,13 @@ class C {
 >["method"] : Symbol(C["method"], Decl(decoratorOnClassMethod4.ts, 2, 9))
 >"method" : Symbol(C["method"], Decl(decoratorOnClassMethod4.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethod4.ts, 6, 5))
+
+    @dec ["method"]() {}
+>dec : Symbol(dec, Decl(decoratorOnClassMethod4.ts, 0, 0))
+>["method"] : Symbol(C1["method"], Decl(decoratorOnClassMethod4.ts, 6, 18))
+>"method" : Symbol(C1["method"], Decl(decoratorOnClassMethod4.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod4.types
+++ b/tests/baselines/reference/decoratorOnClassMethod4.types
@@ -13,3 +13,14 @@ class C {
 >["method"] : () => void
 >"method" : "method"
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec ["method"]() {}} : typeof C1
+
+    @dec ["method"]() {}
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>["method"] : () => void
+>"method" : "method"
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod5.js
+++ b/tests/baselines/reference/decoratorOnClassMethod5.js
@@ -5,6 +5,11 @@ class C {
     @dec() ["method"]() {}
 }
 
+const C1 = class {
+    @dec() ["method"]() {}
+}
+
+
 //// [decoratorOnClassMethod5.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,9 +17,15 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 class C {
     ["method"]() { }
 }
 __decorate([
     dec()
 ], C.prototype, "method", null);
+const C1 = (_a = class {
+    ["method"]() { }
+}, __decorate([
+    dec()
+], _a.prototype, "method", null), _a);

--- a/tests/baselines/reference/decoratorOnClassMethod5.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethod5.symbols
@@ -18,3 +18,13 @@ class C {
 >["method"] : Symbol(C["method"], Decl(decoratorOnClassMethod5.ts, 2, 9))
 >"method" : Symbol(C["method"], Decl(decoratorOnClassMethod5.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethod5.ts, 6, 5))
+
+    @dec() ["method"]() {}
+>dec : Symbol(dec, Decl(decoratorOnClassMethod5.ts, 0, 0))
+>["method"] : Symbol(C1["method"], Decl(decoratorOnClassMethod5.ts, 6, 18))
+>"method" : Symbol(C1["method"], Decl(decoratorOnClassMethod5.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod5.types
+++ b/tests/baselines/reference/decoratorOnClassMethod5.types
@@ -14,3 +14,15 @@ class C {
 >["method"] : () => void
 >"method" : "method"
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec() ["method"]() {}} : typeof C1
+
+    @dec() ["method"]() {}
+>dec() : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>dec : () => <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>["method"] : () => void
+>"method" : "method"
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod6.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassMethod6.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/decorators/class/method/decoratorOnClassMethod6.ts(4,5): error TS1329: 'dec' accepts too few arguments to be used as a decorator here. Did you mean to call it first and write '@dec()'?
+tests/cases/conformance/decorators/class/method/decoratorOnClassMethod6.ts(8,5): error TS1329: 'dec' accepts too few arguments to be used as a decorator here. Did you mean to call it first and write '@dec()'?
 
 
-==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethod6.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethod6.ts (2 errors) ====
     declare function dec(): <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>;
     
     class C {
@@ -9,3 +10,10 @@ tests/cases/conformance/decorators/class/method/decoratorOnClassMethod6.ts(4,5):
         ~~~~
 !!! error TS1329: 'dec' accepts too few arguments to be used as a decorator here. Did you mean to call it first and write '@dec()'?
     }
+    
+    const C1 = class {
+        @dec ["method"]() {}
+        ~~~~
+!!! error TS1329: 'dec' accepts too few arguments to be used as a decorator here. Did you mean to call it first and write '@dec()'?
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassMethod6.js
+++ b/tests/baselines/reference/decoratorOnClassMethod6.js
@@ -5,6 +5,11 @@ class C {
     @dec ["method"]() {}
 }
 
+const C1 = class {
+    @dec ["method"]() {}
+}
+
+
 //// [decoratorOnClassMethod6.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,9 +17,15 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 class C {
     ["method"]() { }
 }
 __decorate([
     dec
 ], C.prototype, "method", null);
+const C1 = (_a = class {
+    ["method"]() { }
+}, __decorate([
+    dec
+], _a.prototype, "method", null), _a);

--- a/tests/baselines/reference/decoratorOnClassMethod6.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethod6.symbols
@@ -18,3 +18,13 @@ class C {
 >["method"] : Symbol(C["method"], Decl(decoratorOnClassMethod6.ts, 2, 9))
 >"method" : Symbol(C["method"], Decl(decoratorOnClassMethod6.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethod6.ts, 6, 5))
+
+    @dec ["method"]() {}
+>dec : Symbol(dec, Decl(decoratorOnClassMethod6.ts, 0, 0))
+>["method"] : Symbol(C1["method"], Decl(decoratorOnClassMethod6.ts, 6, 18))
+>"method" : Symbol(C1["method"], Decl(decoratorOnClassMethod6.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod6.types
+++ b/tests/baselines/reference/decoratorOnClassMethod6.types
@@ -13,3 +13,14 @@ class C {
 >["method"] : () => void
 >"method" : "method"
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec ["method"]() {}} : typeof C1
+
+    @dec ["method"]() {}
+>dec : () => <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>["method"] : () => void
+>"method" : "method"
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod7.js
+++ b/tests/baselines/reference/decoratorOnClassMethod7.js
@@ -5,6 +5,11 @@ class C {
     @dec public ["method"]() {}
 }
 
+const C1 = class {
+    @dec public ["method"]() {}
+}
+
+
 //// [decoratorOnClassMethod7.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,9 +17,15 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 class C {
     ["method"]() { }
 }
 __decorate([
     dec
 ], C.prototype, "method", null);
+const C1 = (_a = class {
+    ["method"]() { }
+}, __decorate([
+    dec
+], _a.prototype, "method", null), _a);

--- a/tests/baselines/reference/decoratorOnClassMethod7.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethod7.symbols
@@ -18,3 +18,13 @@ class C {
 >["method"] : Symbol(C["method"], Decl(decoratorOnClassMethod7.ts, 2, 9))
 >"method" : Symbol(C["method"], Decl(decoratorOnClassMethod7.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethod7.ts, 6, 5))
+
+    @dec public ["method"]() {}
+>dec : Symbol(dec, Decl(decoratorOnClassMethod7.ts, 0, 0))
+>["method"] : Symbol(C1["method"], Decl(decoratorOnClassMethod7.ts, 6, 18))
+>"method" : Symbol(C1["method"], Decl(decoratorOnClassMethod7.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod7.types
+++ b/tests/baselines/reference/decoratorOnClassMethod7.types
@@ -13,3 +13,14 @@ class C {
 >["method"] : () => void
 >"method" : "method"
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec public ["method"]() {}} : typeof C1
+
+    @dec public ["method"]() {}
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>["method"] : () => void
+>"method" : "method"
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod8.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassMethod8.errors.txt
@@ -1,9 +1,12 @@
 tests/cases/conformance/decorators/class/method/decoratorOnClassMethod8.ts(4,5): error TS1241: Unable to resolve signature of method decorator when called as an expression.
 tests/cases/conformance/decorators/class/method/decoratorOnClassMethod8.ts(4,5): error TS1241: Unable to resolve signature of method decorator when called as an expression.
   Type 'C' has no properties in common with type 'TypedPropertyDescriptor<() => void>'.
+tests/cases/conformance/decorators/class/method/decoratorOnClassMethod8.ts(8,5): error TS1241: Unable to resolve signature of method decorator when called as an expression.
+tests/cases/conformance/decorators/class/method/decoratorOnClassMethod8.ts(8,5): error TS1241: Unable to resolve signature of method decorator when called as an expression.
+  Type 'C1' has no properties in common with type 'TypedPropertyDescriptor<() => void>'.
 
 
-==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethod8.ts (2 errors) ====
+==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethod8.ts (4 errors) ====
     declare function dec<T>(target: T): T;
     
     class C {
@@ -14,3 +17,13 @@ tests/cases/conformance/decorators/class/method/decoratorOnClassMethod8.ts(4,5):
 !!! error TS1241: Unable to resolve signature of method decorator when called as an expression.
 !!! error TS1241:   Type 'C' has no properties in common with type 'TypedPropertyDescriptor<() => void>'.
     }
+    
+    const C1 = class {
+        @dec method() {}
+        ~~~~
+!!! error TS1241: Unable to resolve signature of method decorator when called as an expression.
+        ~~~~
+!!! error TS1241: Unable to resolve signature of method decorator when called as an expression.
+!!! error TS1241:   Type 'C1' has no properties in common with type 'TypedPropertyDescriptor<() => void>'.
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassMethod8.js
+++ b/tests/baselines/reference/decoratorOnClassMethod8.js
@@ -5,6 +5,11 @@ class C {
     @dec method() {}
 }
 
+const C1 = class {
+    @dec method() {}
+}
+
+
 //// [decoratorOnClassMethod8.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -21,3 +27,11 @@ var C = /** @class */ (function () {
     ], C.prototype, "method", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    class_1.prototype.method = function () { };
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "method", null), _a);

--- a/tests/baselines/reference/decoratorOnClassMethod8.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethod8.symbols
@@ -13,3 +13,12 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassMethod8.ts, 0, 0))
 >method : Symbol(C.method, Decl(decoratorOnClassMethod8.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethod8.ts, 6, 5))
+
+    @dec method() {}
+>dec : Symbol(dec, Decl(decoratorOnClassMethod8.ts, 0, 0))
+>method : Symbol(C1.method, Decl(decoratorOnClassMethod8.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethod8.types
+++ b/tests/baselines/reference/decoratorOnClassMethod8.types
@@ -10,3 +10,13 @@ class C {
 >dec : <T>(target: T) => T
 >method : () => void
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec method() {}} : typeof C1
+
+    @dec method() {}
+>dec : <T>(target: T) => T
+>method : () => void
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethodOverload1.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassMethodOverload1.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload1.ts(4,5): error TS1249: A decorator can only decorate a method implementation, not an overload.
+tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload1.ts(10,5): error TS1249: A decorator can only decorate a method implementation, not an overload.
 
 
-==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload1.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload1.ts (2 errors) ====
     declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
     
     class C {
@@ -11,3 +12,12 @@ tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload1.
         method()
         method() { }
     }
+    
+    const C1 = class {
+        @dec
+        ~
+!!! error TS1249: A decorator can only decorate a method implementation, not an overload.
+        method()
+        method() { }
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassMethodOverload1.js
+++ b/tests/baselines/reference/decoratorOnClassMethodOverload1.js
@@ -7,10 +7,23 @@ class C {
     method() { }
 }
 
+const C1 = class {
+    @dec
+    method()
+    method() { }
+}
+
+
 //// [decoratorOnClassMethodOverload1.js]
 var C = /** @class */ (function () {
     function C() {
     }
     C.prototype.method = function () { };
     return C;
+}());
+var C1 = /** @class */ (function () {
+    function class_1() {
+    }
+    class_1.prototype.method = function () { };
+    return class_1;
 }());

--- a/tests/baselines/reference/decoratorOnClassMethodOverload1.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethodOverload1.symbols
@@ -22,3 +22,17 @@ class C {
     method() { }
 >method : Symbol(C.method, Decl(decoratorOnClassMethodOverload1.ts, 2, 9), Decl(decoratorOnClassMethodOverload1.ts, 4, 12))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethodOverload1.ts, 8, 5))
+
+    @dec
+>dec : Symbol(dec, Decl(decoratorOnClassMethodOverload1.ts, 0, 0))
+
+    method()
+>method : Symbol(C1.method, Decl(decoratorOnClassMethodOverload1.ts, 8, 18), Decl(decoratorOnClassMethodOverload1.ts, 10, 12))
+
+    method() { }
+>method : Symbol(C1.method, Decl(decoratorOnClassMethodOverload1.ts, 8, 18), Decl(decoratorOnClassMethodOverload1.ts, 10, 12))
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethodOverload1.types
+++ b/tests/baselines/reference/decoratorOnClassMethodOverload1.types
@@ -17,3 +17,18 @@ class C {
     method() { }
 >method : () => any
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec    method()    method() { }} : typeof C1
+
+    @dec
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+
+    method()
+>method : () => any
+
+    method() { }
+>method : () => any
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethodOverload2.js
+++ b/tests/baselines/reference/decoratorOnClassMethodOverload2.js
@@ -7,6 +7,13 @@ class C {
     method() { }
 }
 
+const C1 = class {
+    method()
+    @dec
+    method() { }
+}
+
+
 //// [decoratorOnClassMethodOverload2.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -14,6 +21,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -23,3 +31,11 @@ var C = /** @class */ (function () {
     ], C.prototype, "method", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    class_1.prototype.method = function () { };
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "method", null), _a);

--- a/tests/baselines/reference/decoratorOnClassMethodOverload2.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethodOverload2.symbols
@@ -22,3 +22,17 @@ class C {
     method() { }
 >method : Symbol(C.method, Decl(decoratorOnClassMethodOverload2.ts, 2, 9), Decl(decoratorOnClassMethodOverload2.ts, 3, 12))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethodOverload2.ts, 8, 5))
+
+    method()
+>method : Symbol(C1.method, Decl(decoratorOnClassMethodOverload2.ts, 8, 18), Decl(decoratorOnClassMethodOverload2.ts, 9, 12))
+
+    @dec
+>dec : Symbol(dec, Decl(decoratorOnClassMethodOverload2.ts, 0, 0))
+
+    method() { }
+>method : Symbol(C1.method, Decl(decoratorOnClassMethodOverload2.ts, 8, 18), Decl(decoratorOnClassMethodOverload2.ts, 9, 12))
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethodOverload2.types
+++ b/tests/baselines/reference/decoratorOnClassMethodOverload2.types
@@ -17,3 +17,18 @@ class C {
     method() { }
 >method : () => any
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    method()    @dec    method() { }} : typeof C1
+
+    method()
+>method : () => any
+
+    @dec
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+
+    method() { }
+>method : () => any
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethodParameter1.js
+++ b/tests/baselines/reference/decoratorOnClassMethodParameter1.js
@@ -5,6 +5,11 @@ class C {
     method(@dec p: number) {}
 }
 
+const C1 = class {
+    method(@dec p: number) {}
+}
+
+
 //// [decoratorOnClassMethodParameter1.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -15,6 +20,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 var __param = (this && this.__param) || function (paramIndex, decorator) {
     return function (target, key) { decorator(target, key, paramIndex); }
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -24,3 +30,11 @@ var C = /** @class */ (function () {
     ], C.prototype, "method", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    class_1.prototype.method = function (p) { };
+    return class_1;
+}()), __decorate([
+    __param(0, dec)
+], _a.prototype, "method", null), _a);

--- a/tests/baselines/reference/decoratorOnClassMethodParameter1.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethodParameter1.symbols
@@ -14,3 +14,13 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassMethodParameter1.ts, 0, 0))
 >p : Symbol(p, Decl(decoratorOnClassMethodParameter1.ts, 3, 11))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethodParameter1.ts, 6, 5))
+
+    method(@dec p: number) {}
+>method : Symbol(C1.method, Decl(decoratorOnClassMethodParameter1.ts, 6, 18))
+>dec : Symbol(dec, Decl(decoratorOnClassMethodParameter1.ts, 0, 0))
+>p : Symbol(p, Decl(decoratorOnClassMethodParameter1.ts, 7, 11))
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethodParameter1.types
+++ b/tests/baselines/reference/decoratorOnClassMethodParameter1.types
@@ -13,3 +13,14 @@ class C {
 >dec : (target: Object, propertyKey: string | symbol, parameterIndex: number) => void
 >p : number
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    method(@dec p: number) {}} : typeof C1
+
+    method(@dec p: number) {}
+>method : (p: number) => void
+>dec : (target: Object, propertyKey: string | symbol, parameterIndex: number) => void
+>p : number
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethodParameter2.js
+++ b/tests/baselines/reference/decoratorOnClassMethodParameter2.js
@@ -5,6 +5,11 @@ class C {
     method(this: C, @dec p: number) {}
 }
 
+const C1 = class {
+    method(this: {}, @dec p: number) {}
+}
+
+
 //// [decoratorOnClassMethodParameter2.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -15,6 +20,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 var __param = (this && this.__param) || function (paramIndex, decorator) {
     return function (target, key) { decorator(target, key, paramIndex); }
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -24,3 +30,11 @@ var C = /** @class */ (function () {
     ], C.prototype, "method", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    class_1.prototype.method = function (p) { };
+    return class_1;
+}()), __decorate([
+    __param(0, dec)
+], _a.prototype, "method", null), _a);

--- a/tests/baselines/reference/decoratorOnClassMethodParameter2.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethodParameter2.symbols
@@ -16,3 +16,14 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassMethodParameter2.ts, 0, 0))
 >p : Symbol(p, Decl(decoratorOnClassMethodParameter2.ts, 3, 19))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassMethodParameter2.ts, 6, 5))
+
+    method(this: {}, @dec p: number) {}
+>method : Symbol(C1.method, Decl(decoratorOnClassMethodParameter2.ts, 6, 18))
+>this : Symbol(this, Decl(decoratorOnClassMethodParameter2.ts, 7, 11))
+>dec : Symbol(dec, Decl(decoratorOnClassMethodParameter2.ts, 0, 0))
+>p : Symbol(p, Decl(decoratorOnClassMethodParameter2.ts, 7, 20))
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethodParameter2.types
+++ b/tests/baselines/reference/decoratorOnClassMethodParameter2.types
@@ -14,3 +14,15 @@ class C {
 >dec : (target: Object, propertyKey: string | symbol, parameterIndex: number) => void
 >p : number
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    method(this: {}, @dec p: number) {}} : typeof C1
+
+    method(this: {}, @dec p: number) {}
+>method : (this: {}, p: number) => void
+>this : {}
+>dec : (target: Object, propertyKey: string | symbol, parameterIndex: number) => void
+>p : number
+}
+

--- a/tests/baselines/reference/decoratorOnClassMethodThisParameter.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassMethodThisParameter.errors.txt
@@ -19,3 +19,4 @@ tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethod
                                  ~~~~~~~~~~~~~
 !!! error TS2680: A 'this' parameter must be the first parameter.
     }
+    

--- a/tests/baselines/reference/decoratorOnClassMethodThisParameter.js
+++ b/tests/baselines/reference/decoratorOnClassMethodThisParameter.js
@@ -9,6 +9,7 @@ class C2 {
     method(@dec allowed: C2, @dec this: C2) {}
 }
 
+
 //// [decoratorOnClassMethodThisParameter.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;

--- a/tests/baselines/reference/decoratorOnClassMethodThisParameter.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethodThisParameter.symbols
@@ -28,3 +28,4 @@ class C2 {
 >this : Symbol(this, Decl(decoratorOnClassMethodThisParameter.ts, 7, 28))
 >C2 : Symbol(C2, Decl(decoratorOnClassMethodThisParameter.ts, 4, 1))
 }
+

--- a/tests/baselines/reference/decoratorOnClassMethodThisParameter.types
+++ b/tests/baselines/reference/decoratorOnClassMethodThisParameter.types
@@ -24,3 +24,4 @@ class C2 {
 >dec : (target: Object, propertyKey: string | symbol, parameterIndex: number) => void
 >this : C2
 }
+

--- a/tests/baselines/reference/decoratorOnClassProperty1.js
+++ b/tests/baselines/reference/decoratorOnClassProperty1.js
@@ -5,6 +5,11 @@ class C {
     @dec prop;
 }
 
+const C1 = class {
+    @dec prop;
+}
+
+
 //// [decoratorOnClassProperty1.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -20,3 +26,10 @@ var C = /** @class */ (function () {
     ], C.prototype, "prop", void 0);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "prop", void 0), _a);

--- a/tests/baselines/reference/decoratorOnClassProperty1.symbols
+++ b/tests/baselines/reference/decoratorOnClassProperty1.symbols
@@ -11,3 +11,12 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassProperty1.ts, 0, 0))
 >prop : Symbol(C.prop, Decl(decoratorOnClassProperty1.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassProperty1.ts, 6, 5))
+
+    @dec prop;
+>dec : Symbol(dec, Decl(decoratorOnClassProperty1.ts, 0, 0))
+>prop : Symbol(C1.prop, Decl(decoratorOnClassProperty1.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassProperty1.types
+++ b/tests/baselines/reference/decoratorOnClassProperty1.types
@@ -11,3 +11,13 @@ class C {
 >dec : (target: any, propertyKey: string) => void
 >prop : any
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec prop;} : typeof C1
+
+    @dec prop;
+>dec : (target: any, propertyKey: string) => void
+>prop : any
+}
+

--- a/tests/baselines/reference/decoratorOnClassProperty10.js
+++ b/tests/baselines/reference/decoratorOnClassProperty10.js
@@ -5,6 +5,11 @@ class C {
     @dec() prop;
 }
 
+const C1 = class {
+    @dec() prop;
+}
+
+
 //// [decoratorOnClassProperty10.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -20,3 +26,10 @@ var C = /** @class */ (function () {
     ], C.prototype, "prop", void 0);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    return class_1;
+}()), __decorate([
+    dec()
+], _a.prototype, "prop", void 0), _a);

--- a/tests/baselines/reference/decoratorOnClassProperty10.symbols
+++ b/tests/baselines/reference/decoratorOnClassProperty10.symbols
@@ -12,3 +12,12 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassProperty10.ts, 0, 0))
 >prop : Symbol(C.prop, Decl(decoratorOnClassProperty10.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassProperty10.ts, 6, 5))
+
+    @dec() prop;
+>dec : Symbol(dec, Decl(decoratorOnClassProperty10.ts, 0, 0))
+>prop : Symbol(C1.prop, Decl(decoratorOnClassProperty10.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassProperty10.types
+++ b/tests/baselines/reference/decoratorOnClassProperty10.types
@@ -12,3 +12,14 @@ class C {
 >dec : () => <T>(target: any, propertyKey: string) => void
 >prop : any
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec() prop;} : typeof C1
+
+    @dec() prop;
+>dec() : <T>(target: any, propertyKey: string) => void
+>dec : () => <T>(target: any, propertyKey: string) => void
+>prop : any
+}
+

--- a/tests/baselines/reference/decoratorOnClassProperty11.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassProperty11.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/decorators/class/property/decoratorOnClassProperty11.ts(4,5): error TS1329: 'dec' accepts too few arguments to be used as a decorator here. Did you mean to call it first and write '@dec()'?
+tests/cases/conformance/decorators/class/property/decoratorOnClassProperty11.ts(8,5): error TS1329: 'dec' accepts too few arguments to be used as a decorator here. Did you mean to call it first and write '@dec()'?
 
 
-==== tests/cases/conformance/decorators/class/property/decoratorOnClassProperty11.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/property/decoratorOnClassProperty11.ts (2 errors) ====
     declare function dec(): <T>(target: any, propertyKey: string) => void;
     
     class C {
@@ -9,3 +10,10 @@ tests/cases/conformance/decorators/class/property/decoratorOnClassProperty11.ts(
         ~~~~
 !!! error TS1329: 'dec' accepts too few arguments to be used as a decorator here. Did you mean to call it first and write '@dec()'?
     }
+    
+    const C1 = class {
+        @dec prop;
+        ~~~~
+!!! error TS1329: 'dec' accepts too few arguments to be used as a decorator here. Did you mean to call it first and write '@dec()'?
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassProperty11.js
+++ b/tests/baselines/reference/decoratorOnClassProperty11.js
@@ -5,6 +5,11 @@ class C {
     @dec prop;
 }
 
+const C1 = class {
+    @dec prop;
+}
+
+
 //// [decoratorOnClassProperty11.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -20,3 +26,10 @@ var C = /** @class */ (function () {
     ], C.prototype, "prop", void 0);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "prop", void 0), _a);

--- a/tests/baselines/reference/decoratorOnClassProperty11.symbols
+++ b/tests/baselines/reference/decoratorOnClassProperty11.symbols
@@ -12,3 +12,12 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassProperty11.ts, 0, 0))
 >prop : Symbol(C.prop, Decl(decoratorOnClassProperty11.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassProperty11.ts, 6, 5))
+
+    @dec prop;
+>dec : Symbol(dec, Decl(decoratorOnClassProperty11.ts, 0, 0))
+>prop : Symbol(C1.prop, Decl(decoratorOnClassProperty11.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassProperty11.types
+++ b/tests/baselines/reference/decoratorOnClassProperty11.types
@@ -11,3 +11,13 @@ class C {
 >dec : () => <T>(target: any, propertyKey: string) => void
 >prop : any
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec prop;} : typeof C1
+
+    @dec prop;
+>dec : () => <T>(target: any, propertyKey: string) => void
+>prop : any
+}
+

--- a/tests/baselines/reference/decoratorOnClassProperty2.js
+++ b/tests/baselines/reference/decoratorOnClassProperty2.js
@@ -5,6 +5,11 @@ class C {
     @dec public prop;
 }
 
+const C1 = class {
+    @dec public prop;
+}
+
+
 //// [decoratorOnClassProperty2.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -20,3 +26,10 @@ var C = /** @class */ (function () {
     ], C.prototype, "prop", void 0);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "prop", void 0), _a);

--- a/tests/baselines/reference/decoratorOnClassProperty2.symbols
+++ b/tests/baselines/reference/decoratorOnClassProperty2.symbols
@@ -11,3 +11,12 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassProperty2.ts, 0, 0))
 >prop : Symbol(C.prop, Decl(decoratorOnClassProperty2.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassProperty2.ts, 6, 5))
+
+    @dec public prop;
+>dec : Symbol(dec, Decl(decoratorOnClassProperty2.ts, 0, 0))
+>prop : Symbol(C1.prop, Decl(decoratorOnClassProperty2.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassProperty2.types
+++ b/tests/baselines/reference/decoratorOnClassProperty2.types
@@ -11,3 +11,13 @@ class C {
 >dec : (target: any, propertyKey: string) => void
 >prop : any
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec public prop;} : typeof C1
+
+    @dec public prop;
+>dec : (target: any, propertyKey: string) => void
+>prop : any
+}
+

--- a/tests/baselines/reference/decoratorOnClassProperty3.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassProperty3.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/decorators/class/property/decoratorOnClassProperty3.ts(4,12): error TS1005: ';' expected.
+tests/cases/conformance/decorators/class/property/decoratorOnClassProperty3.ts(8,12): error TS1005: ';' expected.
 
 
-==== tests/cases/conformance/decorators/class/property/decoratorOnClassProperty3.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/property/decoratorOnClassProperty3.ts (2 errors) ====
     declare function dec(target: any, propertyKey: string): void;
     
     class C {
@@ -9,3 +10,10 @@ tests/cases/conformance/decorators/class/property/decoratorOnClassProperty3.ts(4
                ~
 !!! error TS1005: ';' expected.
     }
+    
+    const C1 = class {
+        public @dec prop;
+               ~
+!!! error TS1005: ';' expected.
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassProperty3.js
+++ b/tests/baselines/reference/decoratorOnClassProperty3.js
@@ -5,6 +5,11 @@ class C {
     public @dec prop;
 }
 
+const C1 = class {
+    public @dec prop;
+}
+
+
 //// [decoratorOnClassProperty3.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -20,3 +26,10 @@ var C = /** @class */ (function () {
     ], C.prototype, "prop", void 0);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "prop", void 0), _a);

--- a/tests/baselines/reference/decoratorOnClassProperty3.symbols
+++ b/tests/baselines/reference/decoratorOnClassProperty3.symbols
@@ -12,3 +12,13 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassProperty3.ts, 0, 0))
 >prop : Symbol(C.prop, Decl(decoratorOnClassProperty3.ts, 3, 10))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassProperty3.ts, 6, 5))
+
+    public @dec prop;
+>public : Symbol(C1.public, Decl(decoratorOnClassProperty3.ts, 6, 18))
+>dec : Symbol(dec, Decl(decoratorOnClassProperty3.ts, 0, 0))
+>prop : Symbol(C1.prop, Decl(decoratorOnClassProperty3.ts, 7, 10))
+}
+

--- a/tests/baselines/reference/decoratorOnClassProperty3.types
+++ b/tests/baselines/reference/decoratorOnClassProperty3.types
@@ -12,3 +12,14 @@ class C {
 >dec : (target: any, propertyKey: string) => void
 >prop : any
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    public @dec prop;} : typeof C1
+
+    public @dec prop;
+>public : any
+>dec : (target: any, propertyKey: string) => void
+>prop : any
+}
+

--- a/tests/baselines/reference/decoratorOnClassProperty6.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassProperty6.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/decorators/class/property/decoratorOnClassProperty6.ts(4,5): error TS1240: Unable to resolve signature of property decorator when called as an expression.
+tests/cases/conformance/decorators/class/property/decoratorOnClassProperty6.ts(8,5): error TS1240: Unable to resolve signature of property decorator when called as an expression.
 
 
-==== tests/cases/conformance/decorators/class/property/decoratorOnClassProperty6.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/property/decoratorOnClassProperty6.ts (2 errors) ====
     declare function dec(target: Function): void;
     
     class C {
@@ -9,3 +10,10 @@ tests/cases/conformance/decorators/class/property/decoratorOnClassProperty6.ts(4
         ~~~~
 !!! error TS1240: Unable to resolve signature of property decorator when called as an expression.
     }
+    
+    const C1 = class {
+        @dec prop;
+        ~~~~
+!!! error TS1240: Unable to resolve signature of property decorator when called as an expression.
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassProperty6.js
+++ b/tests/baselines/reference/decoratorOnClassProperty6.js
@@ -5,6 +5,11 @@ class C {
     @dec prop;
 }
 
+const C1 = class {
+    @dec prop;
+}
+
+
 //// [decoratorOnClassProperty6.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -20,3 +26,10 @@ var C = /** @class */ (function () {
     ], C.prototype, "prop", void 0);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "prop", void 0), _a);

--- a/tests/baselines/reference/decoratorOnClassProperty6.symbols
+++ b/tests/baselines/reference/decoratorOnClassProperty6.symbols
@@ -11,3 +11,12 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassProperty6.ts, 0, 0))
 >prop : Symbol(C.prop, Decl(decoratorOnClassProperty6.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassProperty6.ts, 6, 5))
+
+    @dec prop;
+>dec : Symbol(dec, Decl(decoratorOnClassProperty6.ts, 0, 0))
+>prop : Symbol(C1.prop, Decl(decoratorOnClassProperty6.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassProperty6.types
+++ b/tests/baselines/reference/decoratorOnClassProperty6.types
@@ -10,3 +10,13 @@ class C {
 >dec : (target: Function) => void
 >prop : any
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec prop;} : typeof C1
+
+    @dec prop;
+>dec : (target: Function) => void
+>prop : any
+}
+

--- a/tests/baselines/reference/decoratorOnClassProperty7.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassProperty7.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/decorators/class/property/decoratorOnClassProperty7.ts(4,5): error TS1240: Unable to resolve signature of property decorator when called as an expression.
+tests/cases/conformance/decorators/class/property/decoratorOnClassProperty7.ts(8,5): error TS1240: Unable to resolve signature of property decorator when called as an expression.
 
 
-==== tests/cases/conformance/decorators/class/property/decoratorOnClassProperty7.ts (1 errors) ====
+==== tests/cases/conformance/decorators/class/property/decoratorOnClassProperty7.ts (2 errors) ====
     declare function dec(target: Function, propertyKey: string | symbol, paramIndex: number): void;
     
     class C {
@@ -9,3 +10,10 @@ tests/cases/conformance/decorators/class/property/decoratorOnClassProperty7.ts(4
         ~~~~
 !!! error TS1240: Unable to resolve signature of property decorator when called as an expression.
     }
+    
+    const C1 = class {
+        @dec prop;
+        ~~~~
+!!! error TS1240: Unable to resolve signature of property decorator when called as an expression.
+    }
+    

--- a/tests/baselines/reference/decoratorOnClassProperty7.js
+++ b/tests/baselines/reference/decoratorOnClassProperty7.js
@@ -5,6 +5,11 @@ class C {
     @dec prop;
 }
 
+const C1 = class {
+    @dec prop;
+}
+
+
 //// [decoratorOnClassProperty7.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -12,6 +17,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -20,3 +26,10 @@ var C = /** @class */ (function () {
     ], C.prototype, "prop", void 0);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "prop", void 0), _a);

--- a/tests/baselines/reference/decoratorOnClassProperty7.symbols
+++ b/tests/baselines/reference/decoratorOnClassProperty7.symbols
@@ -13,3 +13,12 @@ class C {
 >dec : Symbol(dec, Decl(decoratorOnClassProperty7.ts, 0, 0))
 >prop : Symbol(C.prop, Decl(decoratorOnClassProperty7.ts, 2, 9))
 }
+
+const C1 = class {
+>C1 : Symbol(C1, Decl(decoratorOnClassProperty7.ts, 6, 5))
+
+    @dec prop;
+>dec : Symbol(dec, Decl(decoratorOnClassProperty7.ts, 0, 0))
+>prop : Symbol(C1.prop, Decl(decoratorOnClassProperty7.ts, 6, 18))
+}
+

--- a/tests/baselines/reference/decoratorOnClassProperty7.types
+++ b/tests/baselines/reference/decoratorOnClassProperty7.types
@@ -12,3 +12,13 @@ class C {
 >dec : (target: Function, propertyKey: string | symbol, paramIndex: number) => void
 >prop : any
 }
+
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec prop;} : typeof C1
+
+    @dec prop;
+>dec : (target: Function, propertyKey: string | symbol, paramIndex: number) => void
+>prop : any
+}
+

--- a/tests/baselines/reference/decoratorsOnComputedProperties.errors.txt
+++ b/tests/baselines/reference/decoratorsOnComputedProperties.errors.txt
@@ -4,84 +4,63 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(20,8): error TS1166: A co
 tests/cases/compiler/decoratorsOnComputedProperties.ts(21,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(22,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(23,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(27,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(28,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(29,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(30,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(35,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(36,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(37,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(36,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(37,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(38,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(39,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(40,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(39,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(40,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(52,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(53,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(54,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(55,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(56,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(57,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(62,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(63,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(64,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(65,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(70,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(71,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(72,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(71,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(72,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(73,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(74,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(75,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(74,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(75,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(88,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(89,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(90,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(92,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(93,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(94,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(98,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(99,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(100,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(101,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(106,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(107,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(108,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(107,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(108,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(110,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(111,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(112,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(111,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(112,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(124,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(125,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(126,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(128,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(129,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(131,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(135,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(136,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(137,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(138,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(143,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(144,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(145,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(144,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(145,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(147,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(148,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(150,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(148,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(150,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(162,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(163,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(164,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(166,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(167,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(169,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(173,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(174,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(175,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(176,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(181,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(182,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(183,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(184,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(182,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(183,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(185,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(186,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Decorators are not valid here.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(186,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(188,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 
 
-==== tests/cases/compiler/decoratorsOnComputedProperties.ts (81 errors) ====
+==== tests/cases/compiler/decoratorsOnComputedProperties.ts (60 errors) ====
     function x(o: object, k: PropertyKey) { }
     let i = 0;
     function foo(): string { return ++i + ""; }
@@ -121,17 +100,9 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
     
     void class B {
         @x ["property"]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x [Symbol.toStringTag]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x ["property2"]: any = 2;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x [Symbol.iterator]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
         ["property3"]: any;
         [Symbol.isConcatSpreadable]: any;
         ["property4"]: any = 2;
@@ -140,20 +111,20 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         ~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         [fieldNameA]: any;
         ~~~~~~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameC]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
     };
     
     class C {
@@ -188,17 +159,9 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
     
     void class D {
         @x ["property"]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x [Symbol.toStringTag]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x ["property2"]: any = 2;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x [Symbol.iterator]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
         ["property3"]: any;
         [Symbol.isConcatSpreadable]: any;
         ["property4"]: any = 2;
@@ -207,20 +170,20 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         ~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         [fieldNameA]: any;
         ~~~~~~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameC]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ["some" + "method"]() {}
     };
     
@@ -256,17 +219,9 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
     
     void class F {
         @x ["property"]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x [Symbol.toStringTag]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x ["property2"]: any = 2;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x [Symbol.iterator]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
         ["property3"]: any;
         [Symbol.isConcatSpreadable]: any;
         ["property4"]: any = 2;
@@ -275,21 +230,21 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         ~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ["some" + "method"]() {}
         [fieldNameA]: any;
         ~~~~~~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameC]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
     };
     
     class G {
@@ -325,17 +280,9 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
     
     void class H {
         @x ["property"]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x [Symbol.toStringTag]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x ["property2"]: any = 2;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x [Symbol.iterator]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
         ["property3"]: any;
         [Symbol.isConcatSpreadable]: any;
         ["property4"]: any = 2;
@@ -344,22 +291,22 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         ~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ["some" + "method"]() {}
         [fieldNameA]: any;
         ~~~~~~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ["some" + "method2"]() {}
         @x [fieldNameC]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
     };
     
     class I {
@@ -395,17 +342,9 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
     
     void class J {
         @x ["property"]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x [Symbol.toStringTag]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x ["property2"]: any = 2;
-        ~
-!!! error TS1206: Decorators are not valid here.
         @x [Symbol.iterator]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
         ["property3"]: any;
         [Symbol.isConcatSpreadable]: any;
         ["property4"]: any = 2;
@@ -414,22 +353,20 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         ~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x ["some" + "method"]() {}
-        ~
-!!! error TS1206: Decorators are not valid here.
         [fieldNameA]: any;
         ~~~~~~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ["some" + "method2"]() {}
         @x [fieldNameC]: any = null;
-        ~
-!!! error TS1206: Decorators are not valid here.
+           ~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
     };

--- a/tests/baselines/reference/decoratorsOnComputedProperties.js
+++ b/tests/baselines/reference/decoratorsOnComputedProperties.js
@@ -197,7 +197,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
 var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p;
-var _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51;
+var _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56;
 function x(o, k) { }
 let i = 0;
 function foo() { return ++i + ""; }
@@ -239,7 +239,7 @@ __decorate([
 __decorate([
     x
 ], A.prototype, _v, void 0);
-void (_c = class B {
+void (_2 = (_c = class B {
         constructor() {
             this["property2"] = 2;
             this[_x] = null;
@@ -258,30 +258,43 @@ void (_c = class B {
     _z = foo(),
     _0 = fieldNameB,
     _1 = fieldNameC,
-    _c);
+    _c), __decorate([
+    x
+], _2.prototype, "property", void 0), __decorate([
+    x
+], _2.prototype, _w, void 0), __decorate([
+    x
+], _2.prototype, "property2", void 0), __decorate([
+    x
+], _2.prototype, _x, void 0), __decorate([
+    x
+], _2.prototype, _y, void 0), __decorate([
+    x
+], _2.prototype, _z, void 0), __decorate([
+    x
+], _2.prototype, _0, void 0), __decorate([
+    x
+], _2.prototype, _1, void 0), _2);
 class C {
     constructor() {
         this["property2"] = 2;
-        this[_3] = null;
+        this[_4] = null;
         this["property4"] = 2;
         this[_d] = null;
-        this[_5] = null;
-        this[_7] = null;
+        this[_6] = null;
+        this[_8] = null;
     }
-    [(_2 = Symbol.toStringTag, _3 = Symbol.iterator, Symbol.isConcatSpreadable, _d = Symbol.match, foo(), _4 = foo(), _5 = foo(), _6 = fieldNameB, _7 = fieldNameC, "some" + "method")]() { }
+    [(_3 = Symbol.toStringTag, _4 = Symbol.iterator, Symbol.isConcatSpreadable, _d = Symbol.match, foo(), _5 = foo(), _6 = foo(), _7 = fieldNameB, _8 = fieldNameC, "some" + "method")]() { }
 }
 __decorate([
     x
 ], C.prototype, "property", void 0);
 __decorate([
     x
-], C.prototype, _2, void 0);
+], C.prototype, _3, void 0);
 __decorate([
     x
 ], C.prototype, "property2", void 0);
-__decorate([
-    x
-], C.prototype, _3, void 0);
 __decorate([
     x
 ], C.prototype, _4, void 0);
@@ -294,44 +307,57 @@ __decorate([
 __decorate([
     x
 ], C.prototype, _7, void 0);
-void class D {
+__decorate([
+    x
+], C.prototype, _8, void 0);
+void (_15 = class D {
     constructor() {
         this["property2"] = 2;
-        this[_9] = null;
+        this[_10] = null;
         this["property4"] = 2;
         this[_e] = null;
-        this[_11] = null;
-        this[_13] = null;
+        this[_12] = null;
+        this[_14] = null;
     }
-    [(_8 = Symbol.toStringTag, _9 = Symbol.iterator, Symbol.isConcatSpreadable, _e = Symbol.match, foo(), _10 = foo(), _11 = foo(), _12 = fieldNameB, _13 = fieldNameC, "some" + "method")]() { }
-};
+    [(_9 = Symbol.toStringTag, _10 = Symbol.iterator, Symbol.isConcatSpreadable, _e = Symbol.match, foo(), _11 = foo(), _12 = foo(), _13 = fieldNameB, _14 = fieldNameC, "some" + "method")]() { }
+}, __decorate([
+    x
+], _15.prototype, "property", void 0), __decorate([
+    x
+], _15.prototype, _9, void 0), __decorate([
+    x
+], _15.prototype, "property2", void 0), __decorate([
+    x
+], _15.prototype, _10, void 0), __decorate([
+    x
+], _15.prototype, _11, void 0), __decorate([
+    x
+], _15.prototype, _12, void 0), __decorate([
+    x
+], _15.prototype, _13, void 0), __decorate([
+    x
+], _15.prototype, _14, void 0), _15);
 class E {
     constructor() {
         this["property2"] = 2;
-        this[_15] = null;
+        this[_17] = null;
         this["property4"] = 2;
         this[_f] = null;
-        this[_17] = null;
         this[_19] = null;
+        this[_21] = null;
     }
-    [(_14 = Symbol.toStringTag, _15 = Symbol.iterator, Symbol.isConcatSpreadable, _f = Symbol.match, foo(), _16 = foo(), _17 = foo(), "some" + "method")]() { }
+    [(_16 = Symbol.toStringTag, _17 = Symbol.iterator, Symbol.isConcatSpreadable, _f = Symbol.match, foo(), _18 = foo(), _19 = foo(), "some" + "method")]() { }
 }
-_18 = fieldNameB, _19 = fieldNameC;
+_20 = fieldNameB, _21 = fieldNameC;
 __decorate([
     x
 ], E.prototype, "property", void 0);
 __decorate([
     x
-], E.prototype, _14, void 0);
+], E.prototype, _16, void 0);
 __decorate([
     x
 ], E.prototype, "property2", void 0);
-__decorate([
-    x
-], E.prototype, _15, void 0);
-__decorate([
-    x
-], E.prototype, _16, void 0);
 __decorate([
     x
 ], E.prototype, _17, void 0);
@@ -341,122 +367,178 @@ __decorate([
 __decorate([
     x
 ], E.prototype, _19, void 0);
-void (_h = class F {
+__decorate([
+    x
+], E.prototype, _20, void 0);
+__decorate([
+    x
+], E.prototype, _21, void 0);
+void (_28 = (_h = class F {
         constructor() {
             this["property2"] = 2;
-            this[_21] = null;
+            this[_23] = null;
             this["property4"] = 2;
             this[_g] = null;
-            this[_23] = null;
             this[_25] = null;
+            this[_27] = null;
         }
-        [(_20 = Symbol.toStringTag, _21 = Symbol.iterator, Symbol.isConcatSpreadable, _g = Symbol.match, foo(), _22 = foo(), _23 = foo(), "some" + "method")]() { }
+        [(_22 = Symbol.toStringTag, _23 = Symbol.iterator, Symbol.isConcatSpreadable, _g = Symbol.match, foo(), _24 = foo(), _25 = foo(), "some" + "method")]() { }
     },
-    _24 = fieldNameB,
-    _25 = fieldNameC,
-    _h);
+    _26 = fieldNameB,
+    _27 = fieldNameC,
+    _h), __decorate([
+    x
+], _28.prototype, "property", void 0), __decorate([
+    x
+], _28.prototype, _22, void 0), __decorate([
+    x
+], _28.prototype, "property2", void 0), __decorate([
+    x
+], _28.prototype, _23, void 0), __decorate([
+    x
+], _28.prototype, _24, void 0), __decorate([
+    x
+], _28.prototype, _25, void 0), __decorate([
+    x
+], _28.prototype, _26, void 0), __decorate([
+    x
+], _28.prototype, _27, void 0), _28);
 class G {
     constructor() {
         this["property2"] = 2;
-        this[_27] = null;
+        this[_30] = null;
         this["property4"] = 2;
         this[_j] = null;
-        this[_29] = null;
-        this[_31] = null;
+        this[_32] = null;
+        this[_34] = null;
     }
-    [(_26 = Symbol.toStringTag, _27 = Symbol.iterator, Symbol.isConcatSpreadable, _j = Symbol.match, foo(), _28 = foo(), _29 = foo(), "some" + "method")]() { }
-    [(_30 = fieldNameB, "some" + "method2")]() { }
+    [(_29 = Symbol.toStringTag, _30 = Symbol.iterator, Symbol.isConcatSpreadable, _j = Symbol.match, foo(), _31 = foo(), _32 = foo(), "some" + "method")]() { }
+    [(_33 = fieldNameB, "some" + "method2")]() { }
 }
-_31 = fieldNameC;
+_34 = fieldNameC;
 __decorate([
     x
 ], G.prototype, "property", void 0);
 __decorate([
     x
-], G.prototype, _26, void 0);
+], G.prototype, _29, void 0);
 __decorate([
     x
 ], G.prototype, "property2", void 0);
-__decorate([
-    x
-], G.prototype, _27, void 0);
-__decorate([
-    x
-], G.prototype, _28, void 0);
-__decorate([
-    x
-], G.prototype, _29, void 0);
 __decorate([
     x
 ], G.prototype, _30, void 0);
 __decorate([
     x
 ], G.prototype, _31, void 0);
-void (_l = class H {
+__decorate([
+    x
+], G.prototype, _32, void 0);
+__decorate([
+    x
+], G.prototype, _33, void 0);
+__decorate([
+    x
+], G.prototype, _34, void 0);
+void (_41 = (_l = class H {
         constructor() {
             this["property2"] = 2;
-            this[_33] = null;
+            this[_36] = null;
             this["property4"] = 2;
             this[_k] = null;
-            this[_35] = null;
-            this[_37] = null;
+            this[_38] = null;
+            this[_40] = null;
         }
-        [(_32 = Symbol.toStringTag, _33 = Symbol.iterator, Symbol.isConcatSpreadable, _k = Symbol.match, foo(), _34 = foo(), _35 = foo(), "some" + "method")]() { }
-        [(_36 = fieldNameB, "some" + "method2")]() { }
+        [(_35 = Symbol.toStringTag, _36 = Symbol.iterator, Symbol.isConcatSpreadable, _k = Symbol.match, foo(), _37 = foo(), _38 = foo(), "some" + "method")]() { }
+        [(_39 = fieldNameB, "some" + "method2")]() { }
     },
-    _37 = fieldNameC,
-    _l);
+    _40 = fieldNameC,
+    _l), __decorate([
+    x
+], _41.prototype, "property", void 0), __decorate([
+    x
+], _41.prototype, _35, void 0), __decorate([
+    x
+], _41.prototype, "property2", void 0), __decorate([
+    x
+], _41.prototype, _36, void 0), __decorate([
+    x
+], _41.prototype, _37, void 0), __decorate([
+    x
+], _41.prototype, _38, void 0), __decorate([
+    x
+], _41.prototype, _39, void 0), __decorate([
+    x
+], _41.prototype, _40, void 0), _41);
 class I {
     constructor() {
         this["property2"] = 2;
-        this[_39] = null;
+        this[_43] = null;
         this["property4"] = 2;
         this[_m] = null;
-        this[_41] = null;
-        this[_44] = null;
+        this[_45] = null;
+        this[_48] = null;
     }
-    [(_38 = Symbol.toStringTag, _39 = Symbol.iterator, Symbol.isConcatSpreadable, _m = Symbol.match, foo(), _40 = foo(), _41 = foo(), _42 = "some" + "method")]() { }
-    [(_43 = fieldNameB, "some" + "method2")]() { }
+    [(_42 = Symbol.toStringTag, _43 = Symbol.iterator, Symbol.isConcatSpreadable, _m = Symbol.match, foo(), _44 = foo(), _45 = foo(), _46 = "some" + "method")]() { }
+    [(_47 = fieldNameB, "some" + "method2")]() { }
 }
-_44 = fieldNameC;
+_48 = fieldNameC;
 __decorate([
     x
 ], I.prototype, "property", void 0);
 __decorate([
     x
-], I.prototype, _38, void 0);
+], I.prototype, _42, void 0);
 __decorate([
     x
 ], I.prototype, "property2", void 0);
-__decorate([
-    x
-], I.prototype, _39, void 0);
-__decorate([
-    x
-], I.prototype, _40, void 0);
-__decorate([
-    x
-], I.prototype, _41, void 0);
-__decorate([
-    x
-], I.prototype, _42, null);
 __decorate([
     x
 ], I.prototype, _43, void 0);
 __decorate([
     x
 ], I.prototype, _44, void 0);
-void (_p = class J {
+__decorate([
+    x
+], I.prototype, _45, void 0);
+__decorate([
+    x
+], I.prototype, _46, null);
+__decorate([
+    x
+], I.prototype, _47, void 0);
+__decorate([
+    x
+], I.prototype, _48, void 0);
+void (_56 = (_p = class J {
         constructor() {
             this["property2"] = 2;
-            this[_46] = null;
+            this[_50] = null;
             this["property4"] = 2;
             this[_o] = null;
-            this[_48] = null;
-            this[_51] = null;
+            this[_52] = null;
+            this[_55] = null;
         }
-        [(_45 = Symbol.toStringTag, _46 = Symbol.iterator, Symbol.isConcatSpreadable, _o = Symbol.match, foo(), _47 = foo(), _48 = foo(), _49 = "some" + "method")]() { }
-        [(_50 = fieldNameB, "some" + "method2")]() { }
+        [(_49 = Symbol.toStringTag, _50 = Symbol.iterator, Symbol.isConcatSpreadable, _o = Symbol.match, foo(), _51 = foo(), _52 = foo(), _53 = "some" + "method")]() { }
+        [(_54 = fieldNameB, "some" + "method2")]() { }
     },
-    _51 = fieldNameC,
-    _p);
+    _55 = fieldNameC,
+    _p), __decorate([
+    x
+], _56.prototype, "property", void 0), __decorate([
+    x
+], _56.prototype, _49, void 0), __decorate([
+    x
+], _56.prototype, "property2", void 0), __decorate([
+    x
+], _56.prototype, _50, void 0), __decorate([
+    x
+], _56.prototype, _51, void 0), __decorate([
+    x
+], _56.prototype, _52, void 0), __decorate([
+    x
+], _56.prototype, _53, null), __decorate([
+    x
+], _56.prototype, _54, void 0), __decorate([
+    x
+], _56.prototype, _55, void 0), _56);

--- a/tests/baselines/reference/missingDecoratorType.errors.txt
+++ b/tests/baselines/reference/missingDecoratorType.errors.txt
@@ -20,4 +20,8 @@ error TS2318: Cannot find global type 'TypedPropertyDescriptor'.
         method() {}
     }
     
+    const C1 = class {
+        @dec
+        method() {}
+    }
     

--- a/tests/baselines/reference/missingDecoratorType.js
+++ b/tests/baselines/reference/missingDecoratorType.js
@@ -18,6 +18,10 @@ class C {
     method() {}
 }
 
+const C1 = class {
+    @dec
+    method() {}
+}
 
 
 //// [a.js]
@@ -28,6 +32,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
+var _a;
 var C = /** @class */ (function () {
     function C() {
     }
@@ -37,3 +42,11 @@ var C = /** @class */ (function () {
     ], C.prototype, "method", null);
     return C;
 }());
+var C1 = (_a = /** @class */ (function () {
+    function class_1() {
+    }
+    class_1.prototype.method = function () { };
+    return class_1;
+}()), __decorate([
+    dec
+], _a.prototype, "method", null), _a);

--- a/tests/baselines/reference/missingDecoratorType.symbols
+++ b/tests/baselines/reference/missingDecoratorType.symbols
@@ -41,4 +41,13 @@ class C {
 >method : Symbol(C.method, Decl(b.ts, 2, 9))
 }
 
+const C1 = class {
+>C1 : Symbol(C1, Decl(b.ts, 7, 5))
+
+    @dec
+>dec : Symbol(dec, Decl(b.ts, 0, 0))
+
+    method() {}
+>method : Symbol(C1.method, Decl(b.ts, 7, 18))
+}
 

--- a/tests/baselines/reference/missingDecoratorType.types
+++ b/tests/baselines/reference/missingDecoratorType.types
@@ -25,4 +25,14 @@ class C {
 >method : () => void
 }
 
+const C1 = class {
+>C1 : typeof C1
+>class {    @dec    method() {}} : typeof C1
+
+    @dec
+>dec : (t: any, k: any, d: any) => any
+
+    method() {}
+>method : () => void
+}
 

--- a/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor1.ts
+++ b/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor1.ts
@@ -1,7 +1,11 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
 
 class C {
+    @dec get accessor() { return 1; }
+}
+
+const C1 = class {
     @dec get accessor() { return 1; }
 }

--- a/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor2.ts
+++ b/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor2.ts
@@ -1,7 +1,11 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
 
 class C {
+    @dec public get accessor() { return 1; }
+}
+
+const C1 = class {
     @dec public get accessor() { return 1; }
 }

--- a/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor3.ts
+++ b/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor3.ts
@@ -1,7 +1,11 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
 
 class C {
+    public @dec get accessor() { return 1; }
+}
+
+const C1 = class {
     public @dec get accessor() { return 1; }
 }

--- a/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor4.ts
+++ b/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor4.ts
@@ -1,7 +1,11 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
 
 class C {
+    @dec set accessor(value: number) { }
+}
+
+const C1 = class {
     @dec set accessor(value: number) { }
 }

--- a/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor5.ts
+++ b/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor5.ts
@@ -1,7 +1,11 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
 
 class C {
+    @dec public set accessor(value: number) { }
+}
+
+const C1 = class {
     @dec public set accessor(value: number) { }
 }

--- a/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor6.ts
+++ b/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor6.ts
@@ -1,7 +1,11 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
 
 class C {
+    public @dec set accessor(value: number) { }
+}
+
+const C1 = class {
     public @dec set accessor(value: number) { }
 }

--- a/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts
+++ b/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts
@@ -1,4 +1,4 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 declare function dec1<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
 declare function dec2<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
@@ -29,6 +29,36 @@ class E {
 }
 
 class F {
+    @dec1 set x(value: number) { }
+    @dec2 get x() { return 0; }
+}
+
+const A1 = class {
+    @dec1 get x() { return 0; }
+    set x(value: number) { }
+}
+
+const B1 = class {
+    get x() { return 0; }
+    @dec2 set x(value: number) { }
+}
+
+const C1 = class {
+    @dec1 set x(value: number) { }
+    get x() { return 0; }
+}
+
+const D1 = class {
+    set x(value: number) { }
+    @dec2 get x() { return 0; }
+}
+
+const E1 = class {
+    @dec1 get x() { return 0; }
+    @dec2 set x(value: number) { }
+}
+
+const F1 = class {
     @dec1 set x(value: number) { }
     @dec2 get x() { return 0; }
 }

--- a/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor8.ts
+++ b/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor8.ts
@@ -1,4 +1,4 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 // @emitdecoratormetadata: true
 declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
@@ -28,5 +28,33 @@ class E {
 }
 
 class F {
+    @dec set x(value: number) { }
+}
+
+const A1 = class {
+    @dec get x() { return 0; }
+    set x(value: number) { }
+}
+
+const B1 = class {
+    get x() { return 0; }
+    @dec set x(value: number) { }
+}
+
+const C1 = class {
+    @dec set x(value: number) { }
+    get x() { return 0; }
+}
+
+const D1 = class {
+    set x(value: number) { }
+    @dec get x() { return 0; }
+}
+
+const E1 = class {
+    @dec get x() { return 0; }
+}
+
+const F1 = class {
     @dec set x(value: number) { }
 }

--- a/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor1.ts
+++ b/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor1.ts
@@ -1,7 +1,11 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
 
 class C {
+    @dec constructor() {}
+}
+
+const C1 = class {
     @dec constructor() {}
 }

--- a/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor2.ts
+++ b/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor2.ts
@@ -9,7 +9,14 @@ export function foo(target: Object, propertyKey: string | symbol, parameterIndex
 // @Filename: 2.ts
 import {base} from "./0.ts"
 import {foo} from "./0.ts"
-export class C  extends base{
+
+export class C  extends base {
+    constructor(@foo prop: any) {
+        super();
+    }
+}
+
+export const C1 = class extends base {
     constructor(@foo prop: any) {
         super();
     }

--- a/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor3.ts
+++ b/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor3.ts
@@ -11,7 +11,13 @@ import {base} from "./0"
 import {foo} from "./0"
 
 /* Comment on the Class Declaration */
-export class C  extends base{
+export class C  extends base {
+    constructor(@foo prop: any) {
+        super();
+    }
+}
+
+export const C1 = class extends base {
     constructor(@foo prop: any) {
         super();
     }

--- a/tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter1.ts
+++ b/tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter1.ts
@@ -1,7 +1,11 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 declare function dec(target: Function, propertyKey: string | symbol, parameterIndex: number): void;
 
 class C {
+    constructor(@dec p: number) {}
+}
+
+const C1 = class {
     constructor(@dec p: number) {}
 }

--- a/tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter4.ts
+++ b/tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter4.ts
@@ -1,7 +1,11 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 declare function dec(target: Function, propertyKey: string | symbol, parameterIndex: number): void;
 
 class C {
+    constructor(public @dec p: number) {}
+}
+
+const C1 = class {
     constructor(public @dec p: number) {}
 }

--- a/tests/cases/conformance/decorators/class/decoratorChecksFunctionBodies.ts
+++ b/tests/cases/conformance/decorators/class/decoratorChecksFunctionBodies.ts
@@ -1,4 +1,4 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 
 // from #2971
@@ -6,6 +6,17 @@ function func(s: string): void {
 }
 
 class A {
+    @((x, p) => {
+        var a = 3;
+        func(a);
+        return x; 
+    })
+    m() {
+
+    }
+}
+
+const A1 = class {
     @((x, p) => {
         var a = 3;
         func(a);

--- a/tests/cases/conformance/decorators/class/decoratorInstantiateModulesInFunctionBodies.ts
+++ b/tests/cases/conformance/decorators/class/decoratorInstantiateModulesInFunctionBodies.ts
@@ -1,4 +1,4 @@
-// @target:es5
+// @target: es5
 // @module:commonjs
 // @experimentaldecorators: true
 // @filename: a.ts
@@ -15,7 +15,14 @@ function filter(handler: any) {
     };
 }
 
-class Wat {
+class A {
+    @filter(() => test == 'abc')
+    static whatever() {
+        // ...
+    }
+}
+
+const A1 = class {
     @filter(() => test == 'abc')
     static whatever() {
         // ...

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod1.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod1.ts
@@ -5,3 +5,7 @@ declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPrope
 class C {
     @dec method() {}
 }
+
+const C1 = class {
+    @dec method() {}
+}

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod10.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod10.ts
@@ -5,3 +5,7 @@ declare function dec(target: Function, paramIndex: number): void;
 class C {
     @dec method() {}
 }
+
+const C1 = class {
+    @dec method() {}
+}

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod11.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod11.ts
@@ -7,4 +7,11 @@ module M {
         @this.decorator
         method() { }
     }
+
+    const C1 = class {
+        decorator(target: Object, key: string): void { }
+
+        @this.decorator
+        method() { }
+    }
 }

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod12.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod12.ts
@@ -4,7 +4,13 @@ module M {
     class S {
         decorator(target: Object, key: string): void { }
     }
+
     class C extends S {
+        @super.decorator
+        method() { }
+    }
+
+    const C1 = class extends S {
         @super.decorator
         method() { }
     }

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod13.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod13.ts
@@ -6,3 +6,8 @@ class C {
     @dec ["1"]() { }
     @dec ["b"]() { }
 }
+
+const C1 = class {
+    @dec ["1"]() { }
+    @dec ["b"]() { }
+}

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod2.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod2.ts
@@ -5,3 +5,7 @@ declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPrope
 class C {
     @dec public method() {}
 }
+
+const C1 = class {
+    @dec public method() {}
+}

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod3.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod3.ts
@@ -5,3 +5,7 @@ declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPrope
 class C {
     public @dec method() {}
 }
+
+const C1 = class {
+    public @dec method() {}
+}

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod4.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod4.ts
@@ -5,3 +5,7 @@ declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPrope
 class C {
     @dec ["method"]() {}
 }
+
+const C1 = class {
+    @dec ["method"]() {}
+}

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod5.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod5.ts
@@ -5,3 +5,7 @@ declare function dec(): <T>(target: any, propertyKey: string, descriptor: TypedP
 class C {
     @dec() ["method"]() {}
 }
+
+const C1 = class {
+    @dec() ["method"]() {}
+}

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod6.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod6.ts
@@ -5,3 +5,7 @@ declare function dec(): <T>(target: any, propertyKey: string, descriptor: TypedP
 class C {
     @dec ["method"]() {}
 }
+
+const C1 = class {
+    @dec ["method"]() {}
+}

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod7.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod7.ts
@@ -5,3 +5,7 @@ declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPrope
 class C {
     @dec public ["method"]() {}
 }
+
+const C1 = class {
+    @dec public ["method"]() {}
+}

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod8.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod8.ts
@@ -5,3 +5,7 @@ declare function dec<T>(target: T): T;
 class C {
     @dec method() {}
 }
+
+const C1 = class {
+    @dec method() {}
+}

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload1.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload1.ts
@@ -7,3 +7,9 @@ class C {
     method()
     method() { }
 }
+
+const C1 = class {
+    @dec
+    method()
+    method() { }
+}

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload2.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload2.ts
@@ -7,3 +7,9 @@ class C {
     @dec
     method() { }
 }
+
+const C1 = class {
+    method()
+    @dec
+    method() { }
+}

--- a/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter1.ts
+++ b/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter1.ts
@@ -1,7 +1,11 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
 
 class C {
+    method(@dec p: number) {}
+}
+
+const C1 = class {
     method(@dec p: number) {}
 }

--- a/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter2.ts
+++ b/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter2.ts
@@ -1,7 +1,11 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
 
 class C {
     method(this: C, @dec p: number) {}
+}
+
+const C1 = class {
+    method(this: {}, @dec p: number) {}
 }

--- a/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts
+++ b/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts
@@ -1,4 +1,4 @@
-// @target:es5
+// @target: es5
 // @experimentaldecorators: true
 declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
 

--- a/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty1.ts
+++ b/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty1.ts
@@ -5,3 +5,7 @@ declare function dec(target: any, propertyKey: string): void;
 class C {
     @dec prop;
 }
+
+const C1 = class {
+    @dec prop;
+}

--- a/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty10.ts
+++ b/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty10.ts
@@ -5,3 +5,7 @@ declare function dec(): <T>(target: any, propertyKey: string) => void;
 class C {
     @dec() prop;
 }
+
+const C1 = class {
+    @dec() prop;
+}

--- a/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty11.ts
+++ b/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty11.ts
@@ -5,3 +5,7 @@ declare function dec(): <T>(target: any, propertyKey: string) => void;
 class C {
     @dec prop;
 }
+
+const C1 = class {
+    @dec prop;
+}

--- a/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty2.ts
+++ b/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty2.ts
@@ -5,3 +5,7 @@ declare function dec(target: any, propertyKey: string): void;
 class C {
     @dec public prop;
 }
+
+const C1 = class {
+    @dec public prop;
+}

--- a/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty3.ts
+++ b/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty3.ts
@@ -5,3 +5,7 @@ declare function dec(target: any, propertyKey: string): void;
 class C {
     public @dec prop;
 }
+
+const C1 = class {
+    public @dec prop;
+}

--- a/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty6.ts
+++ b/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty6.ts
@@ -5,3 +5,7 @@ declare function dec(target: Function): void;
 class C {
     @dec prop;
 }
+
+const C1 = class {
+    @dec prop;
+}

--- a/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty7.ts
+++ b/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty7.ts
@@ -5,3 +5,7 @@ declare function dec(target: Function, propertyKey: string | symbol, paramIndex:
 class C {
     @dec prop;
 }
+
+const C1 = class {
+    @dec prop;
+}

--- a/tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts
+++ b/tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts
@@ -12,3 +12,12 @@ class X {
     @decorator()
     c?: *;
 }
+
+const X1 = class {
+    @decorator()
+    a?: string?;
+    @decorator()
+    b?: string!;
+    @decorator()
+    c?: *;
+}

--- a/tests/cases/conformance/decorators/missingDecoratorType.ts
+++ b/tests/cases/conformance/decorators/missingDecoratorType.ts
@@ -20,3 +20,7 @@ class C {
     method() {}
 }
 
+const C1 = class {
+    @dec
+    method() {}
+}


### PR DESCRIPTION
Fixes #7342

This is an experimental PR that aims to allow using decorators in ClassExpression members. Transform idea was taken from Babel, not sure if this is an acceptable way for TypeScript.

Any feedbacks are welcome.

--- 

Babel - **es5**
```js
var _class;
function decorator() { }
var foo = (_class = /*#__PURE__*/function () {
  function _class() {
    _classCallCheck(this, _class);
  }

  _createClass(_class, [{
    key: "x",
    value: function x() {}
  }]);

  return _class;
}(), (_applyDecoratedDescriptor(_class.prototype, "x", [decorator], Object.getOwnPropertyDescriptor(_class.prototype, "x"), _class.prototype)), _class);
```

TS - **es5**
```js
var _a;
function decorator() { }
var foo = (_a = /** @class */ (function () {
    function class_1() {
    }
    class_1.prototype.x = function () { };
    return class_1;
}()), __decorate([
    decorator
], _a.prototype, "x", null), _a);
```

Babel - **esnext**
```js
var _class;

function decorator() {}

var foo = (_class = class {
  x() {}

}, (_applyDecoratedDescriptor(_class.prototype, "x", [decorator], Object.getOwnPropertyDescriptor(_class.prototype, "x"), _class.prototype)), _class);
```

TS - **esnext**
```js
var _a;
function decorator() { }
const foo = (_a = class {
    x() { }
}, __decorate([
    decorator
], _a.prototype, "x", null), _a);
```
