### PR TITLE
fix es5 isNaN type

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -47,10 +47,10 @@ declare function parseInt(s: string, radix?: number): number;
 declare function parseFloat(string: string): number;
 
 /**
- * Returns a Boolean value that indicates whether a value is the reserved value NaN (not a number).
- * @param number A numeric value.
+ * Returns a Boolean value that indicates whether a value is NaN (not a number).
+ * @param value Any value to test.
  */
-declare function isNaN(number: number): boolean;
+declare function isNaN(value: any): boolean;
 
 /**
  * Determines whether a supplied number is finite.


### PR DESCRIPTION
this function accepts any value and tries to coerce it to a number, as demonstrated in the MDN docs https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN

e.g `isNaN(new Date())` -> `false`

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [/] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
