### PR TITLE
Fix indentation for closing > of ExpressionWithTypeArguments

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -592,6 +592,7 @@ namespace ts.formatting {
                             case SyntaxKind.JsxOpeningElement:
                             case SyntaxKind.JsxClosingElement:
                             case SyntaxKind.JsxSelfClosingElement:
+                            case SyntaxKind.ExpressionWithTypeArguments:
                                 return false;
                         }
                         break;

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -581,7 +581,7 @@ namespace ts.formatting {
                     if (childKind === SyntaxKind.TypeLiteral || childKind === SyntaxKind.TupleType) {
                         return false;
                     }
-                    // falls through
+                    break;
             }
             // No explicit rule for given nodes so the result will follow the default value argument
             return indentByDefault;

--- a/tests/cases/fourslash/formatMultilineExtendsGeneric.ts
+++ b/tests/cases/fourslash/formatMultilineExtendsGeneric.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+//// class Favorite extends Array<
+////     string
+//// > {
+////     private foo = 2
+//// }
+
+verify.formatDocumentChangesNothing();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #15782
