### PR TITLE
Fix formatter determination of initial indentation of list items after the first

### DIFF
--- a/tests/cases/fourslash/formatSelectionSingleProperty.ts
+++ b/tests/cases/fourslash/formatSelectionSingleProperty.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+//// console.log({
+//// }, {
+//// /*1*/    a: 1,
+//// /*2*/    b: 2
+//// })
+
+format.selection("1", "2");
+verify.currentFileContentIs(
+`console.log({
+}, {
+    a: 1,
+    b: 2
+})`);
+
+// verify.formatDocumentChangesNothing();

--- a/tests/cases/fourslash/formatSelectionSingleProperty.ts
+++ b/tests/cases/fourslash/formatSelectionSingleProperty.ts
@@ -13,5 +13,3 @@ verify.currentFileContentIs(
     a: 1,
     b: 2
 })`);
-
-// verify.formatDocumentChangesNothing();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #42309 
