### PR TITLE
Fix double asterisk formatting in JSDoc

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7602,8 +7602,15 @@ namespace ts {
                                 if (state === JSDocState.BeginningOfLine) {
                                     // leading asterisks start recording on the *next* (non-whitespace) token
                                     state = JSDocState.SawAsterisk;
-                                    indent += 1;
-                                    break;
+
+                                    if (lookAhead(() => nextTokenJSDoc() === SyntaxKind.AsteriskToken)) {
+                                        pushComment(scanner.getTokenText());
+                                        tok = nextTokenJSDoc();
+                                    }
+                                    else {
+                                        indent += 1;
+                                        break;
+                                    }
                                 }
                                 // record the * as a comment
                                 // falls through

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7694,7 +7694,7 @@ namespace ts {
                         typeExpression = tryParseTypeExpression();
                     }
 
-                    const comment = parseTrailingTagComments(indent + scanner.getStartPos() - start, getNodePos(), indent, indentText);
+                    const comment = parseTrailingTagComments(start, getNodePos(), indent, indentText);
 
                     const nestedTypeLiteral = target !== PropertyLikeParse.CallbackParameter && parseNestedTypeLiteral(typeExpression, name, target, indent);
                     if (nestedTypeLiteral) {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7602,15 +7602,8 @@ namespace ts {
                                 if (state === JSDocState.BeginningOfLine) {
                                     // leading asterisks start recording on the *next* (non-whitespace) token
                                     state = JSDocState.SawAsterisk;
-
-                                    if (lookAhead(() => nextTokenJSDoc() === SyntaxKind.AsteriskToken)) {
-                                        pushComment(scanner.getTokenText());
-                                        tok = nextTokenJSDoc();
-                                    }
-                                    else {
-                                        indent += 1;
-                                        break;
-                                    }
+                                    indent += 1;
+                                    break;
                                 }
                                 // record the * as a comment
                                 // falls through
@@ -7695,13 +7688,14 @@ namespace ts {
                     skipWhitespaceOrAsterisk();
 
                     const { name, isBracketed } = parseBracketNameInPropertyAndParamTag();
-                    skipWhitespace();
+                    const indentText = skipWhitespaceOrAsterisk();
 
                     if (isNameFirst) {
                         typeExpression = tryParseTypeExpression();
                     }
 
-                    const comment = parseTagComments(indent + scanner.getStartPos() - start);
+                    const comment = parseTrailingTagComments(indent + scanner.getStartPos() - start, getNodePos(), indent, indentText);
+
                     const nestedTypeLiteral = target !== PropertyLikeParse.CallbackParameter && parseNestedTypeLiteral(typeExpression, name, target, indent);
                     if (nestedTypeLiteral) {
                         typeExpression = nestedTypeLiteral;

--- a/tests/cases/fourslash/commentsLinePreservation.ts
+++ b/tests/cases/fourslash/commentsLinePreservation.ts
@@ -129,16 +129,16 @@ verify.quickInfos({
     3: ["(parameter) param1: string", "first line of param\n\nparam information third line"],
 
     g: ["function g(param1: string): void", "This is firstLine\nThis is second Line"],
-    4: ["(parameter) param1: string", "param information first line"],
+    4: ["(parameter) param1: string", " param information first line"],
 
     h: ["function h(param1: string): void", "This is firstLine\nThis is second Line"],
-    5: ["(parameter) param1: string", "param information first line\n\nparam information third line"],
+    5: ["(parameter) param1: string", " param information first line\n\n param information third line"],
 
     i: ["function i(param1: string): void", "This is firstLine\nThis is second Line"],
-    6: ["(parameter) param1: string", "param information first line\n\nparam information third line"],
+    6: ["(parameter) param1: string", " param information first line\n\n param information third line"],
 
     j: ["function j(param1: string): void", "This is firstLine\nThis is second Line"],
-    7: ["(parameter) param1: string", "param information first line\n\nparam information third line"],
+    7: ["(parameter) param1: string", " param information first line\n\n param information third line"],
 
     k: ["function k(param1: string): void", "This is firstLine\nThis is second Line"],
     8: ["(parameter) param1: string", "hello"],

--- a/tests/cases/fourslash/quickInfoJsDocTextFormatting1.ts
+++ b/tests/cases/fourslash/quickInfoJsDocTextFormatting1.ts
@@ -9,7 +9,7 @@
 //// function f1(var1, var2) { }
 //// 
 //// /**
-////  * @param {number} var1 *This asterisk gets trimmed unfortunatelly
+////  * @param {number} var1 *Regular text with an asterisk
 ////  * @param {string} var2 Another *Regular text with an asterisk
 //// */
 //// function f2(var1, var2) { }
@@ -57,10 +57,10 @@ verify.signatureHelp({
 });
 verify.signatureHelp({
     marker: "2",
-    parameterDocComment: "This asterisk gets trimmed unfortunatelly",
+    parameterDocComment: "*Regular text with an asterisk",
     tags: [{
         name: "param",
-        text: "var1 This asterisk gets trimmed unfortunatelly"
+        text: "var1 *Regular text with an asterisk"
     }, {
         name: "param",
         text: "var2 Another *Regular text with an asterisk"

--- a/tests/cases/fourslash/quickInfoJsDocTextFormatting1.ts
+++ b/tests/cases/fourslash/quickInfoJsDocTextFormatting1.ts
@@ -1,0 +1,101 @@
+/// <reference path='fourslash.ts'/>
+
+// Regression test for #33386
+
+//// /**
+////  * @param {number} var1 **Highlighted text**
+////  * @param {string} var2 Another **Highlighted text**
+//// */
+//// function f1(var1, var2) { }
+//// 
+//// /**
+////  * @param {number} var1 *This asterisk gets trimmed unfortunatelly
+////  * @param {string} var2 Another *Regular text with an asterisk
+//// */
+//// function f2(var1, var2) { }
+//// 
+//// /**
+////  * @param {number} var1 
+////  * *Regular text with an asterisk
+////  * @param {string} var2 
+////  * Another *Regular text with an asterisk
+//// */
+//// function f3(var1, var2) { }
+//// 
+//// /**
+////  * @param {number} var1 
+////  * **Highlighted text**
+////  * @param {string} var2 
+////  * Another **Highlighted text**
+//// */
+//// function f4(var1, var2) { }
+//// 
+//// /**
+////  * @param {number} var1 
+////    **Highlighted text**
+////  * @param {string} var2 
+////    Another **Highlighted text**
+//// */
+//// function f5(var1, var2) { }
+//// 
+//// f1(/*1*/);
+//// f2(/*2*/);
+//// f3(/*3*/);
+//// f4(/*4*/);
+//// f5(/*5*/);
+
+verify.signatureHelp({
+    marker: "1",
+    parameterDocComment: "**Highlighted text**",
+    tags: [{
+        name: "param",
+        text: "var1 **Highlighted text**"
+    }, {
+        name: "param",
+        text: "var2 Another **Highlighted text**"
+    }]
+});
+verify.signatureHelp({
+    marker: "2",
+    parameterDocComment: "This asterisk gets trimmed unfortunatelly",
+    tags: [{
+        name: "param",
+        text: "var1 This asterisk gets trimmed unfortunatelly"
+    }, {
+        name: "param",
+        text: "var2 Another *Regular text with an asterisk"
+    }]
+});
+verify.signatureHelp({
+    marker: "3",
+    parameterDocComment: "*Regular text with an asterisk",
+    tags: [{
+        name: "param",
+        text: "var1 *Regular text with an asterisk"
+    }, {
+        name: "param",
+        text: "var2 Another *Regular text with an asterisk"
+    }]
+});
+verify.signatureHelp({
+    marker: "4",
+    parameterDocComment: "**Highlighted text**",
+    tags: [{
+        name: "param",
+        text: "var1 **Highlighted text**"
+    }, {
+        name: "param",
+        text: "var2 Another **Highlighted text**"
+    }]
+});
+verify.signatureHelp({
+    marker: "5",
+    parameterDocComment: "**Highlighted text**",
+    tags: [{
+        name: "param",
+        text: "var1 **Highlighted text**"
+    }, {
+        name: "param",
+        text: "var2 Another **Highlighted text**"
+    }]
+});


### PR DESCRIPTION
Fixes #33386.

It has the problem that still doesn't identify when the documentation starts with a single `*`. This issue already exists, and fixing it requires more thinking. 

Let me know if this is acceptable for now.
