### PR TITLE
feat: support __proto__ in object literal (type-check only)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25103,6 +25103,26 @@ namespace ts {
             return links.immediateTarget;
         }
 
+        /**
+         * If the node is a `__proto__` literal declaration.
+         * According to ECMA262 B.3.1 only this syntax counted in
+         *      PropertyName ":" AssignmentExpression
+         *
+         * It works in thoes forms:
+         *      { __proto__: value }; { "__proto__": value }; { __proto_\u005f: value };
+         *  It does not work in thoes forms:
+         *      { ["__proto__"]: value }; { __proto__ }
+         */
+        function getProtoLiteralDeclarationInitializer(node: ObjectLiteralElementLike): false | Expression {
+            if (node.kind !== SyntaxKind.PropertyAssignment) return false;
+            const name = node.name;
+            if (!name) return false;
+            // Identifier.escapedText says if the identifier starts with __, it will starts with 3 "_".
+            if (name.kind === SyntaxKind.Identifier && name.escapedText === "___proto__") return node.initializer;
+            if (name.kind === SyntaxKind.StringLiteral && name.text === "__proto__") return node.initializer;
+            return false;
+        }
+
         function checkObjectLiteral(node: ObjectLiteralExpression, checkMode?: CheckMode): Type {
             const inDestructuringPattern = isAssignmentTarget(node);
             // Grammar checking
@@ -25135,8 +25155,26 @@ namespace ts {
                 }
             }
 
+            const skippedProperties = new Set<ObjectLiteralElementLike>();
+            // It should be the left-most spread element so we loop this first
+            for (const memberDecl of node.properties) {
+                const item = getProtoLiteralDeclarationInitializer(memberDecl);
+                if (!item) continue;
+                // Don't add __proto__ literal to the properties table
+                skippedProperties.add(memberDecl);
+                // it's prototype is null so it works like normal object (despite Object.prototype things).
+                if (item.kind === SyntaxKind.NullKeyword) continue;
+                const type = getReducedType(checkExpression(item));
+                if (!(type.flags & TypeFlags.Object)) {
+                    error(memberDecl, Diagnostics.Type_0_is_not_assignable_to_type_1, typeToString(type), "object | null");
+                }
+                else {
+                    spread = getSpreadType(spread, type, node.symbol, objectFlags, inConstContext);
+                }
+            }
             let offset = 0;
             for (const memberDecl of node.properties) {
+                if (skippedProperties.has(memberDecl)) continue;
                 let member = getSymbolOfNode(memberDecl);
                 const computedNameType = memberDecl.name && memberDecl.name.kind === SyntaxKind.ComputedPropertyName && !isWellKnownSymbolSyntactically(memberDecl.name.expression) ?
                     checkComputedPropertyName(memberDecl.name) : undefined;

--- a/tests/baselines/reference/__proto__literal.errors.txt
+++ b/tests/baselines/reference/__proto__literal.errors.txt
@@ -1,0 +1,38 @@
+tests/cases/compiler/__proto__literal.ts(10,28): error TS2300: Duplicate identifier '__proto_\u005f'.
+tests/cases/compiler/__proto__literal.ts(20,13): error TS2322: Type '1' is not assignable to type 'object | null'.
+
+
+==== tests/cases/compiler/__proto__literal.ts (2 errors) ====
+    const o = { a: 1 }
+    const __proto__ = o
+    // Should
+    const x1 = { __proto__: o }
+    const x2 = { __proto_\u005f: o }
+    const x3 = { "__proto__": o }
+    const x4 = { "__proto_\u005f": o }
+    
+    // Duplicate
+    const y1 = { __proto__: o, __proto_\u005f: o }
+                               ~~~~~~~~~~~~~~
+!!! error TS2300: Duplicate identifier '__proto_\u005f'.
+    
+    // Spread order
+    const z1 = { ...({a: ''}), __proto__: o }
+    const z2 = { __proto__: o, ...({a: ''}) }
+    
+    // Null
+    const w = { __proto__: null }
+    
+    // Non-object
+    const q = { __proto__: 1, x: 1 }
+                ~~~~~~~~~~~~
+!!! error TS2322: Type '1' is not assignable to type 'object | null'.
+    
+    // Should not
+    const x5 = { ["__proto__"]: o }
+    const x6 = { __proto__ }
+    const x7 = { __proto__() {} }
+    enum e { __proto__ = 1 }
+    {
+        const { __proto__ } = { ['__proto__']: 1 }
+    }

--- a/tests/baselines/reference/__proto__literal.js
+++ b/tests/baselines/reference/__proto__literal.js
@@ -1,0 +1,71 @@
+//// [__proto__literal.ts]
+const o = { a: 1 }
+const __proto__ = o
+// Should
+const x1 = { __proto__: o }
+const x2 = { __proto_\u005f: o }
+const x3 = { "__proto__": o }
+const x4 = { "__proto_\u005f": o }
+
+// Duplicate
+const y1 = { __proto__: o, __proto_\u005f: o }
+
+// Spread order
+const z1 = { ...({a: ''}), __proto__: o }
+const z2 = { __proto__: o, ...({a: ''}) }
+
+// Null
+const w = { __proto__: null }
+
+// Non-object
+const q = { __proto__: 1, x: 1 }
+
+// Should not
+const x5 = { ["__proto__"]: o }
+const x6 = { __proto__ }
+const x7 = { __proto__() {} }
+enum e { __proto__ = 1 }
+{
+    const { __proto__ } = { ['__proto__']: 1 }
+}
+
+//// [__proto__literal.js]
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var _a, _b;
+var o = { a: 1 };
+var __proto__ = o;
+// Should
+var x1 = { __proto__: o };
+var x2 = { __proto_\u005f: o };
+var x3 = { "__proto__": o };
+var x4 = { "__proto_\u005f": o };
+// Duplicate
+var y1 = { __proto__: o, __proto_\u005f: o };
+// Spread order
+var z1 = __assign(__assign({}, ({ a: '' })), { __proto__: o });
+var z2 = __assign({ __proto__: o }, ({ a: '' }));
+// Null
+var w = { __proto__: null };
+// Non-object
+var q = { __proto__: 1, x: 1 };
+// Should not
+var x5 = (_a = {}, _a["__proto__"] = o, _a);
+var x6 = { __proto__: __proto__ };
+var x7 = { __proto__: function () { } };
+var e;
+(function (e) {
+    e[e["__proto__"] = 1] = "__proto__";
+})(e || (e = {}));
+{
+    var __proto__1 = (_b = {}, _b['__proto__'] = 1, _b).__proto__;
+}

--- a/tests/baselines/reference/__proto__literal.symbols
+++ b/tests/baselines/reference/__proto__literal.symbols
@@ -1,0 +1,86 @@
+=== tests/cases/compiler/__proto__literal.ts ===
+const o = { a: 1 }
+>o : Symbol(o, Decl(__proto__literal.ts, 0, 5))
+>a : Symbol(a, Decl(__proto__literal.ts, 0, 11))
+
+const __proto__ = o
+>__proto__ : Symbol(__proto__, Decl(__proto__literal.ts, 1, 5))
+>o : Symbol(o, Decl(__proto__literal.ts, 0, 5))
+
+// Should
+const x1 = { __proto__: o }
+>x1 : Symbol(x1, Decl(__proto__literal.ts, 3, 5))
+>__proto__ : Symbol(__proto__, Decl(__proto__literal.ts, 3, 12))
+>o : Symbol(o, Decl(__proto__literal.ts, 0, 5))
+
+const x2 = { __proto_\u005f: o }
+>x2 : Symbol(x2, Decl(__proto__literal.ts, 4, 5))
+>__proto_\u005f : Symbol(__proto_\u005f, Decl(__proto__literal.ts, 4, 12))
+>o : Symbol(o, Decl(__proto__literal.ts, 0, 5))
+
+const x3 = { "__proto__": o }
+>x3 : Symbol(x3, Decl(__proto__literal.ts, 5, 5))
+>"__proto__" : Symbol("__proto__", Decl(__proto__literal.ts, 5, 12))
+>o : Symbol(o, Decl(__proto__literal.ts, 0, 5))
+
+const x4 = { "__proto_\u005f": o }
+>x4 : Symbol(x4, Decl(__proto__literal.ts, 6, 5))
+>"__proto_\u005f" : Symbol("__proto_\u005f", Decl(__proto__literal.ts, 6, 12))
+>o : Symbol(o, Decl(__proto__literal.ts, 0, 5))
+
+// Duplicate
+const y1 = { __proto__: o, __proto_\u005f: o }
+>y1 : Symbol(y1, Decl(__proto__literal.ts, 9, 5))
+>__proto__ : Symbol(__proto__, Decl(__proto__literal.ts, 9, 12), Decl(__proto__literal.ts, 9, 26))
+>o : Symbol(o, Decl(__proto__literal.ts, 0, 5))
+>__proto_\u005f : Symbol(__proto__, Decl(__proto__literal.ts, 9, 12), Decl(__proto__literal.ts, 9, 26))
+>o : Symbol(o, Decl(__proto__literal.ts, 0, 5))
+
+// Spread order
+const z1 = { ...({a: ''}), __proto__: o }
+>z1 : Symbol(z1, Decl(__proto__literal.ts, 12, 5))
+>a : Symbol(a, Decl(__proto__literal.ts, 12, 18))
+>__proto__ : Symbol(__proto__, Decl(__proto__literal.ts, 12, 26))
+>o : Symbol(o, Decl(__proto__literal.ts, 0, 5))
+
+const z2 = { __proto__: o, ...({a: ''}) }
+>z2 : Symbol(z2, Decl(__proto__literal.ts, 13, 5))
+>__proto__ : Symbol(__proto__, Decl(__proto__literal.ts, 13, 12))
+>o : Symbol(o, Decl(__proto__literal.ts, 0, 5))
+>a : Symbol(a, Decl(__proto__literal.ts, 13, 32))
+
+// Null
+const w = { __proto__: null }
+>w : Symbol(w, Decl(__proto__literal.ts, 16, 5))
+>__proto__ : Symbol(__proto__, Decl(__proto__literal.ts, 16, 11))
+
+// Non-object
+const q = { __proto__: 1, x: 1 }
+>q : Symbol(q, Decl(__proto__literal.ts, 19, 5))
+>__proto__ : Symbol(__proto__, Decl(__proto__literal.ts, 19, 11))
+>x : Symbol(x, Decl(__proto__literal.ts, 19, 25))
+
+// Should not
+const x5 = { ["__proto__"]: o }
+>x5 : Symbol(x5, Decl(__proto__literal.ts, 22, 5))
+>["__proto__"] : Symbol(["__proto__"], Decl(__proto__literal.ts, 22, 12))
+>"__proto__" : Symbol(["__proto__"], Decl(__proto__literal.ts, 22, 12))
+>o : Symbol(o, Decl(__proto__literal.ts, 0, 5))
+
+const x6 = { __proto__ }
+>x6 : Symbol(x6, Decl(__proto__literal.ts, 23, 5))
+>__proto__ : Symbol(__proto__, Decl(__proto__literal.ts, 23, 12))
+
+const x7 = { __proto__() {} }
+>x7 : Symbol(x7, Decl(__proto__literal.ts, 24, 5))
+>__proto__ : Symbol(__proto__, Decl(__proto__literal.ts, 24, 12))
+
+enum e { __proto__ = 1 }
+>e : Symbol(e, Decl(__proto__literal.ts, 24, 29))
+>__proto__ : Symbol(e.__proto__, Decl(__proto__literal.ts, 25, 8))
+{
+    const { __proto__ } = { ['__proto__']: 1 }
+>__proto__ : Symbol(__proto__, Decl(__proto__literal.ts, 27, 11))
+>['__proto__'] : Symbol(['__proto__'], Decl(__proto__literal.ts, 27, 27))
+>'__proto__' : Symbol(['__proto__'], Decl(__proto__literal.ts, 27, 27))
+}

--- a/tests/baselines/reference/__proto__literal.types
+++ b/tests/baselines/reference/__proto__literal.types
@@ -1,0 +1,112 @@
+=== tests/cases/compiler/__proto__literal.ts ===
+const o = { a: 1 }
+>o : { a: number; }
+>{ a: 1 } : { a: number; }
+>a : number
+>1 : 1
+
+const __proto__ = o
+>__proto__ : { a: number; }
+>o : { a: number; }
+
+// Should
+const x1 = { __proto__: o }
+>x1 : { a: number; }
+>{ __proto__: o } : { a: number; }
+>__proto__ : { a: number; }
+>o : { a: number; }
+
+const x2 = { __proto_\u005f: o }
+>x2 : { a: number; }
+>{ __proto_\u005f: o } : { a: number; }
+>__proto_\u005f : { a: number; }
+>o : { a: number; }
+
+const x3 = { "__proto__": o }
+>x3 : { a: number; }
+>{ "__proto__": o } : { a: number; }
+>"__proto__" : { a: number; }
+>o : { a: number; }
+
+const x4 = { "__proto_\u005f": o }
+>x4 : { a: number; }
+>{ "__proto_\u005f": o } : { a: number; }
+>"__proto_\u005f" : { a: number; }
+>o : { a: number; }
+
+// Duplicate
+const y1 = { __proto__: o, __proto_\u005f: o }
+>y1 : { a: number; }
+>{ __proto__: o, __proto_\u005f: o } : { a: number; }
+>__proto__ : { a: number; }
+>o : { a: number; }
+>__proto_\u005f : { a: number; }
+>o : { a: number; }
+
+// Spread order
+const z1 = { ...({a: ''}), __proto__: o }
+>z1 : { a: string; }
+>{ ...({a: ''}), __proto__: o } : { a: string; }
+>({a: ''}) : { a: string; }
+>{a: ''} : { a: string; }
+>a : string
+>'' : ""
+>__proto__ : { a: number; }
+>o : { a: number; }
+
+const z2 = { __proto__: o, ...({a: ''}) }
+>z2 : { a: string; }
+>{ __proto__: o, ...({a: ''}) } : { a: string; }
+>__proto__ : { a: number; }
+>o : { a: number; }
+>({a: ''}) : { a: string; }
+>{a: ''} : { a: string; }
+>a : string
+>'' : ""
+
+// Null
+const w = { __proto__: null }
+>w : {}
+>{ __proto__: null } : {}
+>__proto__ : null
+>null : null
+
+// Non-object
+const q = { __proto__: 1, x: 1 }
+>q : { x: number; }
+>{ __proto__: 1, x: 1 } : { x: number; }
+>__proto__ : number
+>1 : 1
+>x : number
+>1 : 1
+
+// Should not
+const x5 = { ["__proto__"]: o }
+>x5 : { __proto__: { a: number; }; }
+>{ ["__proto__"]: o } : { __proto__: { a: number; }; }
+>["__proto__"] : { a: number; }
+>"__proto__" : "__proto__"
+>o : { a: number; }
+
+const x6 = { __proto__ }
+>x6 : { __proto__: { a: number; }; }
+>{ __proto__ } : { __proto__: { a: number; }; }
+>__proto__ : { a: number; }
+
+const x7 = { __proto__() {} }
+>x7 : { __proto__(): void; }
+>{ __proto__() {} } : { __proto__(): void; }
+>__proto__ : () => void
+
+enum e { __proto__ = 1 }
+>e : e
+>__proto__ : e.__proto__
+>1 : 1
+{
+    const { __proto__ } = { ['__proto__']: 1 }
+>__proto__ : number
+>{ ['__proto__']: 1 } : { __proto__: number; }
+>['__proto__'] : number
+>'__proto__' : "__proto__"
+>1 : 1
+}

--- a/tests/baselines/reference/escapedReservedCompilerNamedIdentifier.errors.txt
+++ b/tests/baselines/reference/escapedReservedCompilerNamedIdentifier.errors.txt
@@ -1,0 +1,36 @@
+tests/cases/compiler/escapedReservedCompilerNamedIdentifier.ts(4,5): error TS2322: Type '0' is not assignable to type 'object | null'.
+
+
+==== tests/cases/compiler/escapedReservedCompilerNamedIdentifier.ts (1 errors) ====
+    // double underscores
+    var __proto__ = 10;
+    var o = {
+        "__proto__": 0
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type '0' is not assignable to type 'object | null'.
+    };
+    var b = o["__proto__"];
+    var o1 = {
+        __proto__: {}
+    };
+    var b1 = o1["__proto__"];
+    // Triple underscores
+    var ___proto__ = 10;
+    var o2 = {
+        "___proto__": 0
+    };
+    var b2 = o2["___proto__"];
+    var o3 = {
+        ___proto__: 0
+    };
+    var b3 = o3["___proto__"];
+    // One underscore
+    var _proto__ = 10;
+    var o4 = {
+        "_proto__": 0
+    };
+    var b4 = o4["_proto__"];
+    var o5 = {
+        _proto__: 0
+    };
+    var b5 = o5["_proto__"];

--- a/tests/baselines/reference/escapedReservedCompilerNamedIdentifier.js
+++ b/tests/baselines/reference/escapedReservedCompilerNamedIdentifier.js
@@ -6,7 +6,7 @@ var o = {
 };
 var b = o["__proto__"];
 var o1 = {
-    __proto__: 0
+    __proto__: {}
 };
 var b1 = o1["__proto__"];
 // Triple underscores
@@ -38,7 +38,7 @@ var o = {
 };
 var b = o["__proto__"];
 var o1 = {
-    __proto__: 0
+    __proto__: {}
 };
 var b1 = o1["__proto__"];
 // Triple underscores
@@ -65,14 +65,10 @@ var b5 = o5["_proto__"];
 
 //// [escapedReservedCompilerNamedIdentifier.d.ts]
 declare var __proto__: number;
-declare var o: {
-    __proto__: number;
-};
-declare var b: number;
-declare var o1: {
-    __proto__: number;
-};
-declare var b1: number;
+declare var o: {};
+declare var b: any;
+declare var o1: {};
+declare var b1: any;
 declare var ___proto__: number;
 declare var o2: {
     ___proto__: number;

--- a/tests/baselines/reference/escapedReservedCompilerNamedIdentifier.symbols
+++ b/tests/baselines/reference/escapedReservedCompilerNamedIdentifier.symbols
@@ -13,19 +13,17 @@ var o = {
 var b = o["__proto__"];
 >b : Symbol(b, Decl(escapedReservedCompilerNamedIdentifier.ts, 5, 3))
 >o : Symbol(o, Decl(escapedReservedCompilerNamedIdentifier.ts, 2, 3))
->"__proto__" : Symbol("__proto__", Decl(escapedReservedCompilerNamedIdentifier.ts, 2, 9))
 
 var o1 = {
 >o1 : Symbol(o1, Decl(escapedReservedCompilerNamedIdentifier.ts, 6, 3))
 
-    __proto__: 0
+    __proto__: {}
 >__proto__ : Symbol(__proto__, Decl(escapedReservedCompilerNamedIdentifier.ts, 6, 10))
 
 };
 var b1 = o1["__proto__"];
 >b1 : Symbol(b1, Decl(escapedReservedCompilerNamedIdentifier.ts, 9, 3))
 >o1 : Symbol(o1, Decl(escapedReservedCompilerNamedIdentifier.ts, 6, 3))
->"__proto__" : Symbol(__proto__, Decl(escapedReservedCompilerNamedIdentifier.ts, 6, 10))
 
 // Triple underscores
 var ___proto__ = 10;

--- a/tests/baselines/reference/escapedReservedCompilerNamedIdentifier.types
+++ b/tests/baselines/reference/escapedReservedCompilerNamedIdentifier.types
@@ -5,8 +5,8 @@ var __proto__ = 10;
 >10 : 10
 
 var o = {
->o : { __proto__: number; }
->{    "__proto__": 0} : { __proto__: number; }
+>o : {}
+>{    "__proto__": 0} : {}
 
     "__proto__": 0
 >"__proto__" : number
@@ -14,24 +14,24 @@ var o = {
 
 };
 var b = o["__proto__"];
->b : number
->o["__proto__"] : number
->o : { __proto__: number; }
+>b : any
+>o["__proto__"] : any
+>o : {}
 >"__proto__" : "__proto__"
 
 var o1 = {
->o1 : { __proto__: number; }
->{    __proto__: 0} : { __proto__: number; }
+>o1 : {}
+>{    __proto__: {}} : {}
 
-    __proto__: 0
->__proto__ : number
->0 : 0
+    __proto__: {}
+>__proto__ : {}
+>{} : {}
 
 };
 var b1 = o1["__proto__"];
->b1 : number
->o1["__proto__"] : number
->o1 : { __proto__: number; }
+>b1 : any
+>o1["__proto__"] : any
+>o1 : {}
 >"__proto__" : "__proto__"
 
 // Triple underscores

--- a/tests/baselines/reference/exportsAndImportsWithUnderscores2.errors.txt
+++ b/tests/baselines/reference/exportsAndImportsWithUnderscores2.errors.txt
@@ -1,0 +1,16 @@
+tests/cases/conformance/es6/modules/m2.ts(2,21): error TS2339: Property '__proto__' does not exist on type '{ __esmodule: boolean; }'.
+
+
+==== tests/cases/conformance/es6/modules/m1.ts (0 errors) ====
+    var R: any
+    export default R = {
+        "__esmodule": true,
+        "__proto__": {}
+    }
+    
+==== tests/cases/conformance/es6/modules/m2.ts (1 errors) ====
+    import R from "./m1";
+    const { __esmodule, __proto__ } = R;
+                        ~~~~~~~~~
+!!! error TS2339: Property '__proto__' does not exist on type '{ __esmodule: boolean; }'.
+    

--- a/tests/baselines/reference/exportsAndImportsWithUnderscores2.types
+++ b/tests/baselines/reference/exportsAndImportsWithUnderscores2.types
@@ -3,9 +3,9 @@ var R: any
 >R : any
 
 export default R = {
->R = {    "__esmodule": true,    "__proto__": {}} : { __esmodule: boolean; __proto__: {}; }
+>R = {    "__esmodule": true,    "__proto__": {}} : { __esmodule: boolean; }
 >R : any
->{    "__esmodule": true,    "__proto__": {}} : { __esmodule: boolean; __proto__: {}; }
+>{    "__esmodule": true,    "__proto__": {}} : { __esmodule: boolean; }
 
     "__esmodule": true,
 >"__esmodule" : boolean
@@ -18,10 +18,10 @@ export default R = {
 
 === tests/cases/conformance/es6/modules/m2.ts ===
 import R from "./m1";
->R : { __esmodule: boolean; __proto__: {}; }
+>R : { __esmodule: boolean; }
 
 const { __esmodule, __proto__ } = R;
 >__esmodule : boolean
->__proto__ : {}
->R : { __esmodule: boolean; __proto__: {}; }
+>__proto__ : any
+>R : { __esmodule: boolean; }
 

--- a/tests/baselines/reference/jsDeclarationsFunctionLikeClasses2.errors.txt
+++ b/tests/baselines/reference/jsDeclarationsFunctionLikeClasses2.errors.txt
@@ -1,0 +1,92 @@
+tests/cases/conformance/jsdoc/declarations/referencer.js(4,34): error TS2339: Property 'dot' does not exist on type 'Point2D'.
+tests/cases/conformance/jsdoc/declarations/source.js(50,21): error TS2339: Property 'storage' does not exist on type '{ x: number; y: number; dot(other: Vec): number; magnitude(): number; }'.
+tests/cases/conformance/jsdoc/declarations/source.js(56,14): error TS2339: Property 'storage' does not exist on type '{ x: number; y: number; dot(other: Vec): number; magnitude(): number; }'.
+tests/cases/conformance/jsdoc/declarations/source.js(59,21): error TS2339: Property 'storage' does not exist on type '{ x: number; y: number; dot(other: Vec): number; magnitude(): number; }'.
+tests/cases/conformance/jsdoc/declarations/source.js(65,14): error TS2339: Property 'storage' does not exist on type '{ x: number; y: number; dot(other: Vec): number; magnitude(): number; }'.
+
+
+==== tests/cases/conformance/jsdoc/declarations/source.js (4 errors) ====
+    /**
+     * @param {number} len
+     */
+    export function Vec(len) {
+        /**
+         * @type {number[]}
+         */
+        this.storage = new Array(len);
+    }
+    
+    Vec.prototype = {
+        /**
+         * @param {Vec} other
+         */
+        dot(other) {
+            if (other.storage.length !== this.storage.length) {
+                throw new Error(`Dot product only applicable for vectors of equal length`);
+            }
+            let sum = 0;
+            for (let i = 0; i < this.storage.length; i++) {
+                sum += (this.storage[i] * other.storage[i]);
+            }
+            return sum;
+        },
+        magnitude() {
+            let sum = 0;
+            for (let i = 0; i < this.storage.length; i++) {
+                sum += (this.storage[i] ** 2);
+            }
+            return Math.sqrt(sum);
+        }
+    }
+    
+    /**
+     * @param {number} x
+     * @param {number} y
+     */
+    export function Point2D(x, y) {
+        if (!(this instanceof Point2D)) {
+            return new Point2D(x, y);
+        }
+        Vec.call(this, 2);
+        this.x = x;
+        this.y = y;
+    }
+    
+    Point2D.prototype = {
+        __proto__: Vec.prototype,
+        get x() {
+            return this.storage[0];
+                        ~~~~~~~
+!!! error TS2339: Property 'storage' does not exist on type '{ x: number; y: number; dot(other: Vec): number; magnitude(): number; }'.
+        },
+        /**
+         * @param {number} x
+         */
+        set x(x) {
+            this.storage[0] = x;
+                 ~~~~~~~
+!!! error TS2339: Property 'storage' does not exist on type '{ x: number; y: number; dot(other: Vec): number; magnitude(): number; }'.
+        },
+        get y() {
+            return this.storage[1];
+                        ~~~~~~~
+!!! error TS2339: Property 'storage' does not exist on type '{ x: number; y: number; dot(other: Vec): number; magnitude(): number; }'.
+        },
+        /**
+         * @param {number} y
+         */
+        set y(y) {
+            this.storage[1] = y;
+                 ~~~~~~~
+!!! error TS2339: Property 'storage' does not exist on type '{ x: number; y: number; dot(other: Vec): number; magnitude(): number; }'.
+        }
+    };
+    
+==== tests/cases/conformance/jsdoc/declarations/referencer.js (1 errors) ====
+    import {Point2D} from "./source";
+    
+    export const origin = new Point2D(0, 0);
+    export const res = Point2D(2, 3).dot(origin);
+                                     ~~~
+!!! error TS2339: Property 'dot' does not exist on type 'Point2D'.
+    

--- a/tests/baselines/reference/jsDeclarationsFunctionLikeClasses2.js
+++ b/tests/baselines/reference/jsDeclarationsFunctionLikeClasses2.js
@@ -48,7 +48,7 @@ export function Point2D(x, y) {
 }
 
 Point2D.prototype = {
-    __proto__: Vec,
+    __proto__: Vec.prototype,
     get x() {
         return this.storage[0];
     },
@@ -73,7 +73,7 @@ Point2D.prototype = {
 import {Point2D} from "./source";
 
 export const origin = new Point2D(0, 0);
-// export const res = Point2D(2, 3).dot(origin); // TODO: when __proto__ works, validate this
+export const res = Point2D(2, 3).dot(origin);
 
 
 //// [source.js]
@@ -126,7 +126,7 @@ function Point2D(x, y) {
 }
 exports.Point2D = Point2D;
 Point2D.prototype = {
-    __proto__: Vec,
+    __proto__: Vec.prototype,
     get x() {
         return this.storage[0];
     },
@@ -149,10 +149,10 @@ Point2D.prototype = {
 //// [referencer.js]
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.origin = void 0;
+exports.res = exports.origin = void 0;
 var source_1 = require("./source");
 exports.origin = new source_1.Point2D(0, 0);
-// export const res = Point2D(2, 3).dot(origin); // TODO: when __proto__ works, validate this
+exports.res = source_1.Point2D(2, 3).dot(exports.origin);
 
 
 //// [source.d.ts]
@@ -196,8 +196,15 @@ export class Point2D {
      */
     set y(arg: number);
     get y(): number;
-    __proto__: typeof Vec;
+    __proto__: {
+        /**
+         * @param {Vec} other
+         */
+        dot(other: Vec): number;
+        magnitude(): number;
+    };
 }
 //// [referencer.d.ts]
 export const origin: Point2D;
+export const res: any;
 import { Point2D } from "./source";

--- a/tests/baselines/reference/jsDeclarationsFunctionLikeClasses2.symbols
+++ b/tests/baselines/reference/jsDeclarationsFunctionLikeClasses2.symbols
@@ -125,17 +125,14 @@ export function Point2D(x, y) {
 >Vec.call : Symbol(Function.call, Decl(lib.es5.d.ts, --, --))
 >Vec : Symbol(Vec, Decl(source.js, 0, 0), Decl(source.js, 8, 1))
 >call : Symbol(Function.call, Decl(lib.es5.d.ts, --, --))
->this : Symbol(Point2D, Decl(source.js, 31, 1), Decl(source.js, 44, 1))
 
     this.x = x;
->this.x : Symbol(Point2D.x, Decl(source.js, 41, 22), Decl(source.js, 47, 19), Decl(source.js, 50, 6))
->this : Symbol(Point2D, Decl(source.js, 31, 1), Decl(source.js, 44, 1))
->x : Symbol(Point2D.x, Decl(source.js, 41, 22), Decl(source.js, 47, 19), Decl(source.js, 50, 6))
+>this.x : Symbol(Point2D.x, Decl(source.js, 41, 22), Decl(source.js, 47, 29), Decl(source.js, 50, 6))
+>x : Symbol(Point2D.x, Decl(source.js, 41, 22), Decl(source.js, 47, 29), Decl(source.js, 50, 6))
 >x : Symbol(x, Decl(source.js, 37, 24))
 
     this.y = y;
 >this.y : Symbol(Point2D.y, Decl(source.js, 42, 15), Decl(source.js, 56, 6), Decl(source.js, 59, 6))
->this : Symbol(Point2D, Decl(source.js, 31, 1), Decl(source.js, 44, 1))
 >y : Symbol(Point2D.y, Decl(source.js, 42, 15), Decl(source.js, 56, 6), Decl(source.js, 59, 6))
 >y : Symbol(y, Decl(source.js, 37, 26))
 }
@@ -145,12 +142,14 @@ Point2D.prototype = {
 >Point2D : Symbol(Point2D, Decl(source.js, 31, 1), Decl(source.js, 44, 1))
 >prototype : Symbol(Point2D.prototype, Decl(source.js, 44, 1))
 
-    __proto__: Vec,
+    __proto__: Vec.prototype,
 >__proto__ : Symbol(__proto__, Decl(source.js, 46, 21))
+>Vec.prototype : Symbol(Vec.prototype, Decl(source.js, 8, 1))
 >Vec : Symbol(Vec, Decl(source.js, 0, 0), Decl(source.js, 8, 1))
+>prototype : Symbol(Vec.prototype, Decl(source.js, 8, 1))
 
     get x() {
->x : Symbol(Point2D.x, Decl(source.js, 41, 22), Decl(source.js, 47, 19), Decl(source.js, 50, 6))
+>x : Symbol(Point2D.x, Decl(source.js, 41, 22), Decl(source.js, 47, 29), Decl(source.js, 50, 6))
 
         return this.storage[0];
 >this : Symbol(__object, Decl(source.js, 46, 19))
@@ -160,7 +159,7 @@ Point2D.prototype = {
      * @param {number} x
      */
     set x(x) {
->x : Symbol(Point2D.x, Decl(source.js, 41, 22), Decl(source.js, 47, 19), Decl(source.js, 50, 6))
+>x : Symbol(Point2D.x, Decl(source.js, 41, 22), Decl(source.js, 47, 29), Decl(source.js, 50, 6))
 >x : Symbol(x, Decl(source.js, 54, 10))
 
         this.storage[0] = x;
@@ -196,5 +195,8 @@ export const origin = new Point2D(0, 0);
 >origin : Symbol(origin, Decl(referencer.js, 2, 12))
 >Point2D : Symbol(Point2D, Decl(referencer.js, 0, 8))
 
-// export const res = Point2D(2, 3).dot(origin); // TODO: when __proto__ works, validate this
+export const res = Point2D(2, 3).dot(origin);
+>res : Symbol(res, Decl(referencer.js, 3, 12))
+>Point2D : Symbol(Point2D, Decl(referencer.js, 0, 8))
+>origin : Symbol(origin, Decl(referencer.js, 2, 12))
 

--- a/tests/baselines/reference/jsDeclarationsFunctionLikeClasses2.types
+++ b/tests/baselines/reference/jsDeclarationsFunctionLikeClasses2.types
@@ -156,34 +156,36 @@ export function Point2D(x, y) {
 >Vec.call : (this: Function, thisArg: any, ...argArray: any[]) => any
 >Vec : typeof Vec
 >call : (this: Function, thisArg: any, ...argArray: any[]) => any
->this : this
+>this : this & { x: number; y: number; dot(other: Vec): number; magnitude(): number; }
 >2 : 2
 
     this.x = x;
 >this.x = x : number
 >this.x : number
->this : this
+>this : this & { x: number; y: number; dot(other: Vec): number; magnitude(): number; }
 >x : number
 >x : number
 
     this.y = y;
 >this.y = y : number
 >this.y : number
->this : this
+>this : this & { x: number; y: number; dot(other: Vec): number; magnitude(): number; }
 >y : number
 >y : number
 }
 
 Point2D.prototype = {
->Point2D.prototype = {    __proto__: Vec,    get x() {        return this.storage[0];    },    /**     * @param {number} x     */    set x(x) {        this.storage[0] = x;    },    get y() {        return this.storage[1];    },    /**     * @param {number} y     */    set y(y) {        this.storage[1] = y;    }} : { __proto__: typeof Vec; x: number; y: number; }
->Point2D.prototype : { __proto__: typeof Vec; x: number; y: number; }
+>Point2D.prototype = {    __proto__: Vec.prototype,    get x() {        return this.storage[0];    },    /**     * @param {number} x     */    set x(x) {        this.storage[0] = x;    },    get y() {        return this.storage[1];    },    /**     * @param {number} y     */    set y(y) {        this.storage[1] = y;    }} : { x: number; y: number; dot(other: Vec): number; magnitude(): number; }
+>Point2D.prototype : { x: number; y: number; dot(other: Vec): number; magnitude(): number; }
 >Point2D : typeof Point2D
->prototype : { __proto__: typeof Vec; x: number; y: number; }
->{    __proto__: Vec,    get x() {        return this.storage[0];    },    /**     * @param {number} x     */    set x(x) {        this.storage[0] = x;    },    get y() {        return this.storage[1];    },    /**     * @param {number} y     */    set y(y) {        this.storage[1] = y;    }} : { __proto__: typeof Vec; x: number; y: number; }
+>prototype : { x: number; y: number; dot(other: Vec): number; magnitude(): number; }
+>{    __proto__: Vec.prototype,    get x() {        return this.storage[0];    },    /**     * @param {number} x     */    set x(x) {        this.storage[0] = x;    },    get y() {        return this.storage[1];    },    /**     * @param {number} y     */    set y(y) {        this.storage[1] = y;    }} : { x: number; y: number; dot(other: Vec): number; magnitude(): number; }
 
-    __proto__: Vec,
->__proto__ : typeof Vec
+    __proto__: Vec.prototype,
+>__proto__ : { dot(other: Vec): number; magnitude(): number; }
+>Vec.prototype : { dot(other: Vec): number; magnitude(): number; }
 >Vec : typeof Vec
+>prototype : { dot(other: Vec): number; magnitude(): number; }
 
     get x() {
 >x : number
@@ -191,7 +193,7 @@ Point2D.prototype = {
         return this.storage[0];
 >this.storage[0] : any
 >this.storage : any
->this : { __proto__: typeof Vec; x: number; y: number; }
+>this : { x: number; y: number; dot(other: Vec): number; magnitude(): number; }
 >storage : any
 >0 : 0
 
@@ -207,7 +209,7 @@ Point2D.prototype = {
 >this.storage[0] = x : number
 >this.storage[0] : any
 >this.storage : any
->this : { __proto__: typeof Vec; x: number; y: number; }
+>this : { x: number; y: number; dot(other: Vec): number; magnitude(): number; }
 >storage : any
 >0 : 0
 >x : number
@@ -219,7 +221,7 @@ Point2D.prototype = {
         return this.storage[1];
 >this.storage[1] : any
 >this.storage : any
->this : { __proto__: typeof Vec; x: number; y: number; }
+>this : { x: number; y: number; dot(other: Vec): number; magnitude(): number; }
 >storage : any
 >1 : 1
 
@@ -235,7 +237,7 @@ Point2D.prototype = {
 >this.storage[1] = y : number
 >this.storage[1] : any
 >this.storage : any
->this : { __proto__: typeof Vec; x: number; y: number; }
+>this : { x: number; y: number; dot(other: Vec): number; magnitude(): number; }
 >storage : any
 >1 : 1
 >y : number
@@ -253,5 +255,14 @@ export const origin = new Point2D(0, 0);
 >0 : 0
 >0 : 0
 
-// export const res = Point2D(2, 3).dot(origin); // TODO: when __proto__ works, validate this
+export const res = Point2D(2, 3).dot(origin);
+>res : any
+>Point2D(2, 3).dot(origin) : any
+>Point2D(2, 3).dot : any
+>Point2D(2, 3) : Point2D
+>Point2D : typeof Point2D
+>2 : 2
+>3 : 3
+>dot : any
+>origin : Point2D
 

--- a/tests/baselines/reference/protoAsIndexInIndexExpression.js
+++ b/tests/baselines/reference/protoAsIndexInIndexExpression.js
@@ -13,7 +13,7 @@ var WorkspacePrototype = {
 WorkspacePrototype['__proto__'] = EntityPrototype;
 
 var o = {
-    "__proto__": 0
+    "__proto__": {}
 };
 class C {
     "__proto__" = 0;
@@ -32,7 +32,7 @@ var WorkspacePrototype = {
 };
 WorkspacePrototype['__proto__'] = EntityPrototype;
 var o = {
-    "__proto__": 0
+    "__proto__": {}
 };
 var C = /** @class */ (function () {
     function C() {

--- a/tests/baselines/reference/protoAsIndexInIndexExpression.symbols
+++ b/tests/baselines/reference/protoAsIndexInIndexExpression.symbols
@@ -18,7 +18,7 @@ WorkspacePrototype['__proto__'] = EntityPrototype;
 var o = {
 >o : Symbol(o, Decl(protoAsIndexInIndexExpression_1.ts, 8, 3))
 
-    "__proto__": 0
+    "__proto__": {}
 >"__proto__" : Symbol("__proto__", Decl(protoAsIndexInIndexExpression_1.ts, 8, 9))
 
 };

--- a/tests/baselines/reference/protoAsIndexInIndexExpression.types
+++ b/tests/baselines/reference/protoAsIndexInIndexExpression.types
@@ -21,12 +21,12 @@ WorkspacePrototype['__proto__'] = EntityPrototype;
 >EntityPrototype : any
 
 var o = {
->o : { __proto__: number; }
->{    "__proto__": 0} : { __proto__: number; }
+>o : {}
+>{    "__proto__": {}} : {}
 
-    "__proto__": 0
->"__proto__" : number
->0 : 0
+    "__proto__": {}
+>"__proto__" : {}
+>{} : {}
 
 };
 class C {

--- a/tests/baselines/reference/superInObjectLiterals_ES5.types
+++ b/tests/baselines/reference/superInObjectLiterals_ES5.types
@@ -1,7 +1,7 @@
 === tests/cases/compiler/superInObjectLiterals_ES5.ts ===
 var obj = {
->obj : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
->{    __proto__: {        method() {        }    },    method() {        super.method();    },    get prop() {        super.method();        return 10;    },    set prop(value) {        super.method();    },    p1: function () {        super.method();    },    p2: function f() {        super.method();    },    p3: () => {        super.method();    }} : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
+>obj : { method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
+>{    __proto__: {        method() {        }    },    method() {        super.method();    },    get prop() {        super.method();        return 10;    },    set prop(value) {        super.method();    },    p1: function () {        super.method();    },    p2: function f() {        super.method();    },    p3: () => {        super.method();    }} : { method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
 
     __proto__: {
 >__proto__ : { method(): void; }
@@ -95,8 +95,8 @@ class B extends A {
 >f : () => void
 
         var obj = {
->obj : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
->{            __proto__: {                method() {                }            },            method() {                super.method();            },            get prop() {                super.method();                return 10;            },            set prop(value) {                super.method();            },            p1: function () {                super.method();            },            p2: function f() {                super.method();            },            p3: () => {                super.method();            }        } : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
+>obj : { method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
+>{            __proto__: {                method() {                }            },            method() {                super.method();            },            get prop() {                super.method();                return 10;            },            set prop(value) {                super.method();            },            p1: function () {                super.method();            },            p2: function f() {                super.method();            },            p3: () => {                super.method();            }        } : { method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
 
             __proto__: {
 >__proto__ : { method(): void; }

--- a/tests/baselines/reference/superInObjectLiterals_ES6.types
+++ b/tests/baselines/reference/superInObjectLiterals_ES6.types
@@ -1,7 +1,7 @@
 === tests/cases/compiler/superInObjectLiterals_ES6.ts ===
 var obj = {
->obj : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
->{    __proto__: {        method() {        }    },    method() {        super.method();    },    get prop() {        super.method();        return 10;    },    set prop(value) {        super.method();    },    p1: function () {        super.method();    },    p2: function f() {        super.method();    },    p3: () => {        super.method();    }} : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
+>obj : { method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
+>{    __proto__: {        method() {        }    },    method() {        super.method();    },    get prop() {        super.method();        return 10;    },    set prop(value) {        super.method();    },    p1: function () {        super.method();    },    p2: function f() {        super.method();    },    p3: () => {        super.method();    }} : { method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
 
     __proto__: {
 >__proto__ : { method(): void; }
@@ -95,8 +95,8 @@ class B extends A {
 >f : () => void
 
         var obj = {
->obj : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
->{            __proto__: {                method() {                }            },            method() {                super.method();            },            get prop() {                super.method();                return 10;            },            set prop(value) {                super.method();            },            p1: function () {                super.method();            },            p2: function f() {                super.method();            },            p3: () => {                super.method();            }        } : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
+>obj : { method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
+>{            __proto__: {                method() {                }            },            method() {                super.method();            },            get prop() {                super.method();                return 10;            },            set prop(value) {                super.method();            },            p1: function () {                super.method();            },            p2: function f() {                super.method();            },            p3: () => {                super.method();            }        } : { method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
 
             __proto__: {
 >__proto__ : { method(): void; }

--- a/tests/cases/compiler/__proto__literal.ts
+++ b/tests/cases/compiler/__proto__literal.ts
@@ -1,0 +1,29 @@
+const o = { a: 1 }
+const __proto__ = o
+// Should
+const x1 = { __proto__: o }
+const x2 = { __proto_\u005f: o }
+const x3 = { "__proto__": o }
+const x4 = { "__proto_\u005f": o }
+
+// Duplicate
+const y1 = { __proto__: o, __proto_\u005f: o }
+
+// Spread order
+const z1 = { ...({a: ''}), __proto__: o }
+const z2 = { __proto__: o, ...({a: ''}) }
+
+// Null
+const w = { __proto__: null }
+
+// Non-object
+const q = { __proto__: 1, x: 1 }
+
+// Should not
+const x5 = { ["__proto__"]: o }
+const x6 = { __proto__ }
+const x7 = { __proto__() {} }
+enum e { __proto__ = 1 }
+{
+    const { __proto__ } = { ['__proto__']: 1 }
+}

--- a/tests/cases/compiler/escapedReservedCompilerNamedIdentifier.ts
+++ b/tests/cases/compiler/escapedReservedCompilerNamedIdentifier.ts
@@ -6,7 +6,7 @@ var o = {
 };
 var b = o["__proto__"];
 var o1 = {
-    __proto__: 0
+    __proto__: {}
 };
 var b1 = o1["__proto__"];
 // Triple underscores

--- a/tests/cases/compiler/protoAsIndexInIndexExpression.ts
+++ b/tests/cases/compiler/protoAsIndexInIndexExpression.ts
@@ -12,7 +12,7 @@ var WorkspacePrototype = {
 WorkspacePrototype['__proto__'] = EntityPrototype;
 
 var o = {
-    "__proto__": 0
+    "__proto__": {}
 };
 class C {
     "__proto__" = 0;

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsFunctionLikeClasses2.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsFunctionLikeClasses2.ts
@@ -52,7 +52,7 @@ export function Point2D(x, y) {
 }
 
 Point2D.prototype = {
-    __proto__: Vec,
+    __proto__: Vec.prototype,
     get x() {
         return this.storage[0];
     },
@@ -78,4 +78,4 @@ Point2D.prototype = {
 import {Point2D} from "./source";
 
 export const origin = new Point2D(0, 0);
-// export const res = Point2D(2, 3).dot(origin); // TODO: when __proto__ works, validate this
+export const res = Point2D(2, 3).dot(origin);

--- a/tests/cases/fourslash/protoPropertyInObjectLiteral.ts
+++ b/tests/cases/fourslash/protoPropertyInObjectLiteral.ts
@@ -1,20 +1,9 @@
 /// <reference path='fourslash.ts' />
 
-////var o1 = {
-////    "__proto__": 10
-////};
-////var o2 = {
-////    __proto__: 10
-////};
-////o1./*1*/
+////var proto = { a: 1 }
+////var o2 = { __proto__: proto }
 ////o2./*2*/
 
-verify.completions({ marker: "1", exact: { name: "__proto__", text: '(property) "__proto__": number' } });
-edit.insert("__proto__ = 10;");
-
-verify.quickInfoAt("1", '(property) "__proto__": number');
-
-verify.completions({ marker: "2", exact: { name: "__proto__", text: "(property) __proto__: number" } });
-edit.insert("__proto__ = 10;");
-
-verify.quickInfoAt("2", "(property) __proto__: number");
+verify.completions({ marker: "2", exact: { name: "a", text: "(property) a: number" } });
+edit.insert("a = 10;");
+verify.quickInfoAt("2", "(property) a: number");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

related #38385
close #13933

Related:

https://tc39.es/ecma262/#sec-__proto__-property-names-in-object-initializers

https://github.com/tc39/ecma262/pull/2125