### PR TITLE
At starts jsdoc tag only after whitespace

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7532,6 +7532,7 @@ namespace ts {
                 function parseTagComments(indent: number, initialMargin?: string): string | undefined {
                     const comments: string[] = [];
                     let state = JSDocState.BeginningOfLine;
+                    let previousWhitespace = true;
                     let margin: number | undefined;
                     function pushComment(text: string) {
                         if (!margin) {
@@ -7557,7 +7558,8 @@ namespace ts {
                                 indent = 0;
                                 break;
                             case SyntaxKind.AtToken:
-                                if (state === JSDocState.SavingBackticks) {
+                                if (state === JSDocState.SavingBackticks || !previousWhitespace && state === JSDocState.SavingComments) {
+                                    // @ doesn't start a new tag inside ``, and inside a comment, only after whitespace
                                     comments.push(scanner.getTokenText());
                                     break;
                                 }
@@ -7614,6 +7616,7 @@ namespace ts {
                                 pushComment(scanner.getTokenText());
                                 break;
                         }
+                        previousWhitespace = token() === SyntaxKind.WhitespaceTrivia;
                         tok = nextTokenJSDoc();
                     }
 

--- a/src/testRunner/unittests/jsDocParsing.ts
+++ b/src/testRunner/unittests/jsDocParsing.ts
@@ -331,7 +331,7 @@ namespace ts {
  *   Comments
  * @author Early Close Caret > <a@b>
  * @author No Line Breaks:
- *   <the.email@address> must be on the same line to parse
+ *   <the email @address> must be on the same line to parse
  * @author Long Comment <long@comment.org> I
  *  want to keep commenting down here, I dunno.
  */`);
@@ -340,6 +340,17 @@ namespace ts {
                     `/**
  * @example
  * Some\n\n * text\r\n * with newlines.
+ */`);
+                parsesCorrectly(
+                    "no space before @ is not a new tag",
+                    `/**
+ * @param this (@is@)
+ * @param fine its@fine
+ */`);
+                parsesCorrectly(
+                    "@@ does not start a new tag",
+                    `/**
+ * @param this is @@fine@@and is one comment
  */`);
             });
         });

--- a/src/testRunner/unittests/jsDocParsing.ts
+++ b/src/testRunner/unittests/jsDocParsing.ts
@@ -341,16 +341,21 @@ namespace ts {
  * @example
  * Some\n\n * text\r\n * with newlines.
  */`);
-                parsesCorrectly(
-                    "no space before @ is not a new tag",
+                parsesCorrectly("Chained tags, no leading whitespace", `/**@a @b @c@d*/`);
+                parsesCorrectly("Initial star is not a tag", `/***@a*/`);
+                parsesCorrectly("Initial star space is not a tag", `/*** @a*/`);
+                parsesCorrectly("Initial email address is not a tag", `/**bill@example.com*/`);
+                parsesCorrectly("no space before @ is not a new tag",
                     `/**
  * @param this (@is@)
  * @param fine its@fine
+@zerowidth
+*@singlestar
+**@doublestar
  */`);
-                parsesCorrectly(
-                    "@@ does not start a new tag",
+                parsesCorrectly("@@ does not start a new tag",
                     `/**
- * @param this is @@fine@@and is one comment
+ * @param this is (@@fine@@and) is one comment
  */`);
             });
         });

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.@@ does not start a new tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.@@ does not start a new tag.json
@@ -1,0 +1,42 @@
+{
+    "kind": "JSDocComment",
+    "pos": 0,
+    "end": 54,
+    "flags": "JSDoc",
+    "modifierFlagsCache": 0,
+    "transformFlags": 0,
+    "tags": {
+        "0": {
+            "kind": "JSDocParameterTag",
+            "pos": 7,
+            "end": 52,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 8,
+                "end": 13,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "param"
+            },
+            "comment": "is (@@fine@@and) is one comment",
+            "name": {
+                "kind": "Identifier",
+                "pos": 14,
+                "end": 18,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "originalKeywordKind": "ThisKeyword",
+                "escapedText": "this"
+            },
+            "isNameFirst": true,
+            "isBracketed": false
+        },
+        "length": 1,
+        "pos": 7,
+        "end": 52,
+        "hasTrailingComma": false,
+        "transformFlags": 0
+    }
+}

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Chained tags, no leading whitespace.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Chained tags, no leading whitespace.json
@@ -1,0 +1,75 @@
+{
+    "kind": "JSDocComment",
+    "pos": 0,
+    "end": 15,
+    "flags": "JSDoc",
+    "modifierFlagsCache": 0,
+    "transformFlags": 0,
+    "tags": {
+        "0": {
+            "kind": "JSDocTag",
+            "pos": 3,
+            "end": 6,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 4,
+                "end": 5,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "a"
+            }
+        },
+        "1": {
+            "kind": "JSDocTag",
+            "pos": 6,
+            "end": 9,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 7,
+                "end": 8,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "b"
+            }
+        },
+        "2": {
+            "kind": "JSDocTag",
+            "pos": 9,
+            "end": 11,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 10,
+                "end": 11,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "c"
+            }
+        },
+        "3": {
+            "kind": "JSDocTag",
+            "pos": 11,
+            "end": 13,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 12,
+                "end": 13,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "d"
+            }
+        },
+        "length": 4,
+        "pos": 3,
+        "end": 13,
+        "hasTrailingComma": false,
+        "transformFlags": 0
+    }
+}

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial email address is not a tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial email address is not a tag.json
@@ -1,0 +1,9 @@
+{
+    "kind": "JSDocComment",
+    "pos": 0,
+    "end": 21,
+    "flags": "JSDoc",
+    "modifierFlagsCache": 0,
+    "transformFlags": 0,
+    "comment": "bill@example.com"
+}

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star ignores tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star ignores tag.json
@@ -1,0 +1,9 @@
+{
+    "kind": "JSDocComment",
+    "pos": 0,
+    "end": 8,
+    "flags": "JSDoc",
+    "modifierFlagsCache": 0,
+    "transformFlags": 0,
+    "comment": "*@a"
+}

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star is not a tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star is not a tag.json
@@ -1,0 +1,9 @@
+{
+    "kind": "JSDocComment",
+    "pos": 0,
+    "end": 8,
+    "flags": "JSDoc",
+    "modifierFlagsCache": 0,
+    "transformFlags": 0,
+    "comment": "*@a"
+}

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star space ignores tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star space ignores tag.json
@@ -1,0 +1,9 @@
+{
+    "kind": "JSDocComment",
+    "pos": 0,
+    "end": 9,
+    "flags": "JSDoc",
+    "modifierFlagsCache": 0,
+    "transformFlags": 0,
+    "comment": "* @a"
+}

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star space is not a tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star space is not a tag.json
@@ -1,0 +1,9 @@
+{
+    "kind": "JSDocComment",
+    "pos": 0,
+    "end": 9,
+    "flags": "JSDoc",
+    "modifierFlagsCache": 0,
+    "transformFlags": 0,
+    "comment": "* @a"
+}

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.authorTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.authorTag.json
@@ -1,7 +1,7 @@
 {
     "kind": "JSDocComment",
     "pos": 0,
-    "end": 738,
+    "end": 739,
     "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
@@ -262,7 +262,7 @@
         "16": {
             "kind": "JSDocAuthorTag",
             "pos": 559,
-            "end": 598,
+            "end": 599,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -273,18 +273,18 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "No Line Breaks:<the.email"
+            "comment": "No Line Breaks:<the email"
         },
         "17": {
             "kind": "JSDocTag",
-            "pos": 598,
-            "end": 606,
+            "pos": 599,
+            "end": 607,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
                 "kind": "Identifier",
-                "pos": 599,
-                "end": 606,
+                "pos": 600,
+                "end": 607,
                 "modifierFlagsCache": 0,
                 "transformFlags": 0,
                 "escapedText": "address"
@@ -293,14 +293,14 @@
         },
         "18": {
             "kind": "JSDocAuthorTag",
-            "pos": 645,
-            "end": 736,
+            "pos": 646,
+            "end": 737,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
                 "kind": "Identifier",
-                "pos": 646,
-                "end": 652,
+                "pos": 647,
+                "end": 653,
                 "modifierFlagsCache": 0,
                 "transformFlags": 0,
                 "escapedText": "author"
@@ -309,7 +309,7 @@
         },
         "length": 19,
         "pos": 7,
-        "end": 736,
+        "end": 737,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.no space before @ is not a new tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.no space before @ is not a new tag.json
@@ -1,0 +1,68 @@
+{
+    "kind": "JSDocComment",
+    "pos": 0,
+    "end": 53,
+    "flags": "JSDoc",
+    "modifierFlagsCache": 0,
+    "transformFlags": 0,
+    "tags": {
+        "0": {
+            "kind": "JSDocParameterTag",
+            "pos": 7,
+            "end": 29,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 8,
+                "end": 13,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "param"
+            },
+            "comment": "(@is@)",
+            "name": {
+                "kind": "Identifier",
+                "pos": 14,
+                "end": 18,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "originalKeywordKind": "ThisKeyword",
+                "escapedText": "this"
+            },
+            "isNameFirst": true,
+            "isBracketed": false
+        },
+        "1": {
+            "kind": "JSDocParameterTag",
+            "pos": 29,
+            "end": 51,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 30,
+                "end": 35,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "param"
+            },
+            "comment": "its@fine",
+            "name": {
+                "kind": "Identifier",
+                "pos": 36,
+                "end": 40,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "fine"
+            },
+            "isNameFirst": true,
+            "isBracketed": false
+        },
+        "length": 2,
+        "pos": 7,
+        "end": 51,
+        "hasTrailingComma": false,
+        "transformFlags": 0
+    }
+}

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.no space before @ is not a new tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.no space before @ is not a new tag.json
@@ -1,7 +1,7 @@
 {
     "kind": "JSDocComment",
     "pos": 0,
-    "end": 53,
+    "end": 91,
     "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
@@ -36,7 +36,7 @@
         "1": {
             "kind": "JSDocParameterTag",
             "pos": 29,
-            "end": 51,
+            "end": 50,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -59,9 +59,40 @@
             "isNameFirst": true,
             "isBracketed": false
         },
-        "length": 2,
+        "2": {
+            "kind": "JSDocTag",
+            "pos": 50,
+            "end": 62,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 51,
+                "end": 60,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "zerowidth"
+            }
+        },
+        "3": {
+            "kind": "JSDocTag",
+            "pos": 62,
+            "end": 75,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 63,
+                "end": 73,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "singlestar"
+            },
+            "comment": "*@doublestar"
+        },
+        "length": 4,
         "pos": 7,
-        "end": 51,
+        "end": 75,
         "hasTrailingComma": false,
         "transformFlags": 0
     }


### PR DESCRIPTION
Previously, inside a JSDoc tag's comment, @ would start a tag unless it was surrounded by backticks. However, looking at real code showed that only whitespace-preceded uses of @ were intended to start tags.

Please suggest new test cases if you can think of them. I feel like there are not quite enough.

## Discussion ##

### Why add a boolean flag as context instead of more states? ###

Whitespace parsing applies to all four states and doesn't currently change states. Correctly representing was-previous-character-whitespace would require doubling the state space. For example, I would have split SavingComments into SavingCommentsNoWhitespace and SavingCommentsPreviousWhitespace. The code would have lots more transitions to worry about as well. I decided representing the decision as a single context boolean was simpler.

### Why doesn't top-level parsing change? ###

Top-level parsing already behaves the way strict JSDoc parsers do -- anything preceding the first `@` except (1) start of comment or (2) newline plus optional asterisk causes the `@` to be treated as a comment.

Nobody's complained about this much!

Fixes #39371