### PR TITLE
Add missing unwrap call for the inferredExtendsType

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14613,7 +14613,7 @@ namespace ts {
                     combinedMapper = mergeTypeMappers(mapper, context.mapper);
                 }
                 // Instantiate the extends type including inferences for 'infer T' type parameters
-                const inferredExtendsType = combinedMapper ? instantiateType(root.extendsType, combinedMapper) : extendsType;
+                const inferredExtendsType = combinedMapper ? instantiateType(unwrapNondistributiveConditionalTuple(root, root.extendsType), combinedMapper) : extendsType;
                 // We attempt to resolve the conditional type only when the check and extends types are non-generic
                 if (!checkTypeInstantiable && !isGenericObjectType(inferredExtendsType) && !isGenericIndexType(inferredExtendsType)) {
                     // Return falseType for a definitely false extends check. We check an instantiations of the two

--- a/tests/baselines/reference/nondistributiveConditionalTypeInfer.js
+++ b/tests/baselines/reference/nondistributiveConditionalTypeInfer.js
@@ -1,0 +1,16 @@
+//// [nondistributiveConditionalTypeInfer.ts]
+type _R<T> = [T] extends [{ _R: (_: infer R) => void }] ? R : never;
+type _E<T> = [T] extends [{ _E: () => infer E }] ? E : never;
+type _A<T> = [T] extends [{ _A: () => infer A }] ? A : never;
+
+interface Sync<R, E, A> {
+  _R: (_: R) => void;
+  _E: () => E;
+  _A: () => A;
+}
+
+type R = _R<Sync<number, string, void>>;
+type E = _E<Sync<number, string, void>>;
+type A = _A<Sync<number, string, void>>;
+
+//// [nondistributiveConditionalTypeInfer.js]

--- a/tests/baselines/reference/nondistributiveConditionalTypeInfer.symbols
+++ b/tests/baselines/reference/nondistributiveConditionalTypeInfer.symbols
@@ -1,0 +1,61 @@
+=== tests/cases/compiler/nondistributiveConditionalTypeInfer.ts ===
+type _R<T> = [T] extends [{ _R: (_: infer R) => void }] ? R : never;
+>_R : Symbol(_R, Decl(nondistributiveConditionalTypeInfer.ts, 0, 0))
+>T : Symbol(T, Decl(nondistributiveConditionalTypeInfer.ts, 0, 8))
+>T : Symbol(T, Decl(nondistributiveConditionalTypeInfer.ts, 0, 8))
+>_R : Symbol(_R, Decl(nondistributiveConditionalTypeInfer.ts, 0, 27))
+>_ : Symbol(_, Decl(nondistributiveConditionalTypeInfer.ts, 0, 33))
+>R : Symbol(R, Decl(nondistributiveConditionalTypeInfer.ts, 0, 41))
+>R : Symbol(R, Decl(nondistributiveConditionalTypeInfer.ts, 0, 41))
+
+type _E<T> = [T] extends [{ _E: () => infer E }] ? E : never;
+>_E : Symbol(_E, Decl(nondistributiveConditionalTypeInfer.ts, 0, 68))
+>T : Symbol(T, Decl(nondistributiveConditionalTypeInfer.ts, 1, 8))
+>T : Symbol(T, Decl(nondistributiveConditionalTypeInfer.ts, 1, 8))
+>_E : Symbol(_E, Decl(nondistributiveConditionalTypeInfer.ts, 1, 27))
+>E : Symbol(E, Decl(nondistributiveConditionalTypeInfer.ts, 1, 43))
+>E : Symbol(E, Decl(nondistributiveConditionalTypeInfer.ts, 1, 43))
+
+type _A<T> = [T] extends [{ _A: () => infer A }] ? A : never;
+>_A : Symbol(_A, Decl(nondistributiveConditionalTypeInfer.ts, 1, 61))
+>T : Symbol(T, Decl(nondistributiveConditionalTypeInfer.ts, 2, 8))
+>T : Symbol(T, Decl(nondistributiveConditionalTypeInfer.ts, 2, 8))
+>_A : Symbol(_A, Decl(nondistributiveConditionalTypeInfer.ts, 2, 27))
+>A : Symbol(A, Decl(nondistributiveConditionalTypeInfer.ts, 2, 43))
+>A : Symbol(A, Decl(nondistributiveConditionalTypeInfer.ts, 2, 43))
+
+interface Sync<R, E, A> {
+>Sync : Symbol(Sync, Decl(nondistributiveConditionalTypeInfer.ts, 2, 61))
+>R : Symbol(R, Decl(nondistributiveConditionalTypeInfer.ts, 4, 15))
+>E : Symbol(E, Decl(nondistributiveConditionalTypeInfer.ts, 4, 17))
+>A : Symbol(A, Decl(nondistributiveConditionalTypeInfer.ts, 4, 20))
+
+  _R: (_: R) => void;
+>_R : Symbol(Sync._R, Decl(nondistributiveConditionalTypeInfer.ts, 4, 25))
+>_ : Symbol(_, Decl(nondistributiveConditionalTypeInfer.ts, 5, 7))
+>R : Symbol(R, Decl(nondistributiveConditionalTypeInfer.ts, 4, 15))
+
+  _E: () => E;
+>_E : Symbol(Sync._E, Decl(nondistributiveConditionalTypeInfer.ts, 5, 21))
+>E : Symbol(E, Decl(nondistributiveConditionalTypeInfer.ts, 4, 17))
+
+  _A: () => A;
+>_A : Symbol(Sync._A, Decl(nondistributiveConditionalTypeInfer.ts, 6, 14))
+>A : Symbol(A, Decl(nondistributiveConditionalTypeInfer.ts, 4, 20))
+}
+
+type R = _R<Sync<number, string, void>>;
+>R : Symbol(R, Decl(nondistributiveConditionalTypeInfer.ts, 8, 1))
+>_R : Symbol(_R, Decl(nondistributiveConditionalTypeInfer.ts, 0, 0))
+>Sync : Symbol(Sync, Decl(nondistributiveConditionalTypeInfer.ts, 2, 61))
+
+type E = _E<Sync<number, string, void>>;
+>E : Symbol(E, Decl(nondistributiveConditionalTypeInfer.ts, 10, 40))
+>_E : Symbol(_E, Decl(nondistributiveConditionalTypeInfer.ts, 0, 68))
+>Sync : Symbol(Sync, Decl(nondistributiveConditionalTypeInfer.ts, 2, 61))
+
+type A = _A<Sync<number, string, void>>;
+>A : Symbol(A, Decl(nondistributiveConditionalTypeInfer.ts, 11, 40))
+>_A : Symbol(_A, Decl(nondistributiveConditionalTypeInfer.ts, 1, 61))
+>Sync : Symbol(Sync, Decl(nondistributiveConditionalTypeInfer.ts, 2, 61))
+

--- a/tests/baselines/reference/nondistributiveConditionalTypeInfer.types
+++ b/tests/baselines/reference/nondistributiveConditionalTypeInfer.types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/nondistributiveConditionalTypeInfer.ts ===
+type _R<T> = [T] extends [{ _R: (_: infer R) => void }] ? R : never;
+>_R : _R<T>
+>_R : (_: infer R) => void
+>_ : R
+
+type _E<T> = [T] extends [{ _E: () => infer E }] ? E : never;
+>_E : _E<T>
+>_E : () => infer E
+
+type _A<T> = [T] extends [{ _A: () => infer A }] ? A : never;
+>_A : _A<T>
+>_A : () => infer A
+
+interface Sync<R, E, A> {
+  _R: (_: R) => void;
+>_R : (_: R) => void
+>_ : R
+
+  _E: () => E;
+>_E : () => E
+
+  _A: () => A;
+>_A : () => A
+}
+
+type R = _R<Sync<number, string, void>>;
+>R : number
+
+type E = _E<Sync<number, string, void>>;
+>E : string
+
+type A = _A<Sync<number, string, void>>;
+>A : void
+

--- a/tests/cases/compiler/nondistributiveConditionalTypeInfer.ts
+++ b/tests/cases/compiler/nondistributiveConditionalTypeInfer.ts
@@ -1,0 +1,13 @@
+type _R<T> = [T] extends [{ _R: (_: infer R) => void }] ? R : never;
+type _E<T> = [T] extends [{ _E: () => infer E }] ? E : never;
+type _A<T> = [T] extends [{ _A: () => infer A }] ? A : never;
+
+interface Sync<R, E, A> {
+  _R: (_: R) => void;
+  _E: () => E;
+  _A: () => A;
+}
+
+type R = _R<Sync<number, string, void>>;
+type E = _E<Sync<number, string, void>>;
+type A = _A<Sync<number, string, void>>;


### PR DESCRIPTION
Since comparing a not-unwrapped type to an unwrapped one will not yield good results. Honestly surprised this being missing didn't trigger any existing baseline changes, so I'm glad to have the new testcase.

Fixes #42331
