### PR TITLE
Fix Format Selection on JSDoc comments

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -390,7 +390,8 @@ namespace ts.formatting {
                 sourceFile));
     }
 
-    function formatSpanWorker(originalRange: TextRange,
+    function formatSpanWorker(
+        originalRange: TextRange,
         enclosingNode: Node,
         initialIndentation: number,
         delta: number,
@@ -424,14 +425,18 @@ namespace ts.formatting {
         }
 
         if (!formattingScanner.isOnToken()) {
+            const indentation = SmartIndenter.nodeWillIndentChild(options, enclosingNode, /*child*/ undefined, sourceFile, /*indentByDefault*/ false)
+                ? initialIndentation + options.indentSize!
+                : initialIndentation;
             const leadingTrivia = formattingScanner.getCurrentLeadingTrivia();
             if (leadingTrivia) {
-                indentTriviaItems(leadingTrivia, initialIndentation, /*indentNextTokenOrTrivia*/ false,
+                indentTriviaItems(leadingTrivia, indentation, /*indentNextTokenOrTrivia*/ false,
                     item => processRange(item, sourceFile.getLineAndCharacterOfPosition(item.pos), enclosingNode, enclosingNode, /*dynamicIndentation*/ undefined!));
-                if (options.trimTrailingWhitespace !== false) {
-                    trimTrailingWhitespacesForRemainingRange();
-                }
             }
+        }
+
+        if (options.trimTrailingWhitespace !== false) {
+            trimTrailingWhitespacesForRemainingRange();
         }
 
         return edits;

--- a/tests/cases/fourslash/formatSelectionDocCommentInBlock.ts
+++ b/tests/cases/fourslash/formatSelectionDocCommentInBlock.ts
@@ -1,0 +1,44 @@
+/// <reference path="fourslash.ts" />
+
+//// {
+////     /*1*//**
+////      * Some doc comment
+////      *//*2*/
+////     const a = 1;
+//// }
+////
+//// while (true) {
+//// /*3*//**
+////  * Some doc comment
+////  *//*4*/
+//// }
+
+format.selection("1", "2");
+verify.currentFileContentIs(
+`{
+    /**
+     * Some doc comment
+     */
+    const a = 1;
+}
+
+while (true) {
+/**
+ * Some doc comment
+ */
+}`);
+
+format.selection("3", "4");
+verify.currentFileContentIs(
+`{
+    /**
+     * Some doc comment
+     */
+    const a = 1;
+}
+
+while (true) {
+    /**
+     * Some doc comment
+     */
+}`);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #42310 

This is probably incorrect, but couldn’t figure out what the correct thing is after 1.5 business days of staring at it.
