### PR TITLE
Avoid using variance results when relating `any` type arguments for positions originating in intersections

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -972,7 +972,7 @@ namespace ts {
 
         let _jsxNamespace: __String;
         let _jsxFactoryEntity: EntityName | undefined;
-        let outofbandVarianceMarkerHandler: ((onlyUnreliable: boolean) => void) | undefined;
+        let outofbandVarianceMarkerHandler: ((flag: VarianceFlags) => void) | undefined;
 
         const subtypeRelation = new Map<string, RelationComparisonResult>();
         const strictSubtypeRelation = new Map<string, RelationComparisonResult>();
@@ -7940,6 +7940,8 @@ namespace ts {
             return getTypeOfPropertyOfType(type, name) || isNumericLiteralName(name) && getIndexTypeOfType(type, IndexKind.Number) || getIndexTypeOfType(type, IndexKind.String) || unknownType;
         }
 
+        function isTypeAny(type: Type): boolean;
+        function isTypeAny(type: Type | undefined): boolean | undefined;
         function isTypeAny(type: Type | undefined) {
             return type && (type.flags & TypeFlags.Any) !== 0;
         }
@@ -17492,6 +17494,7 @@ namespace ts {
             function typeRelatedToEachType(source: Type, target: IntersectionType, reportErrors: boolean, intersectionState: IntersectionState): Ternary {
                 let result = Ternary.True;
                 const targetTypes = target.types;
+                forEach(targetTypes, reportUnmeasurableIfAnyMarkers);
                 for (const targetType of targetTypes) {
                     const related = isRelatedTo(source, targetType, reportErrors, /*headMessage*/ undefined, intersectionState);
                     if (!related) {
@@ -17573,7 +17576,7 @@ namespace ts {
                         const s = sources[i];
                         const t = targets[i];
                         let related = Ternary.True;
-                        if (varianceFlags & VarianceFlags.Unmeasurable) {
+                        if (varianceFlags & VarianceFlags.Unmeasurable || (isTypeAny(s) || isTypeAny(t)) && varianceFlags & VarianceFlags.UnmeasurableIfAny) {
                             // Even an `Unmeasurable` variance works out without a structural check if the source and target are _identical_.
                             // We can't simply assume invariance, because `Unmeasurable` marks nonlinear relations, for example, a relation tained by
                             // the `-?` modifier in a mapped type (where, no matter how the inputs are related, the outputs still might not be)
@@ -17613,6 +17616,12 @@ namespace ts {
                 return result;
             }
 
+            function varianceFlagsToRelationCacheFlags(flags: VarianceFlags): RelationComparisonResult {
+                return ((flags & VarianceFlags.Unreliable) ? RelationComparisonResult.ReportsUnreliable : 0)
+                    | ((flags & VarianceFlags.Unmeasurable) ? RelationComparisonResult.ReportsUnmeasurable : 0)
+                    | ((flags & VarianceFlags.UnmeasurableIfAny) ? RelationComparisonResult.ReportsUnmeasurableIfAny : 0);
+            }
+
             // Determine if possibly recursive types are related. First, check if the result is already available in the global cache.
             // Second, check if we have already started a comparison of the given two types in which case we assume the result to be true.
             // Third, check if both types are part of deeply nested chains of generic type instantiations and if so assume the types are
@@ -17635,6 +17644,9 @@ namespace ts {
                             const saved = entry & RelationComparisonResult.ReportsMask;
                             if (saved & RelationComparisonResult.ReportsUnmeasurable) {
                                 instantiateType(source, makeFunctionTypeMapper(reportUnmeasurableMarkers));
+                            }
+                            if (saved & RelationComparisonResult.ReportsUnmeasurableIfAny) {
+                                instantiateType(source, makeFunctionTypeMapper(reportUnmeasurableIfAnyMarkers));
                             }
                             if (saved & RelationComparisonResult.ReportsUnreliable) {
                                 instantiateType(source, makeFunctionTypeMapper(reportUnreliableMarkers));
@@ -17673,9 +17685,9 @@ namespace ts {
                 let propagatingVarianceFlags: RelationComparisonResult = 0;
                 if (outofbandVarianceMarkerHandler) {
                     originalHandler = outofbandVarianceMarkerHandler;
-                    outofbandVarianceMarkerHandler = onlyUnreliable => {
-                        propagatingVarianceFlags |= onlyUnreliable ? RelationComparisonResult.ReportsUnreliable : RelationComparisonResult.ReportsUnmeasurable;
-                        return originalHandler!(onlyUnreliable);
+                    outofbandVarianceMarkerHandler = flags => {
+                        propagatingVarianceFlags |= varianceFlagsToRelationCacheFlags(flags);
+                        return originalHandler!(flags);
                     };
                 }
 
@@ -18190,14 +18202,22 @@ namespace ts {
 
             function reportUnmeasurableMarkers(p: TypeParameter) {
                 if (outofbandVarianceMarkerHandler && (p === markerSuperType || p === markerSubType || p === markerOtherType)) {
-                    outofbandVarianceMarkerHandler(/*onlyUnreliable*/ false);
+                    outofbandVarianceMarkerHandler(VarianceFlags.Unmeasurable);
+                }
+                return p;
+            }
+
+
+            function reportUnmeasurableIfAnyMarkers(p: TypeParameter) {
+                if (outofbandVarianceMarkerHandler && (p === markerSuperType || p === markerSubType || p === markerOtherType)) {
+                    outofbandVarianceMarkerHandler(VarianceFlags.UnmeasurableIfAny);
                 }
                 return p;
             }
 
             function reportUnreliableMarkers(p: TypeParameter) {
                 if (outofbandVarianceMarkerHandler && (p === markerSuperType || p === markerSubType || p === markerOtherType)) {
-                    outofbandVarianceMarkerHandler(/*onlyUnreliable*/ true);
+                    outofbandVarianceMarkerHandler(VarianceFlags.Unreliable);
                 }
                 return p;
             }
@@ -19031,10 +19051,9 @@ namespace ts {
                 cache.variances = emptyArray;
                 variances = [];
                 for (const tp of typeParameters) {
-                    let unmeasurable = false;
-                    let unreliable = false;
+                    let outOfBandFlags: VarianceFlags = 0;
                     const oldHandler = outofbandVarianceMarkerHandler;
-                    outofbandVarianceMarkerHandler = (onlyUnreliable) => onlyUnreliable ? unreliable = true : unmeasurable = true;
+                    outofbandVarianceMarkerHandler = flags => outOfBandFlags |= flags;
                     // We first compare instantiations where the type parameter is replaced with
                     // marker types that have a known subtype relationship. From this we can infer
                     // invariance, covariance, contravariance or bivariance.
@@ -19050,13 +19069,8 @@ namespace ts {
                         variance = VarianceFlags.Independent;
                     }
                     outofbandVarianceMarkerHandler = oldHandler;
-                    if (unmeasurable || unreliable) {
-                        if (unmeasurable) {
-                            variance |= VarianceFlags.Unmeasurable;
-                        }
-                        if (unreliable) {
-                            variance |= VarianceFlags.Unreliable;
-                        }
+                    if (outOfBandFlags) {
+                        variance |= outOfBandFlags;
                     }
                     variances.push(variance);
                 }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -828,7 +828,8 @@ namespace ts {
 
         ReportsUnmeasurable = 1 << 3,
         ReportsUnreliable   = 1 << 4,
-        ReportsMask         = ReportsUnmeasurable | ReportsUnreliable
+        ReportsUnmeasurableIfAny = 1 << 5,
+        ReportsMask         = ReportsUnmeasurable | ReportsUnreliable | ReportsUnmeasurableIfAny
     }
 
     /* @internal */
@@ -5242,7 +5243,8 @@ namespace ts {
         VarianceMask  = Invariant | Covariant | Contravariant | Independent, // Mask containing all measured variances without the unmeasurable flag
         Unmeasurable  = 1 << 3,  // Variance result is unusable - relationship relies on structural comparisons which are not reflected in generic relationships
         Unreliable    = 1 << 4,  // Variance result is unreliable - checking may produce false negatives, but not false positives
-        AllowsStructuralFallback = Unmeasurable | Unreliable,
+        UnmeasurableIfAny = 1 << 5, // Variance result cannot be used when comparing with `any`
+        AllowsStructuralFallback = Unmeasurable | Unreliable | UnmeasurableIfAny,
     }
 
     // Generic class and interface types

--- a/tests/baselines/reference/varianceResultBetweenIntersectionAndObject.js
+++ b/tests/baselines/reference/varianceResultBetweenIntersectionAndObject.js
@@ -1,0 +1,12 @@
+//// [varianceResultBetweenIntersectionAndObject.ts]
+type X<T, U> = { traits: T & U };
+// XX: true
+type XX = X<true, true> extends X<any, false> ? false : true;
+
+// Same as above, but with & {} at the end
+type Y<T, U> = { traits: T & U } & {};
+// YY: false
+type YY = Y<true, true> extends Y<any, false> ? false : true;
+
+
+//// [varianceResultBetweenIntersectionAndObject.js]

--- a/tests/baselines/reference/varianceResultBetweenIntersectionAndObject.symbols
+++ b/tests/baselines/reference/varianceResultBetweenIntersectionAndObject.symbols
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/varianceResultBetweenIntersectionAndObject.ts ===
+type X<T, U> = { traits: T & U };
+>X : Symbol(X, Decl(varianceResultBetweenIntersectionAndObject.ts, 0, 0))
+>T : Symbol(T, Decl(varianceResultBetweenIntersectionAndObject.ts, 0, 7))
+>U : Symbol(U, Decl(varianceResultBetweenIntersectionAndObject.ts, 0, 9))
+>traits : Symbol(traits, Decl(varianceResultBetweenIntersectionAndObject.ts, 0, 16))
+>T : Symbol(T, Decl(varianceResultBetweenIntersectionAndObject.ts, 0, 7))
+>U : Symbol(U, Decl(varianceResultBetweenIntersectionAndObject.ts, 0, 9))
+
+// XX: true
+type XX = X<true, true> extends X<any, false> ? false : true;
+>XX : Symbol(XX, Decl(varianceResultBetweenIntersectionAndObject.ts, 0, 33))
+>X : Symbol(X, Decl(varianceResultBetweenIntersectionAndObject.ts, 0, 0))
+>X : Symbol(X, Decl(varianceResultBetweenIntersectionAndObject.ts, 0, 0))
+
+// Same as above, but with & {} at the end
+type Y<T, U> = { traits: T & U } & {};
+>Y : Symbol(Y, Decl(varianceResultBetweenIntersectionAndObject.ts, 2, 61))
+>T : Symbol(T, Decl(varianceResultBetweenIntersectionAndObject.ts, 5, 7))
+>U : Symbol(U, Decl(varianceResultBetweenIntersectionAndObject.ts, 5, 9))
+>traits : Symbol(traits, Decl(varianceResultBetweenIntersectionAndObject.ts, 5, 16))
+>T : Symbol(T, Decl(varianceResultBetweenIntersectionAndObject.ts, 5, 7))
+>U : Symbol(U, Decl(varianceResultBetweenIntersectionAndObject.ts, 5, 9))
+
+// YY: false
+type YY = Y<true, true> extends Y<any, false> ? false : true;
+>YY : Symbol(YY, Decl(varianceResultBetweenIntersectionAndObject.ts, 5, 38))
+>Y : Symbol(Y, Decl(varianceResultBetweenIntersectionAndObject.ts, 2, 61))
+>Y : Symbol(Y, Decl(varianceResultBetweenIntersectionAndObject.ts, 2, 61))
+

--- a/tests/baselines/reference/varianceResultBetweenIntersectionAndObject.types
+++ b/tests/baselines/reference/varianceResultBetweenIntersectionAndObject.types
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/varianceResultBetweenIntersectionAndObject.ts ===
+type X<T, U> = { traits: T & U };
+>X : X<T, U>
+>traits : T & U
+
+// XX: true
+type XX = X<true, true> extends X<any, false> ? false : true;
+>XX : false
+>true : true
+>true : true
+>false : false
+>false : false
+>true : true
+
+// Same as above, but with & {} at the end
+type Y<T, U> = { traits: T & U } & {};
+>Y : { traits: T & U; }
+>traits : T & U
+
+// YY: false
+type YY = Y<true, true> extends Y<any, false> ? false : true;
+>YY : false
+>true : true
+>true : true
+>false : false
+>false : false
+>true : true
+

--- a/tests/cases/compiler/varianceResultBetweenIntersectionAndObject.ts
+++ b/tests/cases/compiler/varianceResultBetweenIntersectionAndObject.ts
@@ -1,0 +1,8 @@
+type X<T, U> = { traits: T & U };
+// XX: true
+type XX = X<true, true> extends X<any, false> ? false : true;
+
+// Same as above, but with & {} at the end
+type Y<T, U> = { traits: T & U } & {};
+// YY: false
+type YY = Y<true, true> extends Y<any, false> ? false : true;


### PR DESCRIPTION
Fixes #42369

This introduces a slight variant on the `Unmeasurable` variance - the `UnmeasurableIfAny` variance. It behaves exactly like the `Unmeasurable` variance flag, except it only takes effect if either the `source` or `target` type parameter being compared are `any`. This allows us to continue using variance results for _most_ intersected type parameter comparisons.
