### PR TITLE
Only when typings file change for the project, schedule the update for the project

### DIFF
--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -16,6 +16,8 @@ namespace ts {
         setFilesWithInvalidatedNonRelativeUnresolvedImports(filesWithUnresolvedImports: ESMap<Path, readonly string[]>): void;
         createHasInvalidatedResolution(forceAllFilesAsInvalidated?: boolean): HasInvalidatedResolution;
         hasChangedAutomaticTypeDirectiveNames(): boolean;
+        isFileWithInvalidatedNonRelativeUnresolvedImports(path: Path): boolean;
+
 
         startCachingPerDirectoryResolution(): void;
         finishCachingPerDirectoryResolution(): void;
@@ -208,6 +210,7 @@ namespace ts {
             invalidateResolutionsOfFailedLookupLocations,
             setFilesWithInvalidatedNonRelativeUnresolvedImports,
             createHasInvalidatedResolution,
+            isFileWithInvalidatedNonRelativeUnresolvedImports,
             updateTypeRootsWatch,
             closeTypeRootsWatch,
             clear

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -922,7 +922,6 @@ namespace ts.server {
                 case ActionSet:
                     // Update the typing files and update the project
                     project.updateTypingFiles(this.typingsCache.updateTypingsForProject(response.projectName, response.compilerOptions, response.typeAcquisition, response.unresolvedImports, response.typings));
-                    this.delayUpdateProjectGraphAndEnsureProjectStructureForOpenFiles(project);
                     return;
                 case ActionInvalidate:
                     // Do not clear resolution cache, there was changes detected in typings, so enque typing request and let it get us correct results

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -922,13 +922,13 @@ namespace ts.server {
                 case ActionSet:
                     // Update the typing files and update the project
                     project.updateTypingFiles(this.typingsCache.updateTypingsForProject(response.projectName, response.compilerOptions, response.typeAcquisition, response.unresolvedImports, response.typings));
-                    break;
+                    this.delayUpdateProjectGraphAndEnsureProjectStructureForOpenFiles(project);
+                    return;
                 case ActionInvalidate:
                     // Do not clear resolution cache, there was changes detected in typings, so enque typing request and let it get us correct results
                     this.typingsCache.enqueueInstallTypingsForProject(project, project.lastCachedUnresolvedImportsList, /*forceRefresh*/ true);
                     return;
             }
-            this.delayUpdateProjectGraphAndEnsureProjectStructureForOpenFiles(project);
         }
 
         /*@internal*/

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1057,13 +1057,16 @@ namespace ts.server {
 
         /*@internal*/
         updateTypingFiles(typingFiles: SortedReadonlyArray<string>) {
-            enumerateInsertsAndDeletes<string, string>(typingFiles, this.typingFiles, getStringComparer(!this.useCaseSensitiveFileNames()),
+            if (enumerateInsertsAndDeletes<string, string>(typingFiles, this.typingFiles, getStringComparer(!this.useCaseSensitiveFileNames()),
                 /*inserted*/ noop,
                 removed => this.detachScriptInfoFromProject(removed)
-            );
-            this.typingFiles = typingFiles;
-            // Invalidate files with unresolved imports
-            this.resolutionCache.setFilesWithInvalidatedNonRelativeUnresolvedImports(this.cachedUnresolvedImportsPerFile);
+            )) {
+                // If typing files changed, then only schedule project update
+                this.typingFiles = typingFiles;
+                // Invalidate files with unresolved imports
+                this.resolutionCache.setFilesWithInvalidatedNonRelativeUnresolvedImports(this.cachedUnresolvedImportsPerFile);
+                this.projectService.delayUpdateProjectGraphAndEnsureProjectStructureForOpenFiles(this);
+            }
         }
 
         /* @internal */

--- a/src/testRunner/unittests/tsserver/projectErrors.ts
+++ b/src/testRunner/unittests/tsserver/projectErrors.ts
@@ -409,7 +409,7 @@ namespace ts.projectSystem {
             checkErrors([serverUtilities.path, app.path]);
 
             function checkErrors(openFiles: [string, string]) {
-                verifyGetErrRequestNoErrors({ session, host, files: openFiles, existingTimeouts: 2 });
+                verifyGetErrRequestNoErrors({ session, host, files: openFiles });
             }
         });
 

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -419,7 +419,7 @@ namespace ts.projectSystem {
                 unresolvedImports: response.unresolvedImports,
             });
 
-            host.checkTimeoutQueueLengthAndRun(1);
+            host.checkTimeoutQueueLength(0);
             assert.isUndefined(request);
         });
 

--- a/src/testRunner/unittests/tsserver/resolutionCache.ts
+++ b/src/testRunner/unittests/tsserver/resolutionCache.ts
@@ -198,10 +198,7 @@ namespace ts.projectSystem {
 
             checkNumberOfProjects(service, { inferredProjects: 1 });
             session.clearMessages();
-            host.checkTimeoutQueueLengthAndRun(2);
-
-            checkProjectUpdatedInBackgroundEvent(session, [file.path]);
-
+            host.checkTimeoutQueueLength(0);
             verifyGetErrRequest({
                 session,
                 host,
@@ -240,10 +237,7 @@ namespace ts.projectSystem {
 
             checkNumberOfProjects(service, { inferredProjects: 1 });
             session.clearMessages();
-            host.checkTimeoutQueueLengthAndRun(2);
-
-            checkProjectUpdatedInBackgroundEvent(session, [file.path]);
-
+            host.checkTimeoutQueueLength(0);
             verifyGetErrRequest({
                 session,
                 host,


### PR DESCRIPTION
This avoids unnecessary project updates, project updated in background on which editor normally sends error request so multiple program updates and unnecessarily invalidating resolutions is avoided.
Fixes #39326
