### PR TITLE
Preserve alias information where possible when looking up union and intersection base constraints

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11205,11 +11205,21 @@ namespace ts {
                 if (t.flags & TypeFlags.UnionOrIntersection) {
                     const types = (<UnionOrIntersectionType>t).types;
                     const baseTypes: Type[] = [];
+                    let different = false;
                     for (const type of types) {
                         const baseType = getBaseConstraint(type);
                         if (baseType) {
+                            if (baseType !== type) {
+                                different = true;
+                            }
                             baseTypes.push(baseType);
                         }
+                        else {
+                            different = true;
+                        }
+                    }
+                    if (!different) {
+                        return t;
                     }
                     return t.flags & TypeFlags.Union && baseTypes.length === types.length ? getUnionType(baseTypes) :
                         t.flags & TypeFlags.Intersection && baseTypes.length ? getIntersectionType(baseTypes) :

--- a/tests/baselines/reference/checkJsxChildrenCanBeTupleType.symbols
+++ b/tests/baselines/reference/checkJsxChildrenCanBeTupleType.symbols
@@ -29,10 +29,10 @@ const test = <ResizablePanel>
 >ResizablePanel : Symbol(ResizablePanel, Decl(checkJsxChildrenCanBeTupleType.tsx, 6, 1))
 
   <div />
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
   <div />
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 </ResizablePanel>
 >ResizablePanel : Symbol(ResizablePanel, Decl(checkJsxChildrenCanBeTupleType.tsx, 6, 1))
@@ -42,13 +42,13 @@ const testErr = <ResizablePanel>
 >ResizablePanel : Symbol(ResizablePanel, Decl(checkJsxChildrenCanBeTupleType.tsx, 6, 1))
 
   <div />
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
   <div />
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
   <div />
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 </ResizablePanel>
 >ResizablePanel : Symbol(ResizablePanel, Decl(checkJsxChildrenCanBeTupleType.tsx, 6, 1))

--- a/tests/baselines/reference/checkJsxUnionSFXContextualTypeInferredCorrectly.symbols
+++ b/tests/baselines/reference/checkJsxUnionSFXContextualTypeInferredCorrectly.symbols
@@ -39,8 +39,8 @@ export function ComponentWithUnion(props: PM | PS) {
 >PS : Symbol(PS, Decl(checkJsxUnionSFXContextualTypeInferredCorrectly.tsx, 2, 26))
 
     return <h1></h1>;
->h1 : Symbol(JSX.IntrinsicElements.h1, Decl(react16.d.ts, 2430, 106))
->h1 : Symbol(JSX.IntrinsicElements.h1, Decl(react16.d.ts, 2430, 106))
+>h1 : Symbol(JSX.IntrinsicElements.h1, Decl(react16.d.ts, 2556, 106))
+>h1 : Symbol(JSX.IntrinsicElements.h1, Decl(react16.d.ts, 2556, 106))
 }
 
 // Usage with React tsx

--- a/tests/baselines/reference/jsDeclarationsReactComponents.symbols
+++ b/tests/baselines/reference/jsDeclarationsReactComponents.symbols
@@ -12,7 +12,7 @@ const TabbedShowLayout = ({
 }) => {
     return (
         <div />
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     );
 };
@@ -56,13 +56,13 @@ const TabbedShowLayout = () => {
 
     return (
         <div className="" key="">
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >className : Symbol(className, Decl(jsDeclarationsReactComponents2.jsx, 6, 12))
 >key : Symbol(key, Decl(jsDeclarationsReactComponents2.jsx, 6, 25))
 
             ok
         </div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     );
 };
@@ -92,13 +92,13 @@ const TabbedShowLayout = () => {
 
     return (
         <div className="" key="">
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >className : Symbol(className, Decl(jsDeclarationsReactComponents3.jsx, 6, 12))
 >key : Symbol(key, Decl(jsDeclarationsReactComponents3.jsx, 6, 25))
 
             ok
         </div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     );
 };
@@ -126,7 +126,7 @@ const TabbedShowLayout = (/** @type {{className: string}}*/prop) => {
 
     return (
         <div className={prop.className} key="">
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >className : Symbol(className, Decl(jsDeclarationsReactComponents4.jsx, 3, 12))
 >prop.className : Symbol(className, Decl(jsDeclarationsReactComponents4.jsx, 1, 38))
 >prop : Symbol(prop, Decl(jsDeclarationsReactComponents4.jsx, 1, 26))
@@ -135,7 +135,7 @@ const TabbedShowLayout = (/** @type {{className: string}}*/prop) => {
 
             ok
         </div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     );
 };
@@ -165,7 +165,7 @@ function Tree({ allowDropOnRoot }) {
 >allowDropOnRoot : Symbol(allowDropOnRoot, Decl(jsDeclarationsReactComponents5.jsx, 3, 15))
 
   return <div />
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 }
 
 Tree.propTypes = {

--- a/tests/baselines/reference/jsxChildrenSingleChildConfusableWithMultipleChildrenNoError.symbols
+++ b/tests/baselines/reference/jsxChildrenSingleChildConfusableWithMultipleChildrenNoError.symbols
@@ -23,7 +23,7 @@ function TabLayout(props: Props) {
 >Props : Symbol(Props, Decl(jsxChildrenSingleChildConfusableWithMultipleChildrenNoError.tsx, 4, 36))
 
     return <div/>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 }
 
 export class App extends React.Component<{}> {
@@ -40,10 +40,10 @@ export class App extends React.Component<{}> {
 
             {[
                 ['Users', <div/>],
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
                 ['Products', <div/>]
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
             ]}
         </TabLayout>

--- a/tests/baselines/reference/jsxComplexSignatureHasApplicabilityError.symbols
+++ b/tests/baselines/reference/jsxComplexSignatureHasApplicabilityError.symbols
@@ -183,8 +183,8 @@ export type ValueComponentType<TValue = OptionValues> =  React.ComponentType<Val
 
 export type HandlerRendererResult = JSX.Element | null | false;
 >HandlerRendererResult : Symbol(HandlerRendererResult, Decl(jsxComplexSignatureHasApplicabilityError.tsx, 53, 106))
->JSX : Symbol(JSX, Decl(react16.d.ts, 2367, 12))
->Element : Symbol(JSX.Element, Decl(react16.d.ts, 2368, 23))
+>JSX : Symbol(JSX, Decl(react16.d.ts, 2493, 12))
+>Element : Symbol(JSX.Element, Decl(react16.d.ts, 2494, 23))
 
 // Handlers
 export type FocusOptionHandler<TValue = OptionValues> = (option: Option<TValue>) => void;
@@ -1005,8 +1005,8 @@ export interface ReactSelectProps<TValue = OptionValues> extends React.Props<Rea
      */
     noResultsText?: string | JSX.Element;
 >noResultsText : Symbol(ReactSelectProps.noResultsText, Decl(jsxComplexSignatureHasApplicabilityError.tsx, 438, 18))
->JSX : Symbol(JSX, Decl(react16.d.ts, 2367, 12))
->Element : Symbol(JSX.Element, Decl(react16.d.ts, 2368, 23))
+>JSX : Symbol(JSX, Decl(react16.d.ts, 2493, 12))
+>Element : Symbol(JSX.Element, Decl(react16.d.ts, 2494, 23))
 
     /**
      * onBlur handler: function (event) {}
@@ -1146,8 +1146,8 @@ export interface ReactSelectProps<TValue = OptionValues> extends React.Props<Rea
      */
     placeholder?: string | JSX.Element;
 >placeholder : Symbol(ReactSelectProps.placeholder, Decl(jsxComplexSignatureHasApplicabilityError.tsx, 524, 22))
->JSX : Symbol(JSX, Decl(react16.d.ts, 2367, 12))
->Element : Symbol(JSX.Element, Decl(react16.d.ts, 2368, 23))
+>JSX : Symbol(JSX, Decl(react16.d.ts, 2493, 12))
+>Element : Symbol(JSX.Element, Decl(react16.d.ts, 2494, 23))
 
     /**
      * whether the selected option is removed from the dropdown on multi selects

--- a/tests/baselines/reference/jsxDeclarationsWithEsModuleInteropNoCrash.symbols
+++ b/tests/baselines/reference/jsxDeclarationsWithEsModuleInteropNoCrash.symbols
@@ -30,9 +30,9 @@ function Foo({ bar }) {
 >bar : Symbol(bar, Decl(jsxDeclarationsWithEsModuleInteropNoCrash.jsx, 12, 14))
 
   return <div>{bar}</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >bar : Symbol(bar, Decl(jsxDeclarationsWithEsModuleInteropNoCrash.jsx, 12, 14))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 }
 
 Foo.propTypes = propTypes;

--- a/tests/baselines/reference/jsxEmptyExpressionNotCountedAsChild(jsx=react).symbols
+++ b/tests/baselines/reference/jsxEmptyExpressionNotCountedAsChild(jsx=react).symbols
@@ -18,11 +18,11 @@ function Wrapper(props: Props) {
 >Props : Symbol(Props, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 1, 30))
 
     return <div>{props.children}</div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >props.children : Symbol(Props.children, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 3, 17))
 >props : Symbol(props, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 7, 17))
 >children : Symbol(Props.children, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 3, 17))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 }
 
 const element = (
@@ -33,8 +33,8 @@ const element = (
 
     {/* comment */}
      <div>Hello</div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     </Wrapper>
 >Wrapper : Symbol(Wrapper, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 5, 1))

--- a/tests/baselines/reference/jsxEmptyExpressionNotCountedAsChild(jsx=react-jsx).symbols
+++ b/tests/baselines/reference/jsxEmptyExpressionNotCountedAsChild(jsx=react-jsx).symbols
@@ -18,11 +18,11 @@ function Wrapper(props: Props) {
 >Props : Symbol(Props, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 1, 30))
 
     return <div>{props.children}</div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >props.children : Symbol(Props.children, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 3, 17))
 >props : Symbol(props, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 7, 17))
 >children : Symbol(Props.children, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 3, 17))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 }
 
 const element = (
@@ -33,8 +33,8 @@ const element = (
 
     {/* comment */}
      <div>Hello</div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     </Wrapper>
 >Wrapper : Symbol(Wrapper, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 5, 1))

--- a/tests/baselines/reference/jsxEmptyExpressionNotCountedAsChild(jsx=react-jsxdev).symbols
+++ b/tests/baselines/reference/jsxEmptyExpressionNotCountedAsChild(jsx=react-jsxdev).symbols
@@ -18,11 +18,11 @@ function Wrapper(props: Props) {
 >Props : Symbol(Props, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 1, 30))
 
     return <div>{props.children}</div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >props.children : Symbol(Props.children, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 3, 17))
 >props : Symbol(props, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 7, 17))
 >children : Symbol(Props.children, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 3, 17))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 }
 
 const element = (
@@ -33,8 +33,8 @@ const element = (
 
     {/* comment */}
      <div>Hello</div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     </Wrapper>
 >Wrapper : Symbol(Wrapper, Decl(jsxEmptyExpressionNotCountedAsChild.tsx, 5, 1))

--- a/tests/baselines/reference/jsxFragmentFactoryNoUnusedLocals.symbols
+++ b/tests/baselines/reference/jsxFragmentFactoryNoUnusedLocals.symbols
@@ -22,18 +22,18 @@ export function Counter({ count = 0 }: CounterProps) {
 
     return <>
         <p>{cnt}</p>
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
 >cnt : Symbol(cnt, Decl(jsxFragmentFactoryNoUnusedLocals.tsx, 8, 11))
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
 
         <button onClick={() => setCnt((prev) => prev + 1)} type="button">Update</button>
->button : Symbol(JSX.IntrinsicElements.button, Decl(react16.d.ts, 2406, 96))
+>button : Symbol(JSX.IntrinsicElements.button, Decl(react16.d.ts, 2532, 96))
 >onClick : Symbol(onClick, Decl(jsxFragmentFactoryNoUnusedLocals.tsx, 11, 15))
 >setCnt : Symbol(setCnt, Decl(jsxFragmentFactoryNoUnusedLocals.tsx, 8, 15))
 >prev : Symbol(prev, Decl(jsxFragmentFactoryNoUnusedLocals.tsx, 11, 39))
 >prev : Symbol(prev, Decl(jsxFragmentFactoryNoUnusedLocals.tsx, 11, 39))
 >type : Symbol(type, Decl(jsxFragmentFactoryNoUnusedLocals.tsx, 11, 58))
->button : Symbol(JSX.IntrinsicElements.button, Decl(react16.d.ts, 2406, 96))
+>button : Symbol(JSX.IntrinsicElements.button, Decl(react16.d.ts, 2532, 96))
 
     </>
 }

--- a/tests/baselines/reference/jsxImportForSideEffectsNonExtantNoError.symbols
+++ b/tests/baselines/reference/jsxImportForSideEffectsNonExtantNoError.symbols
@@ -7,6 +7,6 @@ import "./App.css"; // doesn't actually exist
 
 const tag = <div></div>;
 >tag : Symbol(tag, Decl(jsxImportForSideEffectsNonExtantNoError.tsx, 5, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 

--- a/tests/baselines/reference/jsxIntrinsicElementsTypeArgumentErrors.symbols
+++ b/tests/baselines/reference/jsxIntrinsicElementsTypeArgumentErrors.symbols
@@ -6,58 +6,58 @@ import * as React from "react";
 // opening + closing
 const a = <div<>></div>; // empty type args
 >a : Symbol(a, Decl(jsxIntrinsicElementsTypeArgumentErrors.tsx, 4, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const b = <div<number,>></div>; // trailing comma type args
 >b : Symbol(b, Decl(jsxIntrinsicElementsTypeArgumentErrors.tsx, 6, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const c = <div<Missing>></div>; // nonexistant type args
 >c : Symbol(c, Decl(jsxIntrinsicElementsTypeArgumentErrors.tsx, 8, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const d = <div<Missing<AlsoMissing>>></div>; // nested missing type args
 >d : Symbol(d, Decl(jsxIntrinsicElementsTypeArgumentErrors.tsx, 10, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const e = <div<Record<object, object>>></div>; // existing but incorrect nested type args
 >e : Symbol(e, Decl(jsxIntrinsicElementsTypeArgumentErrors.tsx, 12, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const f = <div<number>></div>; // existing type argument with no internal issues
 >f : Symbol(f, Decl(jsxIntrinsicElementsTypeArgumentErrors.tsx, 14, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 // self-closing
 const g = <div<>/>; // empty type args
 >g : Symbol(g, Decl(jsxIntrinsicElementsTypeArgumentErrors.tsx, 17, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const h = <div<number,>/>; // trailing comma type args
 >h : Symbol(h, Decl(jsxIntrinsicElementsTypeArgumentErrors.tsx, 19, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const i = <div<Missing>/>; // nonexistant type args
 >i : Symbol(i, Decl(jsxIntrinsicElementsTypeArgumentErrors.tsx, 21, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const j = <div<Missing<AlsoMissing>>/>; // nested missing type args
 >j : Symbol(j, Decl(jsxIntrinsicElementsTypeArgumentErrors.tsx, 23, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const k = <div<Record<object, object>>/>; // existing but incorrect nested type args
 >k : Symbol(k, Decl(jsxIntrinsicElementsTypeArgumentErrors.tsx, 25, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
 
 const l = <div<number>/>; // existing type argument with no internal issues
 >l : Symbol(l, Decl(jsxIntrinsicElementsTypeArgumentErrors.tsx, 27, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 

--- a/tests/baselines/reference/jsxIssuesErrorWhenTagExpectsTooManyArguments.symbols
+++ b/tests/baselines/reference/jsxIssuesErrorWhenTagExpectsTooManyArguments.symbols
@@ -20,8 +20,8 @@ function MyComp4(props: MyProps, context: any, bad: any, verybad: any) {
 >verybad : Symbol(verybad, Decl(jsxIssuesErrorWhenTagExpectsTooManyArguments.tsx, 8, 56))
 
     return <div></div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 }
 function MyComp3(props: MyProps, context: any, bad: any) {
 >MyComp3 : Symbol(MyComp3, Decl(jsxIssuesErrorWhenTagExpectsTooManyArguments.tsx, 10, 1))
@@ -31,8 +31,8 @@ function MyComp3(props: MyProps, context: any, bad: any) {
 >bad : Symbol(bad, Decl(jsxIssuesErrorWhenTagExpectsTooManyArguments.tsx, 11, 46))
 
     return <div></div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 }
 function MyComp2(props: MyProps, context: any) {
 >MyComp2 : Symbol(MyComp2, Decl(jsxIssuesErrorWhenTagExpectsTooManyArguments.tsx, 13, 1))
@@ -41,8 +41,8 @@ function MyComp2(props: MyProps, context: any) {
 >context : Symbol(context, Decl(jsxIssuesErrorWhenTagExpectsTooManyArguments.tsx, 14, 32))
 
     return <div></div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 }
 
 const a = <MyComp4 x={2}/>; // using `MyComp` as a component should error - it expects more arguments than react provides
@@ -66,8 +66,8 @@ declare function MyTagWithOptionalNonJSXBits(props: MyProps, context: any, nonRe
 >MyProps : Symbol(MyProps, Decl(jsxIssuesErrorWhenTagExpectsTooManyArguments.tsx, 2, 31))
 >context : Symbol(context, Decl(jsxIssuesErrorWhenTagExpectsTooManyArguments.tsx, 22, 60))
 >nonReactArg : Symbol(nonReactArg, Decl(jsxIssuesErrorWhenTagExpectsTooManyArguments.tsx, 22, 74))
->JSX : Symbol(JSX, Decl(react16.d.ts, 2367, 12))
->Element : Symbol(JSX.Element, Decl(react16.d.ts, 2368, 23))
+>JSX : Symbol(JSX, Decl(react16.d.ts, 2493, 12))
+>Element : Symbol(JSX.Element, Decl(react16.d.ts, 2494, 23))
 
 const d = <MyTagWithOptionalNonJSXBits x={2} />; // Technically OK, but probably questionable
 >d : Symbol(d, Decl(jsxIssuesErrorWhenTagExpectsTooManyArguments.tsx, 23, 5))

--- a/tests/baselines/reference/jsxJsxsCjsTransformChildren(jsx=react-jsx).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformChildren(jsx=react-jsx).symbols
@@ -2,8 +2,8 @@
 /// <reference path="react16.d.ts" />
 const a = <div>text</div>;
 >a : Symbol(a, Decl(jsxJsxsCjsTransformChildren.tsx, 1, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 export {};
 

--- a/tests/baselines/reference/jsxJsxsCjsTransformChildren(jsx=react-jsxdev).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformChildren(jsx=react-jsxdev).symbols
@@ -2,8 +2,8 @@
 /// <reference path="react16.d.ts" />
 const a = <div>text</div>;
 >a : Symbol(a, Decl(jsxJsxsCjsTransformChildren.tsx, 1, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 export {};
 

--- a/tests/baselines/reference/jsxJsxsCjsTransformCustomImport(jsx=react-jsx).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformCustomImport(jsx=react-jsx).symbols
@@ -4,14 +4,14 @@ const a = <>
 >a : Symbol(a, Decl(jsxJsxsCjsTransformCustomImport.tsx, 1, 5))
 
   <p></p>
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
 
   text
   <div className="foo"></div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >className : Symbol(className, Decl(jsxJsxsCjsTransformCustomImport.tsx, 4, 6))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 </>
 

--- a/tests/baselines/reference/jsxJsxsCjsTransformCustomImport(jsx=react-jsxdev).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformCustomImport(jsx=react-jsxdev).symbols
@@ -4,14 +4,14 @@ const a = <>
 >a : Symbol(a, Decl(jsxJsxsCjsTransformCustomImport.tsx, 1, 5))
 
   <p></p>
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
 
   text
   <div className="foo"></div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >className : Symbol(className, Decl(jsxJsxsCjsTransformCustomImport.tsx, 4, 6))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 </>
 

--- a/tests/baselines/reference/jsxJsxsCjsTransformCustomImportPragma(jsx=react-jsx).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformCustomImportPragma(jsx=react-jsx).symbols
@@ -6,14 +6,14 @@ const a = <>
 >a : Symbol(a, Decl(react.tsx, 3, 5))
 
   <p></p>
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
 
   text
   <div className="foo"></div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >className : Symbol(className, Decl(react.tsx, 6, 6))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 </>
 
@@ -25,14 +25,14 @@ const a = <>
 >a : Symbol(a, Decl(preact.tsx, 2, 5))
 
   <p></p>
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
 
   text
   <div className="foo"></div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >className : Symbol(className, Decl(preact.tsx, 5, 6))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 </>
 

--- a/tests/baselines/reference/jsxJsxsCjsTransformCustomImportPragma(jsx=react-jsxdev).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformCustomImportPragma(jsx=react-jsxdev).symbols
@@ -6,14 +6,14 @@ const a = <>
 >a : Symbol(a, Decl(react.tsx, 3, 5))
 
   <p></p>
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
 
   text
   <div className="foo"></div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >className : Symbol(className, Decl(react.tsx, 6, 6))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 </>
 
@@ -25,14 +25,14 @@ const a = <>
 >a : Symbol(a, Decl(preact.tsx, 2, 5))
 
   <p></p>
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
 
   text
   <div className="foo"></div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >className : Symbol(className, Decl(preact.tsx, 5, 6))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 </>
 

--- a/tests/baselines/reference/jsxJsxsCjsTransformKeyProp(jsx=react-jsx).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformKeyProp(jsx=react-jsx).symbols
@@ -6,17 +6,17 @@ const props = { answer: 42 }
 
 const a = <div key="foo" {...props}>text</div>;
 >a : Symbol(a, Decl(jsxJsxsCjsTransformKeyProp.tsx, 2, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >key : Symbol(key, Decl(jsxJsxsCjsTransformKeyProp.tsx, 2, 14))
 >props : Symbol(props, Decl(jsxJsxsCjsTransformKeyProp.tsx, 1, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const b = <div {...props} key="bar">text</div>;
 >b : Symbol(b, Decl(jsxJsxsCjsTransformKeyProp.tsx, 3, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >props : Symbol(props, Decl(jsxJsxsCjsTransformKeyProp.tsx, 1, 5))
 >key : Symbol(key, Decl(jsxJsxsCjsTransformKeyProp.tsx, 3, 25))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 export {};
 

--- a/tests/baselines/reference/jsxJsxsCjsTransformKeyProp(jsx=react-jsxdev).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformKeyProp(jsx=react-jsxdev).symbols
@@ -6,17 +6,17 @@ const props = { answer: 42 }
 
 const a = <div key="foo" {...props}>text</div>;
 >a : Symbol(a, Decl(jsxJsxsCjsTransformKeyProp.tsx, 2, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >key : Symbol(key, Decl(jsxJsxsCjsTransformKeyProp.tsx, 2, 14))
 >props : Symbol(props, Decl(jsxJsxsCjsTransformKeyProp.tsx, 1, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const b = <div {...props} key="bar">text</div>;
 >b : Symbol(b, Decl(jsxJsxsCjsTransformKeyProp.tsx, 3, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >props : Symbol(props, Decl(jsxJsxsCjsTransformKeyProp.tsx, 1, 5))
 >key : Symbol(key, Decl(jsxJsxsCjsTransformKeyProp.tsx, 3, 25))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 export {};
 

--- a/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImport(jsx=react-jsx).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImport(jsx=react-jsx).symbols
@@ -6,17 +6,17 @@ const props = { answer: 42 }
 
 const a = <div key="foo" {...props}>text</div>;
 >a : Symbol(a, Decl(jsxJsxsCjsTransformKeyPropCustomImport.tsx, 2, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >key : Symbol(key, Decl(jsxJsxsCjsTransformKeyPropCustomImport.tsx, 2, 14))
 >props : Symbol(props, Decl(jsxJsxsCjsTransformKeyPropCustomImport.tsx, 1, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const b = <div {...props} key="bar">text</div>;
 >b : Symbol(b, Decl(jsxJsxsCjsTransformKeyPropCustomImport.tsx, 3, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >props : Symbol(props, Decl(jsxJsxsCjsTransformKeyPropCustomImport.tsx, 1, 5))
 >key : Symbol(key, Decl(jsxJsxsCjsTransformKeyPropCustomImport.tsx, 3, 25))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 export {};
 

--- a/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImport(jsx=react-jsxdev).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImport(jsx=react-jsxdev).symbols
@@ -6,17 +6,17 @@ const props = { answer: 42 }
 
 const a = <div key="foo" {...props}>text</div>;
 >a : Symbol(a, Decl(jsxJsxsCjsTransformKeyPropCustomImport.tsx, 2, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >key : Symbol(key, Decl(jsxJsxsCjsTransformKeyPropCustomImport.tsx, 2, 14))
 >props : Symbol(props, Decl(jsxJsxsCjsTransformKeyPropCustomImport.tsx, 1, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const b = <div {...props} key="bar">text</div>;
 >b : Symbol(b, Decl(jsxJsxsCjsTransformKeyPropCustomImport.tsx, 3, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >props : Symbol(props, Decl(jsxJsxsCjsTransformKeyPropCustomImport.tsx, 1, 5))
 >key : Symbol(key, Decl(jsxJsxsCjsTransformKeyPropCustomImport.tsx, 3, 25))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 export {};
 

--- a/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImportPragma(jsx=react-jsx).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImportPragma(jsx=react-jsx).symbols
@@ -8,17 +8,17 @@ const props2 = { answer: 42 }
 
 const a2 = <div key="foo" {...props2}>text</div>;
 >a2 : Symbol(a2, Decl(react.tsx, 4, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >key : Symbol(key, Decl(react.tsx, 4, 15))
 >props2 : Symbol(props2, Decl(react.tsx, 3, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const b2 = <div {...props2} key="bar">text</div>;
 >b2 : Symbol(b2, Decl(react.tsx, 5, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >props2 : Symbol(props2, Decl(react.tsx, 3, 5))
 >key : Symbol(key, Decl(react.tsx, 5, 27))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 export {};
 
@@ -31,17 +31,17 @@ const props = { answer: 42 }
 
 const a = <div key="foo" {...props}>text</div>;
 >a : Symbol(a, Decl(preact.tsx, 3, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >key : Symbol(key, Decl(preact.tsx, 3, 14))
 >props : Symbol(props, Decl(preact.tsx, 2, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const b = <div {...props} key="bar">text</div>;
 >b : Symbol(b, Decl(preact.tsx, 4, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >props : Symbol(props, Decl(preact.tsx, 2, 5))
 >key : Symbol(key, Decl(preact.tsx, 4, 25))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 export {};
 

--- a/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImportPragma(jsx=react-jsxdev).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformKeyPropCustomImportPragma(jsx=react-jsxdev).symbols
@@ -8,17 +8,17 @@ const props2 = { answer: 42 }
 
 const a2 = <div key="foo" {...props2}>text</div>;
 >a2 : Symbol(a2, Decl(react.tsx, 4, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >key : Symbol(key, Decl(react.tsx, 4, 15))
 >props2 : Symbol(props2, Decl(react.tsx, 3, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const b2 = <div {...props2} key="bar">text</div>;
 >b2 : Symbol(b2, Decl(react.tsx, 5, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >props2 : Symbol(props2, Decl(react.tsx, 3, 5))
 >key : Symbol(key, Decl(react.tsx, 5, 27))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 export {};
 
@@ -31,17 +31,17 @@ const props = { answer: 42 }
 
 const a = <div key="foo" {...props}>text</div>;
 >a : Symbol(a, Decl(preact.tsx, 3, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >key : Symbol(key, Decl(preact.tsx, 3, 14))
 >props : Symbol(props, Decl(preact.tsx, 2, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 const b = <div {...props} key="bar">text</div>;
 >b : Symbol(b, Decl(preact.tsx, 4, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >props : Symbol(props, Decl(preact.tsx, 2, 5))
 >key : Symbol(key, Decl(preact.tsx, 4, 25))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 export {};
 

--- a/tests/baselines/reference/jsxJsxsCjsTransformNestedSelfClosingChild(jsx=react-jsx).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformNestedSelfClosingChild(jsx=react-jsx).symbols
@@ -9,13 +9,13 @@ console.log(
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 
   <div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     <div />
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
   </div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 )
 
@@ -25,16 +25,16 @@ console.log(
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 
   <div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     <div />
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     <div />
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
   </div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 )
 
@@ -44,19 +44,19 @@ console.log(
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 
   <div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     {[1, 2].map(i => <div key={i}>{i}</div>)}
 >[1, 2].map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
 >map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
 >i : Symbol(i, Decl(jsxJsxsCjsTransformNestedSelfClosingChild.tsx, 18, 16))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >key : Symbol(key, Decl(jsxJsxsCjsTransformNestedSelfClosingChild.tsx, 18, 25))
 >i : Symbol(i, Decl(jsxJsxsCjsTransformNestedSelfClosingChild.tsx, 18, 16))
 >i : Symbol(i, Decl(jsxJsxsCjsTransformNestedSelfClosingChild.tsx, 18, 16))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
   </div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 )

--- a/tests/baselines/reference/jsxJsxsCjsTransformNestedSelfClosingChild(jsx=react-jsxdev).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformNestedSelfClosingChild(jsx=react-jsxdev).symbols
@@ -9,13 +9,13 @@ console.log(
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 
   <div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     <div />
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
   </div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 )
 
@@ -25,16 +25,16 @@ console.log(
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 
   <div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     <div />
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     <div />
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
   </div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 )
 
@@ -44,19 +44,19 @@ console.log(
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 
   <div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
     {[1, 2].map(i => <div key={i}>{i}</div>)}
 >[1, 2].map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
 >map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
 >i : Symbol(i, Decl(jsxJsxsCjsTransformNestedSelfClosingChild.tsx, 18, 16))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >key : Symbol(key, Decl(jsxJsxsCjsTransformNestedSelfClosingChild.tsx, 18, 25))
 >i : Symbol(i, Decl(jsxJsxsCjsTransformNestedSelfClosingChild.tsx, 18, 16))
 >i : Symbol(i, Decl(jsxJsxsCjsTransformNestedSelfClosingChild.tsx, 18, 16))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
   </div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 )

--- a/tests/baselines/reference/jsxJsxsCjsTransformSubstitutesNames(jsx=react-jsx).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformSubstitutesNames(jsx=react-jsx).symbols
@@ -2,7 +2,7 @@
 /// <reference path="react16.d.ts" />
 const a = <div></div>
 >a : Symbol(a, Decl(jsxJsxsCjsTransformSubstitutesNames.tsx, 1, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 export {};

--- a/tests/baselines/reference/jsxJsxsCjsTransformSubstitutesNames(jsx=react-jsxdev).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformSubstitutesNames(jsx=react-jsxdev).symbols
@@ -2,7 +2,7 @@
 /// <reference path="react16.d.ts" />
 const a = <div></div>
 >a : Symbol(a, Decl(jsxJsxsCjsTransformSubstitutesNames.tsx, 1, 5))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 export {};

--- a/tests/baselines/reference/jsxJsxsCjsTransformSubstitutesNamesFragment(jsx=react-jsx).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformSubstitutesNamesFragment(jsx=react-jsx).symbols
@@ -4,13 +4,13 @@ const a = <>
 >a : Symbol(a, Decl(jsxJsxsCjsTransformSubstitutesNamesFragment.tsx, 1, 5))
 
   <p></p>
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
 
   text
   <div></div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 </>
 

--- a/tests/baselines/reference/jsxJsxsCjsTransformSubstitutesNamesFragment(jsx=react-jsxdev).symbols
+++ b/tests/baselines/reference/jsxJsxsCjsTransformSubstitutesNamesFragment(jsx=react-jsxdev).symbols
@@ -4,13 +4,13 @@ const a = <>
 >a : Symbol(a, Decl(jsxJsxsCjsTransformSubstitutesNamesFragment.tsx, 1, 5))
 
   <p></p>
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
 
   text
   <div></div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 
 </>
 

--- a/tests/baselines/reference/jsxPartialSpread.symbols
+++ b/tests/baselines/reference/jsxPartialSpread.symbols
@@ -4,8 +4,8 @@ const Select = (p: {value?: unknown}) => <p></p>;
 >Select : Symbol(Select, Decl(jsxPartialSpread.tsx, 1, 5))
 >p : Symbol(p, Decl(jsxPartialSpread.tsx, 1, 16))
 >value : Symbol(value, Decl(jsxPartialSpread.tsx, 1, 20))
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
->p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2467, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
+>p : Symbol(JSX.IntrinsicElements.p, Decl(react16.d.ts, 2593, 102))
 
 import React from 'react';
 >React : Symbol(React, Decl(jsxPartialSpread.tsx, 2, 6))

--- a/tests/baselines/reference/reactDefaultPropsInferenceSuccess.symbols
+++ b/tests/baselines/reference/reactDefaultPropsInferenceSuccess.symbols
@@ -42,8 +42,8 @@ class FieldFeedback<P extends Props = BaseProps> extends React.Component<P> {
 >render : Symbol(FieldFeedback.render, Decl(reactDefaultPropsInferenceSuccess.tsx, 15, 4))
 
     return <div>Hello</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
   }
 }
 
@@ -89,8 +89,8 @@ class FieldFeedbackBeta<P extends Props = BaseProps> extends React.Component<P> 
 >render : Symbol(FieldFeedbackBeta.render, Decl(reactDefaultPropsInferenceSuccess.tsx, 31, 4))
 
     return <div>Hello</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
   }
 }
 
@@ -153,8 +153,8 @@ class FieldFeedback2<P extends MyPropsProps = MyPropsProps> extends FieldFeedbac
 >when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 44, 38))
 
     return <div>Hello</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
   }
 }
 

--- a/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsx).symbols
+++ b/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsx).symbols
@@ -8,7 +8,7 @@ function Bar() {
 >Bar : Symbol(Bar, Decl(index.tsx, 2, 26))
 
   return <div />;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 }
 
 export function Foo() {

--- a/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsxdev).symbols
+++ b/tests/baselines/reference/reactImportUnusedInNewJSXEmit(jsx=react-jsxdev).symbols
@@ -8,7 +8,7 @@ function Bar() {
 >Bar : Symbol(Bar, Decl(index.tsx, 2, 26))
 
   return <div />;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 }
 
 export function Foo() {

--- a/tests/baselines/reference/spellingSuggestionJSXAttribute.symbols
+++ b/tests/baselines/reference/spellingSuggestionJSXAttribute.symbols
@@ -20,19 +20,19 @@ class MyComp extends React.Component<{ className?: string, htmlFor?: string }> {
 >htmlFor : Symbol(htmlFor, Decl(spellingSuggestionJSXAttribute.tsx, 6, 58))
 
 <a class="" />;
->a : Symbol(JSX.IntrinsicElements.a, Decl(react16.d.ts, 2390, 41))
+>a : Symbol(JSX.IntrinsicElements.a, Decl(react16.d.ts, 2516, 41))
 >class : Symbol(class, Decl(spellingSuggestionJSXAttribute.tsx, 7, 2))
 
 <a for="" />; // should have no fix
->a : Symbol(JSX.IntrinsicElements.a, Decl(react16.d.ts, 2390, 41))
+>a : Symbol(JSX.IntrinsicElements.a, Decl(react16.d.ts, 2516, 41))
 >for : Symbol(for, Decl(spellingSuggestionJSXAttribute.tsx, 8, 2))
 
 <label for="" />;
->label : Symbol(JSX.IntrinsicElements.label, Decl(react16.d.ts, 2448, 102))
+>label : Symbol(JSX.IntrinsicElements.label, Decl(react16.d.ts, 2574, 102))
 >for : Symbol(for, Decl(spellingSuggestionJSXAttribute.tsx, 9, 6))
 
 <label for="" class="" />;
->label : Symbol(JSX.IntrinsicElements.label, Decl(react16.d.ts, 2448, 102))
+>label : Symbol(JSX.IntrinsicElements.label, Decl(react16.d.ts, 2574, 102))
 >for : Symbol(for, Decl(spellingSuggestionJSXAttribute.tsx, 10, 6))
 >class : Symbol(class, Decl(spellingSuggestionJSXAttribute.tsx, 10, 13))
 

--- a/tests/baselines/reference/styledComponentsInstantiaionLimitNotReached.js
+++ b/tests/baselines/reference/styledComponentsInstantiaionLimitNotReached.js
@@ -1,0 +1,201 @@
+//// [styledComponentsInstantiaionLimitNotReached.ts]
+/// <reference path="/.lib/react16.d.ts" />
+import * as React from "react";
+
+interface REACT_STATICS {
+    childContextTypes: true;
+    contextType: true;
+    contextTypes: true;
+    defaultProps: true;
+    displayName: true;
+    getDefaultProps: true;
+    getDerivedStateFromError: true;
+    getDerivedStateFromProps: true;
+    mixins: true;
+    propTypes: true;
+    type: true;
+}
+
+interface KNOWN_STATICS {
+    name: true;
+    length: true;
+    prototype: true;
+    caller: true;
+    callee: true;
+    arguments: true;
+    arity: true;
+}
+
+interface MEMO_STATICS {
+    '$$typeof': true;
+    compare: true;
+    defaultProps: true;
+    displayName: true;
+    propTypes: true;
+    type: true;
+}
+
+interface FORWARD_REF_STATICS {
+    '$$typeof': true;
+    render: true;
+    defaultProps: true;
+    displayName: true;
+    propTypes: true;
+}
+
+
+type NonReactStatics<
+    S extends React.ComponentType<any>,
+    C extends {
+        [key: string]: true
+    } = {}
+    > = {
+        [key in Exclude<
+            keyof S,
+            S extends React.MemoExoticComponent<any>
+            ? keyof MEMO_STATICS | keyof C
+            : S extends React.ForwardRefExoticComponent<any>
+            ? keyof FORWARD_REF_STATICS | keyof C
+            : keyof REACT_STATICS | keyof KNOWN_STATICS | keyof C
+        >]: S[key]
+    };
+
+export type AnyStyledComponent = StyledComponent<any, any, any, any> | StyledComponent<any, any, any>;
+export type StyledComponent<
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+    T extends object,
+    O extends object = {},
+    A extends keyof any = never
+    > = // the "string" allows this to be used as an object key
+    // I really want to avoid this if possible but it's the only way to use nesting with object styles...
+    string &
+    StyledComponentBase<C, T, O, A> &
+    NonReactStatics<C extends React.ComponentType<any> ? C : never>;
+
+export type StyledComponentProps<
+    // The Component from whose props are derived
+    C extends string | React.ComponentType<any>,
+    // The Theme from the current context
+    T extends object,
+    // The other props added by the template
+    O extends object,
+    // The props that are made optional by .attrs
+    A extends keyof any
+    > =
+    // Distribute O if O is a union type
+    O extends object
+    ? WithOptionalTheme<
+        Omit<
+            ReactDefaultizedProps<
+                C,
+                React.ComponentPropsWithRef<
+                    C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+                >
+            > &
+            O,
+            A
+        > &
+        Partial<
+            Pick<
+                React.ComponentPropsWithRef<
+                    C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+                > &
+                O,
+                A
+            >
+        >,
+        T
+    > &
+    WithChildrenIfReactComponentClass<C>
+    : never;
+
+type Defaultize<P, D> = P extends any
+    ? string extends keyof P
+    ? P
+    : Pick<P, Exclude<keyof P, keyof D>> &
+    Partial<Pick<P, Extract<keyof P, keyof D>>> &
+    Partial<Pick<D, Exclude<keyof D, keyof P>>>
+    : never;
+
+type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D } ? Defaultize<P, D> : P;
+
+type WithChildrenIfReactComponentClass<C extends string | React.ComponentType<any>> = C extends React.ComponentClass<
+    any
+>
+    ? { children?: React.ReactNode }
+    : {};
+export type IntrinsicElementsKeys = keyof JSX.IntrinsicElements;
+type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, 'theme'> & {
+    theme?: T;
+};
+
+type ForwardRefExoticBase<P> = Pick<React.ForwardRefExoticComponent<P>, keyof React.ForwardRefExoticComponent<any>>;
+
+type StyledComponentPropsWithAs<
+    C extends string | React.ComponentType<any>,
+    T extends object,
+    O extends object,
+    A extends keyof any,
+    F extends string | React.ComponentType<any> = C
+    > = StyledComponentProps<C, T, O, A> & { as?: C; forwardedAs?: F };
+
+export type StyledComponentInnerOtherProps<C extends AnyStyledComponent> = C extends StyledComponent<
+    any,
+    any,
+    infer O,
+    any
+>
+    ? O
+    : C extends StyledComponent<any, any, infer O>
+    ? O
+    : never;
+export type StyledComponentInnerAttrs<C extends AnyStyledComponent> = C extends StyledComponent<any, any, any, infer A>
+    ? A
+    : never;
+
+export interface StyledComponentBase<
+    C extends string | React.ComponentType<any>,
+    T extends object,
+    O extends object = {},
+    A extends keyof any = never
+    > extends ForwardRefExoticBase<StyledComponentProps<C, T, O, A>> {
+    // add our own fake call signature to implement the polymorphic 'as' prop
+    (props: StyledComponentProps<C, T, O, A> & { as?: never; forwardedAs?: never }): React.ReactElement<
+        StyledComponentProps<C, T, O, A>
+    >;
+    <AsC extends string | React.ComponentType<any> = C, FAsC extends string | React.ComponentType<any> = AsC>(
+        props: StyledComponentPropsWithAs<AsC, T, O, A, FAsC>,
+    ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A, FAsC>>;
+
+    withComponent<WithC extends AnyStyledComponent>(
+        component: WithC,
+    ): StyledComponent<
+        StyledComponentInnerComponent<WithC>,
+        T,
+        O & StyledComponentInnerOtherProps<WithC>,
+        A | StyledComponentInnerAttrs<WithC>
+    >;
+    withComponent<WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(
+        component: WithC,
+    ): StyledComponent<WithC, T, O, A>;
+}
+
+export type StyledComponentInnerComponent<C extends React.ComponentType<any>> = C extends StyledComponent<
+    infer I,
+    any,
+    any,
+    any
+>
+    ? I
+    : C extends StyledComponent<infer I, any, any>
+    ? I
+    : C;
+export type StyledComponentPropsWithRef<
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
+    > = C extends AnyStyledComponent
+    ? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>> // shouldn't have an instantiation limit error
+    : React.ComponentPropsWithRef<C>;
+
+//// [styledComponentsInstantiaionLimitNotReached.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/styledComponentsInstantiaionLimitNotReached.symbols
+++ b/tests/baselines/reference/styledComponentsInstantiaionLimitNotReached.symbols
@@ -1,0 +1,644 @@
+=== tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts ===
+/// <reference path="react16.d.ts" />
+import * as React from "react";
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+
+interface REACT_STATICS {
+>REACT_STATICS : Symbol(REACT_STATICS, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 31))
+
+    childContextTypes: true;
+>childContextTypes : Symbol(REACT_STATICS.childContextTypes, Decl(styledComponentsInstantiaionLimitNotReached.ts, 3, 25))
+
+    contextType: true;
+>contextType : Symbol(REACT_STATICS.contextType, Decl(styledComponentsInstantiaionLimitNotReached.ts, 4, 28))
+
+    contextTypes: true;
+>contextTypes : Symbol(REACT_STATICS.contextTypes, Decl(styledComponentsInstantiaionLimitNotReached.ts, 5, 22))
+
+    defaultProps: true;
+>defaultProps : Symbol(REACT_STATICS.defaultProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 6, 23))
+
+    displayName: true;
+>displayName : Symbol(REACT_STATICS.displayName, Decl(styledComponentsInstantiaionLimitNotReached.ts, 7, 23))
+
+    getDefaultProps: true;
+>getDefaultProps : Symbol(REACT_STATICS.getDefaultProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 8, 22))
+
+    getDerivedStateFromError: true;
+>getDerivedStateFromError : Symbol(REACT_STATICS.getDerivedStateFromError, Decl(styledComponentsInstantiaionLimitNotReached.ts, 9, 26))
+
+    getDerivedStateFromProps: true;
+>getDerivedStateFromProps : Symbol(REACT_STATICS.getDerivedStateFromProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 10, 35))
+
+    mixins: true;
+>mixins : Symbol(REACT_STATICS.mixins, Decl(styledComponentsInstantiaionLimitNotReached.ts, 11, 35))
+
+    propTypes: true;
+>propTypes : Symbol(REACT_STATICS.propTypes, Decl(styledComponentsInstantiaionLimitNotReached.ts, 12, 17))
+
+    type: true;
+>type : Symbol(REACT_STATICS.type, Decl(styledComponentsInstantiaionLimitNotReached.ts, 13, 20))
+}
+
+interface KNOWN_STATICS {
+>KNOWN_STATICS : Symbol(KNOWN_STATICS, Decl(styledComponentsInstantiaionLimitNotReached.ts, 15, 1))
+
+    name: true;
+>name : Symbol(KNOWN_STATICS.name, Decl(styledComponentsInstantiaionLimitNotReached.ts, 17, 25))
+
+    length: true;
+>length : Symbol(KNOWN_STATICS.length, Decl(styledComponentsInstantiaionLimitNotReached.ts, 18, 15))
+
+    prototype: true;
+>prototype : Symbol(KNOWN_STATICS.prototype, Decl(styledComponentsInstantiaionLimitNotReached.ts, 19, 17))
+
+    caller: true;
+>caller : Symbol(KNOWN_STATICS.caller, Decl(styledComponentsInstantiaionLimitNotReached.ts, 20, 20))
+
+    callee: true;
+>callee : Symbol(KNOWN_STATICS.callee, Decl(styledComponentsInstantiaionLimitNotReached.ts, 21, 17))
+
+    arguments: true;
+>arguments : Symbol(KNOWN_STATICS.arguments, Decl(styledComponentsInstantiaionLimitNotReached.ts, 22, 17))
+
+    arity: true;
+>arity : Symbol(KNOWN_STATICS.arity, Decl(styledComponentsInstantiaionLimitNotReached.ts, 23, 20))
+}
+
+interface MEMO_STATICS {
+>MEMO_STATICS : Symbol(MEMO_STATICS, Decl(styledComponentsInstantiaionLimitNotReached.ts, 25, 1))
+
+    '$$typeof': true;
+>'$$typeof' : Symbol(MEMO_STATICS['$$typeof'], Decl(styledComponentsInstantiaionLimitNotReached.ts, 27, 24))
+
+    compare: true;
+>compare : Symbol(MEMO_STATICS.compare, Decl(styledComponentsInstantiaionLimitNotReached.ts, 28, 21))
+
+    defaultProps: true;
+>defaultProps : Symbol(MEMO_STATICS.defaultProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 29, 18))
+
+    displayName: true;
+>displayName : Symbol(MEMO_STATICS.displayName, Decl(styledComponentsInstantiaionLimitNotReached.ts, 30, 23))
+
+    propTypes: true;
+>propTypes : Symbol(MEMO_STATICS.propTypes, Decl(styledComponentsInstantiaionLimitNotReached.ts, 31, 22))
+
+    type: true;
+>type : Symbol(MEMO_STATICS.type, Decl(styledComponentsInstantiaionLimitNotReached.ts, 32, 20))
+}
+
+interface FORWARD_REF_STATICS {
+>FORWARD_REF_STATICS : Symbol(FORWARD_REF_STATICS, Decl(styledComponentsInstantiaionLimitNotReached.ts, 34, 1))
+
+    '$$typeof': true;
+>'$$typeof' : Symbol(FORWARD_REF_STATICS['$$typeof'], Decl(styledComponentsInstantiaionLimitNotReached.ts, 36, 31))
+
+    render: true;
+>render : Symbol(FORWARD_REF_STATICS.render, Decl(styledComponentsInstantiaionLimitNotReached.ts, 37, 21))
+
+    defaultProps: true;
+>defaultProps : Symbol(FORWARD_REF_STATICS.defaultProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 38, 17))
+
+    displayName: true;
+>displayName : Symbol(FORWARD_REF_STATICS.displayName, Decl(styledComponentsInstantiaionLimitNotReached.ts, 39, 23))
+
+    propTypes: true;
+>propTypes : Symbol(FORWARD_REF_STATICS.propTypes, Decl(styledComponentsInstantiaionLimitNotReached.ts, 40, 22))
+}
+
+
+type NonReactStatics<
+>NonReactStatics : Symbol(NonReactStatics, Decl(styledComponentsInstantiaionLimitNotReached.ts, 42, 1))
+
+    S extends React.ComponentType<any>,
+>S : Symbol(S, Decl(styledComponentsInstantiaionLimitNotReached.ts, 45, 21))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+
+    C extends {
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 46, 39))
+
+        [key: string]: true
+>key : Symbol(key, Decl(styledComponentsInstantiaionLimitNotReached.ts, 48, 9))
+
+    } = {}
+    > = {
+        [key in Exclude<
+>key : Symbol(key, Decl(styledComponentsInstantiaionLimitNotReached.ts, 51, 9))
+>Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
+
+            keyof S,
+>S : Symbol(S, Decl(styledComponentsInstantiaionLimitNotReached.ts, 45, 21))
+
+            S extends React.MemoExoticComponent<any>
+>S : Symbol(S, Decl(styledComponentsInstantiaionLimitNotReached.ts, 45, 21))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>MemoExoticComponent : Symbol(React.MemoExoticComponent, Decl(react16.d.ts, 2440, 47))
+
+            ? keyof MEMO_STATICS | keyof C
+>MEMO_STATICS : Symbol(MEMO_STATICS, Decl(styledComponentsInstantiaionLimitNotReached.ts, 25, 1))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 46, 39))
+
+            : S extends React.ForwardRefExoticComponent<any>
+>S : Symbol(S, Decl(styledComponentsInstantiaionLimitNotReached.ts, 45, 21))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ForwardRefExoticComponent : Symbol(React.ForwardRefExoticComponent, Decl(react16.d.ts, 2382, 10))
+
+            ? keyof FORWARD_REF_STATICS | keyof C
+>FORWARD_REF_STATICS : Symbol(FORWARD_REF_STATICS, Decl(styledComponentsInstantiaionLimitNotReached.ts, 34, 1))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 46, 39))
+
+            : keyof REACT_STATICS | keyof KNOWN_STATICS | keyof C
+>REACT_STATICS : Symbol(REACT_STATICS, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 31))
+>KNOWN_STATICS : Symbol(KNOWN_STATICS, Decl(styledComponentsInstantiaionLimitNotReached.ts, 15, 1))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 46, 39))
+
+        >]: S[key]
+>S : Symbol(S, Decl(styledComponentsInstantiaionLimitNotReached.ts, 45, 21))
+>key : Symbol(key, Decl(styledComponentsInstantiaionLimitNotReached.ts, 51, 9))
+
+    };
+
+export type AnyStyledComponent = StyledComponent<any, any, any, any> | StyledComponent<any, any, any>;
+>AnyStyledComponent : Symbol(AnyStyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 59, 6))
+>StyledComponent : Symbol(StyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 61, 102))
+>StyledComponent : Symbol(StyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 61, 102))
+
+export type StyledComponent<
+>StyledComponent : Symbol(StyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 61, 102))
+
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 62, 28))
+>JSX : Symbol(JSX, Decl(react16.d.ts, 2493, 12))
+>IntrinsicElements : Symbol(JSX.IntrinsicElements, Decl(react16.d.ts, 2514, 86))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+
+    T extends object,
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 63, 69))
+
+    O extends object = {},
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 64, 21))
+
+    A extends keyof any = never
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 65, 26))
+
+    > = // the "string" allows this to be used as an object key
+    // I really want to avoid this if possible but it's the only way to use nesting with object styles...
+    string &
+    StyledComponentBase<C, T, O, A> &
+>StyledComponentBase : Symbol(StyledComponentBase, Decl(styledComponentsInstantiaionLimitNotReached.ts, 152, 12))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 62, 28))
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 63, 69))
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 64, 21))
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 65, 26))
+
+    NonReactStatics<C extends React.ComponentType<any> ? C : never>;
+>NonReactStatics : Symbol(NonReactStatics, Decl(styledComponentsInstantiaionLimitNotReached.ts, 42, 1))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 62, 28))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 62, 28))
+
+export type StyledComponentProps<
+>StyledComponentProps : Symbol(StyledComponentProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 71, 68))
+
+    // The Component from whose props are derived
+    C extends string | React.ComponentType<any>,
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 73, 33))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+
+    // The Theme from the current context
+    T extends object,
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 75, 48))
+
+    // The other props added by the template
+    O extends object,
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 77, 21))
+
+    // The props that are made optional by .attrs
+    A extends keyof any
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 79, 21))
+
+    > =
+    // Distribute O if O is a union type
+    O extends object
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 77, 21))
+
+    ? WithOptionalTheme<
+>WithOptionalTheme : Symbol(WithOptionalTheme, Decl(styledComponentsInstantiaionLimitNotReached.ts, 125, 64))
+
+        Omit<
+>Omit : Symbol(Omit, Decl(lib.es5.d.ts, --, --))
+
+            ReactDefaultizedProps<
+>ReactDefaultizedProps : Symbol(ReactDefaultizedProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 116, 12))
+
+                C,
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 73, 33))
+
+                React.ComponentPropsWithRef<
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentPropsWithRef : Symbol(React.ComponentPropsWithRef, Decl(react16.d.ts, 2434, 25))
+
+                    C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 73, 33))
+>IntrinsicElementsKeys : Symbol(IntrinsicElementsKeys, Decl(styledComponentsInstantiaionLimitNotReached.ts, 124, 9))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 73, 33))
+
+                >
+            > &
+            O,
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 77, 21))
+
+            A
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 79, 21))
+
+        > &
+        Partial<
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+
+            Pick<
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+
+                React.ComponentPropsWithRef<
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentPropsWithRef : Symbol(React.ComponentPropsWithRef, Decl(react16.d.ts, 2434, 25))
+
+                    C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 73, 33))
+>IntrinsicElementsKeys : Symbol(IntrinsicElementsKeys, Decl(styledComponentsInstantiaionLimitNotReached.ts, 124, 9))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 73, 33))
+
+                > &
+                O,
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 77, 21))
+
+                A
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 79, 21))
+
+            >
+        >,
+        T
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 75, 48))
+
+    > &
+    WithChildrenIfReactComponentClass<C>
+>WithChildrenIfReactComponentClass : Symbol(WithChildrenIfReactComponentClass, Decl(styledComponentsInstantiaionLimitNotReached.ts, 118, 94))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 73, 33))
+
+    : never;
+
+type Defaultize<P, D> = P extends any
+>Defaultize : Symbol(Defaultize, Decl(styledComponentsInstantiaionLimitNotReached.ts, 108, 12))
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 110, 16))
+>D : Symbol(D, Decl(styledComponentsInstantiaionLimitNotReached.ts, 110, 18))
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 110, 16))
+
+    ? string extends keyof P
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 110, 16))
+
+    ? P
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 110, 16))
+
+    : Pick<P, Exclude<keyof P, keyof D>> &
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 110, 16))
+>Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 110, 16))
+>D : Symbol(D, Decl(styledComponentsInstantiaionLimitNotReached.ts, 110, 18))
+
+    Partial<Pick<P, Extract<keyof P, keyof D>>> &
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 110, 16))
+>Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 110, 16))
+>D : Symbol(D, Decl(styledComponentsInstantiaionLimitNotReached.ts, 110, 18))
+
+    Partial<Pick<D, Exclude<keyof D, keyof P>>>
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>D : Symbol(D, Decl(styledComponentsInstantiaionLimitNotReached.ts, 110, 18))
+>Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
+>D : Symbol(D, Decl(styledComponentsInstantiaionLimitNotReached.ts, 110, 18))
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 110, 16))
+
+    : never;
+
+type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D } ? Defaultize<P, D> : P;
+>ReactDefaultizedProps : Symbol(ReactDefaultizedProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 116, 12))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 118, 27))
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 118, 29))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 118, 27))
+>defaultProps : Symbol(defaultProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 118, 46))
+>D : Symbol(D, Decl(styledComponentsInstantiaionLimitNotReached.ts, 118, 66))
+>Defaultize : Symbol(Defaultize, Decl(styledComponentsInstantiaionLimitNotReached.ts, 108, 12))
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 118, 29))
+>D : Symbol(D, Decl(styledComponentsInstantiaionLimitNotReached.ts, 118, 66))
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 118, 29))
+
+type WithChildrenIfReactComponentClass<C extends string | React.ComponentType<any>> = C extends React.ComponentClass<
+>WithChildrenIfReactComponentClass : Symbol(WithChildrenIfReactComponentClass, Decl(styledComponentsInstantiaionLimitNotReached.ts, 118, 94))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 120, 39))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 120, 39))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentClass : Symbol(React.ComponentClass, Decl(react16.d.ts, 421, 9))
+
+    any
+>
+    ? { children?: React.ReactNode }
+>children : Symbol(children, Decl(styledComponentsInstantiaionLimitNotReached.ts, 123, 7))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ReactNode : Symbol(React.ReactNode, Decl(react16.d.ts, 216, 49))
+
+    : {};
+export type IntrinsicElementsKeys = keyof JSX.IntrinsicElements;
+>IntrinsicElementsKeys : Symbol(IntrinsicElementsKeys, Decl(styledComponentsInstantiaionLimitNotReached.ts, 124, 9))
+>JSX : Symbol(JSX, Decl(react16.d.ts, 2493, 12))
+>IntrinsicElements : Symbol(JSX.IntrinsicElements, Decl(react16.d.ts, 2514, 86))
+
+type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, 'theme'> & {
+>WithOptionalTheme : Symbol(WithOptionalTheme, Decl(styledComponentsInstantiaionLimitNotReached.ts, 125, 64))
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 126, 23))
+>theme : Symbol(theme, Decl(styledComponentsInstantiaionLimitNotReached.ts, 126, 34))
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 126, 47))
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 126, 47))
+>Omit : Symbol(Omit, Decl(lib.es5.d.ts, --, --))
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 126, 23))
+
+    theme?: T;
+>theme : Symbol(theme, Decl(styledComponentsInstantiaionLimitNotReached.ts, 126, 73))
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 126, 47))
+
+};
+
+type ForwardRefExoticBase<P> = Pick<React.ForwardRefExoticComponent<P>, keyof React.ForwardRefExoticComponent<any>>;
+>ForwardRefExoticBase : Symbol(ForwardRefExoticBase, Decl(styledComponentsInstantiaionLimitNotReached.ts, 128, 2))
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 130, 26))
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ForwardRefExoticComponent : Symbol(React.ForwardRefExoticComponent, Decl(react16.d.ts, 2382, 10))
+>P : Symbol(P, Decl(styledComponentsInstantiaionLimitNotReached.ts, 130, 26))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ForwardRefExoticComponent : Symbol(React.ForwardRefExoticComponent, Decl(react16.d.ts, 2382, 10))
+
+type StyledComponentPropsWithAs<
+>StyledComponentPropsWithAs : Symbol(StyledComponentPropsWithAs, Decl(styledComponentsInstantiaionLimitNotReached.ts, 130, 116))
+
+    C extends string | React.ComponentType<any>,
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 132, 32))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+
+    T extends object,
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 133, 48))
+
+    O extends object,
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 134, 21))
+
+    A extends keyof any,
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 135, 21))
+
+    F extends string | React.ComponentType<any> = C
+>F : Symbol(F, Decl(styledComponentsInstantiaionLimitNotReached.ts, 136, 24))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 132, 32))
+
+    > = StyledComponentProps<C, T, O, A> & { as?: C; forwardedAs?: F };
+>StyledComponentProps : Symbol(StyledComponentProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 71, 68))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 132, 32))
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 133, 48))
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 134, 21))
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 135, 21))
+>as : Symbol(as, Decl(styledComponentsInstantiaionLimitNotReached.ts, 138, 44))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 132, 32))
+>forwardedAs : Symbol(forwardedAs, Decl(styledComponentsInstantiaionLimitNotReached.ts, 138, 52))
+>F : Symbol(F, Decl(styledComponentsInstantiaionLimitNotReached.ts, 136, 24))
+
+export type StyledComponentInnerOtherProps<C extends AnyStyledComponent> = C extends StyledComponent<
+>StyledComponentInnerOtherProps : Symbol(StyledComponentInnerOtherProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 138, 71))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 140, 43))
+>AnyStyledComponent : Symbol(AnyStyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 59, 6))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 140, 43))
+>StyledComponent : Symbol(StyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 61, 102))
+
+    any,
+    any,
+    infer O,
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 143, 9))
+
+    any
+>
+    ? O
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 143, 9))
+
+    : C extends StyledComponent<any, any, infer O>
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 140, 43))
+>StyledComponent : Symbol(StyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 61, 102))
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 147, 47))
+
+    ? O
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 147, 47))
+
+    : never;
+export type StyledComponentInnerAttrs<C extends AnyStyledComponent> = C extends StyledComponent<any, any, any, infer A>
+>StyledComponentInnerAttrs : Symbol(StyledComponentInnerAttrs, Decl(styledComponentsInstantiaionLimitNotReached.ts, 149, 12))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 150, 38))
+>AnyStyledComponent : Symbol(AnyStyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 59, 6))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 150, 38))
+>StyledComponent : Symbol(StyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 61, 102))
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 150, 116))
+
+    ? A
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 150, 116))
+
+    : never;
+
+export interface StyledComponentBase<
+>StyledComponentBase : Symbol(StyledComponentBase, Decl(styledComponentsInstantiaionLimitNotReached.ts, 152, 12))
+
+    C extends string | React.ComponentType<any>,
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 154, 37))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+
+    T extends object,
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 155, 48))
+
+    O extends object = {},
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 156, 21))
+
+    A extends keyof any = never
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 157, 26))
+
+    > extends ForwardRefExoticBase<StyledComponentProps<C, T, O, A>> {
+>ForwardRefExoticBase : Symbol(ForwardRefExoticBase, Decl(styledComponentsInstantiaionLimitNotReached.ts, 128, 2))
+>StyledComponentProps : Symbol(StyledComponentProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 71, 68))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 154, 37))
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 155, 48))
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 156, 21))
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 157, 26))
+
+    // add our own fake call signature to implement the polymorphic 'as' prop
+    (props: StyledComponentProps<C, T, O, A> & { as?: never; forwardedAs?: never }): React.ReactElement<
+>props : Symbol(props, Decl(styledComponentsInstantiaionLimitNotReached.ts, 161, 5))
+>StyledComponentProps : Symbol(StyledComponentProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 71, 68))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 154, 37))
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 155, 48))
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 156, 21))
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 157, 26))
+>as : Symbol(as, Decl(styledComponentsInstantiaionLimitNotReached.ts, 161, 48))
+>forwardedAs : Symbol(forwardedAs, Decl(styledComponentsInstantiaionLimitNotReached.ts, 161, 60))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ReactElement : Symbol(React.ReactElement, Decl(react16.d.ts, 135, 9))
+
+        StyledComponentProps<C, T, O, A>
+>StyledComponentProps : Symbol(StyledComponentProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 71, 68))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 154, 37))
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 155, 48))
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 156, 21))
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 157, 26))
+
+    >;
+    <AsC extends string | React.ComponentType<any> = C, FAsC extends string | React.ComponentType<any> = AsC>(
+>AsC : Symbol(AsC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 164, 5))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 154, 37))
+>FAsC : Symbol(FAsC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 164, 55))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+>AsC : Symbol(AsC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 164, 5))
+
+        props: StyledComponentPropsWithAs<AsC, T, O, A, FAsC>,
+>props : Symbol(props, Decl(styledComponentsInstantiaionLimitNotReached.ts, 164, 110))
+>StyledComponentPropsWithAs : Symbol(StyledComponentPropsWithAs, Decl(styledComponentsInstantiaionLimitNotReached.ts, 130, 116))
+>AsC : Symbol(AsC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 164, 5))
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 155, 48))
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 156, 21))
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 157, 26))
+>FAsC : Symbol(FAsC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 164, 55))
+
+    ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A, FAsC>>;
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ReactElement : Symbol(React.ReactElement, Decl(react16.d.ts, 135, 9))
+>StyledComponentPropsWithAs : Symbol(StyledComponentPropsWithAs, Decl(styledComponentsInstantiaionLimitNotReached.ts, 130, 116))
+>AsC : Symbol(AsC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 164, 5))
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 155, 48))
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 156, 21))
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 157, 26))
+>FAsC : Symbol(FAsC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 164, 55))
+
+    withComponent<WithC extends AnyStyledComponent>(
+>withComponent : Symbol(StyledComponentBase.withComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 166, 74), Decl(styledComponentsInstantiaionLimitNotReached.ts, 175, 6))
+>WithC : Symbol(WithC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 168, 18))
+>AnyStyledComponent : Symbol(AnyStyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 59, 6))
+
+        component: WithC,
+>component : Symbol(component, Decl(styledComponentsInstantiaionLimitNotReached.ts, 168, 52))
+>WithC : Symbol(WithC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 168, 18))
+
+    ): StyledComponent<
+>StyledComponent : Symbol(StyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 61, 102))
+
+        StyledComponentInnerComponent<WithC>,
+>StyledComponentInnerComponent : Symbol(StyledComponentInnerComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 179, 1))
+>WithC : Symbol(WithC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 168, 18))
+
+        T,
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 155, 48))
+
+        O & StyledComponentInnerOtherProps<WithC>,
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 156, 21))
+>StyledComponentInnerOtherProps : Symbol(StyledComponentInnerOtherProps, Decl(styledComponentsInstantiaionLimitNotReached.ts, 138, 71))
+>WithC : Symbol(WithC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 168, 18))
+
+        A | StyledComponentInnerAttrs<WithC>
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 157, 26))
+>StyledComponentInnerAttrs : Symbol(StyledComponentInnerAttrs, Decl(styledComponentsInstantiaionLimitNotReached.ts, 149, 12))
+>WithC : Symbol(WithC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 168, 18))
+
+    >;
+    withComponent<WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(
+>withComponent : Symbol(StyledComponentBase.withComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 166, 74), Decl(styledComponentsInstantiaionLimitNotReached.ts, 175, 6))
+>WithC : Symbol(WithC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 176, 18))
+>JSX : Symbol(JSX, Decl(react16.d.ts, 2493, 12))
+>IntrinsicElements : Symbol(JSX.IntrinsicElements, Decl(react16.d.ts, 2514, 86))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+
+        component: WithC,
+>component : Symbol(component, Decl(styledComponentsInstantiaionLimitNotReached.ts, 176, 88))
+>WithC : Symbol(WithC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 176, 18))
+
+    ): StyledComponent<WithC, T, O, A>;
+>StyledComponent : Symbol(StyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 61, 102))
+>WithC : Symbol(WithC, Decl(styledComponentsInstantiaionLimitNotReached.ts, 176, 18))
+>T : Symbol(T, Decl(styledComponentsInstantiaionLimitNotReached.ts, 155, 48))
+>O : Symbol(O, Decl(styledComponentsInstantiaionLimitNotReached.ts, 156, 21))
+>A : Symbol(A, Decl(styledComponentsInstantiaionLimitNotReached.ts, 157, 26))
+}
+
+export type StyledComponentInnerComponent<C extends React.ComponentType<any>> = C extends StyledComponent<
+>StyledComponentInnerComponent : Symbol(StyledComponentInnerComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 179, 1))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 181, 42))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 181, 42))
+>StyledComponent : Symbol(StyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 61, 102))
+
+    infer I,
+>I : Symbol(I, Decl(styledComponentsInstantiaionLimitNotReached.ts, 182, 9))
+
+    any,
+    any,
+    any
+>
+    ? I
+>I : Symbol(I, Decl(styledComponentsInstantiaionLimitNotReached.ts, 182, 9))
+
+    : C extends StyledComponent<infer I, any, any>
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 181, 42))
+>StyledComponent : Symbol(StyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 61, 102))
+>I : Symbol(I, Decl(styledComponentsInstantiaionLimitNotReached.ts, 188, 37))
+
+    ? I
+>I : Symbol(I, Decl(styledComponentsInstantiaionLimitNotReached.ts, 188, 37))
+
+    : C;
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 181, 42))
+
+export type StyledComponentPropsWithRef<
+>StyledComponentPropsWithRef : Symbol(StyledComponentPropsWithRef, Decl(styledComponentsInstantiaionLimitNotReached.ts, 190, 8))
+
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 191, 40))
+>JSX : Symbol(JSX, Decl(react16.d.ts, 2493, 12))
+>IntrinsicElements : Symbol(JSX.IntrinsicElements, Decl(react16.d.ts, 2514, 86))
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentType : Symbol(React.ComponentType, Decl(react16.d.ts, 117, 60))
+
+    > = C extends AnyStyledComponent
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 191, 40))
+>AnyStyledComponent : Symbol(AnyStyledComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 59, 6))
+
+    ? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>> // shouldn't have an instantiation limit error
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentPropsWithRef : Symbol(React.ComponentPropsWithRef, Decl(react16.d.ts, 2434, 25))
+>StyledComponentInnerComponent : Symbol(StyledComponentInnerComponent, Decl(styledComponentsInstantiaionLimitNotReached.ts, 179, 1))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 191, 40))
+
+    : React.ComponentPropsWithRef<C>;
+>React : Symbol(React, Decl(styledComponentsInstantiaionLimitNotReached.ts, 1, 6))
+>ComponentPropsWithRef : Symbol(React.ComponentPropsWithRef, Decl(react16.d.ts, 2434, 25))
+>C : Symbol(C, Decl(styledComponentsInstantiaionLimitNotReached.ts, 191, 40))
+

--- a/tests/baselines/reference/styledComponentsInstantiaionLimitNotReached.types
+++ b/tests/baselines/reference/styledComponentsInstantiaionLimitNotReached.types
@@ -1,0 +1,381 @@
+=== tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts ===
+/// <reference path="react16.d.ts" />
+import * as React from "react";
+>React : typeof React
+
+interface REACT_STATICS {
+    childContextTypes: true;
+>childContextTypes : true
+>true : true
+
+    contextType: true;
+>contextType : true
+>true : true
+
+    contextTypes: true;
+>contextTypes : true
+>true : true
+
+    defaultProps: true;
+>defaultProps : true
+>true : true
+
+    displayName: true;
+>displayName : true
+>true : true
+
+    getDefaultProps: true;
+>getDefaultProps : true
+>true : true
+
+    getDerivedStateFromError: true;
+>getDerivedStateFromError : true
+>true : true
+
+    getDerivedStateFromProps: true;
+>getDerivedStateFromProps : true
+>true : true
+
+    mixins: true;
+>mixins : true
+>true : true
+
+    propTypes: true;
+>propTypes : true
+>true : true
+
+    type: true;
+>type : true
+>true : true
+}
+
+interface KNOWN_STATICS {
+    name: true;
+>name : true
+>true : true
+
+    length: true;
+>length : true
+>true : true
+
+    prototype: true;
+>prototype : true
+>true : true
+
+    caller: true;
+>caller : true
+>true : true
+
+    callee: true;
+>callee : true
+>true : true
+
+    arguments: true;
+>arguments : true
+>true : true
+
+    arity: true;
+>arity : true
+>true : true
+}
+
+interface MEMO_STATICS {
+    '$$typeof': true;
+>'$$typeof' : true
+>true : true
+
+    compare: true;
+>compare : true
+>true : true
+
+    defaultProps: true;
+>defaultProps : true
+>true : true
+
+    displayName: true;
+>displayName : true
+>true : true
+
+    propTypes: true;
+>propTypes : true
+>true : true
+
+    type: true;
+>type : true
+>true : true
+}
+
+interface FORWARD_REF_STATICS {
+    '$$typeof': true;
+>'$$typeof' : true
+>true : true
+
+    render: true;
+>render : true
+>true : true
+
+    defaultProps: true;
+>defaultProps : true
+>true : true
+
+    displayName: true;
+>displayName : true
+>true : true
+
+    propTypes: true;
+>propTypes : true
+>true : true
+}
+
+
+type NonReactStatics<
+>NonReactStatics : NonReactStatics<S, C>
+
+    S extends React.ComponentType<any>,
+>React : any
+
+    C extends {
+        [key: string]: true
+>key : string
+>true : true
+
+    } = {}
+    > = {
+        [key in Exclude<
+            keyof S,
+            S extends React.MemoExoticComponent<any>
+>React : any
+
+            ? keyof MEMO_STATICS | keyof C
+            : S extends React.ForwardRefExoticComponent<any>
+>React : any
+
+            ? keyof FORWARD_REF_STATICS | keyof C
+            : keyof REACT_STATICS | keyof KNOWN_STATICS | keyof C
+        >]: S[key]
+    };
+
+export type AnyStyledComponent = StyledComponent<any, any, any, any> | StyledComponent<any, any, any>;
+>AnyStyledComponent : AnyStyledComponent
+
+export type StyledComponent<
+>StyledComponent : StyledComponent<C, T, O, A>
+
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+>JSX : any
+>React : any
+
+    T extends object,
+    O extends object = {},
+    A extends keyof any = never
+    > = // the "string" allows this to be used as an object key
+    // I really want to avoid this if possible but it's the only way to use nesting with object styles...
+    string &
+    StyledComponentBase<C, T, O, A> &
+    NonReactStatics<C extends React.ComponentType<any> ? C : never>;
+>React : any
+
+export type StyledComponentProps<
+>StyledComponentProps : StyledComponentProps<C, T, O, A>
+
+    // The Component from whose props are derived
+    C extends string | React.ComponentType<any>,
+>React : any
+
+    // The Theme from the current context
+    T extends object,
+    // The other props added by the template
+    O extends object,
+    // The props that are made optional by .attrs
+    A extends keyof any
+    > =
+    // Distribute O if O is a union type
+    O extends object
+    ? WithOptionalTheme<
+        Omit<
+            ReactDefaultizedProps<
+                C,
+                React.ComponentPropsWithRef<
+>React : any
+
+                    C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+>React : any
+
+                >
+            > &
+            O,
+            A
+        > &
+        Partial<
+            Pick<
+                React.ComponentPropsWithRef<
+>React : any
+
+                    C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+>React : any
+
+                > &
+                O,
+                A
+            >
+        >,
+        T
+    > &
+    WithChildrenIfReactComponentClass<C>
+    : never;
+
+type Defaultize<P, D> = P extends any
+>Defaultize : Defaultize<P, D>
+
+    ? string extends keyof P
+    ? P
+    : Pick<P, Exclude<keyof P, keyof D>> &
+    Partial<Pick<P, Extract<keyof P, keyof D>>> &
+    Partial<Pick<D, Exclude<keyof D, keyof P>>>
+    : never;
+
+type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D } ? Defaultize<P, D> : P;
+>ReactDefaultizedProps : ReactDefaultizedProps<C, P>
+>defaultProps : D
+
+type WithChildrenIfReactComponentClass<C extends string | React.ComponentType<any>> = C extends React.ComponentClass<
+>WithChildrenIfReactComponentClass : WithChildrenIfReactComponentClass<C>
+>React : any
+>React : any
+
+    any
+>
+    ? { children?: React.ReactNode }
+>children : React.ReactNode
+>React : any
+
+    : {};
+export type IntrinsicElementsKeys = keyof JSX.IntrinsicElements;
+>IntrinsicElementsKeys : keyof JSX.IntrinsicElements
+>JSX : any
+
+type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, 'theme'> & {
+>WithOptionalTheme : WithOptionalTheme<P, T>
+>theme : T
+
+    theme?: T;
+>theme : T
+
+};
+
+type ForwardRefExoticBase<P> = Pick<React.ForwardRefExoticComponent<P>, keyof React.ForwardRefExoticComponent<any>>;
+>ForwardRefExoticBase : ForwardRefExoticBase<P>
+>React : any
+>React : any
+
+type StyledComponentPropsWithAs<
+>StyledComponentPropsWithAs : StyledComponentPropsWithAs<C, T, O, A, F>
+
+    C extends string | React.ComponentType<any>,
+>React : any
+
+    T extends object,
+    O extends object,
+    A extends keyof any,
+    F extends string | React.ComponentType<any> = C
+>React : any
+
+    > = StyledComponentProps<C, T, O, A> & { as?: C; forwardedAs?: F };
+>as : C
+>forwardedAs : F
+
+export type StyledComponentInnerOtherProps<C extends AnyStyledComponent> = C extends StyledComponent<
+>StyledComponentInnerOtherProps : StyledComponentInnerOtherProps<C>
+
+    any,
+    any,
+    infer O,
+    any
+>
+    ? O
+    : C extends StyledComponent<any, any, infer O>
+    ? O
+    : never;
+export type StyledComponentInnerAttrs<C extends AnyStyledComponent> = C extends StyledComponent<any, any, any, infer A>
+>StyledComponentInnerAttrs : StyledComponentInnerAttrs<C>
+
+    ? A
+    : never;
+
+export interface StyledComponentBase<
+    C extends string | React.ComponentType<any>,
+>React : any
+
+    T extends object,
+    O extends object = {},
+    A extends keyof any = never
+    > extends ForwardRefExoticBase<StyledComponentProps<C, T, O, A>> {
+    // add our own fake call signature to implement the polymorphic 'as' prop
+    (props: StyledComponentProps<C, T, O, A> & { as?: never; forwardedAs?: never }): React.ReactElement<
+>props : StyledComponentProps<C, T, O, A> & { as?: never; forwardedAs?: never; }
+>as : never
+>forwardedAs : never
+>React : any
+
+        StyledComponentProps<C, T, O, A>
+    >;
+    <AsC extends string | React.ComponentType<any> = C, FAsC extends string | React.ComponentType<any> = AsC>(
+>React : any
+>React : any
+
+        props: StyledComponentPropsWithAs<AsC, T, O, A, FAsC>,
+>props : StyledComponentPropsWithAs<AsC, T, O, A, FAsC>
+
+    ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A, FAsC>>;
+>React : any
+
+    withComponent<WithC extends AnyStyledComponent>(
+>withComponent : { <WithC extends AnyStyledComponent>(component: WithC): StyledComponent<StyledComponentInnerComponent<WithC>, T, O & StyledComponentInnerOtherProps<WithC>, A | StyledComponentInnerAttrs<WithC>>; <WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(component: WithC): StyledComponent<WithC, T, O, A>; }
+
+        component: WithC,
+>component : WithC
+
+    ): StyledComponent<
+        StyledComponentInnerComponent<WithC>,
+        T,
+        O & StyledComponentInnerOtherProps<WithC>,
+        A | StyledComponentInnerAttrs<WithC>
+    >;
+    withComponent<WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(
+>withComponent : { <WithC extends AnyStyledComponent>(component: WithC): StyledComponent<StyledComponentInnerComponent<WithC>, T, O & StyledComponentInnerOtherProps<WithC>, A | StyledComponentInnerAttrs<WithC>>; <WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(component: WithC): StyledComponent<WithC, T, O, A>; }
+>JSX : any
+>React : any
+
+        component: WithC,
+>component : WithC
+
+    ): StyledComponent<WithC, T, O, A>;
+}
+
+export type StyledComponentInnerComponent<C extends React.ComponentType<any>> = C extends StyledComponent<
+>StyledComponentInnerComponent : StyledComponentInnerComponent<C>
+>React : any
+
+    infer I,
+    any,
+    any,
+    any
+>
+    ? I
+    : C extends StyledComponent<infer I, any, any>
+    ? I
+    : C;
+export type StyledComponentPropsWithRef<
+>StyledComponentPropsWithRef : StyledComponentPropsWithRef<C>
+
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
+>JSX : any
+>React : any
+
+    > = C extends AnyStyledComponent
+    ? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>> // shouldn't have an instantiation limit error
+>React : any
+
+    : React.ComponentPropsWithRef<C>;
+>React : any
+

--- a/tests/baselines/reference/tsxSpreadDoesNotReportExcessProps.symbols
+++ b/tests/baselines/reference/tsxSpreadDoesNotReportExcessProps.symbols
@@ -16,12 +16,12 @@ class MyComponent extends React.Component<{dataSource: number[], onClick?: any},
 >render : Symbol(MyComponent.render, Decl(tsxSpreadDoesNotReportExcessProps.tsx, 4, 86))
 
         return (<div {...this.props} className="ok"></div>);
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 >this.props : Symbol(React.Component.props, Decl(react16.d.ts, 367, 32))
 >this : Symbol(MyComponent, Decl(tsxSpreadDoesNotReportExcessProps.tsx, 2, 26))
 >props : Symbol(React.Component.props, Decl(react16.d.ts, 367, 32))
 >className : Symbol(className, Decl(tsxSpreadDoesNotReportExcessProps.tsx, 6, 36))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
     }
 }
 

--- a/tests/baselines/reference/tsxStatelessComponentDefaultProps.symbols
+++ b/tests/baselines/reference/tsxStatelessComponentDefaultProps.symbols
@@ -17,7 +17,7 @@ function BackButton(_props: Props) {
 >Props : Symbol(Props, Decl(tsxStatelessComponentDefaultProps.tsx, 2, 26))
 
     return <div />
->div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2546, 114))
 }
 BackButton.defaultProps = {
 >BackButton.defaultProps : Symbol(BackButton.defaultProps, Decl(tsxStatelessComponentDefaultProps.tsx, 9, 1))

--- a/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts
+++ b/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts
@@ -1,0 +1,196 @@
+/// <reference path="/.lib/react16.d.ts" />
+import * as React from "react";
+
+interface REACT_STATICS {
+    childContextTypes: true;
+    contextType: true;
+    contextTypes: true;
+    defaultProps: true;
+    displayName: true;
+    getDefaultProps: true;
+    getDerivedStateFromError: true;
+    getDerivedStateFromProps: true;
+    mixins: true;
+    propTypes: true;
+    type: true;
+}
+
+interface KNOWN_STATICS {
+    name: true;
+    length: true;
+    prototype: true;
+    caller: true;
+    callee: true;
+    arguments: true;
+    arity: true;
+}
+
+interface MEMO_STATICS {
+    '$$typeof': true;
+    compare: true;
+    defaultProps: true;
+    displayName: true;
+    propTypes: true;
+    type: true;
+}
+
+interface FORWARD_REF_STATICS {
+    '$$typeof': true;
+    render: true;
+    defaultProps: true;
+    displayName: true;
+    propTypes: true;
+}
+
+
+type NonReactStatics<
+    S extends React.ComponentType<any>,
+    C extends {
+        [key: string]: true
+    } = {}
+    > = {
+        [key in Exclude<
+            keyof S,
+            S extends React.MemoExoticComponent<any>
+            ? keyof MEMO_STATICS | keyof C
+            : S extends React.ForwardRefExoticComponent<any>
+            ? keyof FORWARD_REF_STATICS | keyof C
+            : keyof REACT_STATICS | keyof KNOWN_STATICS | keyof C
+        >]: S[key]
+    };
+
+export type AnyStyledComponent = StyledComponent<any, any, any, any> | StyledComponent<any, any, any>;
+export type StyledComponent<
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+    T extends object,
+    O extends object = {},
+    A extends keyof any = never
+    > = // the "string" allows this to be used as an object key
+    // I really want to avoid this if possible but it's the only way to use nesting with object styles...
+    string &
+    StyledComponentBase<C, T, O, A> &
+    NonReactStatics<C extends React.ComponentType<any> ? C : never>;
+
+export type StyledComponentProps<
+    // The Component from whose props are derived
+    C extends string | React.ComponentType<any>,
+    // The Theme from the current context
+    T extends object,
+    // The other props added by the template
+    O extends object,
+    // The props that are made optional by .attrs
+    A extends keyof any
+    > =
+    // Distribute O if O is a union type
+    O extends object
+    ? WithOptionalTheme<
+        Omit<
+            ReactDefaultizedProps<
+                C,
+                React.ComponentPropsWithRef<
+                    C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+                >
+            > &
+            O,
+            A
+        > &
+        Partial<
+            Pick<
+                React.ComponentPropsWithRef<
+                    C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never
+                > &
+                O,
+                A
+            >
+        >,
+        T
+    > &
+    WithChildrenIfReactComponentClass<C>
+    : never;
+
+type Defaultize<P, D> = P extends any
+    ? string extends keyof P
+    ? P
+    : Pick<P, Exclude<keyof P, keyof D>> &
+    Partial<Pick<P, Extract<keyof P, keyof D>>> &
+    Partial<Pick<D, Exclude<keyof D, keyof P>>>
+    : never;
+
+type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D } ? Defaultize<P, D> : P;
+
+type WithChildrenIfReactComponentClass<C extends string | React.ComponentType<any>> = C extends React.ComponentClass<
+    any
+>
+    ? { children?: React.ReactNode }
+    : {};
+export type IntrinsicElementsKeys = keyof JSX.IntrinsicElements;
+type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, 'theme'> & {
+    theme?: T;
+};
+
+type ForwardRefExoticBase<P> = Pick<React.ForwardRefExoticComponent<P>, keyof React.ForwardRefExoticComponent<any>>;
+
+type StyledComponentPropsWithAs<
+    C extends string | React.ComponentType<any>,
+    T extends object,
+    O extends object,
+    A extends keyof any,
+    F extends string | React.ComponentType<any> = C
+    > = StyledComponentProps<C, T, O, A> & { as?: C; forwardedAs?: F };
+
+export type StyledComponentInnerOtherProps<C extends AnyStyledComponent> = C extends StyledComponent<
+    any,
+    any,
+    infer O,
+    any
+>
+    ? O
+    : C extends StyledComponent<any, any, infer O>
+    ? O
+    : never;
+export type StyledComponentInnerAttrs<C extends AnyStyledComponent> = C extends StyledComponent<any, any, any, infer A>
+    ? A
+    : never;
+
+export interface StyledComponentBase<
+    C extends string | React.ComponentType<any>,
+    T extends object,
+    O extends object = {},
+    A extends keyof any = never
+    > extends ForwardRefExoticBase<StyledComponentProps<C, T, O, A>> {
+    // add our own fake call signature to implement the polymorphic 'as' prop
+    (props: StyledComponentProps<C, T, O, A> & { as?: never; forwardedAs?: never }): React.ReactElement<
+        StyledComponentProps<C, T, O, A>
+    >;
+    <AsC extends string | React.ComponentType<any> = C, FAsC extends string | React.ComponentType<any> = AsC>(
+        props: StyledComponentPropsWithAs<AsC, T, O, A, FAsC>,
+    ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A, FAsC>>;
+
+    withComponent<WithC extends AnyStyledComponent>(
+        component: WithC,
+    ): StyledComponent<
+        StyledComponentInnerComponent<WithC>,
+        T,
+        O & StyledComponentInnerOtherProps<WithC>,
+        A | StyledComponentInnerAttrs<WithC>
+    >;
+    withComponent<WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(
+        component: WithC,
+    ): StyledComponent<WithC, T, O, A>;
+}
+
+export type StyledComponentInnerComponent<C extends React.ComponentType<any>> = C extends StyledComponent<
+    infer I,
+    any,
+    any,
+    any
+>
+    ? I
+    : C extends StyledComponent<infer I, any, any>
+    ? I
+    : C;
+export type StyledComponentPropsWithRef<
+    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
+    > = C extends AnyStyledComponent
+    ? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>> // shouldn't have an instantiation limit error
+    : React.ComponentPropsWithRef<C>;


### PR DESCRIPTION
Fixes #42320


All the `.symbols` baseline changes are from adding some missing content to the `reeact16.d.ts` test lib to better support the new styled-components-based test case.