### PR TITLE
Don't allow renaming elements from node_modules

### DIFF
--- a/tests/cases/fourslash/renameElementFromExternalLib.ts
+++ b/tests/cases/fourslash/renameElementFromExternalLib.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /node_modules/lib/index.d.ts
+////export declare function foo(): number;
+////export declare class Bar {
+////    static function methodName(): void;
+////}
+
+// @Filename: /a.ts
+////import * as lib from "lib";
+////lib.[|foo|]();
+
+// @Filename: /b.ts
+////import { Bar } from "lib";
+////Bar.[|methodName|]();
+
+goTo.eachRange(range => {
+    verify.renameInfoFailed("You cannot rename this element.");
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #42367

The new added test it's currently failing so I'm marking this as a draft in the meantime. 
In the test, `program.isSourceFileFromExternalLibrary` is returning `false` for `/node_modules/lib/index.d.ts`, can you point to me what I'm missing?

Works fine while testing inside vscode
![ts_rename_from_node_modules](https://user-images.githubusercontent.com/25115070/105280461-d3f1b100-5b77-11eb-898b-ab7a56ffb311.gif)
