### PR TITLE
Semantic highlights in session based TSServer

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -861,6 +861,11 @@ namespace ts.server.protocol {
          * Length of the span.
          */
         length: number;
+        /**
+         * Optional parameter for the semantic highlighting response, if absent it
+         * defaults to "original".
+         */
+        format?: "original" | "2020"
     }
 
     /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1115,7 +1115,8 @@ namespace ts.server {
 
         private getEncodedSemanticClassifications(args: protocol.EncodedSemanticClassificationsRequestArgs) {
             const { file, project } = this.getFileAndProject(args);
-            return project.getLanguageService().getEncodedSemanticClassifications(file, args);
+            const format = args.format === "2020" ? SemanticClassificationFormat.TwentyTwenty : SemanticClassificationFormat.Original;
+            return project.getLanguageService().getEncodedSemanticClassifications(file, args, format);
         }
 
         private getProject(projectFileName: string | undefined): Project | undefined {


### PR DESCRIPTION
Fixes #41262 - I've cloned https://github.com/microsoft/vscode/tree/dev/mjbvz/semantic-ts locally and get working results from the tokenized files. I'm pretty sure this should be it @mjbvz! 

![Screen Shot 2021-01-21 at 1 51 17 PM](https://user-images.githubusercontent.com/49038/105362078-59b24280-5bf2-11eb-85ee-6df09c554d46.png)
