### PR TITLE
Add support for iterating over enums

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -35078,6 +35078,17 @@ namespace ts {
                 return anyIterationTypes;
             }
 
+            const symbolType = getDeclaredTypeOfSymbol(type.symbol);
+
+            if (symbolType.symbol.flags & SymbolFlags.RegularEnum) {
+                return createIterationTypes(
+                    createTupleType([
+                        stringType,
+                        symbolType,
+                    ]),
+                );
+            }
+
             if (use & IterationUse.AllowsAsyncIterablesFlag) {
                 const iterationTypes =
                     getIterationTypesOfIterableCached(type, asyncIterationTypesResolver) ||

--- a/tests/baselines/reference/enumIteratorBasics1.js
+++ b/tests/baselines/reference/enumIteratorBasics1.js
@@ -1,0 +1,35 @@
+//// [enumIteratorBasics1.ts]
+enum Test {
+  Foo,
+  Bar,
+  Baz,
+}
+
+const AlsoTest = Test;
+
+for (const member of AlsoTest) {
+  const x: string = member[0];
+  const y: Test = member[1];
+  console.log(x, y);
+}
+
+const members: [string, Test][] = [...AlsoTest];
+console.log(members);
+
+
+//// [enumIteratorBasics1.js]
+var Test;
+(function (Test) {
+    Test[Test["Foo"] = 0] = "Foo";
+    Test[Test["Bar"] = 1] = "Bar";
+    Test[Test["Baz"] = 2] = "Baz";
+    Test[Symbol.iterator] = function* () { yield* [["Foo", 0], ["Bar", 1], ["Baz", 2]]; };
+})(Test || (Test = {}));
+const AlsoTest = Test;
+for (const member of AlsoTest) {
+    const x = member[0];
+    const y = member[1];
+    console.log(x, y);
+}
+const members = [...AlsoTest];
+console.log(members);

--- a/tests/baselines/reference/enumIteratorBasics1.symbols
+++ b/tests/baselines/reference/enumIteratorBasics1.symbols
@@ -1,0 +1,52 @@
+=== tests/cases/compiler/enumIteratorBasics1.ts ===
+enum Test {
+>Test : Symbol(Test, Decl(enumIteratorBasics1.ts, 0, 0))
+
+  Foo,
+>Foo : Symbol(Test.Foo, Decl(enumIteratorBasics1.ts, 0, 11))
+
+  Bar,
+>Bar : Symbol(Test.Bar, Decl(enumIteratorBasics1.ts, 1, 6))
+
+  Baz,
+>Baz : Symbol(Test.Baz, Decl(enumIteratorBasics1.ts, 2, 6))
+}
+
+const AlsoTest = Test;
+>AlsoTest : Symbol(AlsoTest, Decl(enumIteratorBasics1.ts, 6, 5))
+>Test : Symbol(Test, Decl(enumIteratorBasics1.ts, 0, 0))
+
+for (const member of AlsoTest) {
+>member : Symbol(member, Decl(enumIteratorBasics1.ts, 8, 10))
+>AlsoTest : Symbol(AlsoTest, Decl(enumIteratorBasics1.ts, 6, 5))
+
+  const x: string = member[0];
+>x : Symbol(x, Decl(enumIteratorBasics1.ts, 9, 7))
+>member : Symbol(member, Decl(enumIteratorBasics1.ts, 8, 10))
+>0 : Symbol(0)
+
+  const y: Test = member[1];
+>y : Symbol(y, Decl(enumIteratorBasics1.ts, 10, 7))
+>Test : Symbol(Test, Decl(enumIteratorBasics1.ts, 0, 0))
+>member : Symbol(member, Decl(enumIteratorBasics1.ts, 8, 10))
+>1 : Symbol(1)
+
+  console.log(x, y);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>x : Symbol(x, Decl(enumIteratorBasics1.ts, 9, 7))
+>y : Symbol(y, Decl(enumIteratorBasics1.ts, 10, 7))
+}
+
+const members: [string, Test][] = [...AlsoTest];
+>members : Symbol(members, Decl(enumIteratorBasics1.ts, 14, 5))
+>Test : Symbol(Test, Decl(enumIteratorBasics1.ts, 0, 0))
+>AlsoTest : Symbol(AlsoTest, Decl(enumIteratorBasics1.ts, 6, 5))
+
+console.log(members);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>members : Symbol(members, Decl(enumIteratorBasics1.ts, 14, 5))
+

--- a/tests/baselines/reference/enumIteratorBasics1.types
+++ b/tests/baselines/reference/enumIteratorBasics1.types
@@ -1,0 +1,56 @@
+=== tests/cases/compiler/enumIteratorBasics1.ts ===
+enum Test {
+>Test : Test
+
+  Foo,
+>Foo : Test.Foo
+
+  Bar,
+>Bar : Test.Bar
+
+  Baz,
+>Baz : Test.Baz
+}
+
+const AlsoTest = Test;
+>AlsoTest : typeof Test
+>Test : typeof Test
+
+for (const member of AlsoTest) {
+>member : [string, Test]
+>AlsoTest : typeof Test
+
+  const x: string = member[0];
+>x : string
+>member[0] : string
+>member : [string, Test]
+>0 : 0
+
+  const y: Test = member[1];
+>y : Test
+>member[1] : Test
+>member : [string, Test]
+>1 : 1
+
+  console.log(x, y);
+>console.log(x, y) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>x : string
+>y : Test
+}
+
+const members: [string, Test][] = [...AlsoTest];
+>members : [string, Test][]
+>[...AlsoTest] : [string, Test][]
+>...AlsoTest : [string, Test]
+>AlsoTest : typeof Test
+
+console.log(members);
+>console.log(members) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>members : [string, Test][]
+

--- a/tests/baselines/reference/enumIteratorConstEnum1.errors.txt
+++ b/tests/baselines/reference/enumIteratorConstEnum1.errors.txt
@@ -1,0 +1,19 @@
+tests/cases/compiler/enumIteratorConstEnum1.ts(8,22): error TS2475: 'const' enums can only be used in property or index access expressions or the right hand side of an import declaration or export assignment or type query.
+tests/cases/compiler/enumIteratorConstEnum1.ts(8,22): error TS2488: Type 'typeof ConstTest' must have a '[Symbol.iterator]()' method that returns an iterator.
+
+
+==== tests/cases/compiler/enumIteratorConstEnum1.ts (2 errors) ====
+    const enum ConstTest {
+      Foo,
+      Bar,
+      Baz,
+    }
+    
+    // Should be an error.
+    for (const member of ConstTest) {
+                         ~~~~~~~~~
+!!! error TS2475: 'const' enums can only be used in property or index access expressions or the right hand side of an import declaration or export assignment or type query.
+                         ~~~~~~~~~
+!!! error TS2488: Type 'typeof ConstTest' must have a '[Symbol.iterator]()' method that returns an iterator.
+    }
+    

--- a/tests/baselines/reference/enumIteratorConstEnum1.js
+++ b/tests/baselines/reference/enumIteratorConstEnum1.js
@@ -1,0 +1,16 @@
+//// [enumIteratorConstEnum1.ts]
+const enum ConstTest {
+  Foo,
+  Bar,
+  Baz,
+}
+
+// Should be an error.
+for (const member of ConstTest) {
+}
+
+
+//// [enumIteratorConstEnum1.js]
+// Should be an error.
+for (const member of ConstTest) {
+}

--- a/tests/baselines/reference/enumIteratorConstEnum1.symbols
+++ b/tests/baselines/reference/enumIteratorConstEnum1.symbols
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/enumIteratorConstEnum1.ts ===
+const enum ConstTest {
+>ConstTest : Symbol(ConstTest, Decl(enumIteratorConstEnum1.ts, 0, 0))
+
+  Foo,
+>Foo : Symbol(ConstTest.Foo, Decl(enumIteratorConstEnum1.ts, 0, 22))
+
+  Bar,
+>Bar : Symbol(ConstTest.Bar, Decl(enumIteratorConstEnum1.ts, 1, 6))
+
+  Baz,
+>Baz : Symbol(ConstTest.Baz, Decl(enumIteratorConstEnum1.ts, 2, 6))
+}
+
+// Should be an error.
+for (const member of ConstTest) {
+>member : Symbol(member, Decl(enumIteratorConstEnum1.ts, 7, 10))
+>ConstTest : Symbol(ConstTest, Decl(enumIteratorConstEnum1.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/enumIteratorConstEnum1.types
+++ b/tests/baselines/reference/enumIteratorConstEnum1.types
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/enumIteratorConstEnum1.ts ===
+const enum ConstTest {
+>ConstTest : ConstTest
+
+  Foo,
+>Foo : ConstTest.Foo
+
+  Bar,
+>Bar : ConstTest.Bar
+
+  Baz,
+>Baz : ConstTest.Baz
+}
+
+// Should be an error.
+for (const member of ConstTest) {
+>member : any
+>ConstTest : typeof ConstTest
+}
+

--- a/tests/cases/compiler/enumIteratorBasics1.ts
+++ b/tests/cases/compiler/enumIteratorBasics1.ts
@@ -1,0 +1,17 @@
+// @target: ES6
+enum Test {
+  Foo,
+  Bar,
+  Baz,
+}
+
+const AlsoTest = Test;
+
+for (const member of AlsoTest) {
+  const x: string = member[0];
+  const y: Test = member[1];
+  console.log(x, y);
+}
+
+const members: [string, Test][] = [...AlsoTest];
+console.log(members);

--- a/tests/cases/compiler/enumIteratorConstEnum1.ts
+++ b/tests/cases/compiler/enumIteratorConstEnum1.ts
@@ -1,0 +1,10 @@
+// @target: ES6
+const enum ConstTest {
+  Foo,
+  Bar,
+  Baz,
+}
+
+// Should be an error.
+for (const member of ConstTest) {
+}


### PR DESCRIPTION
I'm fairly confident about the codegen stuff, but I have no idea about the type checker.

~~I also couldn't make it work with type aliases - it complains that the alias is only a type but you're trying to use it as a value.~~ Edit: Actually I think that makes sense.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #42457
