### PR TITLE
Use spaces instead of non-breaking spaces, narrow non-breaking spaces.

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -4331,8 +4331,8 @@ declare namespace Intl {
 
     interface DateTimeFormatOptions {
         localeMatcher?: "best fit" | "lookup";
-        weekday?: "long" | "short" | "narrow";
-        era?: "long" | "short" | "narrow";
+        weekday?: "long" | "short" | "narrow";
+        era?: "long" | "short" | "narrow";
         year?: "numeric" | "2-digit";
         month?: "numeric" | "2-digit" | "long" | "short" | "narrow";
         day?: "numeric" | "2-digit";

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -321,7 +321,7 @@ namespace ts.codefix {
         return typeNode;
     }
 
-    function createDummyParameters(argCount: number, names: (string | undefined)[] | undefined, types: (TypeNode | undefined)[] | undefined, minArgumentCount: number | undefined, inJs: boolean): ParameterDeclaration[] {
+    function createDummyParameters(argCount: number, names: (string | undefined)[] | undefined, types: (TypeNode | undefined)[] | undefined, minArgumentCount: number | undefined, inJs: boolean): ParameterDeclaration[] {
         const parameters: ParameterDeclaration[] = [];
         for (let i = 0; i < argCount; i++) {
             const newParameter = factory.createParameterDeclaration(


### PR DESCRIPTION
Addresses comment from @kaleidawave over at https://github.com/microsoft/TypeScript/commit/16031bc429305e5daabf263f208678a6729a161e#r46271995