### PR TITLE
Fix auto import for path mapping resolving to a package root

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4429,6 +4429,7 @@ namespace ts {
                         isSourceOfProjectReferenceRedirect: fileName => host.isSourceOfProjectReferenceRedirect(fileName),
                         fileExists: fileName => host.fileExists(fileName),
                         getFileIncludeReasons: () => host.getFileIncludeReasons(),
+                        getResolvedPaths: () => host.getResolvedPaths(),
                     } : undefined },
                     encounteredError: false,
                     visitedTypes: undefined,

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -851,6 +851,7 @@ namespace ts {
             getSourceFileFromReference: returnUndefined,
             redirectTargetsMap: createMultiMap(),
             getFileIncludeReasons: notImplemented,
+            getResolvedPaths: notImplemented
         };
         emitFiles(
             notImplementedResolver,

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3662,10 +3662,11 @@ namespace ts {
                 const basePath = getPathsBasePath(options, host)!;
                 for (const pattern in options.paths) {
                     const values = options.paths[pattern];
+                    if (!isArray(values)) continue; // Type of values not validated by config parser
                     let resolvedValues: (string | undefined)[] | undefined;
                     for (let i = 0; i < values.length; i++) {
                         const value = values[i];
-                        if (!stringContains(value, "*")) {
+                        if (typeof value === "string" && !stringContains(value, "*")) {
                             (resolvedValues ||= [])[i] = nodeModuleNameResolver(
                                 combinePaths(basePath, value),
                                 options.configFilePath || combinePaths(currentDirectory, "tsconfig.json"),

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3886,6 +3886,7 @@ namespace ts {
          * This implementation handles file exists to be true if file is source of project reference redirect when program is created using useSourceOfProjectReferenceRedirect
          */
         /*@internal*/ fileExists(fileName: string): boolean;
+        /*@internal*/ getResolvedPaths(): MapLike<readonly (string | undefined)[]>;
     }
 
     /*@internal*/
@@ -7958,6 +7959,7 @@ namespace ts {
         getProjectReferenceRedirect(fileName: string): string | undefined;
         isSourceOfProjectReferenceRedirect(fileName: string): boolean;
         getFileIncludeReasons(): MultiMap<Path, FileIncludeReason>;
+        getResolvedPaths(): MapLike<readonly (string | undefined)[]>;
     }
 
     // Note: this used to be deprecated in our public API, but is still used internally

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1836,6 +1836,7 @@ namespace ts {
             isSourceOfProjectReferenceRedirect: fileName => program.isSourceOfProjectReferenceRedirect(fileName),
             getNearestAncestorDirectoryWithPackageJson: maybeBind(host, host.getNearestAncestorDirectoryWithPackageJson),
             getFileIncludeReasons: () => program.getFileIncludeReasons(),
+            getResolvedPaths: program.getResolvedPaths,
         };
     }
 

--- a/tests/cases/fourslash/importNameCodeFix_pathsToPackageMain1.ts
+++ b/tests/cases/fourslash/importNameCodeFix_pathsToPackageMain1.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// { "compilerOptions": { "moduleResolution": "node", "paths": { "@test/alpha": ["alpha"] } } }
+
+// @Filename: /alpha/package.json
+//// { "main": "src/index.ts" }
+
+// @Filename: /alpha/src/index.ts
+//// export class Alpha {}
+
+// @Filename: /beta/src/index.ts
+//// Alpha/**/
+
+goTo.marker("");
+verify.importFixAtPosition([`import { Alpha } from "@test/alpha";
+
+Alpha`]);

--- a/tests/cases/fourslash/server/importNameCodeFix_pathsToPackageMain2.ts
+++ b/tests/cases/fourslash/server/importNameCodeFix_pathsToPackageMain2.ts
@@ -1,0 +1,26 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /alpha/tsconfig.json
+//// { "compilerOptions": { "rootDir": "src", "outDir": "dist", "composite": true } }
+
+// @Filename: /alpha/package.json
+//// { "main": "dist/index.js" }
+
+// @Filename: /alpha/src/index.ts
+//// export class Alpha {}
+
+// @Filename: /beta/tsconfig.json
+//// {
+////   "compilerOptions": { "moduleResolution": "node", "paths": { "@test/alpha": ["../alpha"] } },
+////   "references": [{ "path": "../alpha" }]
+//// }
+
+// @Filename: /beta/src/index.ts
+//// Alpha/**/
+
+// @Filename: /beta/src/utils.ts
+//// import "@test/alpha";
+
+
+goTo.marker("");
+verify.importFixAtPosition([`import { Alpha } from "@test/alpha";\r\n\r\nAlpha`]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #41152 

Like #41864, but uses the actual module resolver and keeps file IO out of module specifier resolution.
