### PR TITLE
Don’t create missing nodes for identifiers that would be valid in a newer script target

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1637,8 +1637,8 @@ namespace ts {
         // with magic property names like '__proto__'. The 'identifiers' object is used to share a single string instance for
         // each identifier in order to reduce memory consumption.
         function createIdentifier(isIdentifier: boolean, diagnosticMessage?: DiagnosticMessage, privateIdentifierDiagnosticMessage?: DiagnosticMessage): Identifier {
-            identifierCount++;
             if (isIdentifier) {
+                identifierCount++;
                 const pos = getNodePos();
                 // Store original token kind if it is not just an Identifier so we can report appropriate error later in type checker
                 const originalKeywordKind = token();
@@ -1652,6 +1652,12 @@ namespace ts {
                 return createIdentifier(/*isIdentifier*/ true);
             }
 
+            if (token() === SyntaxKind.Unknown && scanner.tryScan(() => scanner.reScanInvalidIdentifier() === SyntaxKind.Identifier)) {
+                // Scanner has already recorded an 'Invalid character' error, so no need to add another from the parser.
+                return createIdentifier(/*isIdentifier*/ true);
+            }
+
+            identifierCount++;
             // Only for end of file because the error gets reported incorrectly on embedded script tags.
             const reportAtCurrentPosition = token() === SyntaxKind.EndOfFileToken;
 

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -2073,7 +2073,7 @@ namespace ts {
                 return token = identifierKind;
             }
             pos += charSize(ch);
-            return token = SyntaxKind.Unknown;
+            return token; // Still `SyntaKind.Unknown`
         }
 
         function scanIdentifier(startCharacter: number, languageVersion: ScriptTarget) {

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -43,6 +43,7 @@ namespace ts {
         reScanJsxToken(): JsxTokenSyntaxKind;
         reScanLessThanToken(): SyntaxKind;
         reScanQuestionToken(): SyntaxKind;
+        reScanInvalidIdentifier(): SyntaxKind;
         scanJsxToken(): JsxTokenSyntaxKind;
         scanJsDocToken(): JSDocSyntaxKind;
         scan(): SyntaxKind;
@@ -966,6 +967,7 @@ namespace ts {
             reScanJsxToken,
             reScanLessThanToken,
             reScanQuestionToken,
+            reScanInvalidIdentifier,
             scanJsxToken,
             scanJsDocToken,
             scan,
@@ -2041,14 +2043,9 @@ namespace ts {
                         }
                         return token = SyntaxKind.PrivateIdentifier;
                     default:
-                        if (isIdentifierStart(ch, languageVersion)) {
-                            pos += charSize(ch);
-                            while (pos < end && isIdentifierPart(ch = codePointAt(text, pos), languageVersion)) pos += charSize(ch);
-                            tokenValue = text.substring(tokenPos, pos);
-                            if (ch === CharacterCodes.backslash) {
-                                tokenValue += scanIdentifierParts();
-                            }
-                            return token = getIdentifierToken();
+                        const identifierKind = scanIdentifier(ch, languageVersion);
+                        if (identifierKind) {
+                            return token = identifierKind;
                         }
                         else if (isWhiteSpaceSingleLine(ch)) {
                             pos += charSize(ch);
@@ -2063,6 +2060,32 @@ namespace ts {
                         pos += charSize(ch);
                         return token = SyntaxKind.Unknown;
                 }
+            }
+        }
+
+        function reScanInvalidIdentifier(): SyntaxKind {
+            Debug.assert(token === SyntaxKind.Unknown, "'reScanInvalidIdentifier' should only be called when the current token is 'SyntaxKind.Unknown'.");
+            pos = tokenPos = startPos;
+            tokenFlags = 0;
+            const ch = codePointAt(text, pos);
+            const identifierKind = scanIdentifier(ch, ScriptTarget.ESNext);
+            if (identifierKind) {
+                return token = identifierKind;
+            }
+            pos += charSize(ch);
+            return token = SyntaxKind.Unknown;
+        }
+
+        function scanIdentifier(startCharacter: number, languageVersion: ScriptTarget) {
+            let ch = startCharacter;
+            if (isIdentifierStart(ch, languageVersion)) {
+                pos += charSize(ch);
+                while (pos < end && isIdentifierPart(ch = codePointAt(text, pos), languageVersion)) pos += charSize(ch);
+                tokenValue = text.substring(tokenPos, pos);
+                if (ch === CharacterCodes.backslash) {
+                    tokenValue += scanIdentifierParts();
+                }
+                return getIdentifierToken();
             }
         }
 

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -1453,9 +1453,9 @@ namespace FourSlash {
         }
 
         public baselineRename(marker: string, options: FourSlashInterface.RenameOptions) {
-            const position = this.getMarkerByName(marker).position;
+            const { fileName, position } = this.getMarkerByName(marker);
             const locations = this.languageService.findRenameLocations(
-                this.activeFile.fileName,
+                fileName,
                 position,
                 options.findInStrings ?? false,
                 options.findInComments ?? false,

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3970,6 +3970,7 @@ declare namespace ts {
         reScanJsxToken(): JsxTokenSyntaxKind;
         reScanLessThanToken(): SyntaxKind;
         reScanQuestionToken(): SyntaxKind;
+        reScanInvalidIdentifier(): SyntaxKind;
         scanJsxToken(): JsxTokenSyntaxKind;
         scanJsDocToken(): JSDocSyntaxKind;
         scan(): SyntaxKind;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3970,6 +3970,7 @@ declare namespace ts {
         reScanJsxToken(): JsxTokenSyntaxKind;
         reScanLessThanToken(): SyntaxKind;
         reScanQuestionToken(): SyntaxKind;
+        reScanInvalidIdentifier(): SyntaxKind;
         scanJsxToken(): JsxTokenSyntaxKind;
         scanJsDocToken(): JSDocSyntaxKind;
         scan(): SyntaxKind;

--- a/tests/baselines/reference/processInvalidSyntax1.baseline
+++ b/tests/baselines/reference/processInvalidSyntax1.baseline
@@ -2,9 +2,17 @@
 
 var RENAME = {};
 
-/*====== /tests/cases/fourslash/unicode.js ======*/
+/*====== /tests/cases/fourslash/unicode1.js ======*/
 
 RENAME.𝒜 ;
+
+/*====== /tests/cases/fourslash/unicode2.js ======*/
+
+RENAME.¬ ;
+
+/*====== /tests/cases/fourslash/unicode3.js ======*/
+
+RENAME¬
 
 /*====== /tests/cases/fourslash/forof.js ======*/
 

--- a/tests/baselines/reference/processInvalidSyntax1.baseline
+++ b/tests/baselines/reference/processInvalidSyntax1.baseline
@@ -1,0 +1,13 @@
+/*====== /tests/cases/fourslash/decl.js ======*/
+
+var RENAME = {};
+
+/*====== /tests/cases/fourslash/unicode.js ======*/
+
+RENAME.𝒜 ;
+
+/*====== /tests/cases/fourslash/forof.js ======*/
+
+for (RENAME.prop of arr) {
+
+}

--- a/tests/cases/fourslash/processInvalidSyntax1.ts
+++ b/tests/cases/fourslash/processInvalidSyntax1.ts
@@ -1,0 +1,13 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+
+// @Filename: unicode.js
+//// obj.𝒜 ;
+
+// @Filename: forof.js
+//// for (obj/**/.prop of arr) {
+//// 
+//// }
+
+verify.baselineRename("", {});

--- a/tests/cases/fourslash/processInvalidSyntax1.ts
+++ b/tests/cases/fourslash/processInvalidSyntax1.ts
@@ -8,8 +8,14 @@
 // @Filename: decl.js
 //// var obj = {};
 
-// @Filename: unicode.js
+// @Filename: unicode1.js
 //// obj.𝒜 ;
+
+// @Filename: unicode2.js
+//// obj.¬ ;
+
+// @Filename: unicode3.js
+//// obj¬
 
 // @Filename: forof.js
 //// for (obj/**/.prop of arr) {

--- a/tests/cases/fourslash/processInvalidSyntax1.ts
+++ b/tests/cases/fourslash/processInvalidSyntax1.ts
@@ -2,6 +2,12 @@
 
 // @allowJs: true
 
+// Test validates that language service getChildren() doesn't
+// crash due to invalid identifier in unicode.js.
+
+// @Filename: decl.js
+//// var obj = {};
+
 // @Filename: unicode.js
 //// obj.𝒜 ;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Instead, put the invalid identifier text in the identifier node. (This is the same strategy we used to clean up the parse tree when private identifiers are used in places where private identifiers should never actually be parsed.)

Fixes one cause of #39854
