### PR TITLE
`typeof` on a well-known symbol in a computed property name has a poor error

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40415,7 +40415,11 @@ namespace ts {
             }
             else if (node.parent.kind === SyntaxKind.TypeLiteral) {
                 if (node.name.kind === SyntaxKind.ComputedPropertyName && node.name.expression.kind === SyntaxKind.TypeOfExpression) {
-                    return checkGrammarForInvalidDynamicName(node.name, Diagnostics.Computed_property_names_can_only_be_named_with_well_known_symbols_without_the_typeof_operator_Try_replacing_typeof_0_with_0, (node.name.expression as TypeOfExpression).expression);
+                    return checkGrammarForInvalidDynamicName(
+                        node.name,
+                        Diagnostics.Computed_property_names_can_only_be_named_with_well_known_symbols_without_the_typeof_operator_Try_replacing_typeof_0_with_0,
+                        tryGetPropertyAccessOrIdentifierToString((node.name.expression as TypeOfExpression).expression)
+                    );
                 }
                 return checkGrammarForInvalidDynamicName(node.name, Diagnostics.A_computed_property_name_in_a_type_literal_must_refer_to_an_expression_whose_type_is_a_literal_type_or_a_unique_symbol_type);
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40365,9 +40365,9 @@ namespace ts {
             }
         }
 
-        function checkGrammarForInvalidDynamicName(node: DeclarationName, message: DiagnosticMessage) {
+        function checkGrammarForInvalidDynamicName(node: DeclarationName, message: DiagnosticMessage, ...args: any[]) {
             if (isNonBindableDynamicName(node)) {
-                return grammarErrorOnNode(node, message);
+                return grammarErrorOnNode(node, message, ...args);
             }
         }
 
@@ -40414,6 +40414,9 @@ namespace ts {
                 return checkGrammarForInvalidDynamicName(node.name, Diagnostics.A_computed_property_name_in_an_interface_must_refer_to_an_expression_whose_type_is_a_literal_type_or_a_unique_symbol_type);
             }
             else if (node.parent.kind === SyntaxKind.TypeLiteral) {
+                if (node.name.kind === SyntaxKind.ComputedPropertyName && node.name.expression.kind === SyntaxKind.TypeOfExpression) {
+                    return checkGrammarForInvalidDynamicName(node.name, Diagnostics.Computed_property_names_can_only_be_named_with_well_known_symbols_without_the_typeof_operator_Try_replacing_typeof_0_with_0, (node.name.expression as TypeOfExpression).expression);
+                }
                 return checkGrammarForInvalidDynamicName(node.name, Diagnostics.A_computed_property_name_in_a_type_literal_must_refer_to_an_expression_whose_type_is_a_literal_type_or_a_unique_symbol_type);
             }
         }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -507,6 +507,10 @@
         "category": "Error",
         "code": 1166
     },
+    "Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof {0}' with '{0}'.": {
+        "category": "Error",
+        "code": 1167
+    },
     "A computed property name in a method overload must refer to an expression whose type is a literal type or a 'unique symbol' type.": {
         "category": "Error",
         "code": 1168
@@ -6342,9 +6346,5 @@
     "Invalid value for 'jsxFragmentFactory'. '{0}' is not a valid identifier or qualified-name.": {
         "category": "Error",
         "code": 18035
-    },
-    "Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof {0}' with '{0}'.": {
-        "category": "Error",
-        "code": 18036
     }
 }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -6342,5 +6342,9 @@
     "Invalid value for 'jsxFragmentFactory'. '{0}' is not a valid identifier or qualified-name.": {
         "category": "Error",
         "code": 18035
+    },
+    "Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof {0}' with '{0}'.": {
+        "category": "Error",
+        "code": 18036
     }
 }

--- a/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.errors.txt
+++ b/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(11,34): error TS18036: Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof [object Object]' with '[object Object]'.
+tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(11,34): error TS1167: Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof [object Object]' with '[object Object]'.
 tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(11,42): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
 tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(13,35): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
 
@@ -16,7 +16,7 @@ tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(13,35): error TS
     
     declare function from1<T>(obj: { [typeof Symbol.observable](): Observable<T> }): Observable<T>;
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS18036: Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof [object Object]' with '[object Object]'.
+!!! error TS1167: Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof [object Object]' with '[object Object]'.
                                              ~~~~~~
 !!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
     //                               ^^^^^^ Look at this use of 'typeof'.

--- a/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.errors.txt
+++ b/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.errors.txt
@@ -1,9 +1,7 @@
 tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(11,34): error TS1167: Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof [object Object]' with '[object Object]'.
-tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(11,42): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(13,35): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
 
 
-==== tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts (3 errors) ====
+==== tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts (1 errors) ====
     interface SymbolConstructor {
       observable: symbol;
     }
@@ -17,10 +15,6 @@ tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(13,35): error TS
     declare function from1<T>(obj: { [typeof Symbol.observable](): Observable<T> }): Observable<T>;
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1167: Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof [object Object]' with '[object Object]'.
-                                             ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
     //                               ^^^^^^ Look at this use of 'typeof'.
     declare function from2<T>(obj: { [Symbol.observable](): Observable<T> }): Observable<T>;
-                                      ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
     

--- a/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.errors.txt
+++ b/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.errors.txt
@@ -1,0 +1,26 @@
+tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(11,34): error TS18036: Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof [object Object]' with '[object Object]'.
+tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(11,42): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(13,35): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+
+
+==== tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts (3 errors) ====
+    interface SymbolConstructor {
+      observable: symbol;
+    }
+    
+    type Observer<T> = (x: T) => void;
+    
+    interface Observable<T> {
+      subscribe(observer: Observer<T>): { unsubscribe(): void }
+    }
+    
+    declare function from1<T>(obj: { [typeof Symbol.observable](): Observable<T> }): Observable<T>;
+                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS18036: Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof [object Object]' with '[object Object]'.
+                                             ~~~~~~
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+    //                               ^^^^^^ Look at this use of 'typeof'.
+    declare function from2<T>(obj: { [Symbol.observable](): Observable<T> }): Observable<T>;
+                                      ~~~~~~
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+    

--- a/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.errors.txt
+++ b/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(11,34): error TS1167: Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof [object Object]' with '[object Object]'.
+tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(11,34): error TS1167: Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof Symbol.observable' with 'Symbol.observable'.
 
 
 ==== tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts (1 errors) ====
@@ -14,7 +14,7 @@ tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts(11,34): error TS
     
     declare function from1<T>(obj: { [typeof Symbol.observable](): Observable<T> }): Observable<T>;
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1167: Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof [object Object]' with '[object Object]'.
+!!! error TS1167: Computed property names can only be named with well-known symbols without the 'typeof' operator. Try replacing 'typeof Symbol.observable' with 'Symbol.observable'.
     //                               ^^^^^^ Look at this use of 'typeof'.
     declare function from2<T>(obj: { [Symbol.observable](): Observable<T> }): Observable<T>;
     

--- a/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.js
+++ b/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.js
@@ -1,0 +1,17 @@
+//// [computedPropertyNamesWithTypeOfOperator.ts]
+interface SymbolConstructor {
+  observable: symbol;
+}
+
+type Observer<T> = (x: T) => void;
+
+interface Observable<T> {
+  subscribe(observer: Observer<T>): { unsubscribe(): void }
+}
+
+declare function from1<T>(obj: { [typeof Symbol.observable](): Observable<T> }): Observable<T>;
+//                               ^^^^^^ Look at this use of 'typeof'.
+declare function from2<T>(obj: { [Symbol.observable](): Observable<T> }): Observable<T>;
+
+
+//// [computedPropertyNamesWithTypeOfOperator.js]

--- a/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.symbols
+++ b/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.symbols
@@ -1,0 +1,47 @@
+=== tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts ===
+interface SymbolConstructor {
+>SymbolConstructor : Symbol(SymbolConstructor, Decl(computedPropertyNamesWithTypeOfOperator.ts, 0, 0))
+
+  observable: symbol;
+>observable : Symbol(SymbolConstructor.observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 0, 29))
+}
+
+type Observer<T> = (x: T) => void;
+>Observer : Symbol(Observer, Decl(computedPropertyNamesWithTypeOfOperator.ts, 2, 1))
+>T : Symbol(T, Decl(computedPropertyNamesWithTypeOfOperator.ts, 4, 14))
+>x : Symbol(x, Decl(computedPropertyNamesWithTypeOfOperator.ts, 4, 20))
+>T : Symbol(T, Decl(computedPropertyNamesWithTypeOfOperator.ts, 4, 14))
+
+interface Observable<T> {
+>Observable : Symbol(Observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 4, 34))
+>T : Symbol(T, Decl(computedPropertyNamesWithTypeOfOperator.ts, 6, 21))
+
+  subscribe(observer: Observer<T>): { unsubscribe(): void }
+>subscribe : Symbol(Observable.subscribe, Decl(computedPropertyNamesWithTypeOfOperator.ts, 6, 25))
+>observer : Symbol(observer, Decl(computedPropertyNamesWithTypeOfOperator.ts, 7, 12))
+>Observer : Symbol(Observer, Decl(computedPropertyNamesWithTypeOfOperator.ts, 2, 1))
+>T : Symbol(T, Decl(computedPropertyNamesWithTypeOfOperator.ts, 6, 21))
+>unsubscribe : Symbol(unsubscribe, Decl(computedPropertyNamesWithTypeOfOperator.ts, 7, 37))
+}
+
+declare function from1<T>(obj: { [typeof Symbol.observable](): Observable<T> }): Observable<T>;
+>from1 : Symbol(from1, Decl(computedPropertyNamesWithTypeOfOperator.ts, 8, 1))
+>T : Symbol(T, Decl(computedPropertyNamesWithTypeOfOperator.ts, 10, 23))
+>obj : Symbol(obj, Decl(computedPropertyNamesWithTypeOfOperator.ts, 10, 26))
+>[typeof Symbol.observable] : Symbol([typeof Symbol.observable], Decl(computedPropertyNamesWithTypeOfOperator.ts, 10, 32))
+>Observable : Symbol(Observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 4, 34))
+>T : Symbol(T, Decl(computedPropertyNamesWithTypeOfOperator.ts, 10, 23))
+>Observable : Symbol(Observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 4, 34))
+>T : Symbol(T, Decl(computedPropertyNamesWithTypeOfOperator.ts, 10, 23))
+
+//                               ^^^^^^ Look at this use of 'typeof'.
+declare function from2<T>(obj: { [Symbol.observable](): Observable<T> }): Observable<T>;
+>from2 : Symbol(from2, Decl(computedPropertyNamesWithTypeOfOperator.ts, 10, 95))
+>T : Symbol(T, Decl(computedPropertyNamesWithTypeOfOperator.ts, 12, 23))
+>obj : Symbol(obj, Decl(computedPropertyNamesWithTypeOfOperator.ts, 12, 26))
+>[Symbol.observable] : Symbol([Symbol.observable], Decl(computedPropertyNamesWithTypeOfOperator.ts, 12, 32))
+>Observable : Symbol(Observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 4, 34))
+>T : Symbol(T, Decl(computedPropertyNamesWithTypeOfOperator.ts, 12, 23))
+>Observable : Symbol(Observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 4, 34))
+>T : Symbol(T, Decl(computedPropertyNamesWithTypeOfOperator.ts, 12, 23))
+

--- a/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.symbols
+++ b/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.symbols
@@ -1,6 +1,6 @@
 === tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts ===
 interface SymbolConstructor {
->SymbolConstructor : Symbol(SymbolConstructor, Decl(computedPropertyNamesWithTypeOfOperator.ts, 0, 0))
+>SymbolConstructor : Symbol(SymbolConstructor, Decl(lib.es2015.symbol.d.ts, --, --), Decl(computedPropertyNamesWithTypeOfOperator.ts, 0, 0))
 
   observable: symbol;
 >observable : Symbol(SymbolConstructor.observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 0, 29))
@@ -29,6 +29,9 @@ declare function from1<T>(obj: { [typeof Symbol.observable](): Observable<T> }):
 >T : Symbol(T, Decl(computedPropertyNamesWithTypeOfOperator.ts, 10, 23))
 >obj : Symbol(obj, Decl(computedPropertyNamesWithTypeOfOperator.ts, 10, 26))
 >[typeof Symbol.observable] : Symbol([typeof Symbol.observable], Decl(computedPropertyNamesWithTypeOfOperator.ts, 10, 32))
+>Symbol.observable : Symbol(SymbolConstructor.observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 0, 29))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>observable : Symbol(SymbolConstructor.observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 0, 29))
 >Observable : Symbol(Observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 4, 34))
 >T : Symbol(T, Decl(computedPropertyNamesWithTypeOfOperator.ts, 10, 23))
 >Observable : Symbol(Observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 4, 34))
@@ -40,6 +43,9 @@ declare function from2<T>(obj: { [Symbol.observable](): Observable<T> }): Observ
 >T : Symbol(T, Decl(computedPropertyNamesWithTypeOfOperator.ts, 12, 23))
 >obj : Symbol(obj, Decl(computedPropertyNamesWithTypeOfOperator.ts, 12, 26))
 >[Symbol.observable] : Symbol([Symbol.observable], Decl(computedPropertyNamesWithTypeOfOperator.ts, 12, 32))
+>Symbol.observable : Symbol(SymbolConstructor.observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 0, 29))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --))
+>observable : Symbol(SymbolConstructor.observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 0, 29))
 >Observable : Symbol(Observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 4, 34))
 >T : Symbol(T, Decl(computedPropertyNamesWithTypeOfOperator.ts, 12, 23))
 >Observable : Symbol(Observable, Decl(computedPropertyNamesWithTypeOfOperator.ts, 4, 34))

--- a/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.types
+++ b/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts ===
+interface SymbolConstructor {
+  observable: symbol;
+>observable : symbol
+}
+
+type Observer<T> = (x: T) => void;
+>Observer : Observer<T>
+>x : T
+
+interface Observable<T> {
+  subscribe(observer: Observer<T>): { unsubscribe(): void }
+>subscribe : (observer: Observer<T>) => {    unsubscribe(): void;}
+>observer : Observer<T>
+>unsubscribe : () => void
+}
+
+declare function from1<T>(obj: { [typeof Symbol.observable](): Observable<T> }): Observable<T>;
+>from1 : <T>(obj: {    [typeof Symbol.observable](): Observable<T>;}) => Observable<T>
+>obj : {}
+>[typeof Symbol.observable] : () => Observable<T>
+>typeof Symbol.observable : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>Symbol.observable : any
+>Symbol : any
+>observable : any
+
+//                               ^^^^^^ Look at this use of 'typeof'.
+declare function from2<T>(obj: { [Symbol.observable](): Observable<T> }): Observable<T>;
+>from2 : <T>(obj: {    [Symbol.observable](): Observable<T>;}) => Observable<T>
+>obj : { [Symbol.observable](): Observable<T>; }
+>[Symbol.observable] : () => Observable<T>
+>Symbol.observable : any
+>Symbol : any
+>observable : any
+

--- a/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.types
+++ b/tests/baselines/reference/computedPropertyNamesWithTypeOfOperator.types
@@ -20,16 +20,16 @@ declare function from1<T>(obj: { [typeof Symbol.observable](): Observable<T> }):
 >obj : {}
 >[typeof Symbol.observable] : () => Observable<T>
 >typeof Symbol.observable : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
->Symbol.observable : any
->Symbol : any
->observable : any
+>Symbol.observable : symbol
+>Symbol : SymbolConstructor
+>observable : symbol
 
 //                               ^^^^^^ Look at this use of 'typeof'.
 declare function from2<T>(obj: { [Symbol.observable](): Observable<T> }): Observable<T>;
 >from2 : <T>(obj: {    [Symbol.observable](): Observable<T>;}) => Observable<T>
 >obj : { [Symbol.observable](): Observable<T>; }
 >[Symbol.observable] : () => Observable<T>
->Symbol.observable : any
->Symbol : any
->observable : any
+>Symbol.observable : symbol
+>Symbol : SymbolConstructor
+>observable : symbol
 

--- a/tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts
+++ b/tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts
@@ -1,3 +1,5 @@
+// @lib: es5, es2015.symbol
+
 interface SymbolConstructor {
   observable: symbol;
 }

--- a/tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts
+++ b/tests/cases/compiler/computedPropertyNamesWithTypeOfOperator.ts
@@ -1,0 +1,13 @@
+interface SymbolConstructor {
+  observable: symbol;
+}
+
+type Observer<T> = (x: T) => void;
+
+interface Observable<T> {
+  subscribe(observer: Observer<T>): { unsubscribe(): void }
+}
+
+declare function from1<T>(obj: { [typeof Symbol.observable](): Observable<T> }): Observable<T>;
+//                               ^^^^^^ Look at this use of 'typeof'.
+declare function from2<T>(obj: { [Symbol.observable](): Observable<T> }): Observable<T>;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #42523
