### PR TITLE
fix(42519): 'Infer function return type' quick fix generates invalid code for arrow functions without parens

### DIFF
--- a/tests/cases/fourslash/refactorInferFunctionReturnType22.ts
+++ b/tests/cases/fourslash/refactorInferFunctionReturnType22.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+////const foo = async /*a*//*b*/a => {
+////    return 1;
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Infer function return type",
+    actionName: "Infer function return type",
+    actionDescription: "Infer function return type",
+    newContent:
+`const foo = async (a): Promise<number> => {
+    return 1;
+}`
+});

--- a/tests/cases/fourslash/refactorInferFunctionReturnType23.ts
+++ b/tests/cases/fourslash/refactorInferFunctionReturnType23.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+////const foo = async /*a*//*b*/(a) => {
+////    return 1;
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Infer function return type",
+    actionName: "Infer function return type",
+    actionDescription: "Infer function return type",
+    newContent:
+`const foo = async (a): Promise<number> => {
+    return 1;
+}`
+});


### PR DESCRIPTION
Fixes #42519


