### PR TITLE
Add 'bitflags' modifier for enum.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30510,8 +30510,9 @@ namespace ts {
                         }
 
                         // try check bitflags enum.
-                        if (leftType.flags & TypeFlags.EnumLike || rightType.flags & TypeFlags.EnumLike) {
+                        if (compilerOptions.bitEnum && (leftType.flags & TypeFlags.EnumLike || rightType.flags & TypeFlags.EnumLike)) {
                             const isBitFlagEnumType = (t: Type) => {
+                                // or use `isBitflagsEnumSymbol(t?.symbol)`, which way is better?
                                 let enumDeclaration: Node = t?.symbol?.valueDeclaration;
                                 if (enumDeclaration?.kind !== SyntaxKind.EnumDeclaration) {
                                     enumDeclaration = enumDeclaration?.parent;
@@ -39096,6 +39097,11 @@ namespace ts {
                     }
                 }
                 switch (modifier.kind) {
+                    case SyntaxKind.BitFlagskeyword:
+                        if (node.kind !== SyntaxKind.EnumDeclaration) {
+                            return grammarErrorOnNode(node, Diagnostics.bitflags_modifier_can_only_be_used_with_enum_declaration);
+                        }
+                        break;
                     case SyntaxKind.ConstKeyword:
                         if (node.kind !== SyntaxKind.EnumDeclaration) {
                             return grammarErrorOnNode(node, Diagnostics.A_class_member_cannot_have_the_0_keyword, tokenToString(SyntaxKind.ConstKeyword));

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -36324,7 +36324,7 @@ namespace ts {
                         else {
                             // where should we report this error? on the whole initializer or more accurate?
                             if (!isAllOperatorBitwiseOrShiftOperator(node.initializer)) {
-                                error(node, Diagnostics.An_enum_member_initializer_can_only_use_bitwise_operator_in_bitflags_enum);
+                                error(node, Diagnostics.An_enum_member_initializer_can_only_use_bitwise_or_shift_operator_in_bitflags_enum);
                             }
                         }
                     }
@@ -36355,7 +36355,7 @@ namespace ts {
                 return result;
             }
 
-            function isAllOperatorBitwiseOrShiftOperator(initializer: BinaryExpression):boolean {
+            function isAllOperatorBitwiseOrShiftOperator(initializer: BinaryExpression): boolean {
                 const leftRes = isBinaryExpression(initializer.left) ? isAllOperatorBitwiseOrShiftOperator(initializer.left) : true;
                 const rightRes = isBinaryExpression(initializer.right) ? isAllOperatorBitwiseOrShiftOperator(initializer.right) : true;
                 const operatorRes = isBitwiseOrShiftOperator(initializer.operatorToken.kind);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30512,8 +30512,8 @@ namespace ts {
                         // try check bitflags enum.
                         if (leftType.flags & TypeFlags.EnumLike || rightType.flags & TypeFlags.EnumLike) {
                             const isBitFlagEnumType = (t: Type) => {
-                                let enumDeclaration = t?.symbol?.valueDeclaration;
-                                if(enumDeclaration?.kind !==SyntaxKind.EnumDeclaration){
+                                let enumDeclaration: Node = t?.symbol?.valueDeclaration;
+                                if (enumDeclaration?.kind !== SyntaxKind.EnumDeclaration) {
                                     enumDeclaration = enumDeclaration?.parent;
                                 }
                                 return enumDeclaration ? hasEffectiveModifier(enumDeclaration, ModifierFlags.BitFlags) : false;
@@ -30529,7 +30529,8 @@ namespace ts {
                                     if (isBitFlagEnumType(leftType) || isBitFlagEnumType(rightType)) {
                                         // which condition is more proper? OR or AND?
                                         // could we give back a accurate return type?
-                                    } else {
+                                    }
+                                    else {
                                         error(errorNode || operatorToken, Diagnostics.Bit_operation_is_only_allowed_for_enum_with_bitflags_modifier);
                                     }
                                     break;

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -855,7 +855,12 @@ namespace ts {
             category: Diagnostics.Advanced_Options,
             description: Diagnostics.Include_modules_imported_with_json_extension
         },
-
+        {
+            name: "bitEnum",
+            type: "boolean",
+            category: Diagnostics.Advanced_Options,
+            description: Diagnostics.Enable_strict_bit_checking_for_enum
+        },
         {
             name: "out",
             type: "string",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -6289,5 +6289,17 @@
     "Invalid value for 'jsxFragmentFactory'. '{0}' is not a valid identifier or qualified-name.": {
         "category": "Error",
         "code": 18035
+    },
+    "An enum member can only be number in bitflags enum.": {
+        "category": "Error",
+        "code": 18036
+    },
+    "An enum member can only set one bit witout operator in bitflags enum.": {
+        "category": "Error",
+        "code": 18037
+    },
+    "An enum member initializer can only use bitwise operator in bitflags enum.": {
+        "category": "Error",
+        "code": 18038
     }
 }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -875,7 +875,10 @@
         "category": "Error",
         "code": 1264
     },
-
+    "'bitflags' modifier can only be used with enum declaration": {
+        "category": "Error",
+        "code": 1265
+    },
     "'with' statements are not allowed in an async function block.": {
         "category": "Error",
         "code": 1300
@@ -4696,7 +4699,10 @@
         "category": "Error",
         "code": 6238
     },
-
+    "Enable strict bit checking for enum.": {
+        "category": "Message",
+        "code": 6239
+    },
     "Projects to reference": {
         "category": "Message",
         "code": 6300

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -6298,7 +6298,7 @@
         "category": "Error",
         "code": 18037
     },
-    "An enum member initializer can only use bitwise operator in bitflags enum.": {
+    "An enum member initializer can only use bitwise or shift operator in bitflags enum.": {
         "category": "Error",
         "code": 18038
     }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2625,6 +2625,10 @@
         "category": "Error",
         "code": 2622
     },
+    "Bit operation is only allowed for enum with 'bitflags' modifier": {
+        "category": "Error",
+        "code": 2623
+    },
 
     "Cannot augment module '{0}' with value exports because it resolves to a non-module entity.": {
         "category": "Error",

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -1027,6 +1027,7 @@ namespace ts {
             if (flags & ModifierFlags.Export) { result.push(createModifier(SyntaxKind.ExportKeyword)); }
             if (flags & ModifierFlags.Ambient) { result.push(createModifier(SyntaxKind.DeclareKeyword)); }
             if (flags & ModifierFlags.Default) { result.push(createModifier(SyntaxKind.DefaultKeyword)); }
+            if (flags & ModifierFlags.BitFlags) { result.push(createModifier(SyntaxKind.BitFlagskeyword)); }
             if (flags & ModifierFlags.Const) { result.push(createModifier(SyntaxKind.ConstKeyword)); }
             if (flags & ModifierFlags.Public) { result.push(createModifier(SyntaxKind.PublicKeyword)); }
             if (flags & ModifierFlags.Private) { result.push(createModifier(SyntaxKind.PrivateKeyword)); }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5879,6 +5879,7 @@ namespace ts {
                         return nextTokenIsIdentifierOrStringLiteralOnSameLine();
                     case SyntaxKind.AbstractKeyword:
                     case SyntaxKind.AsyncKeyword:
+                    case SyntaxKind.BitFlagskeyword:
                     case SyntaxKind.DeclareKeyword:
                     case SyntaxKind.PrivateKeyword:
                     case SyntaxKind.ProtectedKeyword:
@@ -5956,6 +5957,7 @@ namespace ts {
                 case SyntaxKind.ImportKeyword:
                     return isStartOfDeclaration() || lookAhead(nextTokenIsOpenParenOrLessThanOrDot);
 
+                case SyntaxKind.BitFlagskeyword:
                 case SyntaxKind.ConstKeyword:
                 case SyntaxKind.ExportKeyword:
                     return isStartOfDeclaration();
@@ -6048,6 +6050,7 @@ namespace ts {
                 case SyntaxKind.ModuleKeyword:
                 case SyntaxKind.NamespaceKeyword:
                 case SyntaxKind.DeclareKeyword:
+                case SyntaxKind.BitFlagskeyword:
                 case SyntaxKind.ConstKeyword:
                 case SyntaxKind.EnumKeyword:
                 case SyntaxKind.ExportKeyword:

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -81,6 +81,7 @@ namespace ts {
         as: SyntaxKind.AsKeyword,
         asserts: SyntaxKind.AssertsKeyword,
         bigint: SyntaxKind.BigIntKeyword,
+        bitflags: SyntaxKind.BitFlagskeyword,
         boolean: SyntaxKind.BooleanKeyword,
         break: SyntaxKind.BreakKeyword,
         case: SyntaxKind.CaseKeyword,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4786,8 +4786,8 @@ namespace ts {
 
     /* @internal */
     export const enum EnumKind {
-        Numeric,                            // Numeric enum (each member has a TypeFlags.Enum type)
-        Literal                             // Literal enum (each member has a TypeFlags.EnumLiteral type)
+        Numeric,                                  // Numeric enum (each member has a TypeFlags.Enum type)
+        StringLiteral                             // Literal enum (each member has a TypeFlags.EnumLiteral type)
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5822,6 +5822,7 @@ namespace ts {
         allowUnusedLabels?: boolean;
         alwaysStrict?: boolean;  // Always combine with strict property
         baseUrl?: string;
+        bitEnum?: boolean;
         /** An error if set - this should only go through the -b pipeline and not actually be observed */
         /*@internal*/
         build?: boolean;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -109,6 +109,7 @@ namespace ts {
         Identifier,
         PrivateIdentifier,
         // Reserved words
+        BitFlagskeyword,
         BreakKeyword,
         CaseKeyword,
         CatchKeyword,
@@ -539,6 +540,7 @@ namespace ts {
         | SyntaxKind.AsyncKeyword
         | SyntaxKind.AwaitKeyword
         | SyntaxKind.BigIntKeyword
+        | SyntaxKind.BitFlagskeyword
         | SyntaxKind.BooleanKeyword
         | SyntaxKind.BreakKeyword
         | SyntaxKind.CaseKeyword
@@ -614,6 +616,7 @@ namespace ts {
     export type ModifierSyntaxKind =
         | SyntaxKind.AbstractKeyword
         | SyntaxKind.AsyncKeyword
+        | SyntaxKind.BitFlagskeyword
         | SyntaxKind.ConstKeyword
         | SyntaxKind.DeclareKeyword
         | SyntaxKind.DefaultKeyword
@@ -794,6 +797,7 @@ namespace ts {
         Abstract =           1 << 7,  // Class/Method/ConstructSignature
         Async =              1 << 8,  // Property/Method/Function
         Default =            1 << 9,  // Function/Class (export default declaration)
+        BitFlags =           1 << 10, // BitFlags enum
         Const =              1 << 11, // Const enum
         HasComputedJSDocModifiers = 1 << 12, // Indicates the computed modifier flags include modifiers from JSDoc.
 
@@ -805,9 +809,9 @@ namespace ts {
         ParameterPropertyModifier = AccessibilityModifier | Readonly,
         NonPublicAccessibilityModifier = Private | Protected,
 
-        TypeScriptModifier = Ambient | Public | Private | Protected | Readonly | Abstract | Const,
+        TypeScriptModifier = Ambient | Public | Private | Protected | Readonly | Abstract | Const | BitFlags,
         ExportDefault = Export | Default,
-        All = Export | Ambient | Public | Private | Protected | Static | Readonly | Abstract | Async | Default | Const | Deprecated
+        All = Export | Ambient | Public | Private | Protected | Static | Readonly | Abstract | Async | Default | BitFlags | Const | Deprecated
     }
 
     export const enum JsxFlags {
@@ -1019,6 +1023,7 @@ namespace ts {
 
     export type AbstractKeyword = ModifierToken<SyntaxKind.AbstractKeyword>;
     export type AsyncKeyword = ModifierToken<SyntaxKind.AsyncKeyword>;
+    export type BitFlagskeyword = ModifierToken<SyntaxKind.BitFlagskeyword>;
     export type ConstKeyword = ModifierToken<SyntaxKind.ConstKeyword>;
     export type DeclareKeyword = ModifierToken<SyntaxKind.DeclareKeyword>;
     export type DefaultKeyword = ModifierToken<SyntaxKind.DefaultKeyword>;
@@ -1035,6 +1040,7 @@ namespace ts {
     export type Modifier =
         | AbstractKeyword
         | AsyncKeyword
+        | BitFlagskeyword
         | ConstKeyword
         | DeclareKeyword
         | DefaultKeyword
@@ -4629,32 +4635,34 @@ namespace ts {
         Function                = 1 << 4,   // Function
         Class                   = 1 << 5,   // Class
         Interface               = 1 << 6,   // Interface
-        ConstEnum               = 1 << 7,   // Const enum
-        RegularEnum             = 1 << 8,   // Enum
-        ValueModule             = 1 << 9,   // Instantiated module
-        NamespaceModule         = 1 << 10,  // Uninstantiated module
-        TypeLiteral             = 1 << 11,  // Type Literal or mapped type
-        ObjectLiteral           = 1 << 12,  // Object Literal
-        Method                  = 1 << 13,  // Method
-        Constructor             = 1 << 14,  // Constructor
-        GetAccessor             = 1 << 15,  // Get accessor
-        SetAccessor             = 1 << 16,  // Set accessor
-        Signature               = 1 << 17,  // Call, construct, or index signature
-        TypeParameter           = 1 << 18,  // Type parameter
-        TypeAlias               = 1 << 19,  // Type alias
-        ExportValue             = 1 << 20,  // Exported value marker (see comment in declareModuleMember in binder)
-        Alias                   = 1 << 21,  // An alias for another symbol (see comment in isAliasSymbolDeclaration in checker)
-        Prototype               = 1 << 22,  // Prototype property (no source representation)
-        ExportStar              = 1 << 23,  // Export * declaration
-        Optional                = 1 << 24,  // Optional property
-        Transient               = 1 << 25,  // Transient symbol (created during type check)
-        Assignment              = 1 << 26,  // Assignment treated as declaration (eg `this.prop = 1`)
-        ModuleExports           = 1 << 27,  // Symbol for CommonJS `module` of `module.exports`
+        BitFlagsEnum            = 1 << 7,   // Bitflags enum
+        ConstEnum               = 1 << 8,   // Const enum
+        RegularEnum             = 1 << 9,   // Enum
+        ValueModule             = 1 << 10,   // Instantiated module
+        NamespaceModule         = 1 << 11,  // Uninstantiated module
+        TypeLiteral             = 1 << 12,  // Type Literal or mapped type
+        ObjectLiteral           = 1 << 13,  // Object Literal
+        Method                  = 1 << 14,  // Method
+        Constructor             = 1 << 15,  // Constructor
+        GetAccessor             = 1 << 16,  // Get accessor
+        SetAccessor             = 1 << 17,  // Set accessor
+        Signature               = 1 << 18,  // Call, construct, or index signature
+        TypeParameter           = 1 << 19,  // Type parameter
+        TypeAlias               = 1 << 20,  // Type alias
+        ExportValue             = 1 << 21,  // Exported value marker (see comment in declareModuleMember in binder)
+        Alias                   = 1 << 22,  // An alias for another symbol (see comment in isAliasSymbolDeclaration in checker)
+        Prototype               = 1 << 23,  // Prototype property (no source representation)
+        ExportStar              = 1 << 24,  // Export * declaration
+        Optional                = 1 << 25,  // Optional property
+        Transient               = 1 << 26,  // Transient symbol (created during type check)
+        Assignment              = 1 << 27,  // Assignment treated as declaration (eg `this.prop = 1`)
+        ModuleExports           = 1 << 28,  // Symbol for CommonJS `module` of `module.exports`
+
         /* @internal */
-        All = FunctionScopedVariable | BlockScopedVariable | Property | EnumMember | Function | Class | Interface | ConstEnum | RegularEnum | ValueModule | NamespaceModule | TypeLiteral
+        All = FunctionScopedVariable | BlockScopedVariable | Property | EnumMember | Function | Class | Interface | BitFlagsEnum | ConstEnum | RegularEnum | ValueModule | NamespaceModule | TypeLiteral
             | ObjectLiteral | Method | Constructor | GetAccessor | SetAccessor | Signature | TypeParameter | TypeAlias | ExportValue | Alias | Prototype | ExportStar | Optional | Transient,
 
-        Enum = RegularEnum | ConstEnum,
+        Enum = RegularEnum | ConstEnum | BitFlagsEnum,
         Variable = FunctionScopedVariable | BlockScopedVariable,
         Value = Variable | Property | EnumMember | ObjectLiteral | Function | Class | Enum | ValueModule | Method | GetAccessor | SetAccessor,
         Type = Class | Interface | Enum | EnumMember | TypeLiteral | TypeParameter | TypeAlias,

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1136,6 +1136,10 @@ namespace ts {
         return !!(getCombinedModifierFlags(node) & ModifierFlags.Const);
     }
 
+    export function isEnumBitFlags(node: EnumDeclaration): boolean {
+        return !!(getCombinedModifierFlags(node) & ModifierFlags.BitFlags);
+    }
+
     export function isDeclarationReadonly(declaration: Declaration): boolean {
         return !!(getCombinedModifierFlags(declaration) & ModifierFlags.Readonly && !isParameterPropertyDeclaration(declaration, declaration.parent));
     }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4767,6 +4767,7 @@ namespace ts {
             case SyntaxKind.AbstractKeyword: return ModifierFlags.Abstract;
             case SyntaxKind.ExportKeyword: return ModifierFlags.Export;
             case SyntaxKind.DeclareKeyword: return ModifierFlags.Ambient;
+            case SyntaxKind.BitFlagskeyword: return ModifierFlags.BitFlags;
             case SyntaxKind.ConstKeyword: return ModifierFlags.Const;
             case SyntaxKind.DefaultKeyword: return ModifierFlags.Default;
             case SyntaxKind.AsyncKeyword: return ModifierFlags.Async;

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -1139,10 +1139,11 @@ namespace ts {
     // Keywords
 
     /* @internal */
-    export function isModifierKind(token: SyntaxKind): token is Modifier["kind"] {
+    export function isModifierKind(token: SyntaxKind): token is ModifierSyntaxKind {
         switch (token) {
             case SyntaxKind.AbstractKeyword:
             case SyntaxKind.AsyncKeyword:
+            case SyntaxKind.BitFlagskeyword:
             case SyntaxKind.ConstKeyword:
             case SyntaxKind.DeclareKeyword:
             case SyntaxKind.DefaultKeyword:

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -3277,6 +3277,7 @@ namespace ts.server.protocol {
         allowUnusedLabels?: boolean;
         alwaysStrict?: boolean;
         baseUrl?: string;
+        bitEnum?: boolean;
         charset?: string;
         checkJs?: boolean;
         declaration?: boolean;

--- a/src/testRunner/unittests/services/transpile.ts
+++ b/src/testRunner/unittests/services/transpile.ts
@@ -235,6 +235,10 @@ var x = 0;`, {
             options: { compilerOptions: { baseUrl: "./folder/baseUrl" }, fileName: "input.js", reportDiagnostics: true }
         });
 
+        transpilesCorrectly("Supports setting 'bitEnum'", "x;", {
+            options: { compilerOptions: { bitEnum: true }, fileName: "input.js", reportDiagnostics: true }
+        });
+
         transpilesCorrectly("Supports setting 'charset'", "x;", {
             options: { compilerOptions: { charset: "en-us" }, fileName: "input.js", reportDiagnostics: true }
         });

--- a/tests/baselines/reference/bitflagsEnum.errors.txt
+++ b/tests/baselines/reference/bitflagsEnum.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/compiler/bitflagsEnum.ts(14,5): error TS18037: An enum member can only set one bit witout operator in bitflags enum.
 tests/cases/compiler/bitflagsEnum.ts(18,5): error TS18036: An enum member can only be number in bitflags enum.
-tests/cases/compiler/bitflagsEnum.ts(22,5): error TS18038: An enum member initializer can only use bitwise operator in bitflags enum.
-tests/cases/compiler/bitflagsEnum.ts(23,5): error TS18038: An enum member initializer can only use bitwise operator in bitflags enum.
-tests/cases/compiler/bitflagsEnum.ts(24,5): error TS18038: An enum member initializer can only use bitwise operator in bitflags enum.
+tests/cases/compiler/bitflagsEnum.ts(22,5): error TS18038: An enum member initializer can only use bitwise or shift operator in bitflags enum.
+tests/cases/compiler/bitflagsEnum.ts(23,5): error TS18038: An enum member initializer can only use bitwise or shift operator in bitflags enum.
+tests/cases/compiler/bitflagsEnum.ts(24,5): error TS18038: An enum member initializer can only use bitwise or shift operator in bitflags enum.
 tests/cases/compiler/bitflagsEnum.ts(33,9): error TS18033: Only numeric enums can have computed members, but this expression has type 'string'. If you do not need exhaustiveness checks, consider using an object literal instead.
 tests/cases/compiler/bitflagsEnum.ts(38,10): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
 tests/cases/compiler/bitflagsEnum.ts(38,10): error TS2623: Bit operation is only allowed for enum with 'bitflags' modifier
@@ -37,13 +37,13 @@ tests/cases/compiler/bitflagsEnum.ts(39,1): error TS2623: Bit operation is only 
     bitflags enum BitEnum3 {
         FOO = 1 + 2,
         ~~~
-!!! error TS18038: An enum member initializer can only use bitwise operator in bitflags enum.
+!!! error TS18038: An enum member initializer can only use bitwise or shift operator in bitflags enum.
         Foo2 = 1 + 2 | 7,
         ~~~~
-!!! error TS18038: An enum member initializer can only use bitwise operator in bitflags enum.
+!!! error TS18038: An enum member initializer can only use bitwise or shift operator in bitflags enum.
         Foo3 = 7 | 1 + 2
         ~~~~
-!!! error TS18038: An enum member initializer can only use bitwise operator in bitflags enum.
+!!! error TS18038: An enum member initializer can only use bitwise or shift operator in bitflags enum.
     }
     
     enum NormalEnum {

--- a/tests/baselines/reference/bitflagsEnum.errors.txt
+++ b/tests/baselines/reference/bitflagsEnum.errors.txt
@@ -1,0 +1,35 @@
+tests/cases/compiler/bitflagsEnum.ts(8,9): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+tests/cases/compiler/bitflagsEnum.ts(18,10): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+tests/cases/compiler/bitflagsEnum.ts(18,10): error TS2623: Bit operation is only allowed for enum with 'bitflags' modifier
+tests/cases/compiler/bitflagsEnum.ts(19,1): error TS2623: Bit operation is only allowed for enum with 'bitflags' modifier
+
+
+==== tests/cases/compiler/bitflagsEnum.ts (4 errors) ====
+    bitflags enum BitEnum {
+        TS = 3,
+        TSX = 4,
+    }
+    
+    var q = BitEnum.TS;
+    var w = BitEnum.TSX;
+    var e = "123" | w;
+            ~~~~~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+    q |= 2;
+    
+    enum NormalEnum{
+        Black,
+        White
+    }
+    
+    var q1 = NormalEnum.Black;
+    var w1 = NormalEnum.White;
+    var e1 = "123" | w1;
+             ~~~~~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+             ~~~~~~~~~~
+!!! error TS2623: Bit operation is only allowed for enum with 'bitflags' modifier
+    q1 |= 2;
+    ~~~~~~~
+!!! error TS2623: Bit operation is only allowed for enum with 'bitflags' modifier
+    

--- a/tests/baselines/reference/bitflagsEnum.errors.txt
+++ b/tests/baselines/reference/bitflagsEnum.errors.txt
@@ -1,25 +1,60 @@
-tests/cases/compiler/bitflagsEnum.ts(8,9): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
-tests/cases/compiler/bitflagsEnum.ts(18,10): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
-tests/cases/compiler/bitflagsEnum.ts(18,10): error TS2623: Bit operation is only allowed for enum with 'bitflags' modifier
-tests/cases/compiler/bitflagsEnum.ts(19,1): error TS2623: Bit operation is only allowed for enum with 'bitflags' modifier
+tests/cases/compiler/bitflagsEnum.ts(14,5): error TS18037: An enum member can only set one bit witout operator in bitflags enum.
+tests/cases/compiler/bitflagsEnum.ts(18,5): error TS18036: An enum member can only be number in bitflags enum.
+tests/cases/compiler/bitflagsEnum.ts(22,5): error TS18038: An enum member initializer can only use bitwise operator in bitflags enum.
+tests/cases/compiler/bitflagsEnum.ts(23,5): error TS18038: An enum member initializer can only use bitwise operator in bitflags enum.
+tests/cases/compiler/bitflagsEnum.ts(24,5): error TS18038: An enum member initializer can only use bitwise operator in bitflags enum.
+tests/cases/compiler/bitflagsEnum.ts(33,9): error TS18033: Only numeric enums can have computed members, but this expression has type 'string'. If you do not need exhaustiveness checks, consider using an object literal instead.
+tests/cases/compiler/bitflagsEnum.ts(38,10): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+tests/cases/compiler/bitflagsEnum.ts(38,10): error TS2623: Bit operation is only allowed for enum with 'bitflags' modifier
+tests/cases/compiler/bitflagsEnum.ts(39,1): error TS2623: Bit operation is only allowed for enum with 'bitflags' modifier
 
 
-==== tests/cases/compiler/bitflagsEnum.ts (4 errors) ====
+==== tests/cases/compiler/bitflagsEnum.ts (9 errors) ====
     bitflags enum BitEnum {
-        TS = 3,
-        TSX = 4,
+        TS = 1,
+        TSX = 2,
+        All = TS | TSX,
     }
     
-    var q = BitEnum.TS;
-    var w = BitEnum.TSX;
-    var e = "123" | w;
-            ~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
-    q |= 2;
+    var foo1 = BitEnum.TS;
+    var foo2 = BitEnum.TSX;
+    var foo3 = foo1 | foo2; // foo3 is possiable to be BitEnum.All?
+    declare var foo4: BitEnum;
+    var foo5 = foo4 & foo1; // foo5 is possiable to be BitEnum.TS?
     
-    enum NormalEnum{
+    bitflags enum BitEnum1 {
+        FOO = 3
+        ~~~
+!!! error TS18037: An enum member can only set one bit witout operator in bitflags enum.
+    }
+    
+    bitflags enum BitEnum2 {
+        FOO = "foo"
+        ~~~
+!!! error TS18036: An enum member can only be number in bitflags enum.
+    }
+    
+    bitflags enum BitEnum3 {
+        FOO = 1 + 2,
+        ~~~
+!!! error TS18038: An enum member initializer can only use bitwise operator in bitflags enum.
+        Foo2 = 1 + 2 | 7,
+        ~~~~
+!!! error TS18038: An enum member initializer can only use bitwise operator in bitflags enum.
+        Foo3 = 7 | 1 + 2
+        ~~~~
+!!! error TS18038: An enum member initializer can only use bitwise operator in bitflags enum.
+    }
+    
+    enum NormalEnum {
         Black,
         White
+    }
+    
+    enum Q{
+        q = "2"+1
+            ~~~~~
+!!! error TS18033: Only numeric enums can have computed members, but this expression has type 'string'. If you do not need exhaustiveness checks, consider using an object literal instead.
     }
     
     var q1 = NormalEnum.Black;

--- a/tests/baselines/reference/bitflagsEnum.js
+++ b/tests/baselines/reference/bitflagsEnum.js
@@ -1,17 +1,37 @@
 //// [bitflagsEnum.ts]
 bitflags enum BitEnum {
-    TS = 3,
-    TSX = 4,
+    TS = 1,
+    TSX = 2,
+    All = TS | TSX,
 }
 
-var q = BitEnum.TS;
-var w = BitEnum.TSX;
-var e = "123" | w;
-q |= 2;
+var foo1 = BitEnum.TS;
+var foo2 = BitEnum.TSX;
+var foo3 = foo1 | foo2; // foo3 is possiable to be BitEnum.All?
+declare var foo4: BitEnum;
+var foo5 = foo4 & foo1; // foo5 is possiable to be BitEnum.TS?
 
-enum NormalEnum{
+bitflags enum BitEnum1 {
+    FOO = 3
+}
+
+bitflags enum BitEnum2 {
+    FOO = "foo"
+}
+
+bitflags enum BitEnum3 {
+    FOO = 1 + 2,
+    Foo2 = 1 + 2 | 7,
+    Foo3 = 7 | 1 + 2
+}
+
+enum NormalEnum {
     Black,
     White
+}
+
+enum Q{
+    q = "2"+1
 }
 
 var q1 = NormalEnum.Black;
@@ -23,18 +43,37 @@ q1 |= 2;
 //// [bitflagsEnum.js]
 var BitEnum;
 (function (BitEnum) {
-    BitEnum[BitEnum["TS"] = 3] = "TS";
-    BitEnum[BitEnum["TSX"] = 4] = "TSX";
+    BitEnum[BitEnum["TS"] = 1] = "TS";
+    BitEnum[BitEnum["TSX"] = 2] = "TSX";
+    BitEnum[BitEnum["All"] = 3] = "All";
 })(BitEnum || (BitEnum = {}));
-var q = BitEnum.TS;
-var w = BitEnum.TSX;
-var e = "123" | w;
-q |= 2;
+var foo1 = BitEnum.TS;
+var foo2 = BitEnum.TSX;
+var foo3 = foo1 | foo2; // foo3 is possiable to be BitEnum.All?
+var foo5 = foo4 & foo1; // foo5 is possiable to be BitEnum.TS?
+var BitEnum1;
+(function (BitEnum1) {
+    BitEnum1[BitEnum1["FOO"] = 3] = "FOO";
+})(BitEnum1 || (BitEnum1 = {}));
+var BitEnum2;
+(function (BitEnum2) {
+    BitEnum2["FOO"] = "foo";
+})(BitEnum2 || (BitEnum2 = {}));
+var BitEnum3;
+(function (BitEnum3) {
+    BitEnum3[BitEnum3["FOO"] = 3] = "FOO";
+    BitEnum3[BitEnum3["Foo2"] = 7] = "Foo2";
+    BitEnum3[BitEnum3["Foo3"] = 7] = "Foo3";
+})(BitEnum3 || (BitEnum3 = {}));
 var NormalEnum;
 (function (NormalEnum) {
     NormalEnum[NormalEnum["Black"] = 0] = "Black";
     NormalEnum[NormalEnum["White"] = 1] = "White";
 })(NormalEnum || (NormalEnum = {}));
+var Q;
+(function (Q) {
+    Q[Q["q"] = "2" + 1] = "q";
+})(Q || (Q = {}));
 var q1 = NormalEnum.Black;
 var w1 = NormalEnum.White;
 var e1 = "123" | w1;

--- a/tests/baselines/reference/bitflagsEnum.js
+++ b/tests/baselines/reference/bitflagsEnum.js
@@ -1,0 +1,41 @@
+//// [bitflagsEnum.ts]
+bitflags enum BitEnum {
+    TS = 3,
+    TSX = 4,
+}
+
+var q = BitEnum.TS;
+var w = BitEnum.TSX;
+var e = "123" | w;
+q |= 2;
+
+enum NormalEnum{
+    Black,
+    White
+}
+
+var q1 = NormalEnum.Black;
+var w1 = NormalEnum.White;
+var e1 = "123" | w1;
+q1 |= 2;
+
+
+//// [bitflagsEnum.js]
+var BitEnum;
+(function (BitEnum) {
+    BitEnum[BitEnum["TS"] = 3] = "TS";
+    BitEnum[BitEnum["TSX"] = 4] = "TSX";
+})(BitEnum || (BitEnum = {}));
+var q = BitEnum.TS;
+var w = BitEnum.TSX;
+var e = "123" | w;
+q |= 2;
+var NormalEnum;
+(function (NormalEnum) {
+    NormalEnum[NormalEnum["Black"] = 0] = "Black";
+    NormalEnum[NormalEnum["White"] = 1] = "White";
+})(NormalEnum || (NormalEnum = {}));
+var q1 = NormalEnum.Black;
+var w1 = NormalEnum.White;
+var e1 = "123" | w1;
+q1 |= 2;

--- a/tests/baselines/reference/bitflagsEnum.symbols
+++ b/tests/baselines/reference/bitflagsEnum.symbols
@@ -1,0 +1,59 @@
+=== tests/cases/compiler/bitflagsEnum.ts ===
+bitflags enum BitEnum {
+>BitEnum : Symbol(BitEnum, Decl(bitflagsEnum.ts, 0, 0))
+
+    TS = 3,
+>TS : Symbol(BitEnum.TS, Decl(bitflagsEnum.ts, 0, 23))
+
+    TSX = 4,
+>TSX : Symbol(BitEnum.TSX, Decl(bitflagsEnum.ts, 1, 11))
+}
+
+var q = BitEnum.TS;
+>q : Symbol(q, Decl(bitflagsEnum.ts, 5, 3))
+>BitEnum.TS : Symbol(BitEnum.TS, Decl(bitflagsEnum.ts, 0, 23))
+>BitEnum : Symbol(BitEnum, Decl(bitflagsEnum.ts, 0, 0))
+>TS : Symbol(BitEnum.TS, Decl(bitflagsEnum.ts, 0, 23))
+
+var w = BitEnum.TSX;
+>w : Symbol(w, Decl(bitflagsEnum.ts, 6, 3))
+>BitEnum.TSX : Symbol(BitEnum.TSX, Decl(bitflagsEnum.ts, 1, 11))
+>BitEnum : Symbol(BitEnum, Decl(bitflagsEnum.ts, 0, 0))
+>TSX : Symbol(BitEnum.TSX, Decl(bitflagsEnum.ts, 1, 11))
+
+var e = "123" | w;
+>e : Symbol(e, Decl(bitflagsEnum.ts, 7, 3))
+>w : Symbol(w, Decl(bitflagsEnum.ts, 6, 3))
+
+q |= 2;
+>q : Symbol(q, Decl(bitflagsEnum.ts, 5, 3))
+
+enum NormalEnum{
+>NormalEnum : Symbol(NormalEnum, Decl(bitflagsEnum.ts, 8, 7))
+
+    Black,
+>Black : Symbol(NormalEnum.Black, Decl(bitflagsEnum.ts, 10, 16))
+
+    White
+>White : Symbol(NormalEnum.White, Decl(bitflagsEnum.ts, 11, 10))
+}
+
+var q1 = NormalEnum.Black;
+>q1 : Symbol(q1, Decl(bitflagsEnum.ts, 15, 3))
+>NormalEnum.Black : Symbol(NormalEnum.Black, Decl(bitflagsEnum.ts, 10, 16))
+>NormalEnum : Symbol(NormalEnum, Decl(bitflagsEnum.ts, 8, 7))
+>Black : Symbol(NormalEnum.Black, Decl(bitflagsEnum.ts, 10, 16))
+
+var w1 = NormalEnum.White;
+>w1 : Symbol(w1, Decl(bitflagsEnum.ts, 16, 3))
+>NormalEnum.White : Symbol(NormalEnum.White, Decl(bitflagsEnum.ts, 11, 10))
+>NormalEnum : Symbol(NormalEnum, Decl(bitflagsEnum.ts, 8, 7))
+>White : Symbol(NormalEnum.White, Decl(bitflagsEnum.ts, 11, 10))
+
+var e1 = "123" | w1;
+>e1 : Symbol(e1, Decl(bitflagsEnum.ts, 17, 3))
+>w1 : Symbol(w1, Decl(bitflagsEnum.ts, 16, 3))
+
+q1 |= 2;
+>q1 : Symbol(q1, Decl(bitflagsEnum.ts, 15, 3))
+

--- a/tests/baselines/reference/bitflagsEnum.symbols
+++ b/tests/baselines/reference/bitflagsEnum.symbols
@@ -2,58 +2,104 @@
 bitflags enum BitEnum {
 >BitEnum : Symbol(BitEnum, Decl(bitflagsEnum.ts, 0, 0))
 
-    TS = 3,
+    TS = 1,
 >TS : Symbol(BitEnum.TS, Decl(bitflagsEnum.ts, 0, 23))
 
-    TSX = 4,
+    TSX = 2,
+>TSX : Symbol(BitEnum.TSX, Decl(bitflagsEnum.ts, 1, 11))
+
+    All = TS | TSX,
+>All : Symbol(BitEnum.All, Decl(bitflagsEnum.ts, 2, 12))
+>TS : Symbol(BitEnum.TS, Decl(bitflagsEnum.ts, 0, 23))
 >TSX : Symbol(BitEnum.TSX, Decl(bitflagsEnum.ts, 1, 11))
 }
 
-var q = BitEnum.TS;
->q : Symbol(q, Decl(bitflagsEnum.ts, 5, 3))
+var foo1 = BitEnum.TS;
+>foo1 : Symbol(foo1, Decl(bitflagsEnum.ts, 6, 3))
 >BitEnum.TS : Symbol(BitEnum.TS, Decl(bitflagsEnum.ts, 0, 23))
 >BitEnum : Symbol(BitEnum, Decl(bitflagsEnum.ts, 0, 0))
 >TS : Symbol(BitEnum.TS, Decl(bitflagsEnum.ts, 0, 23))
 
-var w = BitEnum.TSX;
->w : Symbol(w, Decl(bitflagsEnum.ts, 6, 3))
+var foo2 = BitEnum.TSX;
+>foo2 : Symbol(foo2, Decl(bitflagsEnum.ts, 7, 3))
 >BitEnum.TSX : Symbol(BitEnum.TSX, Decl(bitflagsEnum.ts, 1, 11))
 >BitEnum : Symbol(BitEnum, Decl(bitflagsEnum.ts, 0, 0))
 >TSX : Symbol(BitEnum.TSX, Decl(bitflagsEnum.ts, 1, 11))
 
-var e = "123" | w;
->e : Symbol(e, Decl(bitflagsEnum.ts, 7, 3))
->w : Symbol(w, Decl(bitflagsEnum.ts, 6, 3))
+var foo3 = foo1 | foo2; // foo3 is possiable to be BitEnum.All?
+>foo3 : Symbol(foo3, Decl(bitflagsEnum.ts, 8, 3))
+>foo1 : Symbol(foo1, Decl(bitflagsEnum.ts, 6, 3))
+>foo2 : Symbol(foo2, Decl(bitflagsEnum.ts, 7, 3))
 
-q |= 2;
->q : Symbol(q, Decl(bitflagsEnum.ts, 5, 3))
+declare var foo4: BitEnum;
+>foo4 : Symbol(foo4, Decl(bitflagsEnum.ts, 9, 11))
+>BitEnum : Symbol(BitEnum, Decl(bitflagsEnum.ts, 0, 0))
 
-enum NormalEnum{
->NormalEnum : Symbol(NormalEnum, Decl(bitflagsEnum.ts, 8, 7))
+var foo5 = foo4 & foo1; // foo5 is possiable to be BitEnum.TS?
+>foo5 : Symbol(foo5, Decl(bitflagsEnum.ts, 10, 3))
+>foo4 : Symbol(foo4, Decl(bitflagsEnum.ts, 9, 11))
+>foo1 : Symbol(foo1, Decl(bitflagsEnum.ts, 6, 3))
+
+bitflags enum BitEnum1 {
+>BitEnum1 : Symbol(BitEnum1, Decl(bitflagsEnum.ts, 10, 23))
+
+    FOO = 3
+>FOO : Symbol(BitEnum1.FOO, Decl(bitflagsEnum.ts, 12, 24))
+}
+
+bitflags enum BitEnum2 {
+>BitEnum2 : Symbol(BitEnum2, Decl(bitflagsEnum.ts, 14, 1))
+
+    FOO = "foo"
+>FOO : Symbol(BitEnum2.FOO, Decl(bitflagsEnum.ts, 16, 24))
+}
+
+bitflags enum BitEnum3 {
+>BitEnum3 : Symbol(BitEnum3, Decl(bitflagsEnum.ts, 18, 1))
+
+    FOO = 1 + 2,
+>FOO : Symbol(BitEnum3.FOO, Decl(bitflagsEnum.ts, 20, 24))
+
+    Foo2 = 1 + 2 | 7,
+>Foo2 : Symbol(BitEnum3.Foo2, Decl(bitflagsEnum.ts, 21, 16))
+
+    Foo3 = 7 | 1 + 2
+>Foo3 : Symbol(BitEnum3.Foo3, Decl(bitflagsEnum.ts, 22, 21))
+}
+
+enum NormalEnum {
+>NormalEnum : Symbol(NormalEnum, Decl(bitflagsEnum.ts, 24, 1))
 
     Black,
->Black : Symbol(NormalEnum.Black, Decl(bitflagsEnum.ts, 10, 16))
+>Black : Symbol(NormalEnum.Black, Decl(bitflagsEnum.ts, 26, 17))
 
     White
->White : Symbol(NormalEnum.White, Decl(bitflagsEnum.ts, 11, 10))
+>White : Symbol(NormalEnum.White, Decl(bitflagsEnum.ts, 27, 10))
+}
+
+enum Q{
+>Q : Symbol(Q, Decl(bitflagsEnum.ts, 29, 1))
+
+    q = "2"+1
+>q : Symbol(Q.q, Decl(bitflagsEnum.ts, 31, 7))
 }
 
 var q1 = NormalEnum.Black;
->q1 : Symbol(q1, Decl(bitflagsEnum.ts, 15, 3))
->NormalEnum.Black : Symbol(NormalEnum.Black, Decl(bitflagsEnum.ts, 10, 16))
->NormalEnum : Symbol(NormalEnum, Decl(bitflagsEnum.ts, 8, 7))
->Black : Symbol(NormalEnum.Black, Decl(bitflagsEnum.ts, 10, 16))
+>q1 : Symbol(q1, Decl(bitflagsEnum.ts, 35, 3))
+>NormalEnum.Black : Symbol(NormalEnum.Black, Decl(bitflagsEnum.ts, 26, 17))
+>NormalEnum : Symbol(NormalEnum, Decl(bitflagsEnum.ts, 24, 1))
+>Black : Symbol(NormalEnum.Black, Decl(bitflagsEnum.ts, 26, 17))
 
 var w1 = NormalEnum.White;
->w1 : Symbol(w1, Decl(bitflagsEnum.ts, 16, 3))
->NormalEnum.White : Symbol(NormalEnum.White, Decl(bitflagsEnum.ts, 11, 10))
->NormalEnum : Symbol(NormalEnum, Decl(bitflagsEnum.ts, 8, 7))
->White : Symbol(NormalEnum.White, Decl(bitflagsEnum.ts, 11, 10))
+>w1 : Symbol(w1, Decl(bitflagsEnum.ts, 36, 3))
+>NormalEnum.White : Symbol(NormalEnum.White, Decl(bitflagsEnum.ts, 27, 10))
+>NormalEnum : Symbol(NormalEnum, Decl(bitflagsEnum.ts, 24, 1))
+>White : Symbol(NormalEnum.White, Decl(bitflagsEnum.ts, 27, 10))
 
 var e1 = "123" | w1;
->e1 : Symbol(e1, Decl(bitflagsEnum.ts, 17, 3))
->w1 : Symbol(w1, Decl(bitflagsEnum.ts, 16, 3))
+>e1 : Symbol(e1, Decl(bitflagsEnum.ts, 37, 3))
+>w1 : Symbol(w1, Decl(bitflagsEnum.ts, 36, 3))
 
 q1 |= 2;
->q1 : Symbol(q1, Decl(bitflagsEnum.ts, 15, 3))
+>q1 : Symbol(q1, Decl(bitflagsEnum.ts, 35, 3))
 

--- a/tests/baselines/reference/bitflagsEnum.types
+++ b/tests/baselines/reference/bitflagsEnum.types
@@ -2,39 +2,91 @@
 bitflags enum BitEnum {
 >BitEnum : BitEnum
 
-    TS = 3,
->TS : BitEnum.TS
->3 : 3
+    TS = 1,
+>TS : BitEnum
+>1 : 1
 
-    TSX = 4,
->TSX : BitEnum.TSX
->4 : 4
-}
-
-var q = BitEnum.TS;
->q : BitEnum
->BitEnum.TS : BitEnum.TS
->BitEnum : typeof BitEnum
->TS : BitEnum.TS
-
-var w = BitEnum.TSX;
->w : BitEnum
->BitEnum.TSX : BitEnum.TSX
->BitEnum : typeof BitEnum
->TSX : BitEnum.TSX
-
-var e = "123" | w;
->e : number
->"123" | w : number
->"123" : "123"
->w : BitEnum.TSX
-
-q |= 2;
->q |= 2 : number
->q : BitEnum
+    TSX = 2,
+>TSX : BitEnum
 >2 : 2
 
-enum NormalEnum{
+    All = TS | TSX,
+>All : BitEnum
+>TS | TSX : number
+>TS : BitEnum
+>TSX : BitEnum
+}
+
+var foo1 = BitEnum.TS;
+>foo1 : BitEnum
+>BitEnum.TS : BitEnum
+>BitEnum : typeof BitEnum
+>TS : BitEnum
+
+var foo2 = BitEnum.TSX;
+>foo2 : BitEnum
+>BitEnum.TSX : BitEnum
+>BitEnum : typeof BitEnum
+>TSX : BitEnum
+
+var foo3 = foo1 | foo2; // foo3 is possiable to be BitEnum.All?
+>foo3 : number
+>foo1 | foo2 : number
+>foo1 : BitEnum
+>foo2 : BitEnum
+
+declare var foo4: BitEnum;
+>foo4 : BitEnum
+
+var foo5 = foo4 & foo1; // foo5 is possiable to be BitEnum.TS?
+>foo5 : number
+>foo4 & foo1 : number
+>foo4 : BitEnum
+>foo1 : BitEnum
+
+bitflags enum BitEnum1 {
+>BitEnum1 : BitEnum1
+
+    FOO = 3
+>FOO : BitEnum1.FOO
+>3 : 3
+}
+
+bitflags enum BitEnum2 {
+>BitEnum2 : BitEnum2
+
+    FOO = "foo"
+>FOO : BitEnum2.FOO
+>"foo" : "foo"
+}
+
+bitflags enum BitEnum3 {
+>BitEnum3 : BitEnum3
+
+    FOO = 1 + 2,
+>FOO : BitEnum3
+>1 + 2 : number
+>1 : 1
+>2 : 2
+
+    Foo2 = 1 + 2 | 7,
+>Foo2 : BitEnum3
+>1 + 2 | 7 : number
+>1 + 2 : number
+>1 : 1
+>2 : 2
+>7 : 7
+
+    Foo3 = 7 | 1 + 2
+>Foo3 : BitEnum3
+>7 | 1 + 2 : number
+>7 : 7
+>1 + 2 : number
+>1 : 1
+>2 : 2
+}
+
+enum NormalEnum {
 >NormalEnum : NormalEnum
 
     Black,
@@ -42,6 +94,16 @@ enum NormalEnum{
 
     White
 >White : NormalEnum.White
+}
+
+enum Q{
+>Q : Q
+
+    q = "2"+1
+>q : Q
+>"2"+1 : string
+>"2" : "2"
+>1 : 1
 }
 
 var q1 = NormalEnum.Black;

--- a/tests/baselines/reference/bitflagsEnum.types
+++ b/tests/baselines/reference/bitflagsEnum.types
@@ -1,0 +1,69 @@
+=== tests/cases/compiler/bitflagsEnum.ts ===
+bitflags enum BitEnum {
+>BitEnum : BitEnum
+
+    TS = 3,
+>TS : BitEnum.TS
+>3 : 3
+
+    TSX = 4,
+>TSX : BitEnum.TSX
+>4 : 4
+}
+
+var q = BitEnum.TS;
+>q : BitEnum
+>BitEnum.TS : BitEnum.TS
+>BitEnum : typeof BitEnum
+>TS : BitEnum.TS
+
+var w = BitEnum.TSX;
+>w : BitEnum
+>BitEnum.TSX : BitEnum.TSX
+>BitEnum : typeof BitEnum
+>TSX : BitEnum.TSX
+
+var e = "123" | w;
+>e : number
+>"123" | w : number
+>"123" : "123"
+>w : BitEnum.TSX
+
+q |= 2;
+>q |= 2 : number
+>q : BitEnum
+>2 : 2
+
+enum NormalEnum{
+>NormalEnum : NormalEnum
+
+    Black,
+>Black : NormalEnum.Black
+
+    White
+>White : NormalEnum.White
+}
+
+var q1 = NormalEnum.Black;
+>q1 : NormalEnum
+>NormalEnum.Black : NormalEnum.Black
+>NormalEnum : typeof NormalEnum
+>Black : NormalEnum.Black
+
+var w1 = NormalEnum.White;
+>w1 : NormalEnum
+>NormalEnum.White : NormalEnum.White
+>NormalEnum : typeof NormalEnum
+>White : NormalEnum.White
+
+var e1 = "123" | w1;
+>e1 : number
+>"123" | w1 : number
+>"123" : "123"
+>w1 : NormalEnum.White
+
+q1 |= 2;
+>q1 |= 2 : number
+>q1 : NormalEnum
+>2 : 2
+

--- a/tests/cases/compiler/bitflagsEnum.ts
+++ b/tests/cases/compiler/bitflagsEnum.ts
@@ -1,14 +1,22 @@
-bitflags enum BitEnum {
-    TS = 3,
-    TSX = 4,
+enum BitEnum {
+    TS = 1,
+    TSX = 3,
+    All = TS | TSX,
 }
 
-var q = BitEnum.TS;
-var w = BitEnum.TSX;
-var e = "123" | w;
+public private const foo111 = 123;
+
+const foo1 = BitEnum.TS;
+var foo2 = BitEnum.TSX;
+var foo3 = foo1 | foo2; // foo3 is possiable to be BitEnum.All?
+declare var foo4: BitEnum;
+var foo5 = foo4 & foo1; // foo5 is possiable to be BitEnum.TS?
+
+w = BitEnum.TS;
+var e = w | w;
 q |= 2;
 
-enum NormalEnum{
+enum NormalEnum {
     Black,
     White
 }

--- a/tests/cases/compiler/bitflagsEnum.ts
+++ b/tests/cases/compiler/bitflagsEnum.ts
@@ -1,0 +1,19 @@
+bitflags enum BitEnum {
+    TS = 3,
+    TSX = 4,
+}
+
+var q = BitEnum.TS;
+var w = BitEnum.TSX;
+var e = "123" | w;
+q |= 2;
+
+enum NormalEnum{
+    Black,
+    White
+}
+
+var q1 = NormalEnum.Black;
+var w1 = NormalEnum.White;
+var e1 = "123" | w1;
+q1 |= 2;

--- a/tests/cases/compiler/bitflagsEnum.ts
+++ b/tests/cases/compiler/bitflagsEnum.ts
@@ -1,24 +1,37 @@
-enum BitEnum {
+// @bitEnum: true
+bitflags enum BitEnum {
     TS = 1,
-    TSX = 3,
+    TSX = 2,
     All = TS | TSX,
 }
 
-public private const foo111 = 123;
-
-const foo1 = BitEnum.TS;
+var foo1 = BitEnum.TS;
 var foo2 = BitEnum.TSX;
 var foo3 = foo1 | foo2; // foo3 is possiable to be BitEnum.All?
 declare var foo4: BitEnum;
 var foo5 = foo4 & foo1; // foo5 is possiable to be BitEnum.TS?
 
-w = BitEnum.TS;
-var e = w | w;
-q |= 2;
+bitflags enum BitEnum1 {
+    FOO = 3
+}
+
+bitflags enum BitEnum2 {
+    FOO = "foo"
+}
+
+bitflags enum BitEnum3 {
+    FOO = 1 + 2,
+    Foo2 = 1 + 2 | 7,
+    Foo3 = 7 | 1 + 2
+}
 
 enum NormalEnum {
     Black,
     White
+}
+
+enum Q{
+    q = "2"+1
 }
 
 var q1 = NormalEnum.Black;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #42521

 - [x] Add modifier `bitflags`.
 - [x] bit operator(`|`,`|=`,`&`,`&=`,`^`,`^=`) is only allowed for bitflags enum, if left or right is enum.
 - [x] Add new flag to enable `bitflags` check.

The second one is a big break! Maybe it should be loosen, but how?

And I think there are more features could be added!
- [x] bitflags enum member could only be initialized by BitwiseOperator(&,|,^) or ShiftOperator(<<,>>,>>>)  or bit number
```
bitflags enum BitEnum {
    TS = 1,     // 1 is 1 << 0, OK
    TSX = 2,    // 2 is 1 << 1, OK
    ERR2 = "1", // "1" is not number, error
    All = TS | TSX, // initialized through `|`, should be OK without "1"
    All2 = 3,    // 3 is not a bit, error
    All3 = 1+2 // '+' is not  BitwiseOperator or ShiftOperator, error.
}
```

- [ ] more accurate type.
``` ts
bitflags enum BitEnum {
    TS = 1,
    TSX = 2,
    TSAlias = TS,
    All = TS | TSX,
}
const foo1 = BitEnum.TSAlias;
const foo2 = BitEnum.TSX;
const foo3 = foo1 | foo2;    // what is foo1 type? `BitEnum.TS` or `BitEnum.TSAlias`?
``` 

- [ ] give accurate type when both bitflags enum are known.
``` ts
bitflags enum BitEnum {
    TS = 1,
    TSX = 2,
    All = TS | TSX,
}

var foo1 = BitEnum.TS;
var foo2 = BitEnum.TSX;
var foo3 = foo1 | foo2; // foo3 is possiable to be BitEnum.All?
declare var foo4: BitEnum;
var foo5 = foo4 & foo1; // foo5 is possiable to be BitEnum.TS?

```


---
Some Questions:
1. What should be the flag name? Should it be "strict"? Personally, I want to enable this feature in any new project, but it might be a big break for current project. Now it is `bitEnum`
2. Is there a better name rather than `bitflags`?
3. How to mark enum as `bit`? Should `bitflags` be a modifier or tag or something else?
4. Are error messages easy to understand? I am clearly not a English native speaker, they might looks wired now.