### PR TITLE
Narrow QualifiedName inside typeof

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2540,6 +2540,11 @@ namespace ts {
                         node.flowNode = currentFlow;
                     }
                     return checkContextualIdentifier(<Identifier>node);
+                case SyntaxKind.QualifiedName:
+                    if (currentFlow && parent.kind === SyntaxKind.TypeQuery) {
+                        node.flowNode = currentFlow;
+                    }
+                    break;
                 case SyntaxKind.SuperKeyword:
                     node.flowNode = currentFlow;
                     break;

--- a/tests/baselines/reference/controlFlowIfStatement.js
+++ b/tests/baselines/reference/controlFlowIfStatement.js
@@ -52,6 +52,15 @@ function d<T extends string>(data: string | T): never {
     }
 }
 
+interface I<T> {
+  p: T;
+}
+function e(x: I<"A" | "B">) {
+    if (x.p === "A") {
+        let a: "A" = (null as unknown as typeof x.p)
+    }
+}
+
 
 //// [controlFlowIfStatement.js]
 var x;
@@ -102,5 +111,10 @@ function d(data) {
     }
     else {
         return data;
+    }
+}
+function e(x) {
+    if (x.p === "A") {
+        var a_1 = null;
     }
 }

--- a/tests/baselines/reference/controlFlowIfStatement.symbols
+++ b/tests/baselines/reference/controlFlowIfStatement.symbols
@@ -110,3 +110,29 @@ function d<T extends string>(data: string | T): never {
     }
 }
 
+interface I<T> {
+>I : Symbol(I, Decl(controlFlowIfStatement.ts, 51, 1))
+>T : Symbol(T, Decl(controlFlowIfStatement.ts, 53, 12))
+
+  p: T;
+>p : Symbol(I.p, Decl(controlFlowIfStatement.ts, 53, 16))
+>T : Symbol(T, Decl(controlFlowIfStatement.ts, 53, 12))
+}
+function e(x: I<"A" | "B">) {
+>e : Symbol(e, Decl(controlFlowIfStatement.ts, 55, 1))
+>x : Symbol(x, Decl(controlFlowIfStatement.ts, 56, 11))
+>I : Symbol(I, Decl(controlFlowIfStatement.ts, 51, 1))
+
+    if (x.p === "A") {
+>x.p : Symbol(I.p, Decl(controlFlowIfStatement.ts, 53, 16))
+>x : Symbol(x, Decl(controlFlowIfStatement.ts, 56, 11))
+>p : Symbol(I.p, Decl(controlFlowIfStatement.ts, 53, 16))
+
+        let a: "A" = (null as unknown as typeof x.p)
+>a : Symbol(a, Decl(controlFlowIfStatement.ts, 58, 11))
+>x.p : Symbol(I.p, Decl(controlFlowIfStatement.ts, 53, 16))
+>x : Symbol(x, Decl(controlFlowIfStatement.ts, 56, 11))
+>p : Symbol(I.p, Decl(controlFlowIfStatement.ts, 53, 16))
+    }
+}
+

--- a/tests/baselines/reference/controlFlowIfStatement.types
+++ b/tests/baselines/reference/controlFlowIfStatement.types
@@ -132,3 +132,30 @@ function d<T extends string>(data: string | T): never {
     }
 }
 
+interface I<T> {
+  p: T;
+>p : T
+}
+function e(x: I<"A" | "B">) {
+>e : (x: I<"A" | "B">) => void
+>x : I<"A" | "B">
+
+    if (x.p === "A") {
+>x.p === "A" : boolean
+>x.p : "A" | "B"
+>x : I<"A" | "B">
+>p : "A" | "B"
+>"A" : "A"
+
+        let a: "A" = (null as unknown as typeof x.p)
+>a : "A"
+>(null as unknown as typeof x.p) : "A"
+>null as unknown as typeof x.p : "A"
+>null as unknown : unknown
+>null : null
+>x.p : "A"
+>x : I<"A" | "B">
+>p : "A"
+    }
+}
+

--- a/tests/cases/conformance/controlFlow/controlFlowIfStatement.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowIfStatement.ts
@@ -52,3 +52,12 @@ function d<T extends string>(data: string | T): never {
         return data;
     }
 }
+
+interface I<T> {
+  p: T;
+}
+function e(x: I<"A" | "B">) {
+    if (x.p === "A") {
+        let a: "A" = (null as unknown as typeof x.p)
+    }
+}


### PR DESCRIPTION
Previously this wasn't narrowed at all. Now there is a control flow node and code in isMatchingReference.

I think this is a straightforward improvement as long as it doesn't cause performance problems.

Fixes #40977
