### PR TITLE
Keep extended config's raw file, include, exclude relative to itself and correct it when setting extending options

### DIFF
--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -112,6 +112,7 @@
         "unittests/services/transpile.ts",
         "unittests/tsbuild/amdModulesWithOut.ts",
         "unittests/tsbuild/configFileErrors.ts",
+        "unittests/tsbuild/configFileExtends.ts",
         "unittests/tsbuild/containerOnlyReferenced.ts",
         "unittests/tsbuild/declarationEmit.ts",
         "unittests/tsbuild/demo.ts",

--- a/src/testRunner/unittests/tsbuild/configFileExtends.ts
+++ b/src/testRunner/unittests/tsbuild/configFileExtends.ts
@@ -1,0 +1,52 @@
+namespace ts {
+    describe("unittests:: tsbuild:: configFileExtends:: when tsconfig extends another config", () => {
+        function getConfigExtendsWithIncludeFs() {
+            return loadProjectFromFiles({
+                "/src/tsconfig.json": JSON.stringify({
+                    references: [
+                        { path: "./shared/tsconfig.json" },
+                        { path: "./webpack/tsconfig.json" }
+                    ],
+                    files: []
+                }),
+                "/src/shared/tsconfig-base.json": JSON.stringify({
+                    include: ["./typings-base/"]
+                }),
+                "/src/shared/typings-base/globals.d.ts": `type Unrestricted = any;`,
+                "/src/shared/tsconfig.json": JSON.stringify({
+                    extends: "./tsconfig-base.json",
+                    compilerOptions: {
+                        composite: true,
+                        outDir: "../target-tsc-build/",
+                        rootDir: ".."
+                    },
+                    files: ["./index.ts"]
+                }),
+                "/src/shared/index.ts": `export const a: Unrestricted = 1;`,
+                "/src/webpack/tsconfig.json": JSON.stringify({
+                    extends: "../shared/tsconfig-base.json",
+                    compilerOptions: {
+                        composite: true,
+                        outDir: "../target-tsc-build/",
+                        rootDir: ".."
+                    },
+                    files: ["./index.ts"],
+                    references: [{ path: "../shared/tsconfig.json" }]
+                }),
+                "/src/webpack/index.ts": `export const b: Unrestricted = 1;`,
+            });
+        }
+        verifyTsc({
+            scenario: "configFileExtends",
+            subScenario: "when building solution with projects extends config with include",
+            fs: getConfigExtendsWithIncludeFs,
+            commandLineArgs: ["--b", "/src/tsconfig.json", "--v", "--listFiles"],
+        });
+        verifyTsc({
+            scenario: "configFileExtends",
+            subScenario: "when building project uses reference and both extend config with include",
+            fs: getConfigExtendsWithIncludeFs,
+            commandLineArgs: ["--b", "/src/webpack/tsconfig.json", "--v", "--listFiles"],
+        });
+    });
+}

--- a/tests/baselines/reference/tsbuild/configFileExtends/initial-build/when-building-project-uses-reference-and-both-extend-config-with-include.js
+++ b/tests/baselines/reference/tsbuild/configFileExtends/initial-build/when-building-project-uses-reference-and-both-extend-config-with-include.js
@@ -1,0 +1,160 @@
+Input::
+//// [/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+//// [/src/shared/index.ts]
+export const a: Unrestricted = 1;
+
+//// [/src/shared/tsconfig-base.json]
+{"include":["./typings-base/"]}
+
+//// [/src/shared/tsconfig.json]
+{"extends":"./tsconfig-base.json","compilerOptions":{"composite":true,"outDir":"../target-tsc-build/","rootDir":".."},"files":["./index.ts"]}
+
+//// [/src/shared/typings-base/globals.d.ts]
+type Unrestricted = any;
+
+//// [/src/tsconfig.json]
+
+
+//// [/src/webpack/index.ts]
+export const b: Unrestricted = 1;
+
+//// [/src/webpack/tsconfig.json]
+{"extends":"../shared/tsconfig-base.json","compilerOptions":{"composite":true,"outDir":"../target-tsc-build/","rootDir":".."},"files":["./index.ts"],"references":[{"path":"../shared/tsconfig.json"}]}
+
+
+
+Output::
+/lib/tsc --b /src/webpack/tsconfig.json --v --listFiles
+[[90m12:00:00 AM[0m] Projects in this build: 
+    * src/shared/tsconfig.json
+    * src/webpack/tsconfig.json
+
+[[90m12:00:00 AM[0m] Project 'src/shared/tsconfig.json' is out of date because output file 'src/target-tsc-build/shared/index.js' does not exist
+
+[[90m12:00:00 AM[0m] Building project '/src/shared/tsconfig.json'...
+
+/lib/lib.d.ts
+/src/shared/index.ts
+/src/shared/typings-base/globals.d.ts
+[[90m12:00:00 AM[0m] Project 'src/webpack/tsconfig.json' is out of date because output file 'src/target-tsc-build/webpack/index.js' does not exist
+
+[[90m12:00:00 AM[0m] Building project '/src/webpack/tsconfig.json'...
+
+/lib/lib.d.ts
+/src/webpack/index.ts
+/src/shared/typings-base/globals.d.ts
+exitCode:: ExitStatus.Success
+
+
+//// [/src/target-tsc-build/shared/index.d.ts]
+export declare const a: Unrestricted;
+
+
+//// [/src/target-tsc-build/shared/index.js]
+"use strict";
+exports.__esModule = true;
+exports.a = void 0;
+exports.a = 1;
+
+
+//// [/src/target-tsc-build/shared/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true
+      },
+      "../../shared/index.ts": {
+        "version": "-22125360210-export const a: Unrestricted = 1;",
+        "signature": "-478734393-export declare const a: Unrestricted;\r\n",
+        "affectsGlobalScope": false
+      },
+      "../../shared/typings-base/globals.d.ts": {
+        "version": "4725476611-type Unrestricted = any;",
+        "signature": "4725476611-type Unrestricted = any;",
+        "affectsGlobalScope": true
+      }
+    },
+    "options": {
+      "composite": true,
+      "outDir": "..",
+      "rootDir": "../..",
+      "listFiles": true,
+      "configFilePath": "../../shared/tsconfig.json"
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../../lib/lib.d.ts",
+      "../../shared/index.ts",
+      "../../shared/typings-base/globals.d.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+
+//// [/src/target-tsc-build/webpack/index.d.ts]
+export declare const b: Unrestricted;
+
+
+//// [/src/target-tsc-build/webpack/index.js]
+"use strict";
+exports.__esModule = true;
+exports.b = void 0;
+exports.b = 1;
+
+
+//// [/src/target-tsc-build/webpack/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true
+      },
+      "../../webpack/index.ts": {
+        "version": "-14405273073-export const b: Unrestricted = 1;",
+        "signature": "-5074241048-export declare const b: Unrestricted;\r\n",
+        "affectsGlobalScope": false
+      },
+      "../../shared/typings-base/globals.d.ts": {
+        "version": "4725476611-type Unrestricted = any;",
+        "signature": "4725476611-type Unrestricted = any;",
+        "affectsGlobalScope": true
+      }
+    },
+    "options": {
+      "composite": true,
+      "outDir": "..",
+      "rootDir": "../..",
+      "listFiles": true,
+      "configFilePath": "../../webpack/tsconfig.json"
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../../lib/lib.d.ts",
+      "../../shared/typings-base/globals.d.ts",
+      "../../webpack/index.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+

--- a/tests/baselines/reference/tsbuild/configFileExtends/initial-build/when-building-solution-with-projects-extends-config-with-include.js
+++ b/tests/baselines/reference/tsbuild/configFileExtends/initial-build/when-building-solution-with-projects-extends-config-with-include.js
@@ -55,17 +55,10 @@ Output::
 
 [[90m12:00:00 AM[0m] Building project '/src/webpack/tsconfig.json'...
 
-[96msrc/webpack/index.ts[0m:[93m1[0m:[93m17[0m - [91merror[0m[90m TS2304: [0mCannot find name 'Unrestricted'.
-
-[7m1[0m export const b: Unrestricted = 1;
-[7m [0m [91m                ~~~~~~~~~~~~[0m
-
 /lib/lib.d.ts
 /src/webpack/index.ts
-
-Found 1 error.
-
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+/src/shared/typings-base/globals.d.ts
+exitCode:: ExitStatus.Success
 
 
 //// [/src/target-tsc-build/shared/index.d.ts]
@@ -117,6 +110,17 @@ exports.a = 1;
   "version": "FakeTSVersion"
 }
 
+//// [/src/target-tsc-build/webpack/index.d.ts]
+export declare const b: Unrestricted;
+
+
+//// [/src/target-tsc-build/webpack/index.js]
+"use strict";
+exports.__esModule = true;
+exports.b = void 0;
+exports.b = 1;
+
+
 //// [/src/target-tsc-build/webpack/tsconfig.tsbuildinfo]
 {
   "program": {
@@ -130,6 +134,11 @@ exports.a = 1;
         "version": "-14405273073-export const b: Unrestricted = 1;",
         "signature": "-5074241048-export declare const b: Unrestricted;\r\n",
         "affectsGlobalScope": false
+      },
+      "../../shared/typings-base/globals.d.ts": {
+        "version": "4725476611-type Unrestricted = any;",
+        "signature": "4725476611-type Unrestricted = any;",
+        "affectsGlobalScope": true
       }
     },
     "options": {
@@ -143,25 +152,8 @@ exports.a = 1;
     "exportedModulesMap": {},
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
-      [
-        "../../webpack/index.ts",
-        [
-          {
-            "file": "../../webpack/index.ts",
-            "start": 16,
-            "length": 12,
-            "messageText": "Cannot find name 'Unrestricted'.",
-            "category": 1,
-            "code": 2304
-          }
-        ]
-      ]
-    ],
-    "affectedFilesPendingEmit": [
-      [
-        "../../webpack/index.ts",
-        1
-      ]
+      "../../shared/typings-base/globals.d.ts",
+      "../../webpack/index.ts"
     ]
   },
   "version": "FakeTSVersion"

--- a/tests/baselines/reference/tsbuild/configFileExtends/initial-build/when-building-solution-with-projects-extends-config-with-include.js
+++ b/tests/baselines/reference/tsbuild/configFileExtends/initial-build/when-building-solution-with-projects-extends-config-with-include.js
@@ -1,0 +1,169 @@
+Input::
+//// [/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+//// [/src/shared/index.ts]
+export const a: Unrestricted = 1;
+
+//// [/src/shared/tsconfig-base.json]
+{"include":["./typings-base/"]}
+
+//// [/src/shared/tsconfig.json]
+{"extends":"./tsconfig-base.json","compilerOptions":{"composite":true,"outDir":"../target-tsc-build/","rootDir":".."},"files":["./index.ts"]}
+
+//// [/src/shared/typings-base/globals.d.ts]
+type Unrestricted = any;
+
+//// [/src/tsconfig.json]
+{"references":[{"path":"./shared/tsconfig.json"},{"path":"./webpack/tsconfig.json"}],"files":[]}
+
+//// [/src/webpack/index.ts]
+export const b: Unrestricted = 1;
+
+//// [/src/webpack/tsconfig.json]
+{"extends":"../shared/tsconfig-base.json","compilerOptions":{"composite":true,"outDir":"../target-tsc-build/","rootDir":".."},"files":["./index.ts"],"references":[{"path":"../shared/tsconfig.json"}]}
+
+
+
+Output::
+/lib/tsc --b /src/tsconfig.json --v --listFiles
+[[90m12:00:00 AM[0m] Projects in this build: 
+    * src/shared/tsconfig.json
+    * src/webpack/tsconfig.json
+    * src/tsconfig.json
+
+[[90m12:00:00 AM[0m] Project 'src/shared/tsconfig.json' is out of date because output file 'src/target-tsc-build/shared/index.js' does not exist
+
+[[90m12:00:00 AM[0m] Building project '/src/shared/tsconfig.json'...
+
+/lib/lib.d.ts
+/src/shared/index.ts
+/src/shared/typings-base/globals.d.ts
+[[90m12:00:00 AM[0m] Project 'src/webpack/tsconfig.json' is out of date because output file 'src/target-tsc-build/webpack/index.js' does not exist
+
+[[90m12:00:00 AM[0m] Building project '/src/webpack/tsconfig.json'...
+
+[96msrc/webpack/index.ts[0m:[93m1[0m:[93m17[0m - [91merror[0m[90m TS2304: [0mCannot find name 'Unrestricted'.
+
+[7m1[0m export const b: Unrestricted = 1;
+[7m [0m [91m                ~~~~~~~~~~~~[0m
+
+/lib/lib.d.ts
+/src/webpack/index.ts
+
+Found 1 error.
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+
+//// [/src/target-tsc-build/shared/index.d.ts]
+export declare const a: Unrestricted;
+
+
+//// [/src/target-tsc-build/shared/index.js]
+"use strict";
+exports.__esModule = true;
+exports.a = void 0;
+exports.a = 1;
+
+
+//// [/src/target-tsc-build/shared/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true
+      },
+      "../../shared/index.ts": {
+        "version": "-22125360210-export const a: Unrestricted = 1;",
+        "signature": "-478734393-export declare const a: Unrestricted;\r\n",
+        "affectsGlobalScope": false
+      },
+      "../../shared/typings-base/globals.d.ts": {
+        "version": "4725476611-type Unrestricted = any;",
+        "signature": "4725476611-type Unrestricted = any;",
+        "affectsGlobalScope": true
+      }
+    },
+    "options": {
+      "composite": true,
+      "outDir": "..",
+      "rootDir": "../..",
+      "listFiles": true,
+      "configFilePath": "../../shared/tsconfig.json"
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../../lib/lib.d.ts",
+      "../../shared/index.ts",
+      "../../shared/typings-base/globals.d.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+
+//// [/src/target-tsc-build/webpack/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true
+      },
+      "../../webpack/index.ts": {
+        "version": "-14405273073-export const b: Unrestricted = 1;",
+        "signature": "-5074241048-export declare const b: Unrestricted;\r\n",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "outDir": "..",
+      "rootDir": "../..",
+      "listFiles": true,
+      "configFilePath": "../../webpack/tsconfig.json"
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../../lib/lib.d.ts",
+      [
+        "../../webpack/index.ts",
+        [
+          {
+            "file": "../../webpack/index.ts",
+            "start": 16,
+            "length": 12,
+            "messageText": "Cannot find name 'Unrestricted'.",
+            "category": 1,
+            "code": 2304
+          }
+        ]
+      ]
+    ],
+    "affectedFilesPendingEmit": [
+      [
+        "../../webpack/index.ts",
+        1
+      ]
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+


### PR DESCRIPTION
Note that this issue came up because of using extended configs cache which stores the result first time computed so the extended config shouldnt be related to base path its computing from but itself
Fixes #40720