### PR TITLE
Use related spans for "implement abstract class" errors

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -36173,6 +36173,8 @@ namespace ts {
 
             // NOTE: assignability is checked in checkClassDeclaration
             const baseProperties = getPropertiesOfType(baseType);
+            const derivedClassDecl = getClassLikeDeclarationOfSymbol(type.symbol)!;
+            const inheritedAbstractMemberNotImplementedErrors: Diagnostic[] = [];
             basePropertyCheck: for (const baseProperty of baseProperties) {
                 const base = getTargetSymbol(baseProperty);
 
@@ -36193,7 +36195,6 @@ namespace ts {
                 // type declaration, derived and base resolve to the same symbol even in the case of generic classes.
                 if (derived === base) {
                     // derived class inherits base without override/redeclaration
-                    const derivedClassDecl = getClassLikeDeclarationOfSymbol(type.symbol)!;
 
                     // It is an error to inherit an abstract member without implementing it or being declared abstract.
                     // If there is no declaration for the derived class (as in the case of class expressions),
@@ -36212,12 +36213,16 @@ namespace ts {
                         }
 
                         if (derivedClassDecl.kind === SyntaxKind.ClassExpression) {
-                            error(derivedClassDecl, Diagnostics.Non_abstract_class_expression_does_not_implement_inherited_abstract_member_0_from_class_1,
+                            const err = createDiagnosticForNode(derivedClassDecl,
+                                Diagnostics.Non_abstract_class_expression_does_not_implement_inherited_abstract_member_0_from_class_1,
                                 symbolToString(baseProperty), typeToString(baseType));
+                            inheritedAbstractMemberNotImplementedErrors.push(err);
                         }
                         else {
-                            error(derivedClassDecl, Diagnostics.Non_abstract_class_0_does_not_implement_inherited_abstract_member_1_from_class_2,
+                            const err = createDiagnosticForNode(derivedClassDecl,
+                                Diagnostics.Non_abstract_class_0_does_not_implement_inherited_abstract_member_1_from_class_2,
                                 typeToString(type), symbolToString(baseProperty), typeToString(baseType));
+                            inheritedAbstractMemberNotImplementedErrors.push(err);
                         }
                     }
                 }
@@ -36291,6 +36296,20 @@ namespace ts {
                     }
 
                     error(getNameOfDeclaration(derived.valueDeclaration) || derived.valueDeclaration, errorMessage, typeToString(baseType), symbolToString(base), typeToString(type));
+                }
+            }
+
+            if (inheritedAbstractMemberNotImplementedErrors.length) {
+                const err = error(
+                    derivedClassDecl,
+                    Diagnostics.Non_abstract_class_0_does_not_implement_all_abstract_members_of_1,
+                    typeToString(type), typeToString(baseType));
+
+                for (const inheritedAbstractMemberNotImplementedError of inheritedAbstractMemberNotImplementedErrors) {
+                    addRelatedInfo(
+                        err,
+                        inheritedAbstractMemberNotImplementedError,
+                    );
                 }
             }
         }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -6346,5 +6346,9 @@
     "Invalid value for 'jsxFragmentFactory'. '{0}' is not a valid identifier or qualified-name.": {
         "category": "Error",
         "code": 18035
+    },
+    "Non-abstract class '{0}' does not implement all abstract members of '{1}'": {
+        "category": "Error",
+        "code": 18036
     }
 }

--- a/src/services/codefixes/fixClassDoesntImplementInheritedAbstractMember.ts
+++ b/src/services/codefixes/fixClassDoesntImplementInheritedAbstractMember.ts
@@ -1,6 +1,7 @@
 /* @internal */
 namespace ts.codefix {
     const errorCodes = [
+        Diagnostics.Non_abstract_class_0_does_not_implement_all_abstract_members_of_1.code,
         Diagnostics.Non_abstract_class_0_does_not_implement_inherited_abstract_member_1_from_class_2.code,
         Diagnostics.Non_abstract_class_expression_does_not_implement_inherited_abstract_member_0_from_class_1.code,
     ];

--- a/tests/baselines/reference/abstractPropertyNegative.errors.txt
+++ b/tests/baselines/reference/abstractPropertyNegative.errors.txt
@@ -1,9 +1,6 @@
 tests/cases/compiler/abstractPropertyNegative.ts(10,18): error TS2380: 'get' and 'set' accessor must have the same type.
 tests/cases/compiler/abstractPropertyNegative.ts(11,18): error TS2380: 'get' and 'set' accessor must have the same type.
-tests/cases/compiler/abstractPropertyNegative.ts(13,7): error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'm' from class 'B'.
-tests/cases/compiler/abstractPropertyNegative.ts(13,7): error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'mismatch' from class 'B'.
-tests/cases/compiler/abstractPropertyNegative.ts(13,7): error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'prop' from class 'B'.
-tests/cases/compiler/abstractPropertyNegative.ts(13,7): error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'readonlyProp' from class 'B'.
+tests/cases/compiler/abstractPropertyNegative.ts(13,7): error TS18036: Non-abstract class 'C' does not implement all abstract members of 'B'
 tests/cases/compiler/abstractPropertyNegative.ts(15,5): error TS1244: Abstract methods can only appear within an abstract class.
 tests/cases/compiler/abstractPropertyNegative.ts(16,37): error TS1005: '{' expected.
 tests/cases/compiler/abstractPropertyNegative.ts(19,3): error TS2540: Cannot assign to 'ro' because it is a read-only property.
@@ -19,7 +16,7 @@ tests/cases/compiler/abstractPropertyNegative.ts(40,9): error TS2676: Accessors 
 tests/cases/compiler/abstractPropertyNegative.ts(41,18): error TS2676: Accessors must both be abstract or non-abstract.
 
 
-==== tests/cases/compiler/abstractPropertyNegative.ts (16 errors) ====
+==== tests/cases/compiler/abstractPropertyNegative.ts (13 errors) ====
     interface A {
         prop: string;
         m(): string;
@@ -38,13 +35,11 @@ tests/cases/compiler/abstractPropertyNegative.ts(41,18): error TS2676: Accessors
     }
     class C extends B {
           ~
-!!! error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'm' from class 'B'.
-          ~
-!!! error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'mismatch' from class 'B'.
-          ~
-!!! error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'prop' from class 'B'.
-          ~
-!!! error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'readonlyProp' from class 'B'.
+!!! error TS18036: Non-abstract class 'C' does not implement all abstract members of 'B'
+!!! related TS2515 tests/cases/compiler/abstractPropertyNegative.ts:13:7: Non-abstract class 'C' does not implement inherited abstract member 'prop' from class 'B'.
+!!! related TS2515 tests/cases/compiler/abstractPropertyNegative.ts:13:7: Non-abstract class 'C' does not implement inherited abstract member 'readonlyProp' from class 'B'.
+!!! related TS2515 tests/cases/compiler/abstractPropertyNegative.ts:13:7: Non-abstract class 'C' does not implement inherited abstract member 'm' from class 'B'.
+!!! related TS2515 tests/cases/compiler/abstractPropertyNegative.ts:13:7: Non-abstract class 'C' does not implement inherited abstract member 'mismatch' from class 'B'.
         readonly ro = "readonly please";
         abstract notAllowed: string;
         ~~~~~~~~

--- a/tests/baselines/reference/classAbstractDeclarations.d.errors.txt
+++ b/tests/baselines/reference/classAbstractDeclarations.d.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts(2,5): error TS1242: 'abstract' modifier can only appear on a class, method, or property declaration.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts(2,28): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts(11,15): error TS2515: Non-abstract class 'CC' does not implement inherited abstract member 'foo' from class 'AA'.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts(13,15): error TS2515: Non-abstract class 'DD' does not implement inherited abstract member 'foo' from class 'BB'.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts(17,15): error TS2515: Non-abstract class 'FF' does not implement inherited abstract member 'foo' from class 'CC'.
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts(11,15): error TS18036: Non-abstract class 'CC' does not implement all abstract members of 'AA'
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts(13,15): error TS18036: Non-abstract class 'DD' does not implement all abstract members of 'BB'
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts(17,15): error TS18036: Non-abstract class 'FF' does not implement all abstract members of 'CC'
 
 
 ==== tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts (5 errors) ====
@@ -22,17 +22,20 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
     
     declare class CC extends AA {}
                   ~~
-!!! error TS2515: Non-abstract class 'CC' does not implement inherited abstract member 'foo' from class 'AA'.
+!!! error TS18036: Non-abstract class 'CC' does not implement all abstract members of 'AA'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts:11:15: Non-abstract class 'CC' does not implement inherited abstract member 'foo' from class 'AA'.
     
     declare class DD extends BB {}
                   ~~
-!!! error TS2515: Non-abstract class 'DD' does not implement inherited abstract member 'foo' from class 'BB'.
+!!! error TS18036: Non-abstract class 'DD' does not implement all abstract members of 'BB'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts:13:15: Non-abstract class 'DD' does not implement inherited abstract member 'foo' from class 'BB'.
     
     declare abstract class EE extends BB {}
     
     declare class FF extends CC {}
                   ~~
-!!! error TS2515: Non-abstract class 'FF' does not implement inherited abstract member 'foo' from class 'CC'.
+!!! error TS18036: Non-abstract class 'FF' does not implement all abstract members of 'CC'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts:17:15: Non-abstract class 'FF' does not implement inherited abstract member 'foo' from class 'CC'.
     
     declare abstract class GG extends CC {}
     

--- a/tests/baselines/reference/classAbstractExtends.errors.txt
+++ b/tests/baselines/reference/classAbstractExtends.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractExtends.ts(9,7): error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'bar' from class 'B'.
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractExtends.ts(9,7): error TS18036: Non-abstract class 'C' does not implement all abstract members of 'B'
 
 
 ==== tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractExtends.ts (1 errors) ====
@@ -12,7 +12,8 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
     
     class C extends B { }
           ~
-!!! error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'bar' from class 'B'.
+!!! error TS18036: Non-abstract class 'C' does not implement all abstract members of 'B'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractExtends.ts:9:7: Non-abstract class 'C' does not implement inherited abstract member 'bar' from class 'B'.
     
     abstract class D extends B {}
     

--- a/tests/baselines/reference/classAbstractGeneric.errors.txt
+++ b/tests/baselines/reference/classAbstractGeneric.errors.txt
@@ -1,12 +1,10 @@
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(10,7): error TS2515: Non-abstract class 'C<T>' does not implement inherited abstract member 'bar' from class 'A<T>'.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(10,7): error TS2515: Non-abstract class 'C<T>' does not implement inherited abstract member 'foo' from class 'A<T>'.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(12,7): error TS2515: Non-abstract class 'D' does not implement inherited abstract member 'bar' from class 'A<number>'.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(12,7): error TS2515: Non-abstract class 'D' does not implement inherited abstract member 'foo' from class 'A<number>'.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(14,7): error TS2515: Non-abstract class 'E<T>' does not implement inherited abstract member 'bar' from class 'A<T>'.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(18,7): error TS2515: Non-abstract class 'F<T>' does not implement inherited abstract member 'foo' from class 'A<T>'.
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(10,7): error TS18036: Non-abstract class 'C<T>' does not implement all abstract members of 'A<T>'
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(12,7): error TS18036: Non-abstract class 'D' does not implement all abstract members of 'A<number>'
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(14,7): error TS18036: Non-abstract class 'E<T>' does not implement all abstract members of 'A<T>'
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(18,7): error TS18036: Non-abstract class 'F<T>' does not implement all abstract members of 'A<T>'
 
 
-==== tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts (6 errors) ====
+==== tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts (4 errors) ====
     abstract class A<T> {
         t: T;
         
@@ -18,25 +16,27 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
     
     class C<T> extends A<T> {} // error -- inherits abstract methods
           ~
-!!! error TS2515: Non-abstract class 'C<T>' does not implement inherited abstract member 'bar' from class 'A<T>'.
-          ~
-!!! error TS2515: Non-abstract class 'C<T>' does not implement inherited abstract member 'foo' from class 'A<T>'.
+!!! error TS18036: Non-abstract class 'C<T>' does not implement all abstract members of 'A<T>'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts:10:7: Non-abstract class 'C<T>' does not implement inherited abstract member 'foo' from class 'A<T>'.
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts:10:7: Non-abstract class 'C<T>' does not implement inherited abstract member 'bar' from class 'A<T>'.
     
     class D extends A<number> {} // error -- inherits abstract methods
           ~
-!!! error TS2515: Non-abstract class 'D' does not implement inherited abstract member 'bar' from class 'A<number>'.
-          ~
-!!! error TS2515: Non-abstract class 'D' does not implement inherited abstract member 'foo' from class 'A<number>'.
+!!! error TS18036: Non-abstract class 'D' does not implement all abstract members of 'A<number>'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts:12:7: Non-abstract class 'D' does not implement inherited abstract member 'foo' from class 'A<number>'.
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts:12:7: Non-abstract class 'D' does not implement inherited abstract member 'bar' from class 'A<number>'.
     
     class E<T> extends A<T> { // error -- doesn't implement bar
           ~
-!!! error TS2515: Non-abstract class 'E<T>' does not implement inherited abstract member 'bar' from class 'A<T>'.
+!!! error TS18036: Non-abstract class 'E<T>' does not implement all abstract members of 'A<T>'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts:14:7: Non-abstract class 'E<T>' does not implement inherited abstract member 'bar' from class 'A<T>'.
         foo() { return this.t; }
     }
     
     class F<T> extends A<T> { // error -- doesn't implement foo
           ~
-!!! error TS2515: Non-abstract class 'F<T>' does not implement inherited abstract member 'foo' from class 'A<T>'.
+!!! error TS18036: Non-abstract class 'F<T>' does not implement all abstract members of 'A<T>'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts:18:7: Non-abstract class 'F<T>' does not implement inherited abstract member 'foo' from class 'A<T>'.
         bar(t : T) {}
     }
     

--- a/tests/baselines/reference/classAbstractInheritance.errors.txt
+++ b/tests/baselines/reference/classAbstractInheritance.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance.ts(13,7): error TS2515: Non-abstract class 'CC' does not implement inherited abstract member 'foo' from class 'AA'.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance.ts(15,7): error TS2515: Non-abstract class 'DD' does not implement inherited abstract member 'foo' from class 'BB'.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance.ts(19,7): error TS2515: Non-abstract class 'FF' does not implement inherited abstract member 'foo' from class 'CC'.
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance.ts(13,7): error TS18036: Non-abstract class 'CC' does not implement all abstract members of 'AA'
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance.ts(15,7): error TS18036: Non-abstract class 'DD' does not implement all abstract members of 'BB'
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance.ts(19,7): error TS18036: Non-abstract class 'FF' does not implement all abstract members of 'CC'
 
 
 ==== tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance.ts (3 errors) ====
@@ -18,16 +18,19 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
     
     class CC extends AA {}
           ~~
-!!! error TS2515: Non-abstract class 'CC' does not implement inherited abstract member 'foo' from class 'AA'.
+!!! error TS18036: Non-abstract class 'CC' does not implement all abstract members of 'AA'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance.ts:13:7: Non-abstract class 'CC' does not implement inherited abstract member 'foo' from class 'AA'.
     
     class DD extends BB {}
           ~~
-!!! error TS2515: Non-abstract class 'DD' does not implement inherited abstract member 'foo' from class 'BB'.
+!!! error TS18036: Non-abstract class 'DD' does not implement all abstract members of 'BB'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance.ts:15:7: Non-abstract class 'DD' does not implement inherited abstract member 'foo' from class 'BB'.
     
     abstract class EE extends BB {}
     
     class FF extends CC {}
           ~~
-!!! error TS2515: Non-abstract class 'FF' does not implement inherited abstract member 'foo' from class 'CC'.
+!!! error TS18036: Non-abstract class 'FF' does not implement all abstract members of 'CC'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance.ts:19:7: Non-abstract class 'FF' does not implement inherited abstract member 'foo' from class 'CC'.
     
     abstract class GG extends CC {}

--- a/tests/baselines/reference/classAbstractInstantiations2.errors.txt
+++ b/tests/baselines/reference/classAbstractInstantiations2.errors.txt
@@ -4,7 +4,7 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts(17,5): error TS2511: Cannot create an instance of an abstract class.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts(21,1): error TS2511: Cannot create an instance of an abstract class.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts(23,15): error TS2449: Class 'C' used before its declaration.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts(26,7): error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'bar' from class 'B'.
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts(26,7): error TS18036: Non-abstract class 'C' does not implement all abstract members of 'B'
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts(46,5): error TS2391: Function implementation is missing or not immediately following the declaration.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts(46,5): error TS2512: Overload signatures must all be abstract or non-abstract.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts(50,5): error TS1244: Abstract methods can only appear within an abstract class.
@@ -50,7 +50,8 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
     
     class C extends B { } // error -- not declared abstract
           ~
-!!! error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'bar' from class 'B'.
+!!! error TS18036: Non-abstract class 'C' does not implement all abstract members of 'B'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts:26:7: Non-abstract class 'C' does not implement inherited abstract member 'bar' from class 'B'.
     
     abstract class D extends B { } // okay
     

--- a/tests/baselines/reference/classAbstractOverrideWithAbstract.errors.txt
+++ b/tests/baselines/reference/classAbstractOverrideWithAbstract.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverrideWithAbstract.ts(19,7): error TS2515: Non-abstract class 'CC' does not implement inherited abstract member 'foo' from class 'BB'.
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverrideWithAbstract.ts(19,7): error TS18036: Non-abstract class 'CC' does not implement all abstract members of 'BB'
 
 
 ==== tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverrideWithAbstract.ts (1 errors) ====
@@ -22,7 +22,8 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
     
     class CC extends BB {} // error
           ~~
-!!! error TS2515: Non-abstract class 'CC' does not implement inherited abstract member 'foo' from class 'BB'.
+!!! error TS18036: Non-abstract class 'CC' does not implement all abstract members of 'BB'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverrideWithAbstract.ts:19:7: Non-abstract class 'CC' does not implement inherited abstract member 'foo' from class 'BB'.
     
     class DD extends BB {
         foo() {}

--- a/tests/baselines/reference/classAbstractUsingAbstractMethods2.errors.txt
+++ b/tests/baselines/reference/classAbstractUsingAbstractMethods2.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethods2.ts(2,5): error TS1244: Abstract methods can only appear within an abstract class.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethods2.ts(5,7): error TS2515: Non-abstract class 'B' does not implement inherited abstract member 'foo' from class 'A'.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethods2.ts(21,7): error TS2515: Non-abstract class 'BB' does not implement inherited abstract member 'foo' from class 'AA'.
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethods2.ts(5,7): error TS18036: Non-abstract class 'B' does not implement all abstract members of 'A'
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethods2.ts(21,7): error TS18036: Non-abstract class 'BB' does not implement all abstract members of 'AA'
 
 
 ==== tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethods2.ts (3 errors) ====
@@ -12,7 +12,8 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
     
     class B extends A  {}
           ~
-!!! error TS2515: Non-abstract class 'B' does not implement inherited abstract member 'foo' from class 'A'.
+!!! error TS18036: Non-abstract class 'B' does not implement all abstract members of 'A'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethods2.ts:5:7: Non-abstract class 'B' does not implement inherited abstract member 'foo' from class 'A'.
     
     abstract class C extends A {}
     
@@ -30,7 +31,8 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
     
     class BB extends AA  {}
           ~~
-!!! error TS2515: Non-abstract class 'BB' does not implement inherited abstract member 'foo' from class 'AA'.
+!!! error TS18036: Non-abstract class 'BB' does not implement all abstract members of 'AA'
+!!! related TS2515 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethods2.ts:21:7: Non-abstract class 'BB' does not implement inherited abstract member 'foo' from class 'AA'.
     
     abstract class CC extends AA {}
     

--- a/tests/baselines/reference/classExpressionExtendingAbstractClass.errors.txt
+++ b/tests/baselines/reference/classExpressionExtendingAbstractClass.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/classExpressionExtendingAbstractClass.ts(5,9): error TS2653: Non-abstract class expression does not implement inherited abstract member 'foo' from class 'A'.
+tests/cases/compiler/classExpressionExtendingAbstractClass.ts(5,9): error TS18036: Non-abstract class 'C' does not implement all abstract members of 'A'
 
 
 ==== tests/cases/compiler/classExpressionExtendingAbstractClass.ts (1 errors) ====
@@ -8,7 +8,8 @@ tests/cases/compiler/classExpressionExtendingAbstractClass.ts(5,9): error TS2653
     
     var C = class extends A {     // no error reported!
             ~~~~~
-!!! error TS2653: Non-abstract class expression does not implement inherited abstract member 'foo' from class 'A'.
+!!! error TS18036: Non-abstract class 'C' does not implement all abstract members of 'A'
+!!! related TS2653 tests/cases/compiler/classExpressionExtendingAbstractClass.ts:5:9: Non-abstract class expression does not implement inherited abstract member 'foo' from class 'A'.
     };
     
     

--- a/tests/baselines/reference/mixinAbstractClasses.2.errors.txt
+++ b/tests/baselines/reference/mixinAbstractClasses.2.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/classes/mixinAbstractClasses.2.ts(7,11): error TS2797: A mixin class that extends from a type variable containing an abstract construct signature must also be declared 'abstract'.
-tests/cases/conformance/classes/mixinAbstractClasses.2.ts(21,7): error TS2515: Non-abstract class 'DerivedFromAbstract' does not implement inherited abstract member 'abstractBaseMethod' from class 'AbstractBase & Mixin'.
+tests/cases/conformance/classes/mixinAbstractClasses.2.ts(21,7): error TS18036: Non-abstract class 'DerivedFromAbstract' does not implement all abstract members of 'AbstractBase & Mixin'
 tests/cases/conformance/classes/mixinAbstractClasses.2.ts(25,1): error TS2511: Cannot create an instance of an abstract class.
 
 
@@ -28,7 +28,8 @@ tests/cases/conformance/classes/mixinAbstractClasses.2.ts(25,1): error TS2511: C
     // error expected: Non-abstract class 'DerivedFromAbstract' does not implement inherited abstract member 'abstractBaseMethod' from class 'AbstractBase & Mixin'.
     class DerivedFromAbstract extends MixedBase {
           ~~~~~~~~~~~~~~~~~~~
-!!! error TS2515: Non-abstract class 'DerivedFromAbstract' does not implement inherited abstract member 'abstractBaseMethod' from class 'AbstractBase & Mixin'.
+!!! error TS18036: Non-abstract class 'DerivedFromAbstract' does not implement all abstract members of 'AbstractBase & Mixin'
+!!! related TS2515 tests/cases/conformance/classes/mixinAbstractClasses.2.ts:21:7: Non-abstract class 'DerivedFromAbstract' does not implement inherited abstract member 'abstractBaseMethod' from class 'AbstractBase & Mixin'.
     }
     
     // error expected: Cannot create an instance of an abstract class.


### PR DESCRIPTION
Hi! This is my first time contributing to Typescript. I picked the smallest issue I could find :)
Please let me know if the solution is acceptable.

Fixes #32848

Example compiling the following code.

```typescript
abstract class A {
	abstract b(): void;
	abstract c(): void;
}

class B extends A { }
```

Error message before:

> hello.ts:6:7 - error TS2515: Non-abstract class 'B' does not implement inherited abstract member 'b' from class 'A'.
> 
> 6 class B extends A { }
>         ~
> 
> hello.ts:6:7 - error TS2515: Non-abstract class 'B' does not implement inherited abstract member 'c' from class 'A'.
> 
> 6 class B extends A { }
>         ~
> 
> 
> Found 2 errors.

Error message after:

> hello.ts:6:7 - error TS18036: Non-abstract class 'B' does not implement all abstract members of 'A'
> 
> 6 class B extends A { }
>         ~
> 
>   hello.ts:6:7
>     6 class B extends A { }
>             ~
>     Non-abstract class 'B' does not implement inherited abstract member 'b' from class 'A'.
>   hello.ts:6:7
>     6 class B extends A { }
>             ~
>     Non-abstract class 'B' does not implement inherited abstract member 'c' from class 'A'.
> 
> 
> Found 1 error.

cc @DanielRosenwasser
