### PR TITLE
Fix completions crash on transient exported property named 'default'

### DIFF
--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -2802,7 +2802,7 @@ namespace FourSlash {
                 const matchingName = completions?.filter(e => e.name === options.name);
                 const detailMessage = matchingName?.length
                     ? `\n  Found ${matchingName.length} with name '${options.name}' from source(s) ${matchingName.map(e => `'${e.source}'`).join(", ")}.`
-                    : "";
+                    : ` (In fact, there were no completions with name '${options.name}' at all.)`;
                 return this.raiseError(`No completions were found for the given name, source, and preferences.` + detailMessage);
             }
             const codeActions = details.codeActions;

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -262,7 +262,7 @@ namespace ts.codefix {
             }
 
             const defaultInfo = getDefaultLikeExportInfo(importingFile, moduleSymbol, checker, compilerOptions);
-            if (defaultInfo && getNameForExportedSymbol(defaultInfo.symbol, compilerOptions.target) === symbolName && skipAlias(defaultInfo.symbol, checker) === exportedSymbol) {
+            if (defaultInfo && (defaultInfo.name === symbolName || moduleSymbolToValidIdentifier(moduleSymbol, compilerOptions.target) === symbolName) && skipAlias(defaultInfo.symbol, checker) === exportedSymbol) {
                 result.push({ moduleSymbol, importKind: defaultInfo.kind, exportedSymbolIsTypeOnly: isTypeOnlySymbol(defaultInfo.symbol, checker) });
             }
 
@@ -581,7 +581,7 @@ namespace ts.codefix {
 
             const compilerOptions = program.getCompilerOptions();
             const defaultInfo = getDefaultLikeExportInfo(sourceFile, moduleSymbol, checker, compilerOptions);
-            if (defaultInfo && getNameForExportedSymbol(defaultInfo.symbol, compilerOptions.target) === symbolName && symbolHasMeaning(defaultInfo.symbolForMeaning, currentTokenMeaning)) {
+            if (defaultInfo && (defaultInfo.name === symbolName || moduleSymbolToValidIdentifier(moduleSymbol, compilerOptions.target) === symbolName) && symbolHasMeaning(defaultInfo.symbolForMeaning, currentTokenMeaning)) {
                 addSymbol(moduleSymbol, defaultInfo.symbol, defaultInfo.kind, checker);
             }
 
@@ -600,7 +600,7 @@ namespace ts.codefix {
         const exported = getDefaultLikeExportWorker(importingFile, moduleSymbol, checker, compilerOptions);
         if (!exported) return undefined;
         const { symbol, kind } = exported;
-        const info = getDefaultExportInfoWorker(symbol, moduleSymbol, checker, compilerOptions);
+        const info = getDefaultExportInfoWorker(symbol, checker, compilerOptions);
         return info && { symbol, kind, ...info };
     }
 
@@ -636,7 +636,7 @@ namespace ts.codefix {
         return allowSyntheticDefaults ? ImportKind.Default : ImportKind.CommonJS;
     }
 
-    function getDefaultExportInfoWorker(defaultExport: Symbol, _moduleSymbol: Symbol, checker: TypeChecker, compilerOptions: CompilerOptions): { readonly symbolForMeaning: Symbol, readonly name: string } | undefined {
+    function getDefaultExportInfoWorker(defaultExport: Symbol, checker: TypeChecker, compilerOptions: CompilerOptions): { readonly symbolForMeaning: Symbol, readonly name: string } | undefined {
         const localSymbol = getLocalSymbolForExportDefault(defaultExport);
         if (localSymbol) return { symbolForMeaning: localSymbol, name: localSymbol.name };
 
@@ -650,7 +650,7 @@ namespace ts.codefix {
                 //    but we can still offer completions for it.
                 // - `aliased.parent` will be undefined if the module is exporting `globalThis.something`,
                 //    or another expression that resolves to a global.
-                return getDefaultExportInfoWorker(aliased, aliased.parent, checker, compilerOptions);
+                return getDefaultExportInfoWorker(aliased, checker, compilerOptions);
             }
         }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -732,7 +732,7 @@ namespace ts.Completions {
             exportedSymbol,
             moduleSymbol,
             sourceFile,
-            getNameForExportedSymbol(symbol, compilerOptions.target!),
+            getNameForExportedSymbol(symbol, compilerOptions.target),
             host,
             program,
             formatContext,

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2880,10 +2880,10 @@ namespace ts {
         return isArray(valueOrArray) ? first(valueOrArray) : valueOrArray;
     }
 
-    export function getNameForExportedSymbol(symbol: Symbol, scriptTarget: ScriptTarget) {
-        if (symbol.escapedName === InternalSymbolName.ExportEquals || symbol.escapedName === InternalSymbolName.Default) {
+    export function getNameForExportedSymbol(symbol: Symbol, scriptTarget: ScriptTarget | undefined) {
+        if (!(symbol.flags & SymbolFlags.Transient) && (symbol.escapedName === InternalSymbolName.ExportEquals || symbol.escapedName === InternalSymbolName.Default)) {
             // Name of "export default foo;" is "foo". Name of "export default 0" is the filename converted to camelCase.
-            return firstDefined(symbol.declarations, d => isExportAssignment(d) && isIdentifier(d.expression) ? d.expression.text : undefined)
+            return firstDefined(symbol.declarations, d => isExportAssignment(d) ? tryCast(skipOuterExpressions(d.expression), isIdentifier)?.text : undefined)
                 || codefix.moduleSymbolToValidIdentifier(getSymbolParentOrFail(symbol), scriptTarget);
         }
         return symbol.name;

--- a/tests/cases/fourslash/completionsImport_weirdDefaultSynthesis.ts
+++ b/tests/cases/fourslash/completionsImport_weirdDefaultSynthesis.ts
@@ -1,0 +1,20 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /collection.ts
+//// class Collection {
+////   public static readonly default: typeof Collection = Collection;
+//// }
+//// export = Collection as typeof Collection & { default: typeof Collection };
+
+// @Filename: /index.ts
+//// Colle/**/
+
+verify.applyCodeActionFromCompletion("", {
+  name: "Collection",
+  source: "/collection",
+  description: `Import 'Collection' from module "./collection"`,
+  preferences: {
+    includeCompletionsForModuleExports: true
+  },
+  newFileContent: `import Collection = require("./collection");\n\nColle`
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #40991

Also includes a drive-by improvement to allow us to get a name for `default` or `export=` when the target is an identifier with parentheses, non-null assertions, type assertions, etc., instead of just a bare identifier.
