### PR TITLE
Add fallback error locations for nameless declarations, better class error locations

### DIFF
--- a/tests/baselines/reference/declarationEmitMixinPrivateProtected.errors.txt
+++ b/tests/baselines/reference/declarationEmitMixinPrivateProtected.errors.txt
@@ -1,0 +1,53 @@
+tests/cases/compiler/another.ts(11,1): error TS4094: Property '_assertIsStripped' of exported class expression may not be private or protected.
+tests/cases/compiler/another.ts(11,1): error TS4094: Property '_onDispose' of exported class expression may not be private or protected.
+tests/cases/compiler/first.ts(12,1): error TS4094: Property '_assertIsStripped' of exported class expression may not be private or protected.
+tests/cases/compiler/first.ts(12,1): error TS4094: Property '_onDispose' of exported class expression may not be private or protected.
+tests/cases/compiler/first.ts(13,14): error TS4094: Property '_assertIsStripped' of exported class expression may not be private or protected.
+tests/cases/compiler/first.ts(13,14): error TS4094: Property '_onDispose' of exported class expression may not be private or protected.
+
+
+==== tests/cases/compiler/first.ts (4 errors) ====
+    declare function mix<TMix>(mixin: TMix): TMix;
+    
+    const DisposableMixin = class {
+        protected _onDispose() {
+            this._assertIsStripped()
+        }
+        private _assertIsStripped() {
+        }
+    };
+    
+    // No error, but definition is wrong. 
+    export default mix(DisposableMixin);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS4094: Property '_assertIsStripped' of exported class expression may not be private or protected.
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS4094: Property '_onDispose' of exported class expression may not be private or protected.
+    export class Monitor extends mix(DisposableMixin) {
+                 ~~~~~~~
+!!! error TS4094: Property '_assertIsStripped' of exported class expression may not be private or protected.
+                 ~~~~~~~
+!!! error TS4094: Property '_onDispose' of exported class expression may not be private or protected.
+        protected _onDispose() {
+        }
+    }
+    
+==== tests/cases/compiler/another.ts (2 errors) ====
+    declare function mix<TMix>(mixin: TMix): TMix;
+    
+    const DisposableMixin = class {
+        protected _onDispose() {
+            this._assertIsStripped()
+        }
+        private _assertIsStripped() {
+        }
+    };
+    
+    export default class extends mix(DisposableMixin) {
+    ~~~~~~
+!!! error TS4094: Property '_assertIsStripped' of exported class expression may not be private or protected.
+    ~~~~~~
+!!! error TS4094: Property '_onDispose' of exported class expression may not be private or protected.
+        protected _onDispose() {
+        }
+    }

--- a/tests/baselines/reference/declarationEmitMixinPrivateProtected.js
+++ b/tests/baselines/reference/declarationEmitMixinPrivateProtected.js
@@ -1,0 +1,115 @@
+//// [tests/cases/compiler/declarationEmitMixinPrivateProtected.ts] ////
+
+//// [first.ts]
+declare function mix<TMix>(mixin: TMix): TMix;
+
+const DisposableMixin = class {
+    protected _onDispose() {
+        this._assertIsStripped()
+    }
+    private _assertIsStripped() {
+    }
+};
+
+// No error, but definition is wrong. 
+export default mix(DisposableMixin);
+export class Monitor extends mix(DisposableMixin) {
+    protected _onDispose() {
+    }
+}
+
+//// [another.ts]
+declare function mix<TMix>(mixin: TMix): TMix;
+
+const DisposableMixin = class {
+    protected _onDispose() {
+        this._assertIsStripped()
+    }
+    private _assertIsStripped() {
+    }
+};
+
+export default class extends mix(DisposableMixin) {
+    protected _onDispose() {
+    }
+}
+
+//// [first.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+exports.__esModule = true;
+exports.Monitor = void 0;
+var DisposableMixin = /** @class */ (function () {
+    function class_1() {
+    }
+    class_1.prototype._onDispose = function () {
+        this._assertIsStripped();
+    };
+    class_1.prototype._assertIsStripped = function () {
+    };
+    return class_1;
+}());
+// No error, but definition is wrong. 
+exports["default"] = mix(DisposableMixin);
+var Monitor = /** @class */ (function (_super) {
+    __extends(Monitor, _super);
+    function Monitor() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Monitor.prototype._onDispose = function () {
+    };
+    return Monitor;
+}(mix(DisposableMixin)));
+exports.Monitor = Monitor;
+//// [another.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+exports.__esModule = true;
+var DisposableMixin = /** @class */ (function () {
+    function class_1() {
+    }
+    class_1.prototype._onDispose = function () {
+        this._assertIsStripped();
+    };
+    class_1.prototype._assertIsStripped = function () {
+    };
+    return class_1;
+}());
+var default_1 = /** @class */ (function (_super) {
+    __extends(default_1, _super);
+    function default_1() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    default_1.prototype._onDispose = function () {
+    };
+    return default_1;
+}(mix(DisposableMixin)));
+exports["default"] = default_1;

--- a/tests/baselines/reference/declarationEmitMixinPrivateProtected.symbols
+++ b/tests/baselines/reference/declarationEmitMixinPrivateProtected.symbols
@@ -1,0 +1,71 @@
+=== tests/cases/compiler/first.ts ===
+declare function mix<TMix>(mixin: TMix): TMix;
+>mix : Symbol(mix, Decl(first.ts, 0, 0))
+>TMix : Symbol(TMix, Decl(first.ts, 0, 21))
+>mixin : Symbol(mixin, Decl(first.ts, 0, 27))
+>TMix : Symbol(TMix, Decl(first.ts, 0, 21))
+>TMix : Symbol(TMix, Decl(first.ts, 0, 21))
+
+const DisposableMixin = class {
+>DisposableMixin : Symbol(DisposableMixin, Decl(first.ts, 2, 5))
+
+    protected _onDispose() {
+>_onDispose : Symbol(DisposableMixin._onDispose, Decl(first.ts, 2, 31))
+
+        this._assertIsStripped()
+>this._assertIsStripped : Symbol(DisposableMixin._assertIsStripped, Decl(first.ts, 5, 5))
+>this : Symbol(DisposableMixin, Decl(first.ts, 2, 23))
+>_assertIsStripped : Symbol(DisposableMixin._assertIsStripped, Decl(first.ts, 5, 5))
+    }
+    private _assertIsStripped() {
+>_assertIsStripped : Symbol(DisposableMixin._assertIsStripped, Decl(first.ts, 5, 5))
+    }
+};
+
+// No error, but definition is wrong. 
+export default mix(DisposableMixin);
+>mix : Symbol(mix, Decl(first.ts, 0, 0))
+>DisposableMixin : Symbol(DisposableMixin, Decl(first.ts, 2, 5))
+
+export class Monitor extends mix(DisposableMixin) {
+>Monitor : Symbol(Monitor, Decl(first.ts, 11, 36))
+>mix : Symbol(mix, Decl(first.ts, 0, 0))
+>DisposableMixin : Symbol(DisposableMixin, Decl(first.ts, 2, 5))
+
+    protected _onDispose() {
+>_onDispose : Symbol(Monitor._onDispose, Decl(first.ts, 12, 51))
+    }
+}
+
+=== tests/cases/compiler/another.ts ===
+declare function mix<TMix>(mixin: TMix): TMix;
+>mix : Symbol(mix, Decl(another.ts, 0, 0))
+>TMix : Symbol(TMix, Decl(another.ts, 0, 21))
+>mixin : Symbol(mixin, Decl(another.ts, 0, 27))
+>TMix : Symbol(TMix, Decl(another.ts, 0, 21))
+>TMix : Symbol(TMix, Decl(another.ts, 0, 21))
+
+const DisposableMixin = class {
+>DisposableMixin : Symbol(DisposableMixin, Decl(another.ts, 2, 5))
+
+    protected _onDispose() {
+>_onDispose : Symbol(DisposableMixin._onDispose, Decl(another.ts, 2, 31))
+
+        this._assertIsStripped()
+>this._assertIsStripped : Symbol(DisposableMixin._assertIsStripped, Decl(another.ts, 5, 5))
+>this : Symbol(DisposableMixin, Decl(another.ts, 2, 23))
+>_assertIsStripped : Symbol(DisposableMixin._assertIsStripped, Decl(another.ts, 5, 5))
+    }
+    private _assertIsStripped() {
+>_assertIsStripped : Symbol(DisposableMixin._assertIsStripped, Decl(another.ts, 5, 5))
+    }
+};
+
+export default class extends mix(DisposableMixin) {
+>mix : Symbol(mix, Decl(another.ts, 0, 0))
+>DisposableMixin : Symbol(DisposableMixin, Decl(another.ts, 2, 5))
+
+    protected _onDispose() {
+>_onDispose : Symbol(default._onDispose, Decl(another.ts, 10, 51))
+    }
+}

--- a/tests/baselines/reference/declarationEmitMixinPrivateProtected.types
+++ b/tests/baselines/reference/declarationEmitMixinPrivateProtected.types
@@ -1,0 +1,72 @@
+=== tests/cases/compiler/first.ts ===
+declare function mix<TMix>(mixin: TMix): TMix;
+>mix : <TMix>(mixin: TMix) => TMix
+>mixin : TMix
+
+const DisposableMixin = class {
+>DisposableMixin : typeof DisposableMixin
+>class {    protected _onDispose() {        this._assertIsStripped()    }    private _assertIsStripped() {    }} : typeof DisposableMixin
+
+    protected _onDispose() {
+>_onDispose : () => void
+
+        this._assertIsStripped()
+>this._assertIsStripped() : void
+>this._assertIsStripped : () => void
+>this : this
+>_assertIsStripped : () => void
+    }
+    private _assertIsStripped() {
+>_assertIsStripped : () => void
+    }
+};
+
+// No error, but definition is wrong. 
+export default mix(DisposableMixin);
+>mix(DisposableMixin) : typeof DisposableMixin
+>mix : <TMix>(mixin: TMix) => TMix
+>DisposableMixin : typeof DisposableMixin
+
+export class Monitor extends mix(DisposableMixin) {
+>Monitor : Monitor
+>mix(DisposableMixin) : DisposableMixin
+>mix : <TMix>(mixin: TMix) => TMix
+>DisposableMixin : typeof DisposableMixin
+
+    protected _onDispose() {
+>_onDispose : () => void
+    }
+}
+
+=== tests/cases/compiler/another.ts ===
+declare function mix<TMix>(mixin: TMix): TMix;
+>mix : <TMix>(mixin: TMix) => TMix
+>mixin : TMix
+
+const DisposableMixin = class {
+>DisposableMixin : typeof DisposableMixin
+>class {    protected _onDispose() {        this._assertIsStripped()    }    private _assertIsStripped() {    }} : typeof DisposableMixin
+
+    protected _onDispose() {
+>_onDispose : () => void
+
+        this._assertIsStripped()
+>this._assertIsStripped() : void
+>this._assertIsStripped : () => void
+>this : this
+>_assertIsStripped : () => void
+    }
+    private _assertIsStripped() {
+>_assertIsStripped : () => void
+    }
+};
+
+export default class extends mix(DisposableMixin) {
+>mix(DisposableMixin) : DisposableMixin
+>mix : <TMix>(mixin: TMix) => TMix
+>DisposableMixin : typeof DisposableMixin
+
+    protected _onDispose() {
+>_onDispose : () => void
+    }
+}

--- a/tests/baselines/reference/emitClassExpressionInDeclarationFile2.errors.txt
+++ b/tests/baselines/reference/emitClassExpressionInDeclarationFile2.errors.txt
@@ -1,9 +1,10 @@
 tests/cases/compiler/emitClassExpressionInDeclarationFile2.ts(1,12): error TS4094: Property 'p' of exported class expression may not be private or protected.
 tests/cases/compiler/emitClassExpressionInDeclarationFile2.ts(1,12): error TS4094: Property 'ps' of exported class expression may not be private or protected.
 tests/cases/compiler/emitClassExpressionInDeclarationFile2.ts(16,17): error TS4094: Property 'property' of exported class expression may not be private or protected.
+tests/cases/compiler/emitClassExpressionInDeclarationFile2.ts(23,14): error TS4094: Property 'property' of exported class expression may not be private or protected.
 
 
-==== tests/cases/compiler/emitClassExpressionInDeclarationFile2.ts (3 errors) ====
+==== tests/cases/compiler/emitClassExpressionInDeclarationFile2.ts (4 errors) ====
     export var noPrivates = class {
                ~~~~~~~~~~
 !!! error TS4094: Property 'p' of exported class expression may not be private or protected.
@@ -33,6 +34,8 @@ tests/cases/compiler/emitClassExpressionInDeclarationFile2.ts(16,17): error TS40
     }
     
     export class Test extends WithTags(FooItem) {}
+                 ~~~~
+!!! error TS4094: Property 'property' of exported class expression may not be private or protected.
     
     const test = new Test();
     

--- a/tests/cases/compiler/declarationEmitMixinPrivateProtected.ts
+++ b/tests/cases/compiler/declarationEmitMixinPrivateProtected.ts
@@ -1,0 +1,34 @@
+// @declaration: true
+// @filename: first.ts
+declare function mix<TMix>(mixin: TMix): TMix;
+
+const DisposableMixin = class {
+    protected _onDispose() {
+        this._assertIsStripped()
+    }
+    private _assertIsStripped() {
+    }
+};
+
+// No error, but definition is wrong. 
+export default mix(DisposableMixin);
+export class Monitor extends mix(DisposableMixin) {
+    protected _onDispose() {
+    }
+}
+
+// @filename: another.ts
+declare function mix<TMix>(mixin: TMix): TMix;
+
+const DisposableMixin = class {
+    protected _onDispose() {
+        this._assertIsStripped()
+    }
+    private _assertIsStripped() {
+    }
+};
+
+export default class extends mix(DisposableMixin) {
+    protected _onDispose() {
+    }
+}


### PR DESCRIPTION
These errors were going unreported because we had no location registered to report them on. Now we allow a non-name fallback location for those declaration emit errors which do not require a name. (And, additionally, set the name location when emitting classes).

Fixes #42499
