### PR TITLE
Switched 'ts.performance' to a mixed mode only uses native performance APIs when necessary

### DIFF
--- a/src/compiler/performance.ts
+++ b/src/compiler/performance.ts
@@ -74,7 +74,8 @@ namespace ts.performance {
         if (enabled) {
             const end = (endMarkName !== undefined ? marks.get(endMarkName) : undefined) ?? timestamp();
             const start = (startMarkName !== undefined ? marks.get(startMarkName) : undefined) ?? timeorigin;
-            durations.set(measureName, end - start);
+            const previousDuration = durations.get(measureName) || 0;
+            durations.set(measureName, previousDuration + (end - start));
             performanceImpl?.measure(measureName, startMarkName, endMarkName);
         }
     }

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1116,6 +1116,7 @@ namespace ts {
         exit(exitCode?: number): void;
         /*@internal*/ enableCPUProfiler?(path: string, continuation: () => void): boolean;
         /*@internal*/ disableCPUProfiler?(continuation: () => void): boolean;
+        /*@internal*/ cpuProfilingEnabled?(): boolean;
         realpath?(path: string): string;
         /*@internal*/ getEnvironmentVariable(name: string): string;
         /*@internal*/ tryEnableSourceMapsForHost?(): void;
@@ -1286,6 +1287,7 @@ namespace ts {
                 },
                 enableCPUProfiler,
                 disableCPUProfiler,
+                cpuProfilingEnabled: () => !!activeSession || contains(process.execArgv, "--cpu-prof") || contains(process.execArgv, "--prof"),
                 realpath,
                 debugMode: !!process.env.NODE_INSPECTOR_IPC || !!process.env.VSCODE_INSPECTOR_OPTIONS || some(<string[]>process.execArgv, arg => /^--(inspect|debug)(-brk)?(=\d+)?$/i.test(arg)),
                 tryEnableSourceMapsForHost() {

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -662,7 +662,7 @@ namespace ts {
 
     function enableStatisticsAndTracing(system: System, compilerOptions: CompilerOptions, isBuildMode: boolean) {
         if (canReportDiagnostics(system, compilerOptions)) {
-            performance.enable();
+            performance.enable(system);
         }
 
         if (canTrace(system, compilerOptions)) {


### PR DESCRIPTION
@amcasey recently discovered that the Web Performance API in NodeJS adds quite a bit more overhead to the total compile time than what we were doing before. This changes our use of native performance APIs in the following ways:

- Revert back to calculating our own `mark` times and `measure` durations in `ts.performance` rather than using `PerformanceObserver`.
- Conditionally call the native `mark` and `measure` when _any_ of the following are true:
  - We are running in the browser (since a debugger can start a cpu profile at any time)
  - We are running in NodeJS with Node's `--cpu-prof` option specified (to capture user timing events in the profile)
  - We are running in NodeJS with V8's `--prof` option specified (to capture user timing events in the profile)
  - We are running in NodeJS with our own `--generateCpuProfile` option specified (to capture user timing events in the profile)
  - We are running in NodeJS and `sys.debugMode` is true (since a debugger can start a cpu profile at any time)

If none of those cases are true, we will not call the native `mark` and `measure` methods. I've filed https://github.com/nodejs/diagnostics/issues/464 to track the performance issue we encountered in NodeJS, and it sounds like they plan to have a patch available in the near future that improves their implementation.