### PR TITLE
Signature help turns off current-parameter display for non-trailing rest parameters

### DIFF
--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -540,7 +540,15 @@ namespace ts.SignatureHelp {
         }
 
         Debug.assert(selectedItemIndex !== -1); // If candidates is non-empty it should always include bestSignature. We check for an empty candidates before calling this function.
-        return { items: flatMapToMutable(items, identity), applicableSpan, selectedItemIndex, argumentIndex, argumentCount };
+        const help = { items: flatMapToMutable(items, identity), applicableSpan, selectedItemIndex, argumentIndex, argumentCount };
+        const selected = help.items[selectedItemIndex];
+        if (selected.isVariadic) {
+            const firstRest = findIndex(selected.parameters, p => !!p.isRest);
+            if (firstRest > -1 && help.argumentIndex > firstRest) {
+                help.argumentIndex = firstRest;
+            }
+        }
+        return help;
     }
 
     function createTypeHelpItems(
@@ -620,12 +628,10 @@ namespace ts.SignatureHelp {
                 printer.writeList(ListFormat.TypeParameters, args, sourceFile, writer);
             }
         });
-        const expansions = checker.getExpandedParameters(candidateSignature);
-        const hasNonTrailingRest = expansions.some(e => e.some((p,i) => (p as TransientSymbol).checkFlags & CheckFlags.RestParameter && i !== e.length - 1));
-        const hasTupleExpansion = expansions.length > 1;
-        return (hasNonTrailingRest ? [candidateSignature.parameters] : expansions).map(parameterList => {
+        const lists = checker.getExpandedParameters(candidateSignature);
+        return lists.map(parameterList => {
             return {
-                isVariadic: isVariadic && (!hasTupleExpansion || !!((parameterList[parameterList.length - 1] as TransientSymbol).checkFlags & CheckFlags.RestParameter)),
+                isVariadic: isVariadic && (lists.length === 1 || !!((parameterList[parameterList.length - 1] as TransientSymbol).checkFlags & CheckFlags.RestParameter)),
                 parameters: parameterList.map(p => createSignatureHelpParameterForParameter(p, checker, enclosingDeclaration, sourceFile, printer)),
                 prefix: [...typeParameterParts, punctuationPart(SyntaxKind.OpenParenToken)],
                 suffix: [punctuationPart(SyntaxKind.CloseParenToken)]
@@ -639,7 +645,8 @@ namespace ts.SignatureHelp {
             printer.writeNode(EmitHint.Unspecified, param, sourceFile, writer);
         });
         const isOptional = checker.isOptionalParameter(parameter.valueDeclaration as ParameterDeclaration);
-        return { name: parameter.name, documentation: parameter.getDocumentationComment(checker), displayParts, isOptional };
+        const isRest = !!((parameter as TransientSymbol).checkFlags & CheckFlags.RestParameter);
+        return { name: parameter.name, documentation: parameter.getDocumentationComment(checker), displayParts, isOptional, isRest };
     }
 
     function createSignatureHelpParameterForTypeParameter(typeParameter: TypeParameter, checker: TypeChecker, enclosingDeclaration: Node, sourceFile: SourceFile, printer: Printer): SignatureHelpParameter {
@@ -647,6 +654,6 @@ namespace ts.SignatureHelp {
             const param = checker.typeParameterToDeclaration(typeParameter, enclosingDeclaration, signatureHelpNodeBuilderFlags)!;
             printer.writeNode(EmitHint.Unspecified, param, sourceFile, writer);
         });
-        return { name: typeParameter.symbol.name, documentation: typeParameter.symbol.getDocumentationComment(checker), displayParts, isOptional: false };
+        return { name: typeParameter.symbol.name, documentation: typeParameter.symbol.getDocumentationComment(checker), displayParts, isOptional: false, isRest: false };
     }
 }

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -544,8 +544,12 @@ namespace ts.SignatureHelp {
         const selected = help.items[selectedItemIndex];
         if (selected.isVariadic) {
             const firstRest = findIndex(selected.parameters, p => !!p.isRest);
-            if (firstRest > -1 && help.argumentIndex > firstRest) {
-                help.argumentIndex = firstRest;
+            if (-1 < firstRest && firstRest < selected.parameters.length - 1) {
+                // We don't have any code to get this correct; instead, don't highlight a current parameter AT ALL
+                help.argumentIndex = selected.parameters.length;
+            }
+            else {
+                help.argumentIndex = Math.min(help.argumentIndex, selected.parameters.length - 1);
             }
         }
         return help;

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -543,9 +543,9 @@ namespace ts.SignatureHelp {
         const help = { items: flatMapToMutable(items, identity), applicableSpan, selectedItemIndex, argumentIndex, argumentCount };
         const selected = help.items[selectedItemIndex];
         if (selected.isVariadic) {
-            const firstVariadic = findIndex(selected.parameters, p => !!p.isVariadic);
-            if (firstVariadic > -1 && help.argumentIndex > firstVariadic) {
-                help.argumentIndex = firstVariadic;
+            const firstRest = findIndex(selected.parameters, p => !!p.isRest);
+            if (firstRest > -1 && help.argumentIndex > firstRest) {
+                help.argumentIndex = firstRest;
             }
         }
         return help;
@@ -646,7 +646,7 @@ namespace ts.SignatureHelp {
         });
         const isOptional = checker.isOptionalParameter(parameter.valueDeclaration as ParameterDeclaration);
         const isVariadic = !!((parameter as TransientSymbol).checkFlags & CheckFlags.RestParameter);
-        return { name: parameter.name, documentation: parameter.getDocumentationComment(checker), displayParts, isOptional, isVariadic };
+        return { name: parameter.name, documentation: parameter.getDocumentationComment(checker), displayParts, isOptional, isRest };
     }
 
     function createSignatureHelpParameterForTypeParameter(typeParameter: TypeParameter, checker: TypeChecker, enclosingDeclaration: Node, sourceFile: SourceFile, printer: Printer): SignatureHelpParameter {
@@ -654,6 +654,6 @@ namespace ts.SignatureHelp {
             const param = checker.typeParameterToDeclaration(typeParameter, enclosingDeclaration, signatureHelpNodeBuilderFlags)!;
             printer.writeNode(EmitHint.Unspecified, param, sourceFile, writer);
         });
-        return { name: typeParameter.symbol.name, documentation: typeParameter.symbol.getDocumentationComment(checker), displayParts, isOptional: false, isVariadic: false };
+        return { name: typeParameter.symbol.name, documentation: typeParameter.symbol.getDocumentationComment(checker), displayParts, isOptional: false, isRest: false };
     }
 }

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -645,7 +645,7 @@ namespace ts.SignatureHelp {
             printer.writeNode(EmitHint.Unspecified, param, sourceFile, writer);
         });
         const isOptional = checker.isOptionalParameter(parameter.valueDeclaration as ParameterDeclaration);
-        const isVariadic = !!((parameter as TransientSymbol).checkFlags & CheckFlags.RestParameter);
+        const isRest = !!((parameter as TransientSymbol).checkFlags & CheckFlags.RestParameter);
         return { name: parameter.name, documentation: parameter.getDocumentationComment(checker), displayParts, isOptional, isRest };
     }
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1078,6 +1078,7 @@ namespace ts {
         documentation: SymbolDisplayPart[];
         displayParts: SymbolDisplayPart[];
         isOptional: boolean;
+        isRest?: boolean;
     }
 
     export interface SelectionRange {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1078,7 +1078,7 @@ namespace ts {
         documentation: SymbolDisplayPart[];
         displayParts: SymbolDisplayPart[];
         isOptional: boolean;
-        isVariadic?: boolean;
+        isRest?: boolean;
     }
 
     export interface SelectionRange {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1078,6 +1078,7 @@ namespace ts {
         documentation: SymbolDisplayPart[];
         displayParts: SymbolDisplayPart[];
         isOptional: boolean;
+        isVariadic?: boolean;
     }
 
     export interface SelectionRange {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1078,7 +1078,6 @@ namespace ts {
         documentation: SymbolDisplayPart[];
         displayParts: SymbolDisplayPart[];
         isOptional: boolean;
-        isRest?: boolean;
     }
 
     export interface SelectionRange {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -6027,6 +6027,7 @@ declare namespace ts {
         documentation: SymbolDisplayPart[];
         displayParts: SymbolDisplayPart[];
         isOptional: boolean;
+        isRest?: boolean;
     }
     interface SelectionRange {
         textSpan: TextSpan;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6027,6 +6027,7 @@ declare namespace ts {
         documentation: SymbolDisplayPart[];
         displayParts: SymbolDisplayPart[];
         isOptional: boolean;
+        isRest?: boolean;
     }
     interface SelectionRange {
         textSpan: TextSpan;

--- a/tests/cases/fourslash/signatureHelpLeadingRestTuple.ts
+++ b/tests/cases/fourslash/signatureHelpLeadingRestTuple.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-////export function leading(...args: [...names: string[], x: boolean, y: number]): void {
+////export function leading(...args: [...names: string[], allCaps: boolean]): void {
 ////}
 ////
 ////leading(/*1*/);
@@ -10,25 +10,29 @@
 verify.signatureHelp(
     {
         marker: "1",
-        text: "leading(...args: [...names: string[], x: boolean, y: number]): void",
+        text: "leading(...names: string[], allCaps: boolean): void",
         overloadsCount: 1,
-        parameterCount: 1,
-        parameterName: "args",
-        parameterSpan: "...args: [...names: string[], x: boolean, y: number]",
+        parameterCount: 2,
+        parameterName: "names",
+        parameterSpan: "...names: string[]",
         isVariadic: true,
     },
     {
         marker: "2",
-        text: "leading(...args: [...names: string[], x: boolean, y: number]): void",
+        text: "leading(...names: string[], allCaps: boolean): void",
         overloadsCount: 1,
-        parameterCount: 1,
+        parameterCount: 2,
+        parameterName: "names",
+        parameterSpan: "...names: string[]",
         isVariadic: true,
     },
     {
         marker: "3",
-        text: "leading(...args: [...names: string[], x: boolean, y: number]): void",
+        text: "leading(...names: string[], allCaps: boolean): void",
         overloadsCount: 1,
-        parameterCount: 1,
+        parameterCount: 2,
+        parameterName: "names",
+        parameterSpan: "...names: string[]",
         isVariadic: true,
     },
 );

--- a/tests/cases/fourslash/signatureHelpLeadingRestTuple.ts
+++ b/tests/cases/fourslash/signatureHelpLeadingRestTuple.ts
@@ -1,0 +1,38 @@
+/// <reference path='fourslash.ts' />
+
+////export function leading(...args: [...names: string[], allCaps: boolean]): void {
+////}
+////
+////leading(/*1*/);
+////leading("ok", /*2*/);
+////leading("ok", "ok", /*3*/);
+
+verify.signatureHelp(
+    {
+        marker: "1",
+        text: "leading(...names: string[], allCaps: boolean): void",
+        overloadsCount: 1,
+        parameterCount: 2,
+        parameterName: "names",
+        parameterSpan: "...names: string[]",
+        isVariadic: true,
+    },
+    {
+        marker: "2",
+        text: "leading(...names: string[], allCaps: boolean): void",
+        overloadsCount: 1,
+        parameterCount: 2,
+        parameterName: "names",
+        parameterSpan: "...names: string[]",
+        isVariadic: true,
+    },
+    {
+        marker: "3",
+        text: "leading(...names: string[], allCaps: boolean): void",
+        overloadsCount: 1,
+        parameterCount: 2,
+        parameterName: "names",
+        parameterSpan: "...names: string[]",
+        isVariadic: true,
+    },
+);

--- a/tests/cases/fourslash/signatureHelpLeadingRestTuple.ts
+++ b/tests/cases/fourslash/signatureHelpLeadingRestTuple.ts
@@ -13,8 +13,6 @@ verify.signatureHelp(
         text: "leading(...names: string[], allCaps: boolean): void",
         overloadsCount: 1,
         parameterCount: 2,
-        parameterName: "names",
-        parameterSpan: "...names: string[]",
         isVariadic: true,
     },
     {
@@ -22,8 +20,6 @@ verify.signatureHelp(
         text: "leading(...names: string[], allCaps: boolean): void",
         overloadsCount: 1,
         parameterCount: 2,
-        parameterName: "names",
-        parameterSpan: "...names: string[]",
         isVariadic: true,
     },
     {
@@ -31,8 +27,6 @@ verify.signatureHelp(
         text: "leading(...names: string[], allCaps: boolean): void",
         overloadsCount: 1,
         parameterCount: 2,
-        parameterName: "names",
-        parameterSpan: "...names: string[]",
         isVariadic: true,
     },
 );

--- a/tests/cases/fourslash/signatureHelpLeadingRestTuple.ts
+++ b/tests/cases/fourslash/signatureHelpLeadingRestTuple.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-////export function leading(...args: [...names: string[], allCaps: boolean]): void {
+////export function leading(...args: [...names: string[], x: boolean, y: number]): void {
 ////}
 ////
 ////leading(/*1*/);
@@ -10,29 +10,25 @@
 verify.signatureHelp(
     {
         marker: "1",
-        text: "leading(...names: string[], allCaps: boolean): void",
+        text: "leading(...args: [...names: string[], x: boolean, y: number]): void",
         overloadsCount: 1,
-        parameterCount: 2,
-        parameterName: "names",
-        parameterSpan: "...names: string[]",
+        parameterCount: 1,
+        parameterName: "args",
+        parameterSpan: "...args: [...names: string[], x: boolean, y: number]",
         isVariadic: true,
     },
     {
         marker: "2",
-        text: "leading(...names: string[], allCaps: boolean): void",
+        text: "leading(...args: [...names: string[], x: boolean, y: number]): void",
         overloadsCount: 1,
-        parameterCount: 2,
-        parameterName: "names",
-        parameterSpan: "...names: string[]",
+        parameterCount: 1,
         isVariadic: true,
     },
     {
         marker: "3",
-        text: "leading(...names: string[], allCaps: boolean): void",
+        text: "leading(...args: [...names: string[], x: boolean, y: number]): void",
         overloadsCount: 1,
-        parameterCount: 2,
-        parameterName: "names",
-        parameterSpan: "...names: string[]",
+        parameterCount: 1,
         isVariadic: true,
     },
 );

--- a/tests/cases/fourslash/signatureHelpTrailingRestTuple.ts
+++ b/tests/cases/fourslash/signatureHelpTrailingRestTuple.ts
@@ -1,0 +1,38 @@
+/// <reference path='fourslash.ts' />
+
+////export function leading(allCaps: boolean, ...names: string[]): void {
+////}
+////
+////leading(/*1*/);
+////leading(false, /*2*/);
+////leading(false, "ok", /*3*/);
+
+verify.signatureHelp(
+    {
+        marker: "1",
+        text: "leading(allCaps: boolean, ...names: string[]): void",
+        overloadsCount: 1,
+        parameterCount: 2,
+        parameterName: "allCaps",
+        parameterSpan: "allCaps: boolean",
+        isVariadic: true,
+    },
+    {
+        marker: "2",
+        text: "leading(allCaps: boolean, ...names: string[]): void",
+        overloadsCount: 1,
+        parameterCount: 2,
+        parameterName: "names",
+        parameterSpan: "...names: string[]",
+        isVariadic: true,
+    },
+    {
+        marker: "3",
+        text: "leading(allCaps: boolean, ...names: string[]): void",
+        overloadsCount: 1,
+        parameterCount: 2,
+        parameterName: "names",
+        parameterSpan: "...names: string[]",
+        isVariadic: true,
+    },
+);


### PR DESCRIPTION
With tuple types as rest parameters, you can now create non-trailing rest parameters. However, the simplistic current-parameter index matching just increments right past them. This PR turns off the current-parameter highlight for non-trailing rest parameters.

```ts
declare function loading(...args: [...names: string[], allCaps: boolean, extra: boolean]): void;

leading(/**/
leading('one', /**/
leading('one', 'two', /**/
```

For these calls, there is no current parameter, because signature help doesn't have any code to map multiple arguments to a single rest parameter. But at least it's never wrong!

Fixes #42292

## Scope Creep Time! ##

I improved current-parameter highlighting for trailing rest parameters as well: the highlight now stops at the end.