### PR TITLE
Error message clarification for accessing protected members

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26153,7 +26153,7 @@ namespace ts {
                 type = (type as TypeParameter).isThisType ? getConstraintOfTypeParameter(<TypeParameter>type)! : getBaseConstraintOfType(<TypeParameter>type)!; // TODO: GH#18217 Use a different variable that's allowed to be undefined
             }
             if (!type || !hasBaseType(type, enclosingClass)) {
-                error(errorNode, Diagnostics.Property_0_is_protected_and_only_accessible_through_an_instance_of_class_1, symbolToString(prop), typeToString(enclosingClass));
+                error(errorNode, Diagnostics.Property_0_is_protected_and_only_accessible_through_an_instance_of_class_1_This_is_an_instance_of_class_2, symbolToString(prop), typeToString(enclosingClass), typeToString(type));
                 return false;
             }
             return true;

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1962,7 +1962,7 @@
         "category": "Error",
         "code": 2445
     },
-    "Property '{0}' is protected and only accessible through an instance of class '{1}'.": {
+    "Property '{0}' is protected and only accessible through an instance of class '{1}'. This is an instance of class '{2}'.": {
         "category": "Error",
         "code": 2446
     },
@@ -6237,7 +6237,6 @@
         "category": "Message",
         "code": 95159
     },
-
 
     "No value exists in scope for the shorthand property '{0}'. Either declare one or provide an initializer.": {
         "category": "Error",

--- a/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedSubclass1.errors.txt
+++ b/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedSubclass1.errors.txt
@@ -1,18 +1,18 @@
 tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(15,20): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(32,19): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(34,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(32,19): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'. This is an instance of class 'Base'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(34,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'. This is an instance of class 'Derived2'.
 tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(35,20): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(36,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(52,19): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(53,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(36,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'. This is an instance of class 'Derived4'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(52,19): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'. This is an instance of class 'Base'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(53,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'. This is an instance of class 'Derived1'.
 tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(55,20): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(73,19): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(74,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(75,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(77,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(93,19): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(94,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(95,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(73,19): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Base'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(74,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Derived1'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(75,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Derived2'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(77,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Derived4'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(93,19): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'. This is an instance of class 'Base'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(94,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'. This is an instance of class 'Derived1'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(95,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'. This is an instance of class 'Derived2'.
 tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(96,20): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
 tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(110,3): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
 tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(111,4): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
@@ -57,17 +57,17 @@ tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAcce
     
                     b.x;            // Error, isn't accessed through an instance of the enclosing class
                       ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'. This is an instance of class 'Base'.
                     d1.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
                     d2.x;           // Error, isn't accessed through an instance of the enclosing class
                        ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'. This is an instance of class 'Derived2'.
                     d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
                        ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
                     d4.x;           // Error, isn't accessed through an instance of the enclosing class
                        ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'. This is an instance of class 'Derived4'.
                 }
             }
         }
@@ -85,10 +85,10 @@ tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAcce
     
                     b.x;            // Error, isn't accessed through an instance of the enclosing class
                       ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'. This is an instance of class 'Base'.
                     d1.x;           // Error, isn't accessed through an instance of the enclosing class
                        ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'. This is an instance of class 'Derived1'.
                     d2.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
                     d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
                        ~
@@ -112,17 +112,17 @@ tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAcce
     
                     b.x;            // Error, isn't accessed through an instance of the enclosing class
                       ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Base'.
                     d1.x;           // Error, isn't accessed through an instance of the enclosing class
                        ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Derived1'.
                     d2.x;           // Error, isn't accessed through an instance of the enclosing class
                        ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Derived2'.
                     d3.x;           // OK, accessed within their declaring class
                     d4.x;           // Error, isn't accessed through an instance of the enclosing class
                        ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Derived4'.
                 }
             }
         }
@@ -140,13 +140,13 @@ tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAcce
     
                     b.x;            // Error, isn't accessed through an instance of the enclosing class
                       ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'. This is an instance of class 'Base'.
                     d1.x;           // Error, isn't accessed through an instance of the enclosing class
                        ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'. This is an instance of class 'Derived1'.
                     d2.x;           // Error, isn't accessed through an instance of the enclosing class
                        ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'. This is an instance of class 'Derived2'.
                     d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
                        ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.

--- a/tests/baselines/reference/protectedClassPropertyAccessibleWithinSubclass2.errors.txt
+++ b/tests/baselines/reference/protectedClassPropertyAccessibleWithinSubclass2.errors.txt
@@ -1,18 +1,18 @@
 tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(13,12): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(26,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(28,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(26,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'. This is an instance of class 'Base'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(28,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'. This is an instance of class 'Derived2'.
 tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(29,12): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(30,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(42,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(43,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(30,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'. This is an instance of class 'Derived4'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(42,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'. This is an instance of class 'Base'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(43,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'. This is an instance of class 'Derived1'.
 tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(45,12): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(59,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(60,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(61,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(63,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(75,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(76,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(77,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(59,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Base'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(60,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Derived1'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(61,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Derived2'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(63,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Derived4'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(75,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'. This is an instance of class 'Base'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(76,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'. This is an instance of class 'Derived1'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(77,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'. This is an instance of class 'Derived2'.
 tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(78,12): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
 tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(90,3): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
 tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(91,4): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
@@ -51,17 +51,17 @@ tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAcce
     
             b.x;            // Error, isn't accessed through an instance of the enclosing class
               ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'. This is an instance of class 'Base'.
             d1.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
             d2.x;           // Error, isn't accessed through an instance of the enclosing class
                ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'. This is an instance of class 'Derived2'.
             d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
                ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
             d4.x;           // Error, isn't accessed through an instance of the enclosing class
                ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'. This is an instance of class 'Derived4'.
         }
     }
     
@@ -75,10 +75,10 @@ tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAcce
     
             b.x;            // Error, isn't accessed through an instance of the enclosing class
               ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'. This is an instance of class 'Base'.
             d1.x;           // Error, isn't accessed through an instance of the enclosing class
                ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'. This is an instance of class 'Derived1'.
             d2.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
             d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
                ~
@@ -98,17 +98,17 @@ tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAcce
     
             b.x;            // Error, isn't accessed through an instance of the enclosing class
               ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Base'.
             d1.x;           // Error, isn't accessed through an instance of the enclosing class
                ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Derived1'.
             d2.x;           // Error, isn't accessed through an instance of the enclosing class
                ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Derived2'.
             d3.x;           // OK, accessed within their declaring class
             d4.x;           // Error, isn't accessed through an instance of the enclosing class
                ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'. This is an instance of class 'Derived4'.
         }
     }
     
@@ -122,13 +122,13 @@ tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAcce
     
             b.x;            // Error, isn't accessed through an instance of the enclosing class
               ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'. This is an instance of class 'Base'.
             d1.x;           // Error, isn't accessed through an instance of the enclosing class
                ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'. This is an instance of class 'Derived1'.
             d2.x;           // Error, isn't accessed through an instance of the enclosing class
                ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'. This is an instance of class 'Derived2'.
             d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
                ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.

--- a/tests/baselines/reference/protectedInstanceMemberAccessibility.errors.txt
+++ b/tests/baselines/reference/protectedInstanceMemberAccessibility.errors.txt
@@ -2,13 +2,13 @@ tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAcc
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(16,24): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(18,24): error TS2339: Property 'y' does not exist on type 'A'.
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(19,24): error TS2339: Property 'z' does not exist on type 'A'.
-tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(22,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'B'.
-tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(23,20): error TS2446: Property 'f' is protected and only accessible through an instance of class 'B'.
+tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(22,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'B'. This is an instance of class 'A'.
+tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(23,20): error TS2446: Property 'f' is protected and only accessible through an instance of class 'B'. This is an instance of class 'A'.
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(24,20): error TS2339: Property 'y' does not exist on type 'A'.
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(25,20): error TS2339: Property 'z' does not exist on type 'A'.
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(31,20): error TS2339: Property 'z' does not exist on type 'B'.
-tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(34,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'B'.
-tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(35,20): error TS2446: Property 'f' is protected and only accessible through an instance of class 'B'.
+tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(34,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'B'. This is an instance of class 'C'.
+tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(35,20): error TS2446: Property 'f' is protected and only accessible through an instance of class 'B'. This is an instance of class 'C'.
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(36,20): error TS2339: Property 'y' does not exist on type 'C'.
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(37,20): error TS2445: Property 'z' is protected and only accessible within class 'C' and its subclasses.
 
@@ -45,10 +45,10 @@ tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAcc
             var a: A;
             var a1 = a.x;    // error
                        ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'B'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'B'. This is an instance of class 'A'.
             var a2 = a.f();  // error
                        ~
-!!! error TS2446: Property 'f' is protected and only accessible through an instance of class 'B'.
+!!! error TS2446: Property 'f' is protected and only accessible through an instance of class 'B'. This is an instance of class 'A'.
             var a3 = a.y;    // error
                        ~
 !!! error TS2339: Property 'y' does not exist on type 'A'.
@@ -67,10 +67,10 @@ tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAcc
             var c: C;
             var c1 = c.x;    // error
                        ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'B'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'B'. This is an instance of class 'C'.
             var c2 = c.f();  // error
                        ~
-!!! error TS2446: Property 'f' is protected and only accessible through an instance of class 'B'.
+!!! error TS2446: Property 'f' is protected and only accessible through an instance of class 'B'. This is an instance of class 'C'.
             var c3 = c.y;    // error
                        ~
 !!! error TS2339: Property 'y' does not exist on type 'C'.

--- a/tests/baselines/reference/protectedMembers.errors.txt
+++ b/tests/baselines/reference/protectedMembers.errors.txt
@@ -6,8 +6,8 @@ tests/cases/compiler/protectedMembers.ts(46,4): error TS2445: Property 'x' is pr
 tests/cases/compiler/protectedMembers.ts(47,4): error TS2445: Property 'f' is protected and only accessible within class 'C2' and its subclasses.
 tests/cases/compiler/protectedMembers.ts(48,4): error TS2445: Property 'sx' is protected and only accessible within class 'C1' and its subclasses.
 tests/cases/compiler/protectedMembers.ts(49,4): error TS2445: Property 'sf' is protected and only accessible within class 'C2' and its subclasses.
-tests/cases/compiler/protectedMembers.ts(68,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'C'.
-tests/cases/compiler/protectedMembers.ts(69,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'C'.
+tests/cases/compiler/protectedMembers.ts(68,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'C'. This is an instance of class 'A'.
+tests/cases/compiler/protectedMembers.ts(69,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'C'. This is an instance of class 'B'.
 tests/cases/compiler/protectedMembers.ts(97,1): error TS2322: Type 'B1' is not assignable to type 'A1'.
   Property 'x' is protected but type 'B1' is not a class derived from 'A1'.
 tests/cases/compiler/protectedMembers.ts(98,1): error TS2322: Type 'A1' is not assignable to type 'B1'.
@@ -102,10 +102,10 @@ tests/cases/compiler/protectedMembers.ts(111,7): error TS2415: Class 'B3' incorr
         static foo(a: A, b: B, c: C, d: D, e: E) {
             a.x = 1;  // Error, access must be through C or type derived from C
               ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'C'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'C'. This is an instance of class 'A'.
             b.x = 1;  // Error, access must be through C or type derived from C
               ~
-!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'C'.
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'C'. This is an instance of class 'B'.
             c.x = 1;
             d.x = 1;
             e.x = 1;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #35989

Adds clarification on the error when accessing protected members of a superclass. Based on this https://github.com/microsoft/TypeScript/issues/35989#issuecomment-572305639.

Old message (from the issue):
```
Property 'doTransfer' is protected and only accessible through an instance of class 'HostileBankAccount'.
```
Adding the actual instance, so new message:
```
Property 'doTransfer' is protected and only accessible through an instance of class 'HostileBankAccount'. This is an instance of 'BankAccount'.
```

Rendered view of  how it looks like when the compiler is run:
![protectedError](https://user-images.githubusercontent.com/5303520/106554840-0df47880-64d1-11eb-90d4-b2cb42f393eb.JPG)

This is my first contribution here so happy to make any changes (or close this if it's not needed, the ticket didn't have much activity lately 😄)

