### PR TITLE
Indexing tuple intersection type beyond length produces unexpected type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14221,6 +14221,7 @@ namespace ts {
                         return noUncheckedIndexedAccessCandidate ? getUnionType([restType, undefinedType]) : restType;
                     });
                 }
+                if (someType(objectType, isTupleType) && isNumericLiteralName(propName) && +propName >= 0) return undefinedType;
             }
             if (!(indexType.flags & TypeFlags.Nullable) && isTypeAssignableToKind(indexType, TypeFlags.StringLike | TypeFlags.NumberLike | TypeFlags.ESSymbolLike)) {
                 if (objectType.flags & (TypeFlags.Any | TypeFlags.Never)) {
@@ -21740,6 +21741,10 @@ namespace ts {
 
         function everyType(type: Type, f: (t: Type) => boolean): boolean {
             return type.flags & TypeFlags.Union ? every((<UnionType>type).types, f) : f(type);
+        }
+
+        function someType(type: Type, f: (t: Type) => boolean): boolean {
+            return type.flags & (TypeFlags.Union | TypeFlags.Intersection) ? some((<UnionType | IntersectionType>type).types, f) : f(type);
         }
 
         function filterType(type: Type, f: (t: Type) => boolean): Type {

--- a/tests/baselines/reference/checkJsxChildrenCanBeTupleType.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenCanBeTupleType.errors.txt
@@ -1,13 +1,8 @@
-tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx(17,18): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx(20,3): error TS2769: No overload matches this call.
   Overload 1 of 2, '(props: Readonly<ResizablePanelProps>): ResizablePanel', gave the following error.
-    Type '{ children: [Element, Element, Element]; }' is not assignable to type 'Readonly<ResizablePanelProps>'.
-      Types of property 'children' are incompatible.
-        Type '[Element, Element, Element]' is not assignable to type '[ReactNode, ReactNode]'.
-          Source has 3 element(s) but target allows only 2.
+    Type 'Element' is not assignable to type 'undefined'.
   Overload 2 of 2, '(props: ResizablePanelProps, context?: any): ResizablePanel', gave the following error.
-    Type '{ children: [Element, Element, Element]; }' is not assignable to type 'Readonly<ResizablePanelProps>'.
-      Types of property 'children' are incompatible.
-        Type '[Element, Element, Element]' is not assignable to type '[ReactNode, ReactNode]'.
+    Type 'Element' is not assignable to type 'undefined'.
 
 
 ==== tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx (1 errors) ====
@@ -28,18 +23,13 @@ tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx(17,18): error TS2
     </ResizablePanel>
     
     const testErr = <ResizablePanel>
-                     ~~~~~~~~~~~~~~
+      <div />
+      <div />
+      <div />
+      ~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(props: Readonly<ResizablePanelProps>): ResizablePanel', gave the following error.
-!!! error TS2769:     Type '{ children: [Element, Element, Element]; }' is not assignable to type 'Readonly<ResizablePanelProps>'.
-!!! error TS2769:       Types of property 'children' are incompatible.
-!!! error TS2769:         Type '[Element, Element, Element]' is not assignable to type '[ReactNode, ReactNode]'.
-!!! error TS2769:           Source has 3 element(s) but target allows only 2.
+!!! error TS2769:     Type 'Element' is not assignable to type 'undefined'.
 !!! error TS2769:   Overload 2 of 2, '(props: ResizablePanelProps, context?: any): ResizablePanel', gave the following error.
-!!! error TS2769:     Type '{ children: [Element, Element, Element]; }' is not assignable to type 'Readonly<ResizablePanelProps>'.
-!!! error TS2769:       Types of property 'children' are incompatible.
-!!! error TS2769:         Type '[Element, Element, Element]' is not assignable to type '[ReactNode, ReactNode]'.
-      <div />
-      <div />
-      <div />
+!!! error TS2769:     Type 'Element' is not assignable to type 'undefined'.
     </ResizablePanel>

--- a/tests/baselines/reference/outOfBoundTupleIndexTypeIsUndefined.errors.txt
+++ b/tests/baselines/reference/outOfBoundTupleIndexTypeIsUndefined.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/compiler/outOfBoundTupleIndexTypeIsUndefined.ts(9,7): error TS2322: Type '0' is not assignable to type 'undefined'.
+
+
+==== tests/cases/compiler/outOfBoundTupleIndexTypeIsUndefined.ts (1 errors) ====
+    type T = [number, boolean] & { x: number };
+    type U = [number, boolean] & { [2]: number };
+    
+    declare const t: T;
+    const a = t[0]; // number
+    const b = t[1]; // boolean
+    const c = t[2]; // undefined
+    
+    const x: T[2] = 0 // error
+          ~
+!!! error TS2322: Type '0' is not assignable to type 'undefined'.
+    const y: U[2] = 0 // no error
+    

--- a/tests/baselines/reference/outOfBoundTupleIndexTypeIsUndefined.js
+++ b/tests/baselines/reference/outOfBoundTupleIndexTypeIsUndefined.js
@@ -1,0 +1,19 @@
+//// [outOfBoundTupleIndexTypeIsUndefined.ts]
+type T = [number, boolean] & { x: number };
+type U = [number, boolean] & { [2]: number };
+
+declare const t: T;
+const a = t[0]; // number
+const b = t[1]; // boolean
+const c = t[2]; // undefined
+
+const x: T[2] = 0 // error
+const y: U[2] = 0 // no error
+
+
+//// [outOfBoundTupleIndexTypeIsUndefined.js]
+var a = t[0]; // number
+var b = t[1]; // boolean
+var c = t[2]; // undefined
+var x = 0; // error
+var y = 0; // no error

--- a/tests/baselines/reference/outOfBoundTupleIndexTypeIsUndefined.symbols
+++ b/tests/baselines/reference/outOfBoundTupleIndexTypeIsUndefined.symbols
@@ -1,0 +1,36 @@
+=== tests/cases/compiler/outOfBoundTupleIndexTypeIsUndefined.ts ===
+type T = [number, boolean] & { x: number };
+>T : Symbol(T, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 0, 0))
+>x : Symbol(x, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 0, 30))
+
+type U = [number, boolean] & { [2]: number };
+>U : Symbol(U, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 0, 43))
+>[2] : Symbol([2], Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 1, 30))
+>2 : Symbol([2], Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 1, 30))
+
+declare const t: T;
+>t : Symbol(t, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 3, 13))
+>T : Symbol(T, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 0, 0))
+
+const a = t[0]; // number
+>a : Symbol(a, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 4, 5))
+>t : Symbol(t, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 3, 13))
+>0 : Symbol(0)
+
+const b = t[1]; // boolean
+>b : Symbol(b, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 5, 5))
+>t : Symbol(t, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 3, 13))
+>1 : Symbol(1)
+
+const c = t[2]; // undefined
+>c : Symbol(c, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 6, 5))
+>t : Symbol(t, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 3, 13))
+
+const x: T[2] = 0 // error
+>x : Symbol(x, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 8, 5))
+>T : Symbol(T, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 0, 0))
+
+const y: U[2] = 0 // no error
+>y : Symbol(y, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 9, 5))
+>U : Symbol(U, Decl(outOfBoundTupleIndexTypeIsUndefined.ts, 0, 43))
+

--- a/tests/baselines/reference/outOfBoundTupleIndexTypeIsUndefined.types
+++ b/tests/baselines/reference/outOfBoundTupleIndexTypeIsUndefined.types
@@ -1,0 +1,39 @@
+=== tests/cases/compiler/outOfBoundTupleIndexTypeIsUndefined.ts ===
+type T = [number, boolean] & { x: number };
+>T : T
+>x : number
+
+type U = [number, boolean] & { [2]: number };
+>U : U
+>[2] : number
+>2 : 2
+
+declare const t: T;
+>t : T
+
+const a = t[0]; // number
+>a : number
+>t[0] : number
+>t : T
+>0 : 0
+
+const b = t[1]; // boolean
+>b : boolean
+>t[1] : boolean
+>t : T
+>1 : 1
+
+const c = t[2]; // undefined
+>c : undefined
+>t[2] : undefined
+>t : T
+>2 : 2
+
+const x: T[2] = 0 // error
+>x : undefined
+>0 : 0
+
+const y: U[2] = 0 // no error
+>y : number
+>0 : 0
+

--- a/tests/cases/compiler/outOfBoundTupleIndexTypeIsUndefined.ts
+++ b/tests/cases/compiler/outOfBoundTupleIndexTypeIsUndefined.ts
@@ -1,0 +1,10 @@
+type T = [number, boolean] & { x: number };
+type U = [number, boolean] & { [2]: number };
+
+declare const t: T;
+const a = t[0]; // number
+const b = t[1]; // boolean
+const c = t[2]; // undefined
+
+const x: T[2] = 0 // error
+const y: U[2] = 0 // no error


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #42557
