### PR TITLE
Make object literal properties new identifier locations when not contextually typed

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1882,7 +1882,8 @@ namespace ts.Completions {
                         return containingNodeKind === SyntaxKind.ModuleDeclaration;           // module A.|
 
                     case SyntaxKind.OpenBraceToken:
-                        return containingNodeKind === SyntaxKind.ClassDeclaration;            // class A{ |
+                        return containingNodeKind === SyntaxKind.ClassDeclaration             // class A { |
+                            || containingNodeKind === SyntaxKind.ObjectLiteralExpression;     // const obj = { |
 
                     case SyntaxKind.EqualsToken:
                         return containingNodeKind === SyntaxKind.VariableDeclaration          // const x = a|

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1387,7 +1387,7 @@ namespace ts.Completions {
 
             // Get all entities in the current scope.
             completionKind = CompletionKind.Global;
-            isNewIdentifierLocation = isNewIdentifierDefinitionLocation(contextToken);
+            isNewIdentifierLocation = isNewIdentifierDefinitionLocation();
 
             if (previousToken !== contextToken) {
                 Debug.assert(!!previousToken, "Expected 'contextToken' to be defined when different from 'previousToken'.");
@@ -1849,18 +1849,19 @@ namespace ts.Completions {
             return false;
         }
 
-        function isNewIdentifierDefinitionLocation(previousToken: Node | undefined): boolean {
-            if (previousToken) {
-                const containingNodeKind = previousToken.parent.kind;
+        function isNewIdentifierDefinitionLocation(): boolean {
+            if (contextToken) {
+                const containingNodeKind = contextToken.parent.kind;
                 // Previous token may have been a keyword that was converted to an identifier.
-                switch (keywordForNode(previousToken)) {
+                switch (keywordForNode(contextToken)) {
                     case SyntaxKind.CommaToken:
                         return containingNodeKind === SyntaxKind.CallExpression               // func( a, |
                             || containingNodeKind === SyntaxKind.Constructor                  // constructor( a, |   /* public, protected, private keywords are allowed here, so show completion */
                             || containingNodeKind === SyntaxKind.NewExpression                // new C(a, |
                             || containingNodeKind === SyntaxKind.ArrayLiteralExpression       // [a, |
                             || containingNodeKind === SyntaxKind.BinaryExpression             // const x = (a, |
-                            || containingNodeKind === SyntaxKind.FunctionType;                // var x: (s: string, list|
+                            || containingNodeKind === SyntaxKind.FunctionType                 // var x: (s: string, list|
+                            || containingNodeKind === SyntaxKind.ObjectLiteralExpression;     // const obj = { x, |
 
                     case SyntaxKind.OpenParenToken:
                         return containingNodeKind === SyntaxKind.CallExpression               // func( |

--- a/tests/cases/fourslash/completionListInObjectLiteral5.ts
+++ b/tests/cases/fourslash/completionListInObjectLiteral5.ts
@@ -23,4 +23,4 @@
 verify.completions({ marker: ["1"], excludes: ['obj'], includes: ['o'] });
 verify.completions({ marker: ["2"], excludes: ['obj1'], includes: ['o', 'obj'] });
 verify.completions({ marker: ["3"], includes: ['o', 'obj', 'obj1'] });
-verify.completions({ marker: ["4"], includes: ['o'], excludes: ['obj'] });
+verify.completions({ marker: ["4"], includes: ['o'], excludes: ['obj'], isNewIdentifierLocation: true });

--- a/tests/cases/fourslash/completionPropertyShorthandForObjectLiteral.ts
+++ b/tests/cases/fourslash/completionPropertyShorthandForObjectLiteral.ts
@@ -44,6 +44,8 @@
 //// f15({f/*15*/});
 //// f16({f/*16*/});
 
+//// f1({ f1, /*17*/ });
+
 const locals = [
     ...(() => {
         const symbols = [];
@@ -63,4 +65,6 @@ verify.completions(
     { marker: ["14"], exact: "prop", isNewIdentifierLocation: true },
     // NumberIndexType
     { marker: ["15", "16"], exact: [], isNewIdentifierLocation: true },
+    // After comma
+    { marker: ["17"], exact: completion.globalsPlus(locals), isNewIdentifierLocation: true },
 );

--- a/tests/cases/fourslash/completionPropertyShorthandForObjectLiteral.ts
+++ b/tests/cases/fourslash/completionPropertyShorthandForObjectLiteral.ts
@@ -56,11 +56,11 @@ const locals = [
 ];
 verify.completions(
     // Non-contextual, any, unknown, object, Record<string, ..>, [key: string]: .., Type parameter, etc..
-    { marker: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"], exact: completion.globalsPlus(locals)},
+    { marker: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"], exact: completion.globalsPlus(locals), isNewIdentifierLocation: true },
     // Has named property
-    { marker: ["12", "13"], exact: "typed"},
+    { marker: ["12", "13"], exact: "typed", isNewIdentifierLocation: false },
     // Has both StringIndexType and named property
-    { marker: ["14"], exact: "prop", isNewIdentifierLocation: true},
+    { marker: ["14"], exact: "prop", isNewIdentifierLocation: true },
     // NumberIndexType
-    { marker: ["15", "16"], exact: [], isNewIdentifierLocation: true},
+    { marker: ["15", "16"], exact: [], isNewIdentifierLocation: true },
 );

--- a/tests/cases/fourslash/completionPropertyShorthandForObjectLiteral5.ts
+++ b/tests/cases/fourslash/completionPropertyShorthandForObjectLiteral5.ts
@@ -10,5 +10,6 @@
 verify.completions({
     marker: "",
     exact: completion.globalsPlus(["foo"]),
+    isNewIdentifierLocation: true,
     preferences: { includeCompletionsForModuleExports: true },
 });

--- a/tests/cases/fourslash/completionsGenericUnconstrained.ts
+++ b/tests/cases/fourslash/completionsGenericUnconstrained.ts
@@ -10,6 +10,7 @@
 
 verify.completions({
   marker: "",
+  isNewIdentifierLocation: true,
   includes: [{
     name: "Object",
     sortText: completion.SortText.GlobalsOrKeywords

--- a/tests/cases/fourslash/completionsSelfDeclaring2.ts
+++ b/tests/cases/fourslash/completionsSelfDeclaring2.ts
@@ -9,10 +9,12 @@
 
 verify.completions({
   marker: "1",
-  exact: completion.globalsPlus(["f1", "f2"])
+  exact: completion.globalsPlus(["f1", "f2"]),
+  isNewIdentifierLocation: true
 });
 
 verify.completions({
   marker: "2",
-  exact: ["xyz"]
+  exact: ["xyz"],
+  isNewIdentifierLocation: false
 });


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #42595

![Kapture 2021-02-02 at 10 54 46](https://user-images.githubusercontent.com/3277153/106648398-16869680-6545-11eb-8ff2-6eca38e4e0d5.gif)

