### PR TITLE
Don’t resolve an index-less module specifier if another file has the same name as the directory

### DIFF
--- a/tests/cases/fourslash/importNameCodeFix_indexNameConflict.ts
+++ b/tests/cases/fourslash/importNameCodeFix_indexNameConflict.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+// @module: commonjs
+
+// @Filename: /a/index.ts
+//// export const aIndex = 0;
+
+// @Filename: /a.ts
+//// export {};
+
+// @Filename: /index.ts
+//// aIndex/**/
+
+goTo.marker("");
+verify.importFixAtPosition([
+`import { aIndex } from "./a/index";
+
+aIndex`
+]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #36730

This has a similar energy to #42502, which I decided wasn’t worth merging. Lots of bugs lately are exposing the fact that module _specifier_ resolution is much, much dumber than module resolution. I’m not sure it’s worth it here to do all these `fileExists` calls, as I’m very sensitive to impacting performance in this process. I’m leaning toward not merging this, but wanted to see if @sheetalkamat had any ideas first.
