### PR TITLE
Expose EncodedSemanticClassificationsRequest in protocol.d.ts

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -868,12 +868,16 @@ namespace ts.server.protocol {
 
     /** The response for a EncodedSemanticClassificationsRequest */
     export interface EncodedSemanticClassificationsResponse extends Response {
-        body?: {
-            endOfLineState: EndOfLineState;
-            spans: number[];
-        };
+        body?: EncodedSemanticClassificationsResponseBody
     }
 
+    /**
+     * Implementation response message. Gives series of text spans depending on the format ar.
+     */
+    export interface EncodedSemanticClassificationsResponseBody {
+        endOfLineState: EndOfLineState;
+        spans: ClassifiedSpan[] | number[];
+    }
     /**
      * Arguments in document highlight request; include: filesToSearch, file,
      * line, offset.

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -876,7 +876,7 @@ namespace ts.server.protocol {
      */
     export interface EncodedSemanticClassificationsResponseBody {
         endOfLineState: EndOfLineState;
-        spans: ClassifiedSpan[] | number[];
+        spans: number[];
     }
     /**
      * Arguments in document highlight request; include: filesToSearch, file,

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -3398,4 +3398,32 @@ namespace ts.server.protocol {
         ES2020 = "ES2020",
         ESNext = "ESNext"
     }
+
+    export const enum ClassificationType {
+        comment = 1,
+        identifier = 2,
+        keyword = 3,
+        numericLiteral = 4,
+        operator = 5,
+        stringLiteral = 6,
+        regularExpressionLiteral = 7,
+        whiteSpace = 8,
+        text = 9,
+        punctuation = 10,
+        className = 11,
+        enumName = 12,
+        interfaceName = 13,
+        moduleName = 14,
+        typeParameterName = 15,
+        typeAliasName = 16,
+        parameterName = 17,
+        docCommentTagName = 18,
+        jsxOpenTagName = 19,
+        jsxCloseTagName = 20,
+        jsxSelfClosingTagName = 21,
+        jsxAttribute = 22,
+        jsxText = 23,
+        jsxAttributeStringLiteralValue = 24,
+        bigintLiteral = 25,
+    }
 }

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -843,7 +843,6 @@ namespace ts.server.protocol {
     /**
      * A request to get encoded semantic classifications for a span in the file
      */
-    /** @internal */
     export interface EncodedSemanticClassificationsRequest extends FileRequest {
         arguments: EncodedSemanticClassificationsRequestArgs;
     }
@@ -851,7 +850,6 @@ namespace ts.server.protocol {
     /**
      * Arguments for EncodedSemanticClassificationsRequest request.
      */
-    /** @internal */
     export interface EncodedSemanticClassificationsRequestArgs extends FileRequestArgs {
         /**
          * Start position of the span.

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -866,6 +866,14 @@ namespace ts.server.protocol {
         format?: "original" | "2020"
     }
 
+    /** The response for a EncodedSemanticClassificationsRequest */
+    export interface EncodedSemanticClassificationsResponse extends Response {
+        body?: {
+            endOfLineState: EndOfLineState;
+            spans: number[];
+        };
+    }
+
     /**
      * Arguments in document highlight request; include: filesToSearch, file,
      * line, offset.

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7159,10 +7159,14 @@ declare namespace ts.server.protocol {
     }
     /** The response for a EncodedSemanticClassificationsRequest */
     interface EncodedSemanticClassificationsResponse extends Response {
-        body?: {
-            endOfLineState: EndOfLineState;
-            spans: number[];
-        };
+        body?: EncodedSemanticClassificationsResponseBody;
+    }
+    /**
+     * Implementation response message. Gives series of text spans depending on the format ar.
+     */
+    interface EncodedSemanticClassificationsResponseBody {
+        endOfLineState: EndOfLineState;
+        spans: ClassifiedSpan[] | number[];
     }
     /**
      * Arguments in document highlight request; include: filesToSearch, file,

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7157,6 +7157,13 @@ declare namespace ts.server.protocol {
          */
         format?: "original" | "2020";
     }
+    /** The response for a EncodedSemanticClassificationsRequest */
+    interface EncodedSemanticClassificationsResponse extends Response {
+        body?: {
+            endOfLineState: EndOfLineState;
+            spans: number[];
+        };
+    }
     /**
      * Arguments in document highlight request; include: filesToSearch, file,
      * line, offset.

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9190,6 +9190,33 @@ declare namespace ts.server.protocol {
         ES2020 = "ES2020",
         ESNext = "ESNext"
     }
+    enum ClassificationType {
+        comment = 1,
+        identifier = 2,
+        keyword = 3,
+        numericLiteral = 4,
+        operator = 5,
+        stringLiteral = 6,
+        regularExpressionLiteral = 7,
+        whiteSpace = 8,
+        text = 9,
+        punctuation = 10,
+        className = 11,
+        enumName = 12,
+        interfaceName = 13,
+        moduleName = 14,
+        typeParameterName = 15,
+        typeAliasName = 16,
+        parameterName = 17,
+        docCommentTagName = 18,
+        jsxOpenTagName = 19,
+        jsxCloseTagName = 20,
+        jsxSelfClosingTagName = 21,
+        jsxAttribute = 22,
+        jsxText = 23,
+        jsxAttributeStringLiteralValue = 24,
+        bigintLiteral = 25
+    }
 }
 declare namespace ts.server {
     interface ScriptInfoVersion {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7134,6 +7134,30 @@ declare namespace ts.server.protocol {
         body?: string[];
     }
     /**
+     * A request to get encoded semantic classifications for a span in the file
+     */
+    interface EncodedSemanticClassificationsRequest extends FileRequest {
+        arguments: EncodedSemanticClassificationsRequestArgs;
+    }
+    /**
+     * Arguments for EncodedSemanticClassificationsRequest request.
+     */
+    interface EncodedSemanticClassificationsRequestArgs extends FileRequestArgs {
+        /**
+         * Start position of the span.
+         */
+        start: number;
+        /**
+         * Length of the span.
+         */
+        length: number;
+        /**
+         * Optional parameter for the semantic highlighting response, if absent it
+         * defaults to "original".
+         */
+        format?: "original" | "2020";
+    }
+    /**
      * Arguments in document highlight request; include: filesToSearch, file,
      * line, offset.
      */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7166,7 +7166,7 @@ declare namespace ts.server.protocol {
      */
     interface EncodedSemanticClassificationsResponseBody {
         endOfLineState: EndOfLineState;
-        spans: ClassifiedSpan[] | number[];
+        spans: number[];
     }
     /**
      * Arguments in document highlight request; include: filesToSearch, file,


### PR DESCRIPTION
Fixes #42587 - I think because this request used to have the same args as many other requests then it was not included in the `protocol.d.ts`. 

Now it differs, so I've removed the internal markers 👍🏻 
