### PR TITLE
Replace _all_ tabs in pretty output, not just the first on each line

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -407,7 +407,7 @@ namespace ts {
             const lineEnd = i < lastLineInFile ? getPositionOfLineAndCharacter(file, i + 1, 0) : file.text.length;
             let lineContent = file.text.slice(lineStart, lineEnd);
             lineContent = lineContent.replace(/\s+$/g, "");  // trim from end
-            lineContent = lineContent.replace("\t", " ");    // convert tabs to single spaces
+            lineContent = lineContent.replace(/\t/g, " ");   // convert tabs to single spaces
 
             // Output the gutter and the actual contents of the line.
             context += indent + formatColorAndReset(padLeft(i + 1 + "", gutterWidth), gutterStyleSequence) + gutterSeparator;

--- a/tests/baselines/reference/prettyFileWithErrorsAndTabs.errors.txt
+++ b/tests/baselines/reference/prettyFileWithErrorsAndTabs.errors.txt
@@ -1,0 +1,30 @@
+[96mtests/cases/compiler/prettyFileWithErrorsAndTabs.ts[0m:[93m3[0m:[93m9[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
+
+[7m3[0m   const x: string = 12;
+[7m [0m [91m        ~[0m
+[96mtests/cases/compiler/prettyFileWithErrorsAndTabs.ts[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
+
+[7m4[0m   const y: string = 12;
+[7m [0m [91m        ~[0m
+[96mtests/cases/compiler/prettyFileWithErrorsAndTabs.ts[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
+
+[7m5[0m   const z: string = 12;
+[7m [0m [91m        ~[0m
+
+
+==== tests/cases/compiler/prettyFileWithErrorsAndTabs.ts (3 errors) ====
+    function f() {
+    	{
+    		const x: string = 12;
+    		      ~
+!!! error TS2322: Type 'number' is not assignable to type 'string'.
+    		const y: string = 12;
+    		      ~
+!!! error TS2322: Type 'number' is not assignable to type 'string'.
+    		const z: string = 12;
+    		      ~
+!!! error TS2322: Type 'number' is not assignable to type 'string'.
+    	}
+    }
+Found 3 errors.
+

--- a/tests/baselines/reference/prettyFileWithErrorsAndTabs.js
+++ b/tests/baselines/reference/prettyFileWithErrorsAndTabs.js
@@ -1,0 +1,17 @@
+//// [prettyFileWithErrorsAndTabs.ts]
+function f() {
+	{
+		const x: string = 12;
+		const y: string = 12;
+		const z: string = 12;
+	}
+}
+
+//// [prettyFileWithErrorsAndTabs.js]
+function f() {
+    {
+        var x = 12;
+        var y = 12;
+        var z = 12;
+    }
+}

--- a/tests/baselines/reference/prettyFileWithErrorsAndTabs.symbols
+++ b/tests/baselines/reference/prettyFileWithErrorsAndTabs.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/prettyFileWithErrorsAndTabs.ts ===
+function f() {
+>f : Symbol(f, Decl(prettyFileWithErrorsAndTabs.ts, 0, 0))
+	{
+		const x: string = 12;
+>x : Symbol(x, Decl(prettyFileWithErrorsAndTabs.ts, 2, 7))
+
+		const y: string = 12;
+>y : Symbol(y, Decl(prettyFileWithErrorsAndTabs.ts, 3, 7))
+
+		const z: string = 12;
+>z : Symbol(z, Decl(prettyFileWithErrorsAndTabs.ts, 4, 7))
+	}
+}

--- a/tests/baselines/reference/prettyFileWithErrorsAndTabs.types
+++ b/tests/baselines/reference/prettyFileWithErrorsAndTabs.types
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/prettyFileWithErrorsAndTabs.ts ===
+function f() {
+>f : () => void
+	{
+		const x: string = 12;
+>x : string
+>12 : 12
+
+		const y: string = 12;
+>y : string
+>12 : 12
+
+		const z: string = 12;
+>z : string
+>12 : 12
+	}
+}

--- a/tests/cases/compiler/prettyFileWithErrorsAndTabs.ts
+++ b/tests/cases/compiler/prettyFileWithErrorsAndTabs.ts
@@ -1,0 +1,8 @@
+// @pretty: true
+function f() {
+	{
+		const x: string = 12;
+		const y: string = 12;
+		const z: string = 12;
+	}
+}


### PR DESCRIPTION
Fixes [a codeQL smell](https://github.com/microsoft/TypeScript/security/code-scanning/4?query=ref%3Arefs%2Fheads%2Fmaster) that turns out to actually be a small bug.
