### PR TITLE
Swapping the quote style of a string for completions should swap _all_ quotes in the string

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2495,7 +2495,7 @@ namespace ts {
         // Editors can pass in undefined or empty string - we want to infer the preference in those cases.
         const quotePreference = getQuotePreference(sourceFile, preferences);
         const quoted = JSON.stringify(text);
-        return quotePreference === QuotePreference.Single ? `'${stripQuotes(quoted).replace("'", "\\'").replace('\\"', '"')}'` : quoted;
+        return quotePreference === QuotePreference.Single ? `'${stripQuotes(quoted).replace(/'/g, "\\'").replace(/\\"/g, '"')}'` : quoted;
     }
 
     export function isEqualityOperatorKind(kind: SyntaxKind): kind is EqualityOperator {

--- a/tests/cases/fourslash/completionForStringLiteral_quotePreference8.ts
+++ b/tests/cases/fourslash/completionForStringLiteral_quotePreference8.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts'/>
+
+// @filename: /a.ts
+////export const a = null;
+
+// @filename: /b.ts
+////import { a } from './a';
+////
+////const foo = { '"a name\'s all good but it\'s better with more"': null };
+////foo[|./**/|]
+
+goTo.file("/b.ts");
+verify.completions({
+    marker: "",
+    exact: [
+        { name: "\"a name's all good but it's better with more\"", insertText: "['\"a name\\'s all good but it\\'s better with more\"']", replacementSpan: test.ranges()[0] },
+    ],
+    preferences: {
+        includeInsertTextCompletions: true,
+        quotePreference: "auto"
+    }
+});


### PR DESCRIPTION
Fixes a [codeQL smell](https://github.com/microsoft/TypeScript/security/code-scanning/8?query=ref%3Arefs%2Fheads%2Fmaster) that looks to be a completions bug.