### PR TITLE
Add check for no match into fs watch rename event handler

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1560,7 +1560,7 @@ namespace ts {
                     return event === "rename" &&
                         (!relativeName ||
                             relativeName === lastDirectoryPart ||
-                            relativeName.lastIndexOf(lastDirectoryPartWithDirectorySeparator!) === relativeName.length - lastDirectoryPartWithDirectorySeparator!.length) &&
+                            (relativeName.lastIndexOf(lastDirectoryPartWithDirectorySeparator!) !== -1 && relativeName.lastIndexOf(lastDirectoryPartWithDirectorySeparator!) === relativeName.length - lastDirectoryPartWithDirectorySeparator!.length)) &&
                         !fileSystemEntryExists(fileOrDirectory, entryKind) ?
                         invokeCallbackAndUpdateWatcher(watchMissingFileSystemEntry) :
                         callback(event, relativeName);


### PR DESCRIPTION
Fixes a [codeQL smell](https://github.com/microsoft/TypeScript/security/code-scanning/1?query=ref%3Arefs%2Fheads%2Fmaster). This codepath is impossible (?) for us to test, since it's in a handler passed to the native `node` `fs.watch` call, using variables only set on linux/osx, however I think it's self-evident the check should exist to handle if, eg, `lastDirectoryPartWithDirectorySeparator` is `/foo/bar/` and `relativeName` is `eight.ts` (so `relativeName` is exactly one character shorter than `lastDirectoryPartWithDirectorySeparator` but has no parts in common).
