### PR TITLE
Refactor params for interface

### DIFF
--- a/src/services/refactors/convertParamsToDestructuredObject.ts
+++ b/src/services/refactors/convertParamsToDestructuredObject.ts
@@ -123,12 +123,21 @@ namespace ts.refactor.convertParamsToDestructuredObject {
                     continue;
                 }
 
-                //
-                if (isValidMethodSignature(entry.node.parent) && contains(interfaceSymbols, getSymbolTargetAtLocation(entry.node))) {
-                    groupedReferences.signature = entry.node.parent;
-                    continue;
+                /* Calls and declarations of implemented interface methods should point to the symbol of the method signature */
+                if (contains(interfaceSymbols, getSymbolTargetAtLocation(entry.node))) {
+                    if (isValidMethodSignature(entry.node.parent)) {
+                        groupedReferences.signature = entry.node.parent;
+                        continue;
+                    }
+                    const call = entryToFunctionCall(entry);
+                    if (call) {
+                        groupedReferences.functionCalls.push(call);
+                        continue;
+                    }
                 }
 
+                /* Declarations in interface implementations have their own symbol so we need to go to the interface declaration
+                to get the type from the method signature. */
                 const interfaceSymbol = getSymbolForInterfaceSignature(entry.node);
                 if (interfaceSymbol && contains(interfaceSymbols, interfaceSymbol)) {
                     const decl = entryToDeclaration(entry);

--- a/src/services/refactors/convertParamsToDestructuredObject.ts
+++ b/src/services/refactors/convertParamsToDestructuredObject.ts
@@ -79,7 +79,8 @@ namespace ts.refactor.convertParamsToDestructuredObject {
                 first(declarationOrSignature.parameters),
                 last(declarationOrSignature.parameters),
                 parameterDeclarations,
-                {   joiner: ", ",
+                {
+                    joiner: ", ",
                     // indentation is set to 0 because otherwise the object parameter will be indented if there is a `this` parameter
                     indentation: 0,
                     leadingTriviaOption: textChanges.LeadingTriviaOption.IncludeAll,

--- a/src/services/refactors/convertParamsToDestructuredObject.ts
+++ b/src/services/refactors/convertParamsToDestructuredObject.ts
@@ -54,7 +54,7 @@ namespace ts.refactor.convertParamsToDestructuredObject {
         const signature = groupedReferences.signature;
         const newParamDeclaration = map(createNewParameters(signature ?? functionDeclaration, program, host), param => getSynthesizedDeepClone(param));
 
-        if(signature) {
+        if (signature) {
             changes.replaceNodeRangeWithNodes(
                 sourceFile,
                 first(signature.parameters),

--- a/src/services/refactors/convertParamsToDestructuredObject.ts
+++ b/src/services/refactors/convertParamsToDestructuredObject.ts
@@ -110,7 +110,7 @@ namespace ts.refactor.convertParamsToDestructuredObject {
             const functionSymbols = map(functionNames, getSymbolTargetAtLocation);
             const classSymbols = map(classNames, getSymbolTargetAtLocation);
             const isConstructor = isConstructorDeclaration(functionDeclaration);
-            const contextualSymbols = map(functionNames, (name) => (getSymbolForContextualType(name, checker)));
+            const contextualSymbols = map(functionNames, name => getSymbolForContextualType(name, checker));
 
             for (const entry of referenceEntries) {
                 if (entry.kind === FindAllReferences.EntryKind.Span) {

--- a/src/services/refactors/convertParamsToDestructuredObject.ts
+++ b/src/services/refactors/convertParamsToDestructuredObject.ts
@@ -360,6 +360,10 @@ namespace ts.refactor.convertParamsToDestructuredObject {
             case SyntaxKind.FunctionDeclaration:
                 return hasNameOrDefault(functionDeclaration) && isSingleImplementation(functionDeclaration, checker);
             case SyntaxKind.MethodDeclaration:
+                if (isObjectLiteralExpression(functionDeclaration.parent)) {
+                    const contextualType = checker.getContextualType(functionDeclaration.parent);
+                    return !contextualType?.isUnion() && isSingleImplementation(functionDeclaration, checker);
+                }
                 return isSingleImplementation(functionDeclaration, checker);
             case SyntaxKind.Constructor:
                 if (isClassDeclaration(functionDeclaration.parent)) {

--- a/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_interface.ts
+++ b/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_interface.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+////interface IFoo {
+////    method(x: string, y: string): void;
+////}
+////const x: IFoo = {
+////    method(/*a*/x: string, y: string/*b*/): void {},
+////};
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Convert parameters to destructured object",
+    actionName: "Convert parameters to destructured object",
+    actionDescription: "Convert parameters to destructured object",
+    newContent: `interface IFoo {
+    method({ x, y }: { x: string; y: string; }): void;
+}
+const x: IFoo = {
+    method({ x, y }: { x: string; y: string; }): void {},
+};`
+});

--- a/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_interfaceAssignability.ts
+++ b/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_interfaceAssignability.ts
@@ -4,7 +4,7 @@
 ////    method(x: string, y: string): void;
 ////}
 ////const x: IFoo = {
-////    method(/*a*/x: string, y: string/*b*/): void {},
+////    method(/*a*/x: string, y: string, z?: string/*b*/): void {},
 ////};
 
 goTo.select("a", "b");
@@ -16,6 +16,6 @@ edit.applyRefactor({
     method({ x, y }: { x: string; y: string; }): void;
 }
 const x: IFoo = {
-    method({ x, y }: { x: string; y: string; }): void {},
+    method({ x, y, z }: { x: string; y: string; z?: string; }): void {},
 };`
 });

--- a/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_interfaceContextualParams.ts
+++ b/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_interfaceContextualParams.ts
@@ -4,9 +4,16 @@
 ////    method(x: string, y: string): void;
 ////}
 ////const x: IFoo = {
-////    method(/*a*/x: string, y: string/*b*/): void {},
+////    method(/*a*/x, y/*b*/): void {},
 ////};
 
+/*
+When there are no type annotations on the params in the implementation, we ultimately
+would like to handle them like we do for calls resulting in `method({x, y}) {}`.
+
+Note that simply adding the annotations from the signature can fail as the implementation 
+can take more paramters than the signatures.
+*/
 goTo.select("a", "b");
 edit.applyRefactor({
     refactorName: "Convert parameters to destructured object",
@@ -16,6 +23,6 @@ edit.applyRefactor({
     method({ x, y }: { x: string; y: string; }): void;
 }
 const x: IFoo = {
-    method({ x, y }: { x: string; y: string; }): void {},
+    method({ x, y }: { x; y; }): void {},
 };`
 });

--- a/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_interfaceMultipleSignatures.ts
+++ b/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_interfaceMultipleSignatures.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+////interface IFoo {
+////    method(x: string, y: string): void;
+////    method(x: number, y: string): void;
+////}
+////const x: IFoo = {
+////    method(/*a*/x: string | number, y: string/*b*/): void {},
+////};
+
+// For multiple signatures, we don't have a reliable way to determine
+// which signature to match to or if all signatures should be changed.
+goTo.select("a", "b");
+verify.not.refactorAvailable("Convert parameters to destructured object");

--- a/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_interfaceNoIntersection.ts
+++ b/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_interfaceNoIntersection.ts
@@ -6,7 +6,7 @@
 ////interface IBar {
 ////    method(x: number): void;
 ////}
-////const x: IFoo | IBar = {
+////const x: IFoo & IBar = {
 ////    method(/*a*/x: string, y: string/*b*/): void {},
 ////};
 

--- a/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_interfaceNoUnion.ts
+++ b/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_interfaceNoUnion.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+////interface IFoo {
+////    method(x: string, y: string): void;
+////}
+////interface IBar {
+////    method(x: number): void;
+////}
+////const x: IFoo | IBar = {
+////    method(/*a*/x: string, y: string/*b*/): void {},
+////};
+
+goTo.select("a", "b");
+verify.not.refactorAvailable("Convert parameters to destructured object");

--- a/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_typeLiteral.ts
+++ b/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_typeLiteral.ts
@@ -1,9 +1,9 @@
 /// <reference path='fourslash.ts' />
 
-////interface IFoo {
+////type Foo = {
 ////    method(x: string, y: string): void;
 ////}
-////const x: IFoo = {
+////const x: Foo = {
 ////    method(/*a*/x: string, y: string/*b*/): void {},
 ////};
 
@@ -12,10 +12,10 @@ edit.applyRefactor({
     refactorName: "Convert parameters to destructured object",
     actionName: "Convert parameters to destructured object",
     actionDescription: "Convert parameters to destructured object",
-    newContent: `interface IFoo {
+    newContent: `type Foo = {
     method({ x, y }: { x: string; y: string; }): void;
 }
-const x: IFoo = {
+const x: Foo = {
     method({ x, y }: { x: string; y: string; }): void {},
 };`
 });


### PR DESCRIPTION
Fixes #30418 for interfaces and type literals.

Cases for which we do not offer the refactor:
* The type is a union or intersection.
* There is more than one method signature.

