### PR TITLE
Use a (hopefully) more efficient regex for matching jquery in the safelist

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -207,7 +207,7 @@ namespace ts.server {
     const defaultTypeSafeList: SafeList = {
         "jquery": {
             // jquery files can have names like "jquery-1.10.2.min.js" (or "jquery.intellisense.js")
-            match: /jquery(-(\.?\d+)+)?(\.intellisense)?(\.min)?\.js$/i,
+            match: /jquery(-[\d\.]+)?(\.intellisense)?(\.min)?\.js$/i,
             types: ["jquery"]
         },
         "WinJS": {


### PR DESCRIPTION
This was flagged as a [potential performance issue](https://github.com/microsoft/TypeScript/security/code-scanning/9?query=ref%3Arefs%2Fheads%2Fmaster) for files named like `jquery-99999999999999999999999999.js` (or similar), which, while unlikely to occur in the wild, is probably simple enough for us to change the regex to avoid triggering (vs suppressing the codeQL result). I'm not 100% sure the new regex won't also have catastrophic backtracking, but I trust codeQL'll probably flag this PR if it does~
