### PR TITLE
Improve JSON parser error recovery

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1603,7 +1603,7 @@ namespace ts {
     export function parseConfigFileTextToJson(fileName: string, jsonText: string): { config?: any; error?: Diagnostic } {
         const jsonSourceFile = parseJsonText(fileName, jsonText);
         return {
-            config: convertToObject(jsonSourceFile, jsonSourceFile.parseDiagnostics),
+            config: convertConfigFileToObject(jsonSourceFile, jsonSourceFile.parseDiagnostics, /*optionsIterator*/ undefined),
             error: jsonSourceFile.parseDiagnostics.length ? jsonSourceFile.parseDiagnostics[0] : undefined
         };
     }
@@ -1767,7 +1767,7 @@ namespace ts {
         onSetUnknownOptionKeyValueInRoot(key: string, keyNode: PropertyName, value: CompilerOptionsValue, valueNode: Expression): void;
     }
 
-    function convertConfigFileToObject(sourceFile: JsonSourceFile, errors: Push<Diagnostic>, optionsIterator: JsonConversionNotifier): any {
+    function convertConfigFileToObject(sourceFile: JsonSourceFile, errors: Push<Diagnostic>, optionsIterator: JsonConversionNotifier | undefined): any {
         const rootExpression: Expression | undefined = sourceFile.statements[0]?.expression;
         const knownRootOptions = getTsconfigRootOptionsMap();
         if (rootExpression && rootExpression.kind !== SyntaxKind.ObjectLiteralExpression) {

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1603,7 +1603,7 @@ namespace ts {
     export function parseConfigFileTextToJson(fileName: string, jsonText: string): { config?: any; error?: Diagnostic } {
         const jsonSourceFile = parseJsonText(fileName, jsonText);
         return {
-            config: convertConfigFileToObject(jsonSourceFile, jsonSourceFile.parseDiagnostics, /*optionsIterator*/ undefined),
+            config: convertConfigFileToObject(jsonSourceFile, jsonSourceFile.parseDiagnostics, /*reportOptionsErrors*/ false, /*optionsIterator*/ undefined),
             error: jsonSourceFile.parseDiagnostics.length ? jsonSourceFile.parseDiagnostics[0] : undefined
         };
     }
@@ -1767,9 +1767,9 @@ namespace ts {
         onSetUnknownOptionKeyValueInRoot(key: string, keyNode: PropertyName, value: CompilerOptionsValue, valueNode: Expression): void;
     }
 
-    function convertConfigFileToObject(sourceFile: JsonSourceFile, errors: Push<Diagnostic>, optionsIterator: JsonConversionNotifier | undefined): any {
+    function convertConfigFileToObject(sourceFile: JsonSourceFile, errors: Push<Diagnostic>, reportOptionsErrors: boolean, optionsIterator: JsonConversionNotifier | undefined): any {
         const rootExpression: Expression | undefined = sourceFile.statements[0]?.expression;
-        const knownRootOptions = getTsconfigRootOptionsMap();
+        const knownRootOptions = reportOptionsErrors ? getTsconfigRootOptionsMap() : undefined;
         if (rootExpression && rootExpression.kind !== SyntaxKind.ObjectLiteralExpression) {
             errors.push(createDiagnosticForNodeInSourceFile(
                 sourceFile,
@@ -2758,7 +2758,7 @@ namespace ts {
                 }
             }
         };
-        const json = convertConfigFileToObject(sourceFile, errors, optionsIterator);
+        const json = convertConfigFileToObject(sourceFile, errors, /*reportOptionsErrors*/ true, optionsIterator);
 
         if (!typeAcquisition) {
             if (typingOptionstypeAcquisition) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3842,6 +3842,10 @@
         "category": "Error",
         "code": 5091
     },
+    "The root value of a '{0}' file must be an object.": {
+        "category": "Error",
+        "code": 5092
+    },
 
     "Generates a sourcemap for each corresponding '.d.ts' file.": {
         "category": "Message",

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -862,36 +862,56 @@ namespace ts {
                 endOfFileToken = parseTokenNode<EndOfFileToken>();
             }
             else {
-                let expression;
-                switch (token()) {
-                    case SyntaxKind.OpenBracketToken:
-                        expression = parseArrayLiteralExpression();
-                        break;
-                    case SyntaxKind.TrueKeyword:
-                    case SyntaxKind.FalseKeyword:
-                    case SyntaxKind.NullKeyword:
-                        expression = parseTokenNode<BooleanLiteral | NullLiteral>();
-                        break;
-                    case SyntaxKind.MinusToken:
-                        if (lookAhead(() => nextToken() === SyntaxKind.NumericLiteral && nextToken() !== SyntaxKind.ColonToken)) {
-                            expression = parsePrefixUnaryExpression() as JsonMinusNumericLiteral;
-                        }
-                        else {
-                            expression = parseObjectLiteralExpression();
-                        }
-                        break;
-                    case SyntaxKind.NumericLiteral:
-                    case SyntaxKind.StringLiteral:
-                        if (lookAhead(() => nextToken() !== SyntaxKind.ColonToken)) {
-                            expression = parseLiteralNode() as StringLiteral | NumericLiteral;
+                // Loop and synthesize an ArrayLiteralExpression if there are more than
+                // one top-level expressions to ensure all input text is consumed.
+                let expressions: Expression[] | Expression | undefined;
+                while (token() !== SyntaxKind.EndOfFileToken) {
+                    let expression;
+                    switch (token()) {
+                        case SyntaxKind.OpenBracketToken:
+                            expression = parseArrayLiteralExpression();
                             break;
+                        case SyntaxKind.TrueKeyword:
+                        case SyntaxKind.FalseKeyword:
+                        case SyntaxKind.NullKeyword:
+                            expression = parseTokenNode<BooleanLiteral | NullLiteral>();
+                            break;
+                        case SyntaxKind.MinusToken:
+                            if (lookAhead(() => nextToken() === SyntaxKind.NumericLiteral && nextToken() !== SyntaxKind.ColonToken)) {
+                                expression = parsePrefixUnaryExpression() as JsonMinusNumericLiteral;
+                            }
+                            else {
+                                expression = parseObjectLiteralExpression();
+                            }
+                            break;
+                        case SyntaxKind.NumericLiteral:
+                        case SyntaxKind.StringLiteral:
+                            if (lookAhead(() => nextToken() !== SyntaxKind.ColonToken)) {
+                                expression = parseLiteralNode() as StringLiteral | NumericLiteral;
+                                break;
+                            }
+                            // falls through
+                        default:
+                            expression = parseObjectLiteralExpression();
+                            break;
+                    }
+
+                    // Error recovery: collect multiple top-level expressions
+                    if (expressions && isArray(expressions)) {
+                        expressions.push(expression);
+                    }
+                    else if (expressions) {
+                        expressions = [expressions, expression];
+                    }
+                    else {
+                        expressions = expression;
+                        if (token() !== SyntaxKind.EndOfFileToken) {
+                            parseErrorAtCurrentToken(Diagnostics.Unexpected_token);
                         }
-                        // falls through
-                    default:
-                        expression = parseObjectLiteralExpression();
-                        break;
+                    }
                 }
 
+                const expression = isArray(expressions) ? finishNode(factory.createArrayLiteralExpression(expressions), pos) : expressions!;
                 const statement = factory.createExpressionStatement(expression) as JsonObjectExpressionStatement;
                 finishNode(statement, pos);
                 statements = createNodeArray([statement], pos);

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -819,7 +819,7 @@ namespace ts {
             scriptKind = ensureScriptKind(fileName, scriptKind);
             if (scriptKind === ScriptKind.JSON) {
                 const result = parseJsonText(fileName, sourceText, languageVersion, syntaxCursor, setParentNodes);
-                convertToObjectWorker(result, result.parseDiagnostics, /*returnValue*/ false, /*knownRootOptions*/ undefined, /*jsonConversionNotifier*/ undefined);
+                convertToObjectWorker(result, result.statements[0]?.expression, result.parseDiagnostics, /*returnValue*/ false, /*knownRootOptions*/ undefined, /*jsonConversionNotifier*/ undefined);
                 result.referencedFiles = emptyArray;
                 result.typeReferenceDirectives = emptyArray;
                 result.libReferenceDirectives = emptyArray;

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -911,7 +911,7 @@ namespace ts {
                     }
                 }
 
-                const expression = isArray(expressions) ? finishNode(factory.createArrayLiteralExpression(expressions), pos) : expressions!;
+                const expression = isArray(expressions) ? finishNode(factory.createArrayLiteralExpression(expressions), pos) : Debug.checkDefined(expressions);
                 const statement = factory.createExpressionStatement(expression) as JsonObjectExpressionStatement;
                 finishNode(statement, pos);
                 statements = createNodeArray([statement], pos);

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -66,6 +66,7 @@
         "unittests/factory.ts",
         "unittests/incrementalParser.ts",
         "unittests/jsDocParsing.ts",
+        "unittests/jsonParserRecovery.ts",
         "unittests/moduleResolution.ts",
         "unittests/parsePseudoBigInt.ts",
         "unittests/paths.ts",

--- a/src/testRunner/unittests/config/convertCompilerOptionsFromJson.ts
+++ b/src/testRunner/unittests/config/convertCompilerOptionsFromJson.ts
@@ -69,7 +69,7 @@ namespace ts {
                 assert.equal(actualError.category, expectedError.category, `Expected error-category: ${JSON.stringify(expectedError.category)}. Actual error-category: ${JSON.stringify(actualError.category)}.`);
                 if (!ignoreLocation) {
                     assert(actualError.file);
-                    assert(actualError.start);
+                    assert.isDefined(actualError.start);
                     assert(actualError.length);
                 }
             }
@@ -601,6 +601,78 @@ namespace ts {
                     experimentalDecorators: true,
                 },
                 hasParseErrors: true
+            });
+        });
+
+        it("Convert a tsconfig file with stray trailing characters", () => {
+            assertCompilerOptionsWithJsonText(`{
+                "compilerOptions": {
+                    "target": "esnext"
+                }
+            } blah`, "tsconfig.json", {
+                compilerOptions: {
+                    target: ScriptTarget.ESNext
+                },
+                hasParseErrors: true,
+                errors: [{
+                    ...Diagnostics.The_root_value_of_a_0_file_must_be_an_object,
+                    messageText: "The root value of a 'tsconfig.json' file must be an object.",
+                    file: undefined,
+                    start: 0,
+                    length: 0
+                }]
+            });
+        });
+
+        it("Convert a tsconfig file with stray leading characters", () => {
+            assertCompilerOptionsWithJsonText(`blah {
+                "compilerOptions": {
+                    "target": "esnext"
+                }
+            }`, "tsconfig.json", {
+                compilerOptions: {
+                    target: ScriptTarget.ESNext
+                },
+                hasParseErrors: true,
+                errors: [{
+                    ...Diagnostics.The_root_value_of_a_0_file_must_be_an_object,
+                    messageText: "The root value of a 'tsconfig.json' file must be an object.",
+                    file: undefined,
+                    start: 0,
+                    length: 0
+                }]
+            });
+        });
+
+        it("Convert a tsconfig file as an array", () => {
+            assertCompilerOptionsWithJsonText(`[{
+                "compilerOptions": {
+                    "target": "esnext"
+                }
+            }]`, "tsconfig.json", {
+                compilerOptions: {
+                    target: ScriptTarget.ESNext
+                },
+                errors: [{
+                    ...Diagnostics.The_root_value_of_a_0_file_must_be_an_object,
+                    messageText: "The root value of a 'tsconfig.json' file must be an object.",
+                    file: undefined,
+                    start: 0,
+                    length: 0
+                }]
+            });
+        });
+
+        it("Don't crash when root expression is not objecty at all", () => {
+            assertCompilerOptionsWithJsonText(`42`, "tsconfig.json", {
+                compilerOptions: {},
+                errors: [{
+                    ...Diagnostics.The_root_value_of_a_0_file_must_be_an_object,
+                    messageText: "The root value of a 'tsconfig.json' file must be an object.",
+                    file: undefined,
+                    start: 0,
+                    length: 0
+                }]
             });
         });
     });

--- a/src/testRunner/unittests/config/convertCompilerOptionsFromJson.ts
+++ b/src/testRunner/unittests/config/convertCompilerOptionsFromJson.ts
@@ -675,5 +675,12 @@ namespace ts {
                 }]
             });
         });
+
+        it("Allow trailing comments", () => {
+            assertCompilerOptionsWithJsonText(`{} // no options`, "tsconfig.json", {
+                compilerOptions: {},
+                errors: []
+            });
+        });
     });
 }

--- a/src/testRunner/unittests/jsonParserRecovery.ts
+++ b/src/testRunner/unittests/jsonParserRecovery.ts
@@ -4,6 +4,13 @@ namespace ts {
             it(name, () => {
                 const file = parseJsonText(name, text);
                 assert(file.parseDiagnostics.length, "Should have parse errors");
+                Harness.Baseline.runBaseline(
+                    `jsonParserRecovery/${name.replace(/[^a-z0-9_-]/ig, "_")}.errors.txt`,
+                    Harness.Compiler.getErrorBaseline([{
+                        content: text,
+                        unitName: name
+                    }], file.parseDiagnostics));
+
                 // Will throw if parse tree does not cover full input text
                 file.getChildren();
             });

--- a/src/testRunner/unittests/jsonParserRecovery.ts
+++ b/src/testRunner/unittests/jsonParserRecovery.ts
@@ -1,0 +1,32 @@
+namespace ts {
+    describe("unittests:: jsonParserRecovery", () => {
+        function parsesToValidSourceFileWithErrors(name: string, text: string) {
+            it(name, () => {
+                const file = parseJsonText(name, text);
+                assert(file.parseDiagnostics.length, "Should have parse errors");
+                // Will throw if parse tree does not cover full input text
+                file.getChildren();
+            });
+        }
+
+        parsesToValidSourceFileWithErrors("trailing identifier", "{} blah");
+        parsesToValidSourceFileWithErrors("TypeScript code", "interface Foo {} blah");
+        parsesToValidSourceFileWithErrors("Two comma-separated objects", "{}, {}");
+        parsesToValidSourceFileWithErrors("Two objects", "{} {}");
+        parsesToValidSourceFileWithErrors("JSX", `
+        interface Test {}
+
+        const Header = () => (
+          <div>
+            <h1>Header</h1>
+            <style jsx>
+              {\`
+                h1 {
+                  color: red;
+                }
+              \`}
+            </style>
+          </div>
+        )`);
+    });
+}

--- a/tests/baselines/reference/jsonParserRecovery/JSX.errors.txt
+++ b/tests/baselines/reference/jsonParserRecovery/JSX.errors.txt
@@ -1,0 +1,37 @@
+JSX(2,9): error TS1005: '{' expected.
+JSX(2,19): error TS1005: ',' expected.
+JSX(2,24): error TS1005: ',' expected.
+JSX(4,9): error TS1012: Unexpected token.
+JSX(4,15): error TS1005: ':' expected.
+JSX(15,10): error TS1005: '}' expected.
+
+
+==== JSX (6 errors) ====
+    
+            interface Test {}
+            ~~~~~~~~~
+!!! error TS1005: '{' expected.
+                      ~~~~
+!!! error TS1005: ',' expected.
+                           ~
+!!! error TS1005: ',' expected.
+    
+            const Header = () => (
+            ~~~~~
+!!! error TS1012: Unexpected token.
+                  ~~~~~~
+!!! error TS1005: ':' expected.
+              <div>
+                <h1>Header</h1>
+                <style jsx>
+                  {`
+                    h1 {
+                      color: red;
+                    }
+                  `}
+                </style>
+              </div>
+            )
+             
+!!! error TS1005: '}' expected.
+!!! related TS1007 JSX:4:9: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/jsonParserRecovery/Two_comma-separated_objects.errors.txt
+++ b/tests/baselines/reference/jsonParserRecovery/Two_comma-separated_objects.errors.txt
@@ -1,0 +1,10 @@
+Two comma-separated objects(1,3): error TS1012: Unexpected token.
+Two comma-separated objects(1,5): error TS1136: Property assignment expected.
+
+
+==== Two comma-separated objects (2 errors) ====
+    {}, {}
+      ~
+!!! error TS1012: Unexpected token.
+        ~
+!!! error TS1136: Property assignment expected.

--- a/tests/baselines/reference/jsonParserRecovery/Two_objects.errors.txt
+++ b/tests/baselines/reference/jsonParserRecovery/Two_objects.errors.txt
@@ -1,0 +1,7 @@
+Two objects(1,4): error TS1012: Unexpected token.
+
+
+==== Two objects (1 errors) ====
+    {} {}
+       ~
+!!! error TS1012: Unexpected token.

--- a/tests/baselines/reference/jsonParserRecovery/TypeScript_code.errors.txt
+++ b/tests/baselines/reference/jsonParserRecovery/TypeScript_code.errors.txt
@@ -1,0 +1,20 @@
+TypeScript code(1,1): error TS1005: '{' expected.
+TypeScript code(1,11): error TS1005: ',' expected.
+TypeScript code(1,15): error TS1005: ',' expected.
+TypeScript code(1,18): error TS1012: Unexpected token.
+TypeScript code(1,22): error TS1005: '}' expected.
+
+
+==== TypeScript code (5 errors) ====
+    interface Foo {} blah
+    ~~~~~~~~~
+!!! error TS1005: '{' expected.
+              ~~~
+!!! error TS1005: ',' expected.
+                  ~
+!!! error TS1005: ',' expected.
+                     ~~~~
+!!! error TS1012: Unexpected token.
+                         
+!!! error TS1005: '}' expected.
+!!! related TS1007 TypeScript code:1:18: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/jsonParserRecovery/trailing_identifier.errors.txt
+++ b/tests/baselines/reference/jsonParserRecovery/trailing_identifier.errors.txt
@@ -1,0 +1,11 @@
+trailing identifier(1,4): error TS1012: Unexpected token.
+trailing identifier(1,8): error TS1005: '}' expected.
+
+
+==== trailing identifier (2 errors) ====
+    {} blah
+       ~~~~
+!!! error TS1012: Unexpected token.
+           
+!!! error TS1005: '}' expected.
+!!! related TS1007 trailing identifier:1:4: The parser expected to find a '}' to match the '{' token here.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Does two loosely related things:

1. After we’ve finished parsing one of the top-level expression kinds that are valid in JSON, we check to see if we’re on the EndOfFileToken yet. If we’re not, we loop and parse another top-level expression, issuing an "unexpected token" error. At the end, if we have more than one top-level expression, we make them the elements of an ArrayLiteralExpression, and that becomes the single top-level expression of the file. This is to make sure that in a case like `{} identifier`, `identifier` actually belongs to a node, instead of being a token totally unaccounted for in the parse tree (which triggers a debug failure if the language service finds out about it). This fixes the remaining repro of #39854.
2. Fixes error reporting in tsconfig parsing when the top-level expression is not an object (#37850).

Neither of these bugs are very important, and parser changes are inherently somewhat risky, so this should wait until 4.3.

Fixes #39854
Fixes #37850
