### PR TITLE
Ensure library name mangling takes place during module resolution in typeRoots

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -343,7 +343,7 @@ namespace ts {
                     trace(host, Diagnostics.Resolving_with_primary_search_path_0, typeRoots.join(", "));
                 }
                 return firstDefined(typeRoots, typeRoot => {
-                    const candidate = combinePaths(typeRoot, typeReferenceDirectiveName);
+                    const candidate = combinePaths(typeRoot, mangleScopedPackageNameWithTrace(typeReferenceDirectiveName, moduleResolutionState));
                     const candidateDirectory = getDirectoryPath(candidate);
                     const directoryExists = directoryProbablyExists(candidateDirectory, host);
                     if (!directoryExists && traceEnabled) {

--- a/src/testRunner/unittests/moduleResolution.ts
+++ b/src/testRunner/unittests/moduleResolution.ts
@@ -1388,6 +1388,11 @@ import b = require("./moduleB");
             }
             {
                 const f1 = { name: "/root/src/app.ts" };
+                const f2 = { name: "/root/src/types/lib__xyz/index.d.ts" };
+                test(/*typesRoot*/"/root/src/types", /* typeDirective */"@lib/xyz", /*primary*/ true, f1, f2);
+            }
+            {
+                const f1 = { name: "/root/src/app.ts" };
                 const f2 = { name: "/root/src/types/lib/typings/lib.d.ts" };
                 const packageFile = { name: "/root/src/types/lib/package.json", content: JSON.stringify({ types: "typings/lib.d.ts" }) };
                 test(/*typesRoot*/"/root/src/types", /* typeDirective */"lib", /*primary*/ true, f1, f2, packageFile);
@@ -1407,6 +1412,11 @@ import b = require("./moduleB");
                 const f1 = { name: "/root/src/app.ts" };
                 const f2 = { name: "/root/src/node_modules/@types/lib/index.d.ts" };
                 test(/*typesRoot*/"/root/src/types", /* typeDirective */"lib", /*primary*/ false, f1, f2);
+            }
+            {
+                const f1 = { name: "/root/src/app.ts" };
+                const f2 = { name: "/root/src/node_modules/@types/lib__xyz/index.d.ts" };
+                test(/*typesRoot*/"/root/src/types", /* typeDirective */"@lib/xyz", /*primary*/ false, f1, f2);
             }
             {
                 const f1 = { name: "/root/src/app.ts" };
@@ -1442,6 +1452,11 @@ import b = require("./moduleB");
                 const f2 = { name: "/root/node_modules/@types/lib/typings/lib.d.ts" };
                 const packageFile = { name: "/root/node_modules/@types/lib/package.json", content: JSON.stringify({ typings: "typings/lib.d.ts" }) };
                 test(/*typesRoot*/"/root/src/types", /* typeDirective */"lib", /*primary*/ false, f1, f2, packageFile);
+            }
+            {
+                const f1 = { name: "/root/src/app.ts" };
+                const f2 = { name: "/root/node_modules/@types/lib__xyz/index.d.ts" };
+                test(/*typesRoot*/"/root/src/types", /* typeDirective */"@lib/xyz", /*primary*/ false, f1, f2);
             }
         });
         it("Primary resolution overrides secondary resolutions", () => {

--- a/tests/baselines/reference/library-reference-scoped-packages-2.js
+++ b/tests/baselines/reference/library-reference-scoped-packages-2.js
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/references/library-reference-scoped-packages-2.ts] ////
+
+//// [index.d.ts]
+export const y = 0;
+
+//// [a.ts]
+/// <reference types="@beep/boop" />
+
+
+//// [a.js]
+/// <reference types="@beep/boop" />

--- a/tests/baselines/reference/library-reference-scoped-packages-2.symbols
+++ b/tests/baselines/reference/library-reference-scoped-packages-2.symbols
@@ -1,0 +1,7 @@
+=== /a.ts ===
+/// <reference types="@beep/boop" />
+No type information for this code.
+No type information for this code.=== /types/beep__boop/index.d.ts ===
+export const y = 0;
+>y : Symbol(y, Decl(index.d.ts, 0, 12))
+

--- a/tests/baselines/reference/library-reference-scoped-packages-2.trace.json
+++ b/tests/baselines/reference/library-reference-scoped-packages-2.trace.json
@@ -1,0 +1,15 @@
+[
+    "======== Resolving type reference directive '@beep/boop', containing file '/a.ts', root directory '/types'. ========",
+    "Resolving with primary search path '/types'.",
+    "Scoped package detected, looking in 'beep__boop'",
+    "File '/types/beep__boop/package.json' does not exist.",
+    "File '/types/beep__boop/index.d.ts' exist - use it as a name resolution result.",
+    "Resolving real path for '/types/beep__boop/index.d.ts', result '/types/beep__boop/index.d.ts'.",
+    "======== Type reference directive '@beep/boop' was successfully resolved to '/types/beep__boop/index.d.ts', primary: true. ========",
+    "======== Resolving type reference directive 'beep__boop', containing file '__inferred type names__.ts', root directory '/types'. ========",
+    "Resolving with primary search path '/types'.",
+    "File '/types/beep__boop/package.json' does not exist.",
+    "File '/types/beep__boop/index.d.ts' exist - use it as a name resolution result.",
+    "Resolving real path for '/types/beep__boop/index.d.ts', result '/types/beep__boop/index.d.ts'.",
+    "======== Type reference directive 'beep__boop' was successfully resolved to '/types/beep__boop/index.d.ts', primary: true. ========"
+]

--- a/tests/baselines/reference/library-reference-scoped-packages-2.types
+++ b/tests/baselines/reference/library-reference-scoped-packages-2.types
@@ -1,0 +1,8 @@
+=== /a.ts ===
+/// <reference types="@beep/boop" />
+No type information for this code.
+No type information for this code.=== /types/beep__boop/index.d.ts ===
+export const y = 0;
+>y : 0
+>0 : 0
+

--- a/tests/baselines/reference/library-reference-scoped-packages-3.js
+++ b/tests/baselines/reference/library-reference-scoped-packages-3.js
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/references/library-reference-scoped-packages-3.ts] ////
+
+//// [index.d.ts]
+// @currentDirectory /foo
+
+export const y = 0;
+
+//// [a.ts]
+/// <reference types="@beep/boop" />
+
+
+//// [a.js]
+/// <reference types="@beep/boop" />

--- a/tests/baselines/reference/library-reference-scoped-packages-3.symbols
+++ b/tests/baselines/reference/library-reference-scoped-packages-3.symbols
@@ -1,0 +1,9 @@
+=== /foo/a.ts ===
+/// <reference types="@beep/boop" />
+No type information for this code.
+No type information for this code.=== /types/beep__boop/index.d.ts ===
+// @currentDirectory /foo
+
+export const y = 0;
+>y : Symbol(y, Decl(index.d.ts, 2, 12))
+

--- a/tests/baselines/reference/library-reference-scoped-packages-3.trace.json
+++ b/tests/baselines/reference/library-reference-scoped-packages-3.trace.json
@@ -1,0 +1,15 @@
+[
+    "======== Resolving type reference directive '@beep/boop', containing file '/foo/a.ts', root directory '/types'. ========",
+    "Resolving with primary search path '/types'.",
+    "Scoped package detected, looking in 'beep__boop'",
+    "File '/types/beep__boop/package.json' does not exist.",
+    "File '/types/beep__boop/index.d.ts' exist - use it as a name resolution result.",
+    "Resolving real path for '/types/beep__boop/index.d.ts', result '/types/beep__boop/index.d.ts'.",
+    "======== Type reference directive '@beep/boop' was successfully resolved to '/types/beep__boop/index.d.ts', primary: true. ========",
+    "======== Resolving type reference directive 'beep__boop', containing file '__inferred type names__.ts', root directory '/types'. ========",
+    "Resolving with primary search path '/types'.",
+    "File '/types/beep__boop/package.json' does not exist.",
+    "File '/types/beep__boop/index.d.ts' exist - use it as a name resolution result.",
+    "Resolving real path for '/types/beep__boop/index.d.ts', result '/types/beep__boop/index.d.ts'.",
+    "======== Type reference directive 'beep__boop' was successfully resolved to '/types/beep__boop/index.d.ts', primary: true. ========"
+]

--- a/tests/baselines/reference/library-reference-scoped-packages-3.types
+++ b/tests/baselines/reference/library-reference-scoped-packages-3.types
@@ -1,0 +1,10 @@
+=== /foo/a.ts ===
+/// <reference types="@beep/boop" />
+No type information for this code.
+No type information for this code.=== /types/beep__boop/index.d.ts ===
+// @currentDirectory /foo
+
+export const y = 0;
+>y : 0
+>0 : 0
+

--- a/tests/baselines/reference/library-reference-scoped-packages.trace.json
+++ b/tests/baselines/reference/library-reference-scoped-packages.trace.json
@@ -1,7 +1,8 @@
 [
     "======== Resolving type reference directive '@beep/boop', containing file '/a.ts', root directory 'types'. ========",
     "Resolving with primary search path 'types'.",
-    "Directory 'types/@beep' does not exist, skipping all lookups in it.",
+    "Scoped package detected, looking in 'beep__boop'",
+    "Directory 'types' does not exist, skipping all lookups in it.",
     "Looking up in 'node_modules' folder, initial location '/'.",
     "Scoped package detected, looking in 'beep__boop'",
     "File '/node_modules/@types/beep__boop/package.json' does not exist.",

--- a/tests/cases/conformance/references/library-reference-scoped-packages-2.ts
+++ b/tests/cases/conformance/references/library-reference-scoped-packages-2.ts
@@ -1,0 +1,9 @@
+// @noImplicitReferences: true
+// @traceResolution: true
+// @typeRoots: /types
+
+// @filename: /types/beep__boop/index.d.ts
+export const y = 0;
+
+// @filename: /a.ts
+/// <reference types="@beep/boop" />

--- a/tests/cases/conformance/references/library-reference-scoped-packages-3.ts
+++ b/tests/cases/conformance/references/library-reference-scoped-packages-3.ts
@@ -1,0 +1,10 @@
+// @noImplicitReferences: true
+// @traceResolution: true
+// @currentDirectory /foo
+// @typeRoots: /types
+
+// @filename: /types/beep__boop/index.d.ts
+export const y = 0;
+
+// @filename: /foo/a.ts
+/// <reference types="@beep/boop" />


### PR DESCRIPTION
Mangling was previously only taking place during secondary resolution lookup, not while searching through specified type roots.
This was causing the following issue in bazel-built projects: bazelbuild/rules_nodejs#1334

I additionally added some missing test cases for the existing mangling functionality in the secondary lookup.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #34917