### PR TITLE
Gh 41788 incorrect output for esprivate with nested class in esnext

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26996,7 +26996,7 @@ namespace ts {
                         const parentStaticFieldInitializerSymbol = getSymbolOfNode(parentStaticFieldInitializer.parent);
                         Debug.assert(parentStaticFieldInitializerSymbol, "Initializer without declaration symbol");
                         const diagnostic = error(node,
-                            Diagnostics.Property_0_has_a_private_name_but_is_used_in_a_static_initializer_in_its_declaring_class_This_is_only_supported_for_an_ESNext_target_if_useDefineForClassFields_is_set_to_true,
+                            Diagnostics.Property_0_is_used_in_a_static_property_s_initializer_in_the_same_class_This_is_only_supported_when_target_set_to_is_esnext_and_if_useDefineForClassFields_is_set_to_true,
                             symbolName(lexicallyScopedSymbol));
                         addRelatedInfo(diagnostic,
                             createDiagnosticForNode(parentStaticFieldInitializer.parent,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26982,17 +26982,17 @@ namespace ts {
                     grammarErrorOnNode(right, Diagnostics.Cannot_assign_to_private_method_0_Private_methods_are_not_writable, idText(right));
                 }
 
-                if(lexicallyScopedSymbol && (compilerOptions.target === ScriptTarget.ESNext && compilerOptions.useDefineForClassFields === false)) {
+                if (lexicallyScopedSymbol && (compilerOptions.target === ScriptTarget.ESNext && !useDefineForClassFields)) {
                     const lexicalValueDecl = lexicallyScopedSymbol.valueDeclaration;
                     const lexicalClass = lexicalValueDecl && getContainingClass(lexicalValueDecl);
                     const parentStaticFieldInitializer = findAncestor(node, (n) => {
-                        if(n === lexicalClass) return "quit";
-                        if(isPropertyDeclaration(n.parent) && n.parent.initializer === n && n.parent.parent === lexicalClass) {
+                        if (n === lexicalClass) return "quit";
+                        if (isPropertyDeclaration(n.parent) && n.parent.initializer === n && n.parent.parent === lexicalClass) {
                             return true;
                         }
                         return false;
                     });
-                    if(parentStaticFieldInitializer) {
+                    if (parentStaticFieldInitializer) {
                         const parentStaticFieldInitializerSymbol = getSymbolOfNode(parentStaticFieldInitializer.parent);
                         Debug.assert(parentStaticFieldInitializerSymbol, "Initializer without declaration symbol");
                         const diagnostic = error(node,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26986,8 +26986,8 @@ namespace ts {
                     const lexicalValueDecl = lexicallyScopedSymbol.valueDeclaration;
                     const lexicalClass = lexicalValueDecl && getContainingClass(lexicalValueDecl);
                     const parentStaticFieldInitializer = findAncestor(node, (n) => {
-                        if(n == lexicalClass) return "quit";
-                        if(isPropertyDeclaration(n.parent) && n.parent.initializer == n && n.parent.parent === lexicalClass) {
+                        if(n === lexicalClass) return "quit";
+                        if(isPropertyDeclaration(n.parent) && n.parent.initializer === n && n.parent.parent === lexicalClass) {
                             return true;
                         }
                         return false;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26982,12 +26982,11 @@ namespace ts {
                     grammarErrorOnNode(right, Diagnostics.Cannot_assign_to_private_method_0_Private_methods_are_not_writable, idText(right));
                 }
 
-                if (lexicallyScopedSymbol && (compilerOptions.target === ScriptTarget.ESNext && !useDefineForClassFields)) {
-                    const lexicalValueDecl = lexicallyScopedSymbol.valueDeclaration;
-                    const lexicalClass = lexicalValueDecl && getContainingClass(lexicalValueDecl);
+                if (lexicallyScopedSymbol?.valueDeclaration && (compilerOptions.target === ScriptTarget.ESNext && !useDefineForClassFields)) {
+                    const lexicalClass = getContainingClass(lexicallyScopedSymbol.valueDeclaration);
                     const parentStaticFieldInitializer = findAncestor(node, (n) => {
                         if (n === lexicalClass) return "quit";
-                        if (isPropertyDeclaration(n.parent) && n.parent.initializer === n && n.parent.parent === lexicalClass) {
+                        if (isPropertyDeclaration(n.parent) && hasStaticModifier(n.parent) && n.parent.initializer === n && n.parent.parent === lexicalClass) {
                             return true;
                         }
                         return false;
@@ -26996,7 +26995,7 @@ namespace ts {
                         const parentStaticFieldInitializerSymbol = getSymbolOfNode(parentStaticFieldInitializer.parent);
                         Debug.assert(parentStaticFieldInitializerSymbol, "Initializer without declaration symbol");
                         const diagnostic = error(node,
-                            Diagnostics.Property_0_is_used_in_a_static_property_s_initializer_in_the_same_class_This_is_only_supported_when_target_set_to_is_esnext_and_if_useDefineForClassFields_is_set_to_true,
+                            Diagnostics.Property_0_may_not_be_used_in_a_static_property_s_initializer_in_the_same_class_when_target_is_esnext_and_useDefineForClassFields_is_false,
                             symbolName(lexicallyScopedSymbol));
                         addRelatedInfo(diagnostic,
                             createDiagnosticForNode(parentStaticFieldInitializer.parent,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -346,6 +346,7 @@ namespace ts {
         const compilerOptions = host.getCompilerOptions();
         const languageVersion = getEmitScriptTarget(compilerOptions);
         const moduleKind = getEmitModuleKind(compilerOptions);
+        const useDefineForClassFields = getUseDefineForClassFields(compilerOptions);
         const allowSyntheticDefaultImports = getAllowSyntheticDefaultImports(compilerOptions);
         const strictNullChecks = getStrictOptionValue(compilerOptions, "strictNullChecks");
         const strictFunctionTypes = getStrictOptionValue(compilerOptions, "strictFunctionTypes");
@@ -1501,7 +1502,7 @@ namespace ts {
                 }
                 else if (isParameterPropertyDeclaration(declaration, declaration.parent)) {
                     // foo = this.bar is illegal in esnext+useDefineForClassFields when bar is a parameter property
-                    return !(compilerOptions.target === ScriptTarget.ESNext && !!compilerOptions.useDefineForClassFields
+                    return !(compilerOptions.target === ScriptTarget.ESNext && useDefineForClassFields
                              && getContainingClass(declaration) === getContainingClass(usage)
                              && isUsedInFunctionOrInstanceProperty(usage, declaration));
                 }
@@ -1532,7 +1533,7 @@ namespace ts {
                 return true;
             }
             if (isUsedInFunctionOrInstanceProperty(usage, declaration)) {
-                if (compilerOptions.target === ScriptTarget.ESNext && !!compilerOptions.useDefineForClassFields
+                if (compilerOptions.target === ScriptTarget.ESNext && useDefineForClassFields
                     && getContainingClass(declaration)
                     && (isPropertyDeclaration(declaration) || isParameterPropertyDeclaration(declaration, declaration.parent))) {
                     return !isPropertyImmediatelyReferencedWithinDeclaration(declaration, usage, /*stopAtAnyPropertyDeclaration*/ true);
@@ -1680,7 +1681,7 @@ namespace ts {
                     case SyntaxKind.PropertyDeclaration:
                         // static properties in classes introduce temporary variables
                         if (hasStaticModifier(node)) {
-                            return target < ScriptTarget.ESNext || !compilerOptions.useDefineForClassFields;
+                            return target < ScriptTarget.ESNext || !useDefineForClassFields;
                         }
                         return requiresScopeChangeWorker((node as PropertyDeclaration).name);
                     default:
@@ -2098,7 +2099,7 @@ namespace ts {
 
             // Perform extra checks only if error reporting was requested
             if (nameNotFoundMessage) {
-                if (propertyWithInvalidInitializer && !(compilerOptions.target === ScriptTarget.ESNext && compilerOptions.useDefineForClassFields)) {
+                if (propertyWithInvalidInitializer && !(compilerOptions.target === ScriptTarget.ESNext && useDefineForClassFields)) {
                     // We have a match, but the reference occurred within a property initializer and the identifier also binds
                     // to a local variable in the constructor where the code will be emitted. Note that this is actually allowed
                     // with ESNext+useDefineForClassFields because the scope semantics are different.
@@ -24183,7 +24184,7 @@ namespace ts {
                     break;
                 case SyntaxKind.PropertyDeclaration:
                 case SyntaxKind.PropertySignature:
-                    if (hasSyntacticModifier(container, ModifierFlags.Static) && !(compilerOptions.target === ScriptTarget.ESNext && compilerOptions.useDefineForClassFields)) {
+                    if (hasSyntacticModifier(container, ModifierFlags.Static) && !(compilerOptions.target === ScriptTarget.ESNext && useDefineForClassFields)) {
                         error(node, Diagnostics.this_cannot_be_referenced_in_a_static_property_initializer);
                         // do not return here so in case if lexical this is captured - it will be reflected in flags on NodeLinks
                     }
@@ -33054,7 +33055,7 @@ namespace ts {
                     // - The constructor declares parameter properties
                     //   or the containing class declares instance member variables with initializers.
                     const superCallShouldBeFirst =
-                        (compilerOptions.target !== ScriptTarget.ESNext || !compilerOptions.useDefineForClassFields) &&
+                        (compilerOptions.target !== ScriptTarget.ESNext || !useDefineForClassFields) &&
                         (some((<ClassDeclaration>node.parent).members, isInstancePropertyWithInitializerOrPrivateIdentifierProperty) ||
                          some(node.parameters, p => hasSyntacticModifier(p, ModifierFlags.ParameterPropertyModifier)));
 
@@ -37059,7 +37060,7 @@ namespace ts {
                                 Diagnostics._0_is_defined_as_a_property_in_class_1_but_is_overridden_here_in_2_as_an_accessor;
                             error(getNameOfDeclaration(derived.valueDeclaration) || derived.valueDeclaration, errorMessage, symbolToString(base), typeToString(baseType), typeToString(type));
                         }
-                        else if (compilerOptions.useDefineForClassFields) {
+                        else if (useDefineForClassFields) {
                             const uninitialized = derived.declarations?.find(d => d.kind === SyntaxKind.PropertyDeclaration && !(d as PropertyDeclaration).initializer);
                             if (uninitialized
                                 && !(derived.flags & SymbolFlags.Transient)

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3312,7 +3312,7 @@
         "category": "Error",
         "code": 2809
     },
-    "Property '{0}' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'": {
+    "Property '{0}' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'": {
         "category": "Error",
         "code": 2810
     },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3312,7 +3312,7 @@
         "category": "Error",
         "code": 2809
     },
-    "Property '{0}' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'": {
+    "Property '{0}' may not be used in a static property's initializer in the same class when 'target' is 'esnext' and 'useDefineForClassFields' is 'false'.": {
         "category": "Error",
         "code": 2810
     },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3312,6 +3312,14 @@
         "category": "Error",
         "code": 2809
     },
+    "Property '{0}' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'": {
+        "category": "Error",
+        "code": 2810
+    },
+    "Initializer for property '{0}'": {
+        "category": "Error",
+        "code": 2811
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -108,6 +108,7 @@ namespace ts {
         const resolver = context.getEmitResolver();
         const compilerOptions = context.getCompilerOptions();
         const languageVersion = getEmitScriptTarget(compilerOptions);
+        const useDefineForClassFields = getUseDefineForClassFields(compilerOptions);
 
         const shouldTransformPrivateElements = languageVersion < ScriptTarget.ESNext;
 
@@ -138,7 +139,7 @@ namespace ts {
         function transformSourceFile(node: SourceFile) {
             const options = context.getCompilerOptions();
             if (node.isDeclarationFile
-                || options.useDefineForClassFields && options.target === ScriptTarget.ESNext) {
+                || useDefineForClassFields && options.target === ScriptTarget.ESNext) {
                 return node;
             }
             const visited = visitEachChild(node, visitor, context);
@@ -340,7 +341,7 @@ namespace ts {
             // Create a temporary variable to store a computed property name (if necessary).
             // If it's not inlineable, then we emit an expression after the class which assigns
             // the property name to the temporary variable.
-            const expr = getPropertyNameExpressionIfNeeded(node.name, !!node.initializer || !!context.getCompilerOptions().useDefineForClassFields);
+            const expr = getPropertyNameExpressionIfNeeded(node.name, !!node.initializer || useDefineForClassFields);
             if (expr && !isSimpleInlineableExpression(expr)) {
                 getPendingExpressions().push(expr);
             }
@@ -829,7 +830,7 @@ namespace ts {
             if (hasStaticModifier(member) || hasSyntacticModifier(getOriginalNode(member), ModifierFlags.Abstract)) {
                 return false;
             }
-            if (context.getCompilerOptions().useDefineForClassFields) {
+            if (useDefineForClassFields) {
                 // If we are using define semantics and targeting ESNext or higher,
                 // then we don't need to transform any class properties.
                 return languageVersion < ScriptTarget.ESNext;
@@ -865,7 +866,6 @@ namespace ts {
         }
 
         function transformConstructorBody(node: ClassDeclaration | ClassExpression, constructor: ConstructorDeclaration | undefined, isDerivedClass: boolean) {
-            const useDefineForClassFields = context.getCompilerOptions().useDefineForClassFields;
             let properties = getProperties(node, /*requireInitializer*/ false, /*isStatic*/ false);
             if (!useDefineForClassFields) {
                 properties = filter(properties, property => !!property.initializer || isPrivateIdentifier(property.name));
@@ -1000,7 +1000,7 @@ namespace ts {
          */
         function transformProperty(property: PropertyDeclaration, receiver: LeftHandSideExpression) {
             // We generate a name here in order to reuse the value cached by the relocated computed name expression (which uses the same generated name)
-            const emitAssignment = !context.getCompilerOptions().useDefineForClassFields;
+            const emitAssignment = !useDefineForClassFields;
             const propertyName = isComputedPropertyName(property.name) && !isSimpleInlineableExpression(property.name.expression)
                 ? factory.updateComputedPropertyName(property.name, factory.getGeneratedNameForNode(property.name))
                 : property.name;

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -1626,7 +1626,7 @@ namespace ts {
             const memberFunction = transformFunctionLikeToExpression(member, /*location*/ member, /*name*/ undefined, container);
             const propertyName = visitNode(member.name, visitor, isPropertyName);
             let e: Expression;
-            if (!isPrivateIdentifier(propertyName) && context.getCompilerOptions().useDefineForClassFields) {
+            if (!isPrivateIdentifier(propertyName) && getUseDefineForClassFields(context.getCompilerOptions())) {
                 const name = isComputedPropertyName(propertyName) ? propertyName.expression
                     : isIdentifier(propertyName) ? factory.createStringLiteral(unescapeLeadingUnderscores(propertyName.escapedText))
                     : propertyName;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6071,6 +6071,10 @@ namespace ts {
         return compilerOptions.allowJs === undefined ? !!compilerOptions.checkJs : compilerOptions.allowJs;
     }
 
+    export function getUseDefineForClassFields(compilerOptions: CompilerOptions): boolean {
+        return compilerOptions.useDefineForClassFields === undefined ? compilerOptions.target === ScriptTarget.ESNext : compilerOptions.useDefineForClassFields;
+    }
+
     export function compilerOptionsAffectSemanticDiagnostics(newOptions: CompilerOptions, oldOptions: CompilerOptions): boolean {
         return oldOptions !== newOptions &&
             semanticDiagnosticsOptionDeclarations.some(option => !isJsonEqual(getCompilerOptionValue(oldOptions, option), getCompilerOptionValue(newOptions, option)));

--- a/src/testRunner/unittests/transform.ts
+++ b/src/testRunner/unittests/transform.ts
@@ -176,6 +176,7 @@ namespace ts {
                 compilerOptions: {
                     target: ScriptTarget.ESNext,
                     newLine: NewLineKind.CarriageReturnLineFeed,
+                    useDefineForClassFields: false,
                 }
             }).outputText;
         });

--- a/tests/baselines/reference/classWithStaticFieldInParameterBindingPattern(target=esnext).js
+++ b/tests/baselines/reference/classWithStaticFieldInParameterBindingPattern(target=esnext).js
@@ -4,7 +4,6 @@
 
 //// [classWithStaticFieldInParameterBindingPattern.js]
 // https://github.com/microsoft/TypeScript/issues/36295
-((_a) => { var _b; var { [(_b = class {
-    },
-    _b.x = 1,
-    _b).x]: b = "" } = _a; })();
+(({ [class {
+    static x = 1;
+}.x]: b = "" }) => { })();

--- a/tests/baselines/reference/classWithStaticFieldInParameterInitializer(target=esnext).js
+++ b/tests/baselines/reference/classWithStaticFieldInParameterInitializer(target=esnext).js
@@ -4,7 +4,6 @@
 
 //// [classWithStaticFieldInParameterInitializer.js]
 // https://github.com/microsoft/TypeScript/issues/36295
-((b) => { var _a; if (b === void 0) { b = (_a = class {
-    },
-    _a.x = 1,
-    _a); } })();
+((b = class {
+    static x = 1;
+}) => { })();

--- a/tests/baselines/reference/privateNameAndStaticInitializer(target=esnext).js
+++ b/tests/baselines/reference/privateNameAndStaticInitializer(target=esnext).js
@@ -9,11 +9,7 @@ class A {
 
 //// [privateNameAndStaticInitializer.js]
 class A {
-    constructor() {
-        this.#foo = 1;
-        this.#prop = 2;
-    }
-    #foo;
-    #prop;
+    #foo = 1;
+    static inst = new A();
+    #prop = 2;
 }
-A.inst = new A();

--- a/tests/baselines/reference/privateNameComputedPropertyName1(target=esnext).js
+++ b/tests/baselines/reference/privateNameComputedPropertyName1(target=esnext).js
@@ -39,18 +39,15 @@ new A().test();
 
 //// [privateNameComputedPropertyName1.js]
 class A {
+    #a = 'a';
+    #b;
+    #c = 'c';
+    #d;
+    #e = '';
     constructor() {
-        this.#a = 'a';
-        this.#c = 'c';
-        this.#e = '';
         this.#b = 'b';
         this.#d = 'd';
     }
-    #a;
-    #b;
-    #c;
-    #d;
-    #e;
     test() {
         const data = { a: 'a', b: 'b', c: 'c', d: 'd', e: 'e' };
         const { [this.#a]: a, [this.#b]: b, [this.#c]: c, [this.#d]: d, [this.#e = 'e']: e, } = data;

--- a/tests/baselines/reference/privateNameComputedPropertyName2(target=esnext).js
+++ b/tests/baselines/reference/privateNameComputedPropertyName2(target=esnext).js
@@ -12,10 +12,7 @@ console.log(getX(new A));
 //// [privateNameComputedPropertyName2.js]
 let getX;
 class A {
-    constructor() {
-        this.#x = 100;
-    }
-    #x;
+    #x = 100;
     [(getX = (a) => a.#x, "_")]() { }
 }
 console.log(getX(new A));

--- a/tests/baselines/reference/privateNameComputedPropertyName3(target=esnext).js
+++ b/tests/baselines/reference/privateNameComputedPropertyName3(target=esnext).js
@@ -26,17 +26,14 @@ console.log(new Foo("NAME").getValue(100));
 
 //// [privateNameComputedPropertyName3.js]
 class Foo {
+    #name;
     constructor(name) {
         this.#name = name;
     }
-    #name;
     getValue(x) {
         const obj = this;
         class Bar {
-            constructor() {
-                this.#y = 100;
-            }
-            #y;
+            #y = 100;
             [obj.#name]() {
                 return x + this.#y;
             }

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).js
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).js
@@ -27,41 +27,40 @@ class Test {
 
 //// [privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.js]
 "use strict";
-var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, privateMap) {
-    if (!privateMap.has(receiver)) {
-        throw new TypeError("attempted to get private field on non-instance");
-    }
-    return privateMap.get(receiver);
+var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, state, kind, f) {
+    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+    return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 };
-var _prop, _foo, _a;
+var _Test_prop, _Inner_foo, _a;
 class Test {
     constructor() {
-        _prop.set(this, 0);
+        _Test_prop.set(this, 0);
     }
 }
-_prop = new WeakMap();
-Test.dd = __classPrivateFieldGet(new Test(), _prop); // Err
+_Test_prop = new WeakMap();
+Test.dd = __classPrivateFieldGet(new Test(), _Test_prop, "f"); // Err
 Test["X_ z_ zz"] = (_a = class Inner {
         constructor() {
-            _foo.set(this, 10);
+            _Inner_foo.set(this, 10);
         }
         m() {
-            __classPrivateFieldGet(new Test(), _prop); // Err
+            __classPrivateFieldGet(new Test(), _Test_prop, "f"); // Err
         }
         static M() {
             return class {
                 m() {
-                    __classPrivateFieldGet(new Test(), _prop); // Err
-                    __classPrivateFieldGet(new Inner(), _foo); // OK
+                    __classPrivateFieldGet(new Test(), _Test_prop, "f"); // Err
+                    __classPrivateFieldGet(new Inner(), _Inner_foo, "f"); // OK
                 }
             };
         }
     },
-    _foo = new WeakMap(),
+    _Inner_foo = new WeakMap(),
     _a.C = class InnerInner {
         m() {
-            __classPrivateFieldGet(new Test(), _prop); // Err
-            __classPrivateFieldGet(new _a(), _foo); // Err
+            __classPrivateFieldGet(new Test(), _Test_prop, "f"); // Err
+            __classPrivateFieldGet(new _a(), _Inner_foo, "f"); // Err
         }
     },
     _a);

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).js
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).js
@@ -1,0 +1,67 @@
+//// [privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts]
+class Test {
+    #prop = 0 
+    static dd = new Test().#prop; // Err
+    static ["X_ z_ zz"] = class Inner {
+        #foo  = 10   
+        m() {
+            new Test().#prop // Err
+        }
+        static C = class InnerInner {
+            m() {
+                new Test().#prop // Err
+                new Inner().#foo; // Err
+            }
+        }
+
+        static M(){
+            return class {
+                m() {
+                    new Test().#prop // Err
+                    new Inner().#foo; // OK
+                }
+            }
+        } 
+    }
+}
+
+//// [privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.js]
+"use strict";
+var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, privateMap) {
+    if (!privateMap.has(receiver)) {
+        throw new TypeError("attempted to get private field on non-instance");
+    }
+    return privateMap.get(receiver);
+};
+var _prop, _foo, _a;
+class Test {
+    constructor() {
+        _prop.set(this, 0);
+    }
+}
+_prop = new WeakMap();
+Test.dd = __classPrivateFieldGet(new Test(), _prop); // Err
+Test["X_ z_ zz"] = (_a = class Inner {
+        constructor() {
+            _foo.set(this, 10);
+        }
+        m() {
+            __classPrivateFieldGet(new Test(), _prop); // Err
+        }
+        static M() {
+            return class {
+                m() {
+                    __classPrivateFieldGet(new Test(), _prop); // Err
+                    __classPrivateFieldGet(new Inner(), _foo); // OK
+                }
+            };
+        }
+    },
+    _foo = new WeakMap(),
+    _a.C = class InnerInner {
+        m() {
+            __classPrivateFieldGet(new Test(), _prop); // Err
+            __classPrivateFieldGet(new _a(), _foo); // Err
+        }
+    },
+    _a);

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).js
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).js
@@ -1,15 +1,15 @@
 //// [privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts]
-class Test {
+class TestWithErrors {
     #prop = 0 
-    static dd = new Test().#prop; // Err
+    static dd = new TestWithErrors().#prop; // Err
     static ["X_ z_ zz"] = class Inner {
         #foo  = 10   
         m() {
-            new Test().#prop // Err
+            new TestWithErrors().#prop // Err
         }
         static C = class InnerInner {
             m() {
-                new Test().#prop // Err
+                new TestWithErrors().#prop // Err
                 new Inner().#foo; // Err
             }
         }
@@ -17,13 +17,39 @@ class Test {
         static M(){
             return class {
                 m() {
-                    new Test().#prop // Err
+                    new TestWithErrors().#prop // Err
                     new Inner().#foo; // OK
                 }
             }
         } 
     }
 }
+
+class TestNoErrors {
+    #prop = 0 
+    dd = new TestNoErrors().#prop; // OK
+    ["X_ z_ zz"] = class Inner {
+        #foo  = 10   
+        m() {
+            new TestNoErrors().#prop // Ok
+        }
+        C = class InnerInner {
+            m() {
+                new TestNoErrors().#prop // Ok
+                new Inner().#foo; // Ok
+            }
+        }
+  
+        static M(){
+            return class {
+                m() {
+                    new TestNoErrors().#prop // OK
+                    new Inner().#foo; // OK
+                }
+            }
+        } 
+    }
+  }
 
 //// [privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.js]
 "use strict";
@@ -32,25 +58,25 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
     if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
     return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 };
-var _Test_prop, _Inner_foo, _a;
-class Test {
+var _TestWithErrors_prop, _Inner_foo, _a, _TestNoErrors_prop;
+class TestWithErrors {
     constructor() {
-        _Test_prop.set(this, 0);
+        _TestWithErrors_prop.set(this, 0);
     }
 }
-_Test_prop = new WeakMap();
-Test.dd = __classPrivateFieldGet(new Test(), _Test_prop, "f"); // Err
-Test["X_ z_ zz"] = (_a = class Inner {
+_TestWithErrors_prop = new WeakMap();
+TestWithErrors.dd = __classPrivateFieldGet(new TestWithErrors(), _TestWithErrors_prop, "f"); // Err
+TestWithErrors["X_ z_ zz"] = (_a = class Inner {
         constructor() {
             _Inner_foo.set(this, 10);
         }
         m() {
-            __classPrivateFieldGet(new Test(), _Test_prop, "f"); // Err
+            __classPrivateFieldGet(new TestWithErrors(), _TestWithErrors_prop, "f"); // Err
         }
         static M() {
             return class {
                 m() {
-                    __classPrivateFieldGet(new Test(), _Test_prop, "f"); // Err
+                    __classPrivateFieldGet(new TestWithErrors(), _TestWithErrors_prop, "f"); // Err
                     __classPrivateFieldGet(new Inner(), _Inner_foo, "f"); // OK
                 }
             };
@@ -59,8 +85,40 @@ Test["X_ z_ zz"] = (_a = class Inner {
     _Inner_foo = new WeakMap(),
     _a.C = class InnerInner {
         m() {
-            __classPrivateFieldGet(new Test(), _Test_prop, "f"); // Err
+            __classPrivateFieldGet(new TestWithErrors(), _TestWithErrors_prop, "f"); // Err
             __classPrivateFieldGet(new _a(), _Inner_foo, "f"); // Err
         }
     },
     _a);
+class TestNoErrors {
+    constructor() {
+        var _Inner_foo_1, _b;
+        _TestNoErrors_prop.set(this, 0);
+        this.dd = __classPrivateFieldGet(new TestNoErrors(), _TestNoErrors_prop, "f"); // OK
+        this["X_ z_ zz"] = (_b = class Inner {
+                constructor() {
+                    _Inner_foo_1.set(this, 10);
+                    this.C = class InnerInner {
+                        m() {
+                            __classPrivateFieldGet(new TestNoErrors(), _TestNoErrors_prop, "f"); // Ok
+                            __classPrivateFieldGet(new Inner(), _Inner_foo_1, "f"); // Ok
+                        }
+                    };
+                }
+                m() {
+                    __classPrivateFieldGet(new TestNoErrors(), _TestNoErrors_prop, "f"); // Ok
+                }
+                static M() {
+                    return class {
+                        m() {
+                            __classPrivateFieldGet(new TestNoErrors(), _TestNoErrors_prop, "f"); // OK
+                            __classPrivateFieldGet(new Inner(), _Inner_foo_1, "f"); // OK
+                        }
+                    };
+                }
+            },
+            _Inner_foo_1 = new WeakMap(),
+            _b);
+    }
+}
+_TestNoErrors_prop = new WeakMap();

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).symbols
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).symbols
@@ -1,0 +1,63 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts ===
+class Test {
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+    #prop = 0 
+>#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+
+    static dd = new Test().#prop; // Err
+>dd : Symbol(Test.dd, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 1, 13))
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+    static ["X_ z_ zz"] = class Inner {
+>["X_ z_ zz"] : Symbol(Test["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 33))
+>"X_ z_ zz" : Symbol(Test["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 33))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 25))
+
+        #foo  = 10   
+>#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
+
+        m() {
+>m : Symbol(Inner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 4, 18))
+
+            new Test().#prop // Err
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+        }
+        static C = class InnerInner {
+>C : Symbol(Inner.C, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 7, 9))
+>InnerInner : Symbol(InnerInner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 8, 18))
+
+            m() {
+>m : Symbol(InnerInner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 8, 37))
+
+                new Test().#prop // Err
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+                new Inner().#foo; // Err
+>new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 25))
+            }
+        }
+
+        static M(){
+>M : Symbol(Inner.M, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 13, 9))
+
+            return class {
+                m() {
+>m : Symbol((Anonymous class).m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 16, 26))
+
+                    new Test().#prop // Err
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+                    new Inner().#foo; // OK
+>new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 25))
+                }
+            }
+        } 
+    }
+}

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).symbols
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).symbols
@@ -1,18 +1,18 @@
 === tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts ===
-class Test {
->Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+class TestWithErrors {
+>TestWithErrors : Symbol(TestWithErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
 
     #prop = 0 
->#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>#prop : Symbol(TestWithErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 22))
 
-    static dd = new Test().#prop; // Err
->dd : Symbol(Test.dd, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 1, 13))
->new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
->Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+    static dd = new TestWithErrors().#prop; // Err
+>dd : Symbol(TestWithErrors.dd, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 1, 13))
+>new TestWithErrors().#prop : Symbol(TestWithErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 22))
+>TestWithErrors : Symbol(TestWithErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
 
     static ["X_ z_ zz"] = class Inner {
->["X_ z_ zz"] : Symbol(Test["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 33))
->"X_ z_ zz" : Symbol(Test["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 33))
+>["X_ z_ zz"] : Symbol(TestWithErrors["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 43))
+>"X_ z_ zz" : Symbol(TestWithErrors["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 43))
 >Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 25))
 
         #foo  = 10   
@@ -21,9 +21,9 @@ class Test {
         m() {
 >m : Symbol(Inner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 4, 18))
 
-            new Test().#prop // Err
->new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
->Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+            new TestWithErrors().#prop // Err
+>new TestWithErrors().#prop : Symbol(TestWithErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 22))
+>TestWithErrors : Symbol(TestWithErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
         }
         static C = class InnerInner {
 >C : Symbol(Inner.C, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 7, 9))
@@ -32,9 +32,9 @@ class Test {
             m() {
 >m : Symbol(InnerInner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 8, 37))
 
-                new Test().#prop // Err
->new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
->Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+                new TestWithErrors().#prop // Err
+>new TestWithErrors().#prop : Symbol(TestWithErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 22))
+>TestWithErrors : Symbol(TestWithErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
 
                 new Inner().#foo; // Err
 >new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
@@ -49,9 +49,9 @@ class Test {
                 m() {
 >m : Symbol((Anonymous class).m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 16, 26))
 
-                    new Test().#prop // Err
->new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
->Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+                    new TestWithErrors().#prop // Err
+>new TestWithErrors().#prop : Symbol(TestWithErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 22))
+>TestWithErrors : Symbol(TestWithErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
 
                     new Inner().#foo; // OK
 >new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
@@ -61,3 +61,66 @@ class Test {
         } 
     }
 }
+
+class TestNoErrors {
+>TestNoErrors : Symbol(TestNoErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 24, 1))
+
+    #prop = 0 
+>#prop : Symbol(TestNoErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 26, 20))
+
+    dd = new TestNoErrors().#prop; // OK
+>dd : Symbol(TestNoErrors.dd, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 27, 13))
+>new TestNoErrors().#prop : Symbol(TestNoErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 26, 20))
+>TestNoErrors : Symbol(TestNoErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 24, 1))
+
+    ["X_ z_ zz"] = class Inner {
+>["X_ z_ zz"] : Symbol(TestNoErrors["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 28, 34))
+>"X_ z_ zz" : Symbol(TestNoErrors["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 28, 34))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 29, 18))
+
+        #foo  = 10   
+>#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 29, 32))
+
+        m() {
+>m : Symbol(Inner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 30, 18))
+
+            new TestNoErrors().#prop // Ok
+>new TestNoErrors().#prop : Symbol(TestNoErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 26, 20))
+>TestNoErrors : Symbol(TestNoErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 24, 1))
+        }
+        C = class InnerInner {
+>C : Symbol(Inner.C, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 33, 9))
+>InnerInner : Symbol(InnerInner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 34, 11))
+
+            m() {
+>m : Symbol(InnerInner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 34, 30))
+
+                new TestNoErrors().#prop // Ok
+>new TestNoErrors().#prop : Symbol(TestNoErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 26, 20))
+>TestNoErrors : Symbol(TestNoErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 24, 1))
+
+                new Inner().#foo; // Ok
+>new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 29, 32))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 29, 18))
+            }
+        }
+  
+        static M(){
+>M : Symbol(Inner.M, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 39, 9))
+
+            return class {
+                m() {
+>m : Symbol((Anonymous class).m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 42, 26))
+
+                    new TestNoErrors().#prop // OK
+>new TestNoErrors().#prop : Symbol(TestNoErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 26, 20))
+>TestNoErrors : Symbol(TestNoErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 24, 1))
+
+                    new Inner().#foo; // OK
+>new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 29, 32))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 29, 18))
+                }
+            }
+        } 
+    }
+  }

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).types
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).types
@@ -1,0 +1,75 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts ===
+class Test {
+>Test : Test
+
+    #prop = 0 
+>#prop : number
+>0 : 0
+
+    static dd = new Test().#prop; // Err
+>dd : number
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+
+    static ["X_ z_ zz"] = class Inner {
+>["X_ z_ zz"] : typeof Inner
+>"X_ z_ zz" : "X_ z_ zz"
+>class Inner {        #foo  = 10           m() {            new Test().#prop // Err        }        static C = class InnerInner {            m() {                new Test().#prop // Err                new Inner().#foo; // Err            }        }        static M(){            return class {                m() {                    new Test().#prop // Err                    new Inner().#foo; // OK                }            }        }     } : typeof Inner
+>Inner : typeof Inner
+
+        #foo  = 10   
+>#foo : number
+>10 : 10
+
+        m() {
+>m : () => void
+
+            new Test().#prop // Err
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+        }
+        static C = class InnerInner {
+>C : typeof InnerInner
+>class InnerInner {            m() {                new Test().#prop // Err                new Inner().#foo; // Err            }        } : typeof InnerInner
+>InnerInner : typeof InnerInner
+
+            m() {
+>m : () => void
+
+                new Test().#prop // Err
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+
+                new Inner().#foo; // Err
+>new Inner().#foo : number
+>new Inner() : Inner
+>Inner : typeof Inner
+            }
+        }
+
+        static M(){
+>M : () => typeof (Anonymous class)
+
+            return class {
+>class {                m() {                    new Test().#prop // Err                    new Inner().#foo; // OK                }            } : typeof (Anonymous class)
+
+                m() {
+>m : () => void
+
+                    new Test().#prop // Err
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+
+                    new Inner().#foo; // OK
+>new Inner().#foo : number
+>new Inner() : Inner
+>Inner : typeof Inner
+                }
+            }
+        } 
+    }
+}

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).types
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).types
@@ -1,21 +1,21 @@
 === tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts ===
-class Test {
->Test : Test
+class TestWithErrors {
+>TestWithErrors : TestWithErrors
 
     #prop = 0 
 >#prop : number
 >0 : 0
 
-    static dd = new Test().#prop; // Err
+    static dd = new TestWithErrors().#prop; // Err
 >dd : number
->new Test().#prop : number
->new Test() : Test
->Test : typeof Test
+>new TestWithErrors().#prop : number
+>new TestWithErrors() : TestWithErrors
+>TestWithErrors : typeof TestWithErrors
 
     static ["X_ z_ zz"] = class Inner {
 >["X_ z_ zz"] : typeof Inner
 >"X_ z_ zz" : "X_ z_ zz"
->class Inner {        #foo  = 10           m() {            new Test().#prop // Err        }        static C = class InnerInner {            m() {                new Test().#prop // Err                new Inner().#foo; // Err            }        }        static M(){            return class {                m() {                    new Test().#prop // Err                    new Inner().#foo; // OK                }            }        }     } : typeof Inner
+>class Inner {        #foo  = 10           m() {            new TestWithErrors().#prop // Err        }        static C = class InnerInner {            m() {                new TestWithErrors().#prop // Err                new Inner().#foo; // Err            }        }        static M(){            return class {                m() {                    new TestWithErrors().#prop // Err                    new Inner().#foo; // OK                }            }        }     } : typeof Inner
 >Inner : typeof Inner
 
         #foo  = 10   
@@ -25,23 +25,23 @@ class Test {
         m() {
 >m : () => void
 
-            new Test().#prop // Err
->new Test().#prop : number
->new Test() : Test
->Test : typeof Test
+            new TestWithErrors().#prop // Err
+>new TestWithErrors().#prop : number
+>new TestWithErrors() : TestWithErrors
+>TestWithErrors : typeof TestWithErrors
         }
         static C = class InnerInner {
 >C : typeof InnerInner
->class InnerInner {            m() {                new Test().#prop // Err                new Inner().#foo; // Err            }        } : typeof InnerInner
+>class InnerInner {            m() {                new TestWithErrors().#prop // Err                new Inner().#foo; // Err            }        } : typeof InnerInner
 >InnerInner : typeof InnerInner
 
             m() {
 >m : () => void
 
-                new Test().#prop // Err
->new Test().#prop : number
->new Test() : Test
->Test : typeof Test
+                new TestWithErrors().#prop // Err
+>new TestWithErrors().#prop : number
+>new TestWithErrors() : TestWithErrors
+>TestWithErrors : typeof TestWithErrors
 
                 new Inner().#foo; // Err
 >new Inner().#foo : number
@@ -54,15 +54,15 @@ class Test {
 >M : () => typeof (Anonymous class)
 
             return class {
->class {                m() {                    new Test().#prop // Err                    new Inner().#foo; // OK                }            } : typeof (Anonymous class)
+>class {                m() {                    new TestWithErrors().#prop // Err                    new Inner().#foo; // OK                }            } : typeof (Anonymous class)
 
                 m() {
 >m : () => void
 
-                    new Test().#prop // Err
->new Test().#prop : number
->new Test() : Test
->Test : typeof Test
+                    new TestWithErrors().#prop // Err
+>new TestWithErrors().#prop : number
+>new TestWithErrors() : TestWithErrors
+>TestWithErrors : typeof TestWithErrors
 
                     new Inner().#foo; // OK
 >new Inner().#foo : number
@@ -73,3 +73,78 @@ class Test {
         } 
     }
 }
+
+class TestNoErrors {
+>TestNoErrors : TestNoErrors
+
+    #prop = 0 
+>#prop : number
+>0 : 0
+
+    dd = new TestNoErrors().#prop; // OK
+>dd : number
+>new TestNoErrors().#prop : number
+>new TestNoErrors() : TestNoErrors
+>TestNoErrors : typeof TestNoErrors
+
+    ["X_ z_ zz"] = class Inner {
+>["X_ z_ zz"] : typeof Inner
+>"X_ z_ zz" : "X_ z_ zz"
+>class Inner {        #foo  = 10           m() {            new TestNoErrors().#prop // Ok        }        C = class InnerInner {            m() {                new TestNoErrors().#prop // Ok                new Inner().#foo; // Ok            }        }          static M(){            return class {                m() {                    new TestNoErrors().#prop // OK                    new Inner().#foo; // OK                }            }        }     } : typeof Inner
+>Inner : typeof Inner
+
+        #foo  = 10   
+>#foo : number
+>10 : 10
+
+        m() {
+>m : () => void
+
+            new TestNoErrors().#prop // Ok
+>new TestNoErrors().#prop : number
+>new TestNoErrors() : TestNoErrors
+>TestNoErrors : typeof TestNoErrors
+        }
+        C = class InnerInner {
+>C : typeof InnerInner
+>class InnerInner {            m() {                new TestNoErrors().#prop // Ok                new Inner().#foo; // Ok            }        } : typeof InnerInner
+>InnerInner : typeof InnerInner
+
+            m() {
+>m : () => void
+
+                new TestNoErrors().#prop // Ok
+>new TestNoErrors().#prop : number
+>new TestNoErrors() : TestNoErrors
+>TestNoErrors : typeof TestNoErrors
+
+                new Inner().#foo; // Ok
+>new Inner().#foo : number
+>new Inner() : Inner
+>Inner : typeof Inner
+            }
+        }
+  
+        static M(){
+>M : () => typeof (Anonymous class)
+
+            return class {
+>class {                m() {                    new TestNoErrors().#prop // OK                    new Inner().#foo; // OK                }            } : typeof (Anonymous class)
+
+                m() {
+>m : () => void
+
+                    new TestNoErrors().#prop // OK
+>new TestNoErrors().#prop : number
+>new TestNoErrors() : TestNoErrors
+>TestNoErrors : typeof TestNoErrors
+
+                    new Inner().#foo; // OK
+>new Inner().#foo : number
+>new Inner() : Inner
+>Inner : typeof Inner
+                }
+            }
+        } 
+    }
+  }

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).errors.txt
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).errors.txt
@@ -1,34 +1,34 @@
-tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(3,17): error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
-tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(7,13): error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
-tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(11,17): error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
-tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(12,17): error TS2810: Property '#foo' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
-tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(19,21): error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(3,17): error TS2810: Property '#prop' may not be used in a static property's initializer in the same class when 'target' is 'esnext' and 'useDefineForClassFields' is 'false'.
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(7,13): error TS2810: Property '#prop' may not be used in a static property's initializer in the same class when 'target' is 'esnext' and 'useDefineForClassFields' is 'false'.
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(11,17): error TS2810: Property '#prop' may not be used in a static property's initializer in the same class when 'target' is 'esnext' and 'useDefineForClassFields' is 'false'.
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(12,17): error TS2810: Property '#foo' may not be used in a static property's initializer in the same class when 'target' is 'esnext' and 'useDefineForClassFields' is 'false'.
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(19,21): error TS2810: Property '#prop' may not be used in a static property's initializer in the same class when 'target' is 'esnext' and 'useDefineForClassFields' is 'false'.
 
 
 ==== tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts (5 errors) ====
-    class Test {
+    class TestWithErrors {
         #prop = 0 
-        static dd = new Test().#prop; // Err
-                    ~~~~~~~~~~~~~~~~
-!!! error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+        static dd = new TestWithErrors().#prop; // Err
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2810: Property '#prop' may not be used in a static property's initializer in the same class when 'target' is 'esnext' and 'useDefineForClassFields' is 'false'.
 !!! related TS2811 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:3:12: Initializer for property 'dd'
         static ["X_ z_ zz"] = class Inner {
             #foo  = 10   
             m() {
-                new Test().#prop // Err
-                ~~~~~~~~~~~~~~~~
-!!! error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+                new TestWithErrors().#prop // Err
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2810: Property '#prop' may not be used in a static property's initializer in the same class when 'target' is 'esnext' and 'useDefineForClassFields' is 'false'.
 !!! related TS2811 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
             }
             static C = class InnerInner {
                 m() {
-                    new Test().#prop // Err
-                    ~~~~~~~~~~~~~~~~
-!!! error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+                    new TestWithErrors().#prop // Err
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2810: Property '#prop' may not be used in a static property's initializer in the same class when 'target' is 'esnext' and 'useDefineForClassFields' is 'false'.
 !!! related TS2811 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
                     new Inner().#foo; // Err
                     ~~~~~~~~~~~~~~~~
-!!! error TS2810: Property '#foo' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+!!! error TS2810: Property '#foo' may not be used in a static property's initializer in the same class when 'target' is 'esnext' and 'useDefineForClassFields' is 'false'.
 !!! related TS2811 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:9:16: Initializer for property 'C'
                 }
             }
@@ -36,9 +36,9 @@ tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDe
             static M(){
                 return class {
                     m() {
-                        new Test().#prop // Err
-                        ~~~~~~~~~~~~~~~~
-!!! error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+                        new TestWithErrors().#prop // Err
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2810: Property '#prop' may not be used in a static property's initializer in the same class when 'target' is 'esnext' and 'useDefineForClassFields' is 'false'.
 !!! related TS2811 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
                         new Inner().#foo; // OK
                     }
@@ -46,3 +46,29 @@ tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDe
             } 
         }
     }
+    
+    class TestNoErrors {
+        #prop = 0 
+        dd = new TestNoErrors().#prop; // OK
+        ["X_ z_ zz"] = class Inner {
+            #foo  = 10   
+            m() {
+                new TestNoErrors().#prop // Ok
+            }
+            C = class InnerInner {
+                m() {
+                    new TestNoErrors().#prop // Ok
+                    new Inner().#foo; // Ok
+                }
+            }
+      
+            static M(){
+                return class {
+                    m() {
+                        new TestNoErrors().#prop // OK
+                        new Inner().#foo; // OK
+                    }
+                }
+            } 
+        }
+      }

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).errors.txt
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).errors.txt
@@ -1,0 +1,48 @@
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(3,17): error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(7,13): error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(11,17): error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(12,17): error TS2801: Property '#foo' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(19,21): error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+
+
+==== tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts (5 errors) ====
+    class Test {
+        #prop = 0 
+        static dd = new Test().#prop; // Err
+                    ~~~~~~~~~~~~~~~~
+!!! error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:3:12: Initializer for property 'dd'
+        static ["X_ z_ zz"] = class Inner {
+            #foo  = 10   
+            m() {
+                new Test().#prop // Err
+                ~~~~~~~~~~~~~~~~
+!!! error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
+            }
+            static C = class InnerInner {
+                m() {
+                    new Test().#prop // Err
+                    ~~~~~~~~~~~~~~~~
+!!! error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
+                    new Inner().#foo; // Err
+                    ~~~~~~~~~~~~~~~~
+!!! error TS2801: Property '#foo' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:9:16: Initializer for property 'C'
+                }
+            }
+    
+            static M(){
+                return class {
+                    m() {
+                        new Test().#prop // Err
+                        ~~~~~~~~~~~~~~~~
+!!! error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
+                        new Inner().#foo; // OK
+                    }
+                }
+            } 
+        }
+    }

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).errors.txt
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(3,17): error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
-tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(7,13): error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
-tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(11,17): error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
-tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(12,17): error TS2801: Property '#foo' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
-tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(19,21): error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(3,17): error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(7,13): error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(11,17): error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(12,17): error TS2810: Property '#foo' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(19,21): error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
 
 
 ==== tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts (5 errors) ====
@@ -10,26 +10,26 @@ tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDe
         #prop = 0 
         static dd = new Test().#prop; // Err
                     ~~~~~~~~~~~~~~~~
-!!! error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
-!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:3:12: Initializer for property 'dd'
+!!! error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+!!! related TS2811 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:3:12: Initializer for property 'dd'
         static ["X_ z_ zz"] = class Inner {
             #foo  = 10   
             m() {
                 new Test().#prop // Err
                 ~~~~~~~~~~~~~~~~
-!!! error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
-!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
+!!! error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+!!! related TS2811 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
             }
             static C = class InnerInner {
                 m() {
                     new Test().#prop // Err
                     ~~~~~~~~~~~~~~~~
-!!! error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
-!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
+!!! error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+!!! related TS2811 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
                     new Inner().#foo; // Err
                     ~~~~~~~~~~~~~~~~
-!!! error TS2801: Property '#foo' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
-!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:9:16: Initializer for property 'C'
+!!! error TS2810: Property '#foo' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+!!! related TS2811 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:9:16: Initializer for property 'C'
                 }
             }
     
@@ -38,8 +38,8 @@ tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDe
                     m() {
                         new Test().#prop // Err
                         ~~~~~~~~~~~~~~~~
-!!! error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
-!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
+!!! error TS2810: Property '#prop' is used in a static property's initializer in the same class. This is only supported when 'target' set to is 'esnext' and if 'useDefineForClassFields' is set to 'true'
+!!! related TS2811 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
                         new Inner().#foo; // OK
                     }
                 }

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).js
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).js
@@ -1,15 +1,15 @@
 //// [privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts]
-class Test {
+class TestWithErrors {
     #prop = 0 
-    static dd = new Test().#prop; // Err
+    static dd = new TestWithErrors().#prop; // Err
     static ["X_ z_ zz"] = class Inner {
         #foo  = 10   
         m() {
-            new Test().#prop // Err
+            new TestWithErrors().#prop // Err
         }
         static C = class InnerInner {
             m() {
-                new Test().#prop // Err
+                new TestWithErrors().#prop // Err
                 new Inner().#foo; // Err
             }
         }
@@ -17,7 +17,7 @@ class Test {
         static M(){
             return class {
                 m() {
-                    new Test().#prop // Err
+                    new TestWithErrors().#prop // Err
                     new Inner().#foo; // OK
                 }
             }
@@ -25,28 +25,54 @@ class Test {
     }
 }
 
+class TestNoErrors {
+    #prop = 0 
+    dd = new TestNoErrors().#prop; // OK
+    ["X_ z_ zz"] = class Inner {
+        #foo  = 10   
+        m() {
+            new TestNoErrors().#prop // Ok
+        }
+        C = class InnerInner {
+            m() {
+                new TestNoErrors().#prop // Ok
+                new Inner().#foo; // Ok
+            }
+        }
+  
+        static M(){
+            return class {
+                m() {
+                    new TestNoErrors().#prop // OK
+                    new Inner().#foo; // OK
+                }
+            }
+        } 
+    }
+  }
+
 //// [privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.js]
 "use strict";
 var _a;
-class Test {
+class TestWithErrors {
     constructor() {
         this.#prop = 0;
     }
     #prop;
 }
-Test.dd = new Test().#prop; // Err
-Test["X_ z_ zz"] = (_a = class Inner {
+TestWithErrors.dd = new TestWithErrors().#prop; // Err
+TestWithErrors["X_ z_ zz"] = (_a = class Inner {
         constructor() {
             this.#foo = 10;
         }
         #foo;
         m() {
-            new Test().#prop; // Err
+            new TestWithErrors().#prop; // Err
         }
         static M() {
             return class {
                 m() {
-                    new Test().#prop; // Err
+                    new TestWithErrors().#prop; // Err
                     new Inner().#foo; // OK
                 }
             };
@@ -54,8 +80,38 @@ Test["X_ z_ zz"] = (_a = class Inner {
     },
     _a.C = class InnerInner {
         m() {
-            new Test().#prop; // Err
+            new TestWithErrors().#prop; // Err
             new _a().#foo; // Err
         }
     },
     _a);
+class TestNoErrors {
+    constructor() {
+        this.#prop = 0;
+        this.dd = new TestNoErrors().#prop; // OK
+        this["X_ z_ zz"] = class Inner {
+            constructor() {
+                this.#foo = 10;
+                this.C = class InnerInner {
+                    m() {
+                        new TestNoErrors().#prop; // Ok
+                        new Inner().#foo; // Ok
+                    }
+                };
+            }
+            #foo;
+            m() {
+                new TestNoErrors().#prop; // Ok
+            }
+            static M() {
+                return class {
+                    m() {
+                        new TestNoErrors().#prop; // OK
+                        new Inner().#foo; // OK
+                    }
+                };
+            }
+        };
+    }
+    #prop;
+}

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).js
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).js
@@ -1,0 +1,61 @@
+//// [privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts]
+class Test {
+    #prop = 0 
+    static dd = new Test().#prop; // Err
+    static ["X_ z_ zz"] = class Inner {
+        #foo  = 10   
+        m() {
+            new Test().#prop // Err
+        }
+        static C = class InnerInner {
+            m() {
+                new Test().#prop // Err
+                new Inner().#foo; // Err
+            }
+        }
+
+        static M(){
+            return class {
+                m() {
+                    new Test().#prop // Err
+                    new Inner().#foo; // OK
+                }
+            }
+        } 
+    }
+}
+
+//// [privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.js]
+"use strict";
+var _a;
+class Test {
+    constructor() {
+        this.#prop = 0;
+    }
+    #prop;
+}
+Test.dd = new Test().#prop; // Err
+Test["X_ z_ zz"] = (_a = class Inner {
+        constructor() {
+            this.#foo = 10;
+        }
+        #foo;
+        m() {
+            new Test().#prop; // Err
+        }
+        static M() {
+            return class {
+                m() {
+                    new Test().#prop; // Err
+                    new Inner().#foo; // OK
+                }
+            };
+        }
+    },
+    _a.C = class InnerInner {
+        m() {
+            new Test().#prop; // Err
+            new _a().#foo; // Err
+        }
+    },
+    _a);

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).symbols
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).symbols
@@ -1,0 +1,63 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts ===
+class Test {
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+    #prop = 0 
+>#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+
+    static dd = new Test().#prop; // Err
+>dd : Symbol(Test.dd, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 1, 13))
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+    static ["X_ z_ zz"] = class Inner {
+>["X_ z_ zz"] : Symbol(Test["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 33))
+>"X_ z_ zz" : Symbol(Test["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 33))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 25))
+
+        #foo  = 10   
+>#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
+
+        m() {
+>m : Symbol(Inner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 4, 18))
+
+            new Test().#prop // Err
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+        }
+        static C = class InnerInner {
+>C : Symbol(Inner.C, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 7, 9))
+>InnerInner : Symbol(InnerInner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 8, 18))
+
+            m() {
+>m : Symbol(InnerInner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 8, 37))
+
+                new Test().#prop // Err
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+                new Inner().#foo; // Err
+>new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 25))
+            }
+        }
+
+        static M(){
+>M : Symbol(Inner.M, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 13, 9))
+
+            return class {
+                m() {
+>m : Symbol((Anonymous class).m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 16, 26))
+
+                    new Test().#prop // Err
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+                    new Inner().#foo; // OK
+>new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 25))
+                }
+            }
+        } 
+    }
+}

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).symbols
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).symbols
@@ -1,18 +1,18 @@
 === tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts ===
-class Test {
->Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+class TestWithErrors {
+>TestWithErrors : Symbol(TestWithErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
 
     #prop = 0 
->#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>#prop : Symbol(TestWithErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 22))
 
-    static dd = new Test().#prop; // Err
->dd : Symbol(Test.dd, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 1, 13))
->new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
->Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+    static dd = new TestWithErrors().#prop; // Err
+>dd : Symbol(TestWithErrors.dd, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 1, 13))
+>new TestWithErrors().#prop : Symbol(TestWithErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 22))
+>TestWithErrors : Symbol(TestWithErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
 
     static ["X_ z_ zz"] = class Inner {
->["X_ z_ zz"] : Symbol(Test["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 33))
->"X_ z_ zz" : Symbol(Test["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 33))
+>["X_ z_ zz"] : Symbol(TestWithErrors["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 43))
+>"X_ z_ zz" : Symbol(TestWithErrors["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 43))
 >Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 25))
 
         #foo  = 10   
@@ -21,9 +21,9 @@ class Test {
         m() {
 >m : Symbol(Inner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 4, 18))
 
-            new Test().#prop // Err
->new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
->Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+            new TestWithErrors().#prop // Err
+>new TestWithErrors().#prop : Symbol(TestWithErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 22))
+>TestWithErrors : Symbol(TestWithErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
         }
         static C = class InnerInner {
 >C : Symbol(Inner.C, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 7, 9))
@@ -32,9 +32,9 @@ class Test {
             m() {
 >m : Symbol(InnerInner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 8, 37))
 
-                new Test().#prop // Err
->new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
->Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+                new TestWithErrors().#prop // Err
+>new TestWithErrors().#prop : Symbol(TestWithErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 22))
+>TestWithErrors : Symbol(TestWithErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
 
                 new Inner().#foo; // Err
 >new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
@@ -49,9 +49,9 @@ class Test {
                 m() {
 >m : Symbol((Anonymous class).m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 16, 26))
 
-                    new Test().#prop // Err
->new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
->Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+                    new TestWithErrors().#prop // Err
+>new TestWithErrors().#prop : Symbol(TestWithErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 22))
+>TestWithErrors : Symbol(TestWithErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
 
                     new Inner().#foo; // OK
 >new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
@@ -61,3 +61,66 @@ class Test {
         } 
     }
 }
+
+class TestNoErrors {
+>TestNoErrors : Symbol(TestNoErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 24, 1))
+
+    #prop = 0 
+>#prop : Symbol(TestNoErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 26, 20))
+
+    dd = new TestNoErrors().#prop; // OK
+>dd : Symbol(TestNoErrors.dd, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 27, 13))
+>new TestNoErrors().#prop : Symbol(TestNoErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 26, 20))
+>TestNoErrors : Symbol(TestNoErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 24, 1))
+
+    ["X_ z_ zz"] = class Inner {
+>["X_ z_ zz"] : Symbol(TestNoErrors["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 28, 34))
+>"X_ z_ zz" : Symbol(TestNoErrors["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 28, 34))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 29, 18))
+
+        #foo  = 10   
+>#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 29, 32))
+
+        m() {
+>m : Symbol(Inner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 30, 18))
+
+            new TestNoErrors().#prop // Ok
+>new TestNoErrors().#prop : Symbol(TestNoErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 26, 20))
+>TestNoErrors : Symbol(TestNoErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 24, 1))
+        }
+        C = class InnerInner {
+>C : Symbol(Inner.C, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 33, 9))
+>InnerInner : Symbol(InnerInner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 34, 11))
+
+            m() {
+>m : Symbol(InnerInner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 34, 30))
+
+                new TestNoErrors().#prop // Ok
+>new TestNoErrors().#prop : Symbol(TestNoErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 26, 20))
+>TestNoErrors : Symbol(TestNoErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 24, 1))
+
+                new Inner().#foo; // Ok
+>new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 29, 32))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 29, 18))
+            }
+        }
+  
+        static M(){
+>M : Symbol(Inner.M, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 39, 9))
+
+            return class {
+                m() {
+>m : Symbol((Anonymous class).m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 42, 26))
+
+                    new TestNoErrors().#prop // OK
+>new TestNoErrors().#prop : Symbol(TestNoErrors.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 26, 20))
+>TestNoErrors : Symbol(TestNoErrors, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 24, 1))
+
+                    new Inner().#foo; // OK
+>new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 29, 32))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 29, 18))
+                }
+            }
+        } 
+    }
+  }

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).types
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).types
@@ -1,0 +1,75 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts ===
+class Test {
+>Test : Test
+
+    #prop = 0 
+>#prop : number
+>0 : 0
+
+    static dd = new Test().#prop; // Err
+>dd : number
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+
+    static ["X_ z_ zz"] = class Inner {
+>["X_ z_ zz"] : typeof Inner
+>"X_ z_ zz" : "X_ z_ zz"
+>class Inner {        #foo  = 10           m() {            new Test().#prop // Err        }        static C = class InnerInner {            m() {                new Test().#prop // Err                new Inner().#foo; // Err            }        }        static M(){            return class {                m() {                    new Test().#prop // Err                    new Inner().#foo; // OK                }            }        }     } : typeof Inner
+>Inner : typeof Inner
+
+        #foo  = 10   
+>#foo : number
+>10 : 10
+
+        m() {
+>m : () => void
+
+            new Test().#prop // Err
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+        }
+        static C = class InnerInner {
+>C : typeof InnerInner
+>class InnerInner {            m() {                new Test().#prop // Err                new Inner().#foo; // Err            }        } : typeof InnerInner
+>InnerInner : typeof InnerInner
+
+            m() {
+>m : () => void
+
+                new Test().#prop // Err
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+
+                new Inner().#foo; // Err
+>new Inner().#foo : number
+>new Inner() : Inner
+>Inner : typeof Inner
+            }
+        }
+
+        static M(){
+>M : () => typeof (Anonymous class)
+
+            return class {
+>class {                m() {                    new Test().#prop // Err                    new Inner().#foo; // OK                }            } : typeof (Anonymous class)
+
+                m() {
+>m : () => void
+
+                    new Test().#prop // Err
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+
+                    new Inner().#foo; // OK
+>new Inner().#foo : number
+>new Inner() : Inner
+>Inner : typeof Inner
+                }
+            }
+        } 
+    }
+}

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).types
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).types
@@ -1,21 +1,21 @@
 === tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts ===
-class Test {
->Test : Test
+class TestWithErrors {
+>TestWithErrors : TestWithErrors
 
     #prop = 0 
 >#prop : number
 >0 : 0
 
-    static dd = new Test().#prop; // Err
+    static dd = new TestWithErrors().#prop; // Err
 >dd : number
->new Test().#prop : number
->new Test() : Test
->Test : typeof Test
+>new TestWithErrors().#prop : number
+>new TestWithErrors() : TestWithErrors
+>TestWithErrors : typeof TestWithErrors
 
     static ["X_ z_ zz"] = class Inner {
 >["X_ z_ zz"] : typeof Inner
 >"X_ z_ zz" : "X_ z_ zz"
->class Inner {        #foo  = 10           m() {            new Test().#prop // Err        }        static C = class InnerInner {            m() {                new Test().#prop // Err                new Inner().#foo; // Err            }        }        static M(){            return class {                m() {                    new Test().#prop // Err                    new Inner().#foo; // OK                }            }        }     } : typeof Inner
+>class Inner {        #foo  = 10           m() {            new TestWithErrors().#prop // Err        }        static C = class InnerInner {            m() {                new TestWithErrors().#prop // Err                new Inner().#foo; // Err            }        }        static M(){            return class {                m() {                    new TestWithErrors().#prop // Err                    new Inner().#foo; // OK                }            }        }     } : typeof Inner
 >Inner : typeof Inner
 
         #foo  = 10   
@@ -25,23 +25,23 @@ class Test {
         m() {
 >m : () => void
 
-            new Test().#prop // Err
->new Test().#prop : number
->new Test() : Test
->Test : typeof Test
+            new TestWithErrors().#prop // Err
+>new TestWithErrors().#prop : number
+>new TestWithErrors() : TestWithErrors
+>TestWithErrors : typeof TestWithErrors
         }
         static C = class InnerInner {
 >C : typeof InnerInner
->class InnerInner {            m() {                new Test().#prop // Err                new Inner().#foo; // Err            }        } : typeof InnerInner
+>class InnerInner {            m() {                new TestWithErrors().#prop // Err                new Inner().#foo; // Err            }        } : typeof InnerInner
 >InnerInner : typeof InnerInner
 
             m() {
 >m : () => void
 
-                new Test().#prop // Err
->new Test().#prop : number
->new Test() : Test
->Test : typeof Test
+                new TestWithErrors().#prop // Err
+>new TestWithErrors().#prop : number
+>new TestWithErrors() : TestWithErrors
+>TestWithErrors : typeof TestWithErrors
 
                 new Inner().#foo; // Err
 >new Inner().#foo : number
@@ -54,15 +54,15 @@ class Test {
 >M : () => typeof (Anonymous class)
 
             return class {
->class {                m() {                    new Test().#prop // Err                    new Inner().#foo; // OK                }            } : typeof (Anonymous class)
+>class {                m() {                    new TestWithErrors().#prop // Err                    new Inner().#foo; // OK                }            } : typeof (Anonymous class)
 
                 m() {
 >m : () => void
 
-                    new Test().#prop // Err
->new Test().#prop : number
->new Test() : Test
->Test : typeof Test
+                    new TestWithErrors().#prop // Err
+>new TestWithErrors().#prop : number
+>new TestWithErrors() : TestWithErrors
+>TestWithErrors : typeof TestWithErrors
 
                     new Inner().#foo; // OK
 >new Inner().#foo : number
@@ -73,3 +73,78 @@ class Test {
         } 
     }
 }
+
+class TestNoErrors {
+>TestNoErrors : TestNoErrors
+
+    #prop = 0 
+>#prop : number
+>0 : 0
+
+    dd = new TestNoErrors().#prop; // OK
+>dd : number
+>new TestNoErrors().#prop : number
+>new TestNoErrors() : TestNoErrors
+>TestNoErrors : typeof TestNoErrors
+
+    ["X_ z_ zz"] = class Inner {
+>["X_ z_ zz"] : typeof Inner
+>"X_ z_ zz" : "X_ z_ zz"
+>class Inner {        #foo  = 10           m() {            new TestNoErrors().#prop // Ok        }        C = class InnerInner {            m() {                new TestNoErrors().#prop // Ok                new Inner().#foo; // Ok            }        }          static M(){            return class {                m() {                    new TestNoErrors().#prop // OK                    new Inner().#foo; // OK                }            }        }     } : typeof Inner
+>Inner : typeof Inner
+
+        #foo  = 10   
+>#foo : number
+>10 : 10
+
+        m() {
+>m : () => void
+
+            new TestNoErrors().#prop // Ok
+>new TestNoErrors().#prop : number
+>new TestNoErrors() : TestNoErrors
+>TestNoErrors : typeof TestNoErrors
+        }
+        C = class InnerInner {
+>C : typeof InnerInner
+>class InnerInner {            m() {                new TestNoErrors().#prop // Ok                new Inner().#foo; // Ok            }        } : typeof InnerInner
+>InnerInner : typeof InnerInner
+
+            m() {
+>m : () => void
+
+                new TestNoErrors().#prop // Ok
+>new TestNoErrors().#prop : number
+>new TestNoErrors() : TestNoErrors
+>TestNoErrors : typeof TestNoErrors
+
+                new Inner().#foo; // Ok
+>new Inner().#foo : number
+>new Inner() : Inner
+>Inner : typeof Inner
+            }
+        }
+  
+        static M(){
+>M : () => typeof (Anonymous class)
+
+            return class {
+>class {                m() {                    new TestNoErrors().#prop // OK                    new Inner().#foo; // OK                }            } : typeof (Anonymous class)
+
+                m() {
+>m : () => void
+
+                    new TestNoErrors().#prop // OK
+>new TestNoErrors().#prop : number
+>new TestNoErrors() : TestNoErrors
+>TestNoErrors : typeof TestNoErrors
+
+                    new Inner().#foo; // OK
+>new Inner().#foo : number
+>new Inner() : Inner
+>Inner : typeof Inner
+                }
+            }
+        } 
+    }
+  }

--- a/tests/baselines/reference/privateNameFieldDestructuredBinding(target=esnext).js
+++ b/tests/baselines/reference/privateNameFieldDestructuredBinding(target=esnext).js
@@ -26,9 +26,15 @@ class A {
 
 //// [privateNameFieldDestructuredBinding.js]
 class A {
+    #field = 1;
+    otherObject = new A();
+    testObject() {
+        return { x: 10, y: 6 };
+    }
+    testArray() {
+        return [10, 11];
+    }
     constructor() {
-        this.#field = 1;
-        this.otherObject = new A();
         let y;
         ({ x: this.#field, y } = this.testObject());
         ([this.#field, y] = this.testArray());
@@ -37,13 +43,6 @@ class A {
         ({ a: this.#field = 1, b: [this.#field = 1] } = { b: [] });
         [this.#field = 2] = [];
         [this.otherObject.#field = 2] = [];
-    }
-    #field;
-    testObject() {
-        return { x: 10, y: 6 };
-    }
-    testArray() {
-        return [10, 11];
     }
     static test(_a) {
         [_a.#field] = [2];

--- a/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=es2020).js
+++ b/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=es2020).js
@@ -1,0 +1,13 @@
+//// [useDefineForClassFieldsFlagDefault.ts]
+class Foo {
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1; 
+}
+
+//// [useDefineForClassFieldsFlagDefault.js]
+class Foo {
+}
+// For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+// For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+Foo.x = 1;

--- a/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=es2020).symbols
+++ b/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=es2020).symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/useDefineForClassFieldsFlagDefault.ts ===
+class Foo {
+>Foo : Symbol(Foo, Decl(useDefineForClassFieldsFlagDefault.ts, 0, 0))
+
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1; 
+>x : Symbol(Foo.x, Decl(useDefineForClassFieldsFlagDefault.ts, 0, 11))
+}

--- a/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=es2020).types
+++ b/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=es2020).types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/useDefineForClassFieldsFlagDefault.ts ===
+class Foo {
+>Foo : Foo
+
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1; 
+>x : number
+>1 : 1
+}

--- a/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=esnext).js
+++ b/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=esnext).js
@@ -1,0 +1,13 @@
+//// [useDefineForClassFieldsFlagDefault.ts]
+class Foo {
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1; 
+}
+
+//// [useDefineForClassFieldsFlagDefault.js]
+class Foo {
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1;
+}

--- a/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=esnext).symbols
+++ b/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=esnext).symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/useDefineForClassFieldsFlagDefault.ts ===
+class Foo {
+>Foo : Symbol(Foo, Decl(useDefineForClassFieldsFlagDefault.ts, 0, 0))
+
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1; 
+>x : Symbol(Foo.x, Decl(useDefineForClassFieldsFlagDefault.ts, 0, 11))
+}

--- a/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=esnext).types
+++ b/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=esnext).types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/useDefineForClassFieldsFlagDefault.ts ===
+class Foo {
+>Foo : Foo
+
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1; 
+>x : number
+>1 : 1
+}

--- a/tests/cases/compiler/awaitInClassInAsyncFunction.ts
+++ b/tests/cases/compiler/awaitInClassInAsyncFunction.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 // https://github.com/microsoft/TypeScript/issues/34887
 
 async function bar() {

--- a/tests/cases/compiler/checkSuperCallBeforeThisAccess.ts
+++ b/tests/cases/compiler/checkSuperCallBeforeThisAccess.ts
@@ -1,5 +1,6 @@
 // @strict: true
 // @target: esnext
+// @useDefineForClassFields: false
 
 class A {
     x = 1;

--- a/tests/cases/compiler/classIndexer5.ts
+++ b/tests/cases/compiler/classIndexer5.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 
 class Foo {
     [key: string]: number;

--- a/tests/cases/compiler/controlFlowPrivateClassField.ts
+++ b/tests/cases/compiler/controlFlowPrivateClassField.ts
@@ -1,5 +1,6 @@
 // @strict: true
 // @target: esnext
+// @useDefineForClassFields: false
 class Example {
     #test;
 

--- a/tests/cases/compiler/customAsyncIterator.ts
+++ b/tests/cases/compiler/customAsyncIterator.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 
 // GH: https://github.com/microsoft/TypeScript/issues/33239
 class ConstantIterator<T> implements AsyncIterator<T, undefined, T | undefined> {

--- a/tests/cases/compiler/dynamicNamesErrors.ts
+++ b/tests/cases/compiler/dynamicNamesErrors.ts
@@ -1,6 +1,8 @@
 // @target: esnext
 // @module: commonjs
 // @declaration: true
+// @useDefineForClassFields: false
+
 const c0 = "1";
 const c1 = 1;
 

--- a/tests/cases/compiler/intersectionWithConflictingPrivates.ts
+++ b/tests/cases/compiler/intersectionWithConflictingPrivates.ts
@@ -1,5 +1,6 @@
 // @strict: true
 // @target: esnext
+// @useDefineForClassFields: false
 
 class A { private x: unknown; y?: string; }
 class B { private x: unknown; y?: string; }

--- a/tests/cases/compiler/potentiallyUncalledDecorators.ts
+++ b/tests/cases/compiler/potentiallyUncalledDecorators.ts
@@ -1,6 +1,7 @@
 // @target: esnext
 // @module: esnext
 // @experimentalDecorators: true
+// @useDefineForClassFields: false
 
 // Angular-style Input/Output API:
 declare function Input(bindingPropertyName?: string): any;

--- a/tests/cases/compiler/unusedPrivateStaticMembers.ts
+++ b/tests/cases/compiler/unusedPrivateStaticMembers.ts
@@ -1,5 +1,6 @@
 // @noUnusedLocals: true
 // @target: esnext
+// @useDefineForClassFields: false
 
 class Test1 {
     private static m1() {}

--- a/tests/cases/compiler/useDefineForClassFieldsFlagDefault.ts
+++ b/tests/cases/compiler/useDefineForClassFieldsFlagDefault.ts
@@ -1,0 +1,7 @@
+// @target: esNext,es2020
+
+class Foo {
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1; 
+}

--- a/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.2.ts
+++ b/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.2.ts
@@ -1,6 +1,7 @@
 // @target: esnext,es2015,es5
 // @noTypesAndSymbols: true
 // @noEmit: true
+// @useDefineForClassFields: false
 
 // https://github.com/microsoft/TypeScript/issues/36295
 class C {}

--- a/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterInitializer.2.ts
+++ b/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterInitializer.2.ts
@@ -1,6 +1,7 @@
 // @target: esnext,es2015,es5
 // @noTypesAndSymbols: true
 // @noEmit: true
+// @useDefineForClassFields: false
 
 // https://github.com/microsoft/TypeScript/issues/36295
 class C {}

--- a/tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts
@@ -2,17 +2,17 @@
 // @target: esNext,es2020
 // @useDefineForClassFields: false
 
-class Test {
+class TestWithErrors {
     #prop = 0 
-    static dd = new Test().#prop; // Err
+    static dd = new TestWithErrors().#prop; // Err
     static ["X_ z_ zz"] = class Inner {
         #foo  = 10   
         m() {
-            new Test().#prop // Err
+            new TestWithErrors().#prop // Err
         }
         static C = class InnerInner {
             m() {
-                new Test().#prop // Err
+                new TestWithErrors().#prop // Err
                 new Inner().#foo; // Err
             }
         }
@@ -20,10 +20,36 @@ class Test {
         static M(){
             return class {
                 m() {
-                    new Test().#prop // Err
+                    new TestWithErrors().#prop // Err
                     new Inner().#foo; // OK
                 }
             }
         } 
     }
 }
+
+class TestNoErrors {
+    #prop = 0 
+    dd = new TestNoErrors().#prop; // OK
+    ["X_ z_ zz"] = class Inner {
+        #foo  = 10   
+        m() {
+            new TestNoErrors().#prop // Ok
+        }
+        C = class InnerInner {
+            m() {
+                new TestNoErrors().#prop // Ok
+                new Inner().#foo; // Ok
+            }
+        }
+  
+        static M(){
+            return class {
+                m() {
+                    new TestNoErrors().#prop // OK
+                    new Inner().#foo; // OK
+                }
+            }
+        } 
+    }
+  }

--- a/tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts
@@ -1,0 +1,29 @@
+// @strict: true
+// @target: esNext,es2020
+// @useDefineForClassFields: false
+
+class Test {
+    #prop = 0 
+    static dd = new Test().#prop; // Err
+    static ["X_ z_ zz"] = class Inner {
+        #foo  = 10   
+        m() {
+            new Test().#prop // Err
+        }
+        static C = class InnerInner {
+            m() {
+                new Test().#prop // Err
+                new Inner().#foo; // Err
+            }
+        }
+
+        static M(){
+            return class {
+                m() {
+                    new Test().#prop // Err
+                    new Inner().#foo; // OK
+                }
+            }
+        } 
+    }
+}

--- a/tests/cases/conformance/classes/members/privateNames/privateNameFieldsESNext.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNameFieldsESNext.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 
 class C {
     a = 123;

--- a/tests/cases/conformance/classes/members/privateNames/privateNameStaticAndStaticInitializer.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNameStaticAndStaticInitializer.ts
@@ -1,4 +1,5 @@
 // @target: esnext, es2015
+// @useDefineForClassFields: false
 
 class A {
   static #foo = 1;

--- a/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldDestructuredBinding.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldDestructuredBinding.ts
@@ -1,4 +1,5 @@
 // @target: esnext, es2015
+// @useDefineForClassFields: false
 
 class A {
     static #field = 1;

--- a/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldInitializer.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldInitializer.ts
@@ -1,4 +1,5 @@
 // @target: es2015, esnext
+// @useDefineForClassFields: false
 
 class A {
     static #field = 10;

--- a/tests/cases/conformance/classes/members/privateNames/privateNameStaticsAndStaticMethods.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNameStaticsAndStaticMethods.ts
@@ -1,6 +1,7 @@
 // @strict: true
 // @target: esnext
 // @lib: esnext
+// @useDefineForClassFields: false
 
 class A {
     static #foo(a: number) {}

--- a/tests/cases/conformance/classes/members/privateNames/privateNamesAndMethods.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNamesAndMethods.ts
@@ -1,5 +1,6 @@
 // @target: esnext
 // @lib: esnext
+// @useDefineForClassFields: false
 
 class A {
     #foo(a: number) {}

--- a/tests/cases/conformance/classes/members/privateNames/privateNamesAndStaticMethods.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNamesAndStaticMethods.ts
@@ -1,6 +1,7 @@
 // @strict: true
 // @target: esnext
 // @lib: esnext
+// @useDefineForClassFields: false
 
 class A {
     static #foo(a: number) {}

--- a/tests/cases/conformance/classes/members/privateNames/privateNamesAssertion.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNamesAssertion.ts
@@ -1,5 +1,6 @@
 // @strict: true
 // @target: esnext
+// @useDefineForClassFields: false
 
 class Foo {
     #p1: (v: any) => asserts v is string = (v) => {

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/overrideInterfaceProperty.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/overrideInterfaceProperty.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 interface Mup<K, V> {
     readonly size: number;
 }

--- a/tests/cases/conformance/dynamicImport/importCallExpressionInAMD4.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionInAMD4.ts
@@ -1,5 +1,7 @@
 ﻿// @module: amd
 // @target: esnext
+// @useDefineForClassFields: false
+
 // @filename: 0.ts
 export class B {
     print() { return "I am B"}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionInCJS5.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionInCJS5.ts
@@ -1,5 +1,7 @@
 ﻿// @module: commonjs
 // @target: esnext
+// @useDefineForClassFields: false
+
 // @filename: 0.ts
 export class B {
     print() { return "I am B"}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionInSystem4.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionInSystem4.ts
@@ -1,5 +1,7 @@
 ﻿// @module: system
 // @target: esnext
+// @useDefineForClassFields: false
+
 // @filename: 0.ts
 export class B {
     print() { return "I am B"}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionInUMD4.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionInUMD4.ts
@@ -1,5 +1,6 @@
 ﻿// @module: umd
 // @target: esnext
+// @useDefineForClassFields: false
 // @filename: 0.ts
 export class B {
     print() { return "I am B"}

--- a/tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts
+++ b/tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts
@@ -1,5 +1,6 @@
 // @target: esnext
 // @strict: true
+// @useDefineForClassFields: false
 
 export interface SomethingTaggable {
     <T>(t: TemplateStringsArray, ...args: T[]): SomethingNewable;

--- a/tests/cases/conformance/expressions/optionalChaining/privateIdentifierChain/privateIdentifierChain.1.ts
+++ b/tests/cases/conformance/expressions/optionalChaining/privateIdentifierChain/privateIdentifierChain.1.ts
@@ -1,5 +1,6 @@
 // @strict: true
 // @target: esnext
+// @useDefineForClassFields: false
 
 class A {
     a?: A

--- a/tests/cases/conformance/expressions/thisKeyword/typeOfThis.ts
+++ b/tests/cases/conformance/expressions/thisKeyword/typeOfThis.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 class MyTestClass {
     private canary: number;
     static staticCanary: number;

--- a/tests/cases/conformance/externalModules/typeOnly/computedPropertyName.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/computedPropertyName.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 
 // @Filename: framework-hooks.ts
 export const onInit = Symbol("onInit");

--- a/tests/cases/conformance/jsdoc/jsdocReadonlyDeclarations.ts
+++ b/tests/cases/conformance/jsdoc/jsdocReadonlyDeclarations.ts
@@ -4,6 +4,7 @@
 // @out: foo.js
 // @declaration: true
 // @Filename: jsdocReadonlyDeclarations.js
+// @useDefineForClassFields: false
 class C {
     /** @readonly */
     x = 6

--- a/tests/cases/conformance/types/spread/spreadMethods.ts
+++ b/tests/cases/conformance/types/spread/spreadMethods.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 
 class K {
     p = 12;

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbols.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbols.ts
@@ -1,6 +1,7 @@
 // @target: esnext
 // @lib: esnext
 // @declaration: false
+// @useDefineForClassFields: false
 
 // declarations with call initializer
 const constCall = Symbol();

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarations.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarations.ts
@@ -1,6 +1,7 @@
 // @target: esnext
 // @lib: esnext
 // @declaration: true
+// @useDefineForClassFields: false
 
 // declarations with call initializer
 const constCall = Symbol();

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsErrors.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsErrors.ts
@@ -2,6 +2,7 @@
 // @lib: esnext
 // @module: commonjs
 // @declaration: true
+// @useDefineForClassFields: false
 
 declare const s: unique symbol;
 interface I { readonly readonlyType: unique symbol; }

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJs.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJs.ts
@@ -5,6 +5,7 @@
 // @checkJs: true
 // @filename: uniqueSymbolsDeclarationsInJs.js
 // @out: uniqueSymbolsDeclarationsInJs-out.js
+// @useDefineForClassFields: false
 
 // classes
 class C {

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.ts
@@ -5,6 +5,7 @@
 // @checkJs: true
 // @filename: uniqueSymbolsDeclarationsInJsErrors.js
 // @out: uniqueSymbolsDeclarationsInJsErrors-out.js
+// @useDefineForClassFields: false
 
 class C {
     /**

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 
 // declarations
 declare const invalidUniqueType: unique number;


### PR DESCRIPTION
Fixes #41788 

Fixed as described in [comment](https://github.com/microsoft/TypeScript/issues/41788#issuecomment-765400277)

> 1. If `target:esnext`,then `useDefineForClassFields: true` will now be the default.
> 2. If `target:esnext, useDefineForClassFields: true` we emit correct code so no further action is needed ([ex](https://www.typescriptlang.org/play?useDefineForClassFields=true&target=6#code/FAYwNghgzlAECCsDexZtgYgB6wFywFcA7AEwFMAzASyLJIG5V0oAXCFqkWAIVgF5Y4aHBToxggPZFWAJwIgWEmQAoAlMibjxtAO4I1AOmyMtaAL6bYFsa3adYAYX6wKxBVSlqNp2Lv2qjLBN0a3RgCz94A256IA))
> 3. If `target:esnext, useDefineForClassFields: false` and we encounter a usage of a `#private` field  in a static member we emit an error like "You can't do this, change useDefineForClassFields: true, or target an earlier version of ES."