### PR TITLE
Improve error messages for computed class property names

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40738,7 +40738,7 @@ namespace ts {
                 if (isStringLiteral(node.name) && node.name.text === "constructor") {
                     return grammarErrorOnNode(node.name, Diagnostics.Classes_may_not_have_a_field_named_constructor);
                 }
-                if (checkGrammarForInvalidDynamicName(node.name, Diagnostics.A_computed_property_name_in_a_class_property_declaration_must_refer_to_an_expression_whose_type_is_a_literal_type_or_a_unique_symbol_type)) {
+                if (checkGrammarForInvalidDynamicName(node.name, Diagnostics.A_computed_property_name_in_a_class_property_declaration_must_have_a_simple_literal_type_or_a_unique_symbol_type)) {
                     return true;
                 }
                 if (languageVersion < ScriptTarget.ES2015 && isPrivateIdentifier(node.name)) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -503,7 +503,7 @@
         "category": "Error",
         "code": 1165
     },
-    "A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.": {
+    "A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.": {
         "category": "Error",
         "code": 1166
     },

--- a/tests/baselines/reference/awaitAndYieldInProperty.errors.txt
+++ b/tests/baselines/reference/awaitAndYieldInProperty.errors.txt
@@ -1,18 +1,18 @@
-tests/cases/conformance/classes/awaitAndYieldInProperty.ts(3,9): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/classes/awaitAndYieldInProperty.ts(3,9): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(3,21): error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
-tests/cases/conformance/classes/awaitAndYieldInProperty.ts(4,16): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/classes/awaitAndYieldInProperty.ts(4,16): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(4,28): error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
-tests/cases/conformance/classes/awaitAndYieldInProperty.ts(6,9): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/classes/awaitAndYieldInProperty.ts(6,9): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(6,21): error TS1163: A 'yield' expression is only allowed in a generator body.
-tests/cases/conformance/classes/awaitAndYieldInProperty.ts(7,16): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/classes/awaitAndYieldInProperty.ts(7,16): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(7,28): error TS1163: A 'yield' expression is only allowed in a generator body.
-tests/cases/conformance/classes/awaitAndYieldInProperty.ts(11,9): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/classes/awaitAndYieldInProperty.ts(11,9): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(11,21): error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
-tests/cases/conformance/classes/awaitAndYieldInProperty.ts(12,16): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/classes/awaitAndYieldInProperty.ts(12,16): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(12,28): error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
-tests/cases/conformance/classes/awaitAndYieldInProperty.ts(14,9): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/classes/awaitAndYieldInProperty.ts(14,9): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(14,21): error TS1163: A 'yield' expression is only allowed in a generator body.
-tests/cases/conformance/classes/awaitAndYieldInProperty.ts(15,16): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/classes/awaitAndYieldInProperty.ts(15,16): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(15,28): error TS1163: A 'yield' expression is only allowed in a generator body.
 
 
@@ -21,23 +21,23 @@ tests/cases/conformance/classes/awaitAndYieldInProperty.ts(15,28): error TS1163:
         class C {
             [await x] = await x;
             ~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
                         ~~~~~
 !!! error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
             static [await x] = await x;
                    ~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
                                ~~~~~
 !!! error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
     
             [yield 1] = yield 2;
             ~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
                         ~~~~~
 !!! error TS1163: A 'yield' expression is only allowed in a generator body.
             static [yield 3] = yield 4;
                    ~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
                                ~~~~~
 !!! error TS1163: A 'yield' expression is only allowed in a generator body.
         }
@@ -45,23 +45,23 @@ tests/cases/conformance/classes/awaitAndYieldInProperty.ts(15,28): error TS1163:
         return class {
             [await x] = await x;
             ~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
                         ~~~~~
 !!! error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
             static [await x] = await x;
                    ~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
                                ~~~~~
 !!! error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
     
             [yield 1] = yield 2;
             ~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
                         ~~~~~
 !!! error TS1163: A 'yield' expression is only allowed in a generator body.
             static [yield 3] = yield 4;
                    ~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
                                ~~~~~
 !!! error TS1163: A 'yield' expression is only allowed in a generator body.
         }

--- a/tests/baselines/reference/capturedParametersInInitializers2.errors.txt
+++ b/tests/baselines/reference/capturedParametersInInitializers2.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/capturedParametersInInitializers2.ts(3,20): error TS2373: Parameter 'y' cannot reference identifier 'x' declared after it.
 tests/cases/compiler/capturedParametersInInitializers2.ts(4,14): error TS2373: Parameter 'y' cannot reference identifier 'x' declared after it.
 tests/cases/compiler/capturedParametersInInitializers2.ts(6,10): error TS2373: Parameter 'y' cannot reference identifier 'z' declared after it.
-tests/cases/compiler/capturedParametersInInitializers2.ts(13,26): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/capturedParametersInInitializers2.ts(13,26): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/capturedParametersInInitializers2.ts(13,27): error TS2373: Parameter 'y' cannot reference identifier 'x' declared after it.
 
 
@@ -26,7 +26,7 @@ tests/cases/compiler/capturedParametersInInitializers2.ts(13,27): error TS2373: 
     }
     function foo2(y = class {[x] = x}, x = 1) {
                              ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
                               ~
 !!! error TS2373: Parameter 'y' cannot reference identifier 'x' declared after it.
     }

--- a/tests/baselines/reference/computedPropertyNames12_ES5.errors.txt
+++ b/tests/baselines/reference/computedPropertyNames12_ES5.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(5,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(6,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(7,12): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(8,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(9,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(12,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(13,12): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(15,12): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(5,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(6,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(7,12): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(8,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(9,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(12,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(13,12): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(15,12): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 
 
 ==== tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts (8 errors) ====
@@ -15,29 +15,29 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(15
     class C {
         [s]: number;
         ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         [n] = n;
         ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         static [s + s]: string;
                ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         [s + n] = 2;
         ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         [+s]: typeof s;
         ~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         static [""]: number;
         [0]: number;
         [a]: number;
         ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         static [<any>true]: number;
                ~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         [`hello bye`] = 0;
         static [`hello ${a} bye`] = 0
                ~~~~~~~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
     }

--- a/tests/baselines/reference/computedPropertyNames12_ES6.errors.txt
+++ b/tests/baselines/reference/computedPropertyNames12_ES6.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(5,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(6,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(7,12): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(8,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(9,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(12,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(13,12): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(15,12): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(5,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(6,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(7,12): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(8,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(9,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(12,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(13,12): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(15,12): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 
 
 ==== tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts (8 errors) ====
@@ -15,29 +15,29 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(15
     class C {
         [s]: number;
         ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         [n] = n;
         ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         static [s + s]: string;
                ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         [s + n] = 2;
         ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         [+s]: typeof s;
         ~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         static [""]: number;
         [0]: number;
         [a]: number;
         ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         static [<any>true]: number;
                ~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         [`hello bye`] = 0;
         static [`hello ${a} bye`] = 0
                ~~~~~~~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
     }

--- a/tests/baselines/reference/decoratorsOnComputedProperties.errors.txt
+++ b/tests/baselines/reference/decoratorsOnComputedProperties.errors.txt
@@ -1,82 +1,82 @@
-tests/cases/compiler/decoratorsOnComputedProperties.ts(18,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(19,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(20,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(21,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(22,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(23,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(18,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(19,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(20,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(21,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(22,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(23,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(27,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(28,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(29,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(30,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(35,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(35,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(36,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(37,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(38,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(38,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(39,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(40,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(52,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(53,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(54,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(55,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(56,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(57,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(52,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(53,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(54,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(55,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(56,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(57,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(62,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(63,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(64,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(65,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(70,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(70,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(71,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(72,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(73,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(73,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(74,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(75,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(88,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(89,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(90,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(92,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(93,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(94,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(88,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(89,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(90,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(92,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(93,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(94,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(98,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(99,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(100,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(101,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(106,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(106,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(107,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(108,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(110,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(110,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(111,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(112,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(124,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(125,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(126,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(128,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(129,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(131,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(124,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(125,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(126,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(128,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(129,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(131,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(135,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(136,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(137,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(138,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(143,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(143,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(144,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(145,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(147,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(147,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(148,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(150,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(162,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(163,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(164,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(166,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(167,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(169,8): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(162,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(163,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(164,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(166,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(167,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(169,8): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(173,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(174,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(175,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(176,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(181,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(181,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(182,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(183,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(184,5): error TS1206: Decorators are not valid here.
-tests/cases/compiler/decoratorsOnComputedProperties.ts(185,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/decoratorsOnComputedProperties.ts(185,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(186,5): error TS1206: Decorators are not valid here.
 tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Decorators are not valid here.
 
@@ -101,22 +101,22 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         [Symbol.match]: any = null;
         [foo()]: any;
         ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
            ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any = null;
            ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         [fieldNameA]: any;
         ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
            ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameC]: any = null;
            ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
     }
     
     void class B {
@@ -138,7 +138,7 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         [Symbol.match]: any = null;
         [foo()]: any;
         ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
         ~
 !!! error TS1206: Decorators are not valid here.
@@ -147,7 +147,7 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
 !!! error TS1206: Decorators are not valid here.
         [fieldNameA]: any;
         ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
         ~
 !!! error TS1206: Decorators are not valid here.
@@ -167,22 +167,22 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         [Symbol.match]: any = null;
         [foo()]: any;
         ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
            ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any = null;
            ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         [fieldNameA]: any;
         ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
            ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameC]: any = null;
            ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ["some" + "method"]() {}
     }
     
@@ -205,7 +205,7 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         [Symbol.match]: any = null;
         [foo()]: any;
         ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
         ~
 !!! error TS1206: Decorators are not valid here.
@@ -214,7 +214,7 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
 !!! error TS1206: Decorators are not valid here.
         [fieldNameA]: any;
         ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
         ~
 !!! error TS1206: Decorators are not valid here.
@@ -235,23 +235,23 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         [Symbol.match]: any = null;
         [foo()]: any;
         ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
            ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any = null;
            ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ["some" + "method"]() {}
         [fieldNameA]: any;
         ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
            ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameC]: any = null;
            ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
     }
     
     void class F {
@@ -273,7 +273,7 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         [Symbol.match]: any = null;
         [foo()]: any;
         ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
         ~
 !!! error TS1206: Decorators are not valid here.
@@ -283,7 +283,7 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         ["some" + "method"]() {}
         [fieldNameA]: any;
         ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
         ~
 !!! error TS1206: Decorators are not valid here.
@@ -303,24 +303,24 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         [Symbol.match]: any = null;
         [foo()]: any;
         ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
            ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any = null;
            ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ["some" + "method"]() {}
         [fieldNameA]: any;
         ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
            ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ["some" + "method2"]() {}
         @x [fieldNameC]: any = null;
            ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
     }
     
     void class H {
@@ -342,7 +342,7 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         [Symbol.match]: any = null;
         [foo()]: any;
         ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
         ~
 !!! error TS1206: Decorators are not valid here.
@@ -352,7 +352,7 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         ["some" + "method"]() {}
         [fieldNameA]: any;
         ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
         ~
 !!! error TS1206: Decorators are not valid here.
@@ -373,24 +373,24 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         [Symbol.match]: any = null;
         [foo()]: any;
         ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
            ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any = null;
            ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x ["some" + "method"]() {}
         [fieldNameA]: any;
         ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
            ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ["some" + "method2"]() {}
         @x [fieldNameC]: any = null;
            ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
     }
     
     void class J {
@@ -412,7 +412,7 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
         [Symbol.match]: any = null;
         [foo()]: any;
         ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [foo()]: any;
         ~
 !!! error TS1206: Decorators are not valid here.
@@ -424,7 +424,7 @@ tests/cases/compiler/decoratorsOnComputedProperties.ts(188,5): error TS1206: Dec
 !!! error TS1206: Decorators are not valid here.
         [fieldNameA]: any;
         ~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         @x [fieldNameB]: any;
         ~
 !!! error TS1206: Decorators are not valid here.

--- a/tests/baselines/reference/indexSignatureMustHaveTypeAnnotation.errors.txt
+++ b/tests/baselines/reference/indexSignatureMustHaveTypeAnnotation.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/indexSignatureMustHaveTypeAnnotation.ts(3,5): error TS1169: A computed property name in an interface must refer to an expression whose type is a literal type or a 'unique symbol' type.
 tests/cases/compiler/indexSignatureMustHaveTypeAnnotation.ts(3,6): error TS2304: Cannot find name 'x'.
 tests/cases/compiler/indexSignatureMustHaveTypeAnnotation.ts(4,5): error TS1021: An index signature must have a type annotation.
-tests/cases/compiler/indexSignatureMustHaveTypeAnnotation.ts(9,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/indexSignatureMustHaveTypeAnnotation.ts(9,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/indexSignatureMustHaveTypeAnnotation.ts(9,6): error TS2304: Cannot find name 'x'.
 tests/cases/compiler/indexSignatureMustHaveTypeAnnotation.ts(14,5): error TS1021: An index signature must have a type annotation.
 
@@ -23,7 +23,7 @@ tests/cases/compiler/indexSignatureMustHaveTypeAnnotation.ts(14,5): error TS1021
         // Used to be indexer, now it is a computed property
         [x]: string
         ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~
 !!! error TS2304: Cannot find name 'x'.
         

--- a/tests/baselines/reference/indexSignatureWithInitializer.errors.txt
+++ b/tests/baselines/reference/indexSignatureWithInitializer.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/indexSignatureWithInitializer.ts(3,5): error TS1169: A computed property name in an interface must refer to an expression whose type is a literal type or a 'unique symbol' type.
 tests/cases/compiler/indexSignatureWithInitializer.ts(3,6): error TS2304: Cannot find name 'x'.
-tests/cases/compiler/indexSignatureWithInitializer.ts(7,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/indexSignatureWithInitializer.ts(7,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/indexSignatureWithInitializer.ts(7,6): error TS2304: Cannot find name 'x'.
 
 
@@ -17,7 +17,7 @@ tests/cases/compiler/indexSignatureWithInitializer.ts(7,6): error TS2304: Cannot
     class C {
         [x = 0]: string
         ~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~
 !!! error TS2304: Cannot find name 'x'.
     }

--- a/tests/baselines/reference/indexWithoutParamType2.errors.txt
+++ b/tests/baselines/reference/indexWithoutParamType2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/indexWithoutParamType2.ts(3,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/compiler/indexWithoutParamType2.ts(3,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/compiler/indexWithoutParamType2.ts(3,6): error TS2304: Cannot find name 'x'.
 
 
@@ -7,7 +7,7 @@ tests/cases/compiler/indexWithoutParamType2.ts(3,6): error TS2304: Cannot find n
         // Used to be indexer, now it is a computed property
         [x]: string
         ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~
 !!! error TS2304: Cannot find name 'x'.
     }

--- a/tests/baselines/reference/parserComputedPropertyName10.errors.txt
+++ b/tests/baselines/reference/parserComputedPropertyName10.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName10.ts(2,4): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName10.ts(2,4): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName10.ts(2,5): error TS2304: Cannot find name 'e'.
 
 
@@ -6,7 +6,7 @@ tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedP
     class C {
        [e] = 1
        ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ~
 !!! error TS2304: Cannot find name 'e'.
     }

--- a/tests/baselines/reference/parserComputedPropertyName22.errors.txt
+++ b/tests/baselines/reference/parserComputedPropertyName22.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName22.ts(2,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName22.ts(2,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName22.ts(2,6): error TS2304: Cannot find name 'e'.
 
 
@@ -6,7 +6,7 @@ tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedP
     declare class C {
         [e]: number 
         ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~
 !!! error TS2304: Cannot find name 'e'.
     }

--- a/tests/baselines/reference/parserComputedPropertyName25.errors.txt
+++ b/tests/baselines/reference/parserComputedPropertyName25.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName25.ts(3,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName25.ts(3,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName25.ts(3,6): error TS2304: Cannot find name 'e'.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName25.ts(4,6): error TS2304: Cannot find name 'e2'.
 
@@ -8,7 +8,7 @@ tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedP
         // No ASI
         [e] = 0
         ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~
 !!! error TS2304: Cannot find name 'e'.
         [e2] = 1

--- a/tests/baselines/reference/parserComputedPropertyName28.errors.txt
+++ b/tests/baselines/reference/parserComputedPropertyName28.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName28.ts(2,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName28.ts(2,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName28.ts(2,6): error TS2304: Cannot find name 'e'.
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName28.ts(3,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName28.ts(3,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName28.ts(3,6): error TS2304: Cannot find name 'e2'.
 
 
@@ -8,12 +8,12 @@ tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedP
     class C {
         [e]: number = 0;
         ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~
 !!! error TS2304: Cannot find name 'e'.
         [e2]: number
         ~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~~
 !!! error TS2304: Cannot find name 'e2'.
     }

--- a/tests/baselines/reference/parserComputedPropertyName29.errors.txt
+++ b/tests/baselines/reference/parserComputedPropertyName29.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName29.ts(3,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName29.ts(3,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName29.ts(3,6): error TS2304: Cannot find name 'e'.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName29.ts(3,11): error TS2304: Cannot find name 'id'.
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName29.ts(4,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName29.ts(4,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName29.ts(4,6): error TS2304: Cannot find name 'e2'.
 
 
@@ -10,14 +10,14 @@ tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedP
         // yes ASI
         [e] = id++
         ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~
 !!! error TS2304: Cannot find name 'e'.
               ~~
 !!! error TS2304: Cannot find name 'id'.
         [e2]: number
         ~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~~
 !!! error TS2304: Cannot find name 'e2'.
     }

--- a/tests/baselines/reference/parserComputedPropertyName31.errors.txt
+++ b/tests/baselines/reference/parserComputedPropertyName31.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName31.ts(3,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName31.ts(3,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName31.ts(3,6): error TS2304: Cannot find name 'e'.
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName31.ts(4,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName31.ts(4,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName31.ts(4,6): error TS2304: Cannot find name 'e2'.
 
 
@@ -9,12 +9,12 @@ tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedP
         // yes ASI
         [e]: number
         ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~
 !!! error TS2304: Cannot find name 'e'.
         [e2]: number
         ~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~~
 !!! error TS2304: Cannot find name 'e2'.
     }

--- a/tests/baselines/reference/parserComputedPropertyName36.errors.txt
+++ b/tests/baselines/reference/parserComputedPropertyName36.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName36.ts(2,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName36.ts(2,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName36.ts(2,6): error TS1213: Identifier expected. 'public' is a reserved word in strict mode. Class definitions are automatically in strict mode.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName36.ts(2,6): error TS2304: Cannot find name 'public'.
 
@@ -7,7 +7,7 @@ tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedP
     class C {
         [public ]: string;
         ~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~~~~~~
 !!! error TS1213: Identifier expected. 'public' is a reserved word in strict mode. Class definitions are automatically in strict mode.
          ~~~~~~

--- a/tests/baselines/reference/parserComputedPropertyName7.errors.txt
+++ b/tests/baselines/reference/parserComputedPropertyName7.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName7.ts(2,4): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName7.ts(2,4): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName7.ts(2,5): error TS2304: Cannot find name 'e'.
 
 
@@ -6,7 +6,7 @@ tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedP
     class C {
        [e]
        ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ~
 !!! error TS2304: Cannot find name 'e'.
     }

--- a/tests/baselines/reference/parserComputedPropertyName8.errors.txt
+++ b/tests/baselines/reference/parserComputedPropertyName8.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName8.ts(2,11): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName8.ts(2,11): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName8.ts(2,12): error TS2304: Cannot find name 'e'.
 
 
@@ -6,7 +6,7 @@ tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedP
     class C {
        public [e]
               ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
                ~
 !!! error TS2304: Cannot find name 'e'.
     }

--- a/tests/baselines/reference/parserComputedPropertyName9.errors.txt
+++ b/tests/baselines/reference/parserComputedPropertyName9.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName9.ts(2,4): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName9.ts(2,4): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName9.ts(2,5): error TS2304: Cannot find name 'e'.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName9.ts(2,9): error TS2304: Cannot find name 'Type'.
 
@@ -7,7 +7,7 @@ tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedP
     class C {
        [e]: Type
        ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ~
 !!! error TS2304: Cannot find name 'e'.
             ~~~~

--- a/tests/baselines/reference/parserES5ComputedPropertyName1.errors.txt
+++ b/tests/baselines/reference/parserES5ComputedPropertyName1.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName1.ts(2,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName1.ts(2,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName1.ts(2,6): error TS2304: Cannot find name 'e'.
 
 
@@ -6,7 +6,7 @@ tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5Comput
     declare class C {
         [e]: number 
         ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~
 !!! error TS2304: Cannot find name 'e'.
     }

--- a/tests/baselines/reference/parserES5ComputedPropertyName10.errors.txt
+++ b/tests/baselines/reference/parserES5ComputedPropertyName10.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName10.ts(2,4): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName10.ts(2,4): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName10.ts(2,5): error TS2304: Cannot find name 'e'.
 
 
@@ -6,7 +6,7 @@ tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5Comput
     class C {
        [e] = 1
        ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ~
 !!! error TS2304: Cannot find name 'e'.
     }

--- a/tests/baselines/reference/parserES5ComputedPropertyName7.errors.txt
+++ b/tests/baselines/reference/parserES5ComputedPropertyName7.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName7.ts(2,4): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName7.ts(2,4): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName7.ts(2,5): error TS2304: Cannot find name 'e'.
 
 
@@ -6,7 +6,7 @@ tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5Comput
     class C {
        [e]
        ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ~
 !!! error TS2304: Cannot find name 'e'.
     }

--- a/tests/baselines/reference/parserES5ComputedPropertyName9.errors.txt
+++ b/tests/baselines/reference/parserES5ComputedPropertyName9.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName9.ts(2,4): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName9.ts(2,4): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName9.ts(2,5): error TS2304: Cannot find name 'e'.
 tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName9.ts(2,9): error TS2304: Cannot find name 'Type'.
 
@@ -7,7 +7,7 @@ tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5Comput
     class C {
        [e]: Type
        ~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         ~
 !!! error TS2304: Cannot find name 'e'.
             ~~~~

--- a/tests/baselines/reference/symbolProperty7.errors.txt
+++ b/tests/baselines/reference/symbolProperty7.errors.txt
@@ -1,15 +1,15 @@
-tests/cases/conformance/es6/Symbols/symbolProperty7.ts(2,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/Symbols/symbolProperty7.ts(3,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/Symbols/symbolProperty7.ts(2,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+tests/cases/conformance/es6/Symbols/symbolProperty7.ts(3,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 
 
 ==== tests/cases/conformance/es6/Symbols/symbolProperty7.ts (2 errors) ====
     class C {
         [Symbol()] = 0;
         ~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         [Symbol()]: number;
         ~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
         [Symbol()]() { }
         get [Symbol()]() {
             return 0;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

This PR change the `ts(1161)` error message to [the suggestion message](https://github.com/microsoft/TypeScript/issues/42619#issuecomment-772134804)
```
A computed property name in a class property declaration must have a simple literal type or a unique symbol type.
```

Fixes #42619 