### PR TITLE
Refactor emit substitution into transform

### DIFF
--- a/scripts/perf-result-post.js
+++ b/scripts/perf-result-post.js
@@ -42,7 +42,7 @@ async function main() {
             for (const file of resp.items) {
                 if (/[\\/]linux\.benchmark$/.test(file.path)) {
                     const benchmarkUrl = new URL(artifact.resource.url);
-                    benchmarkUrl.search = `artifactName=benchmark&fileId=${file.blob.id}&fileName=${file.path}`;
+                    benchmarkUrl.search = `artifactName=benchmark&fileId=${file.blob.id}&fileName=linux.benchmark`;
                     benchmarkText = `\n<details><summary>Developer Information:</summary><p><a href="${benchmarkUrl.href}">Download Benchmark</a></p></details>\n`;
                     break;
                 }

--- a/scripts/perf-result-post.js
+++ b/scripts/perf-result-post.js
@@ -3,45 +3,86 @@
 // Must reference esnext.asynciterable lib, since octokit uses AsyncIterable internally
 const { Octokit } = require("@octokit/rest");
 const fs = require("fs");
+const ado = require("azure-devops-node-api");
+const { default: fetch } = require("node-fetch");
 
-const requester = process.env.requesting_user;
-const source = process.env.source_issue;
-const postedComment = process.env.status_comment;
-console.log(`Loading fragment from ${process.argv[3]}...`);
-const outputTableText = fs.readFileSync(process.argv[3], { encoding: "utf8" });
-console.log(`Fragment contents:
-${outputTableText}`);
 
-const gh = new Octokit({
-    auth: process.argv[2]
-});
-gh.issues.createComment({
-    issue_number: +source,
-    owner: "Microsoft",
-    repo: "TypeScript",
-    body: `@${requester}
-The results of the perf run you requested are in!
-<details><summary> Here they are:</summary><p>
-${outputTableText}
-</p></details>`
-}).then(async data => {
-    console.log(`Results posted!`);
-    const newCommentUrl = data.data.html_url;
-    const comment = await gh.issues.getComment({
-        owner: "Microsoft",
-        repo: "TypeScript",
-        comment_id: +postedComment
-    });
-    const newBody = `${comment.data.body}
+async function main() {
+    const source = process.env.SOURCE_ISSUE;
+    if (!source) throw new Error("SOURCE_ISSUE environment variable not set.");
 
-Update: [The results are in!](${newCommentUrl})`;
-    return await gh.issues.updateComment({
-        owner: "Microsoft",
-        repo: "TypeScript",
-        comment_id: +postedComment,
-        body: newBody
-    });
-}).catch(e => {
+    const requester = process.env.REQUESTING_USER;
+    if (!requester) throw new Error("REQUESTING_USER environment variable not set.");
+
+    const buildId = process.env.BUILD_BUILDID;
+    if (!requester) throw new Error("BUILD_BUILDID environment variable not set.");
+
+    const postedComment = process.env.STATUS_COMMENT;
+    if (!postedComment) throw new Error("STATUS_COMMENT environment variable not set.");
+
+    const [auth, fragment, includeArtifact] = process.argv.slice(2);
+    if (!auth) throw new Error("First argument must be a GitHub auth token.");
+    if (!fragment) throw new Error("Second argument must be a path to an HTML fragment.");
+
+    const gh = new Octokit({ auth });
+    try {
+        console.log(`Loading fragment from ${fragment}...`);
+        const outputTableText = fs.readFileSync(fragment, { encoding: "utf8" });
+        console.log(`Fragment contents:\n${outputTableText}`);
+
+        let benchmarkText = "";
+        if (includeArtifact === "--include-artifact") {
+            // post a link to the benchmark file
+            const cli = new ado.WebApi("https://typescript.visualstudio.com/defaultcollection", ado.getHandlerFromToken("")); // Empty token, anon auth
+            const build = await cli.getBuildApi();
+            const artifact = await build.getArtifact("typescript", +buildId, "benchmark");
+            const updatedUrl = new URL(artifact.resource.url);
+            updatedUrl.search = `artifactName=benchmark&fileId=${artifact.resource.data}&fileName=manifest`;
+            const resp = await (await fetch(`${updatedUrl}`)).json();
+            for (const file of resp.items) {
+                if (/[\\/]linux\.benchmark$/.test(file.path)) {
+                    const benchmarkUrl = new URL(artifact.resource.url);
+                    benchmarkUrl.search = `artifactName=benchmark&fileId=${file.blob.id}&fileName=${file.path}`;
+                    benchmarkText = `\n<details><summary>Developer Information:</summary><p><a href="${benchmarkUrl.href}">Download Benchmark</a></p></details>\n`;
+                    break;
+                }
+            }
+        }
+
+        const data = await gh.issues.createComment({
+            issue_number: +source,
+            owner: "Microsoft",
+            repo: "TypeScript",
+            body: `@${requester}\nThe results of the perf run you requested are in!\n<details><summary> Here they are:</summary><p>\n${outputTableText}\n</p>${benchmarkText}</details>`
+        });
+
+        console.log(`Results posted!`);
+        const newCommentUrl = data.data.html_url;
+        const comment = await gh.issues.getComment({
+            owner: "Microsoft",
+            repo: "TypeScript",
+            comment_id: +postedComment
+        });
+        const newBody = `${comment.data.body}\n\nUpdate: [The results are in!](${newCommentUrl})`;
+        await gh.issues.updateComment({
+            owner: "Microsoft",
+            repo: "TypeScript",
+            comment_id: +postedComment,
+            body: newBody
+        });
+    }
+    catch (e) {
+        const gh = new Octokit({ auth });
+        await gh.issues.createComment({
+            issue_number: +source,
+            owner: "Microsoft",
+            repo: "TypeScript",
+            body: `Hey @${requester}, something went wrong when publishing results. ([You can check the log here](https://typescript.visualstudio.com/TypeScript/_build/index?buildId=${buildId}&_a=summary)).`
+        });
+    }
+}
+
+main().catch(e => {
     console.error(e);
     process.exit(1);
 });

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1509,7 +1509,7 @@ namespace ts {
                 parentStack: (Node | undefined)[];
             }
 
-            return createBinaryExpressionTrampoline(onEnter, onLeft, onOperator, onRight, onExit, identity);
+            return createBinaryExpressionTrampoline(onEnter, onLeft, onOperator, onRight, onExit, /*foldState*/ undefined);
 
             function onEnter(node: BinaryExpression, state: WorkArea | undefined) {
                 if (state) {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1511,7 +1511,7 @@ namespace ts {
                 }
             }
 
-            return createBinaryExpressionWalker(onEnter, onLeft, onOperator, onRight, onExit, identity);
+            return createBinaryExpressionTrampoline(onEnter, onLeft, onOperator, onRight, onExit, identity);
 
             function onEnter(node: BinaryExpression, prev: BindBinaryExpressionState | undefined) {
                 let state: BindBinaryExpressionState;

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -275,6 +275,14 @@ namespace ts {
             }
         }
 
+        /**
+         * Asserts a value has the specified type in typespace only (does not perform a runtime assertion).
+         * This is useful in cases where we switch on `node.kind` and can be reasonably sure the type is accurate, and
+         * as a result can reduce the number of unnecessary casts.
+         */
+        export function type<T>(value: unknown): asserts value is T;
+        export function type(_value: unknown) { }
+
         export function getFunctionName(func: AnyFunction) {
             if (typeof func !== "function") {
                 return "";

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2531,7 +2531,7 @@ namespace ts {
                 sourceMapRange: SourceMapRange | undefined = undefined;
             }
 
-            return createBinaryExpressionWalker(onEnter, maybeEmitExpression, onOperator, maybeEmitExpression, onExit, identity);
+            return createBinaryExpressionTrampoline(onEnter, maybeEmitExpression, onOperator, maybeEmitExpression, onExit, identity);
 
             function onEnter(node: BinaryExpression, prev: EmitBinaryExpressionState | undefined) {
                 const state = new EmitBinaryExpressionState();
@@ -6666,7 +6666,7 @@ namespace ts {
                 ) {}
             }
 
-            return createBinaryExpressionWalker(onEnter, onLeft, onOperator, onRight, onExit, foldState);
+            return createBinaryExpressionTrampoline(onEnter, onLeft, onOperator, onRight, onExit, foldState);
 
             function onEnter(node: BinaryExpression) {
                 return new PreprintBinaryExpressionState(node.left, node.operatorToken, node.right);

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2520,64 +2520,64 @@ namespace ts {
         }
 
         function createEmitBinaryExpression() {
-            class EmitBinaryExpressionState {
-                nested = false;
-                preserveSourceNewlines: boolean | undefined = undefined;
-                containerPos = -1;
-                containerEnd = -1;
-                declarationListContainerEnd = -1;
-                emitFlags = EmitFlags.None;
-                commentRange: TextRange | undefined = undefined;
-                sourceMapRange: SourceMapRange | undefined = undefined;
-            }
+            // class EmitBinaryExpressionState {
+            //     nested = false;
+            //     preserveSourceNewlines: boolean | undefined = undefined;
+            //     containerPos = -1;
+            //     containerEnd = -1;
+            //     declarationListContainerEnd = -1;
+            //     emitFlags = EmitFlags.None;
+            //     commentRange: TextRange | undefined = undefined;
+            //     sourceMapRange: SourceMapRange | undefined = undefined;
+            // }
 
-            return createBinaryExpressionTrampoline(onEnter, maybeEmitExpression, onOperator, maybeEmitExpression, onExit, identity);
+            return createBinaryExpressionTrampoline(noop, maybeEmitExpression, onOperator, maybeEmitExpression, onExit, identity);
 
-            function onEnter(node: BinaryExpression, prev: EmitBinaryExpressionState | undefined) {
-                const state = new EmitBinaryExpressionState();
-                if (prev) {
-                    // `prev` is only defined when recuring. We can use this fact to indicate
-                    // we are entering into a nested binary expression and can replicate the
-                    // leading comment and sourcemap emit performed by `emitWithContext`.
-                    state.nested = true;
-                    onBeforeEmitNode?.(node);
+            // function onEnter(_node: BinaryExpression, _prev: EmitBinaryExpressionState | undefined) {
+            //     const state = new EmitBinaryExpressionState();
+            //     if (prev) {
+            //         // `prev` is only defined when recuring. We can use this fact to indicate
+            //         // we are entering into a nested binary expression and can replicate the
+            //         // leading comment and sourcemap emit performed by `emitWithContext`.
+            //         state.nested = true;
+            //         onBeforeEmitNode?.(node);
 
-                    state.emitFlags = getEmitFlags(node);
-                    state.preserveSourceNewlines = preserveSourceNewlines;
-                    if (preserveSourceNewlines && (state.emitFlags & EmitFlags.IgnoreSourceNewlines)) {
-                        preserveSourceNewlines = false;
-                    }
+            //         state.emitFlags = getEmitFlags(node);
+            //         state.preserveSourceNewlines = preserveSourceNewlines;
+            //         if (preserveSourceNewlines && (state.emitFlags & EmitFlags.IgnoreSourceNewlines)) {
+            //             preserveSourceNewlines = false;
+            //         }
 
-                    state.containerPos = containerPos;
-                    state.containerEnd = containerEnd;
-                    state.declarationListContainerEnd = declarationListContainerEnd;
-                    state.commentRange = shouldEmitComments(node) ? getCommentRange(node) : undefined;
-                    state.sourceMapRange = shouldEmitSourceMaps(node) ? getSourceMapRange(node) : undefined;
+            //         state.containerPos = containerPos;
+            //         state.containerEnd = containerEnd;
+            //         state.declarationListContainerEnd = declarationListContainerEnd;
+            //         state.commentRange = shouldEmitComments(node) ? getCommentRange(node) : undefined;
+            //         state.sourceMapRange = shouldEmitSourceMaps(node) ? getSourceMapRange(node) : undefined;
 
-                    // Emit leading comments
-                    if (state.commentRange) {
-                        emitLeadingCommentsOfNode(node, state.emitFlags, state.commentRange.pos, state.commentRange.end);
-                        if (state.emitFlags & EmitFlags.NoNestedComments) {
-                            commentsDisabled = true;
-                        }
-                    }
+            //         // Emit leading comments
+            //         if (state.commentRange) {
+            //             emitLeadingCommentsOfNode(node, state.emitFlags, state.commentRange.pos, state.commentRange.end);
+            //             if (state.emitFlags & EmitFlags.NoNestedComments) {
+            //                 commentsDisabled = true;
+            //             }
+            //         }
 
-                    // Emit leading sourcemap
-                    if (state.sourceMapRange) {
-                        const source = state.sourceMapRange.source || sourceMapSource;
-                        if ((state.emitFlags & EmitFlags.NoLeadingSourceMap) === 0
-                            && state.sourceMapRange.pos >= 0) {
-                            emitSourcePos(state.sourceMapRange.source || sourceMapSource, skipSourceTrivia(source, state.sourceMapRange.pos));
-                        }
-                        if (state.emitFlags & EmitFlags.NoNestedSourceMaps) {
-                            sourceMapsDisabled = true;
-                        }
-                    }
-                }
-                return state;
-            }
+            //         // Emit leading sourcemap
+            //         if (state.sourceMapRange) {
+            //             const source = state.sourceMapRange.source || sourceMapSource;
+            //             if ((state.emitFlags & EmitFlags.NoLeadingSourceMap) === 0
+            //                 && state.sourceMapRange.pos >= 0) {
+            //                 emitSourcePos(state.sourceMapRange.source || sourceMapSource, skipSourceTrivia(source, state.sourceMapRange.pos));
+            //             }
+            //             if (state.emitFlags & EmitFlags.NoNestedSourceMaps) {
+            //                 sourceMapsDisabled = true;
+            //             }
+            //         }
+            //     }
+            //     return state;
+            // }
 
-            function onOperator(operatorToken: BinaryOperatorToken, _: unknown, node: BinaryExpression) {
+            function onOperator(operatorToken: BinaryOperatorToken, _state: unknown, node: BinaryExpression) {
                 const isCommaOperator = operatorToken.kind !== SyntaxKind.CommaToken;
                 const linesBeforeOperator = getLinesBetweenNodes(node, node.left, operatorToken);
                 const linesAfterOperator = getLinesBetweenNodes(node, operatorToken, node.right);
@@ -2588,44 +2588,44 @@ namespace ts {
                 writeLinesAndIndent(linesAfterOperator, /*writeSpaceIfNotIndenting*/ true);
             }
 
-            function onExit(node: BinaryExpression, state: EmitBinaryExpressionState) {
+            function onExit(node: BinaryExpression, _state: unknown) {
                 const linesBeforeOperator = getLinesBetweenNodes(node, node.left, node.operatorToken);
                 const linesAfterOperator = getLinesBetweenNodes(node, node.operatorToken, node.right);
                 decreaseIndentIf(linesBeforeOperator, linesAfterOperator);
 
-                if (state.nested) {
-                    // If we are marked as nested, we are recurring. We can use this fact to indicate
-                    // we are exiting from a nested binary expression and can replicate the trailing
-                    // comment and sourcemap emit performed by `emitWithContext`.
+                // if (state.nested) {
+                //     // If we are marked as nested, we are recurring. We can use this fact to indicate
+                //     // we are exiting from a nested binary expression and can replicate the trailing
+                //     // comment and sourcemap emit performed by `emitWithContext`.
 
-                    // Emit trailing sourcemap
-                    if (state.sourceMapRange) {
-                        if (state.emitFlags & EmitFlags.NoNestedSourceMaps) {
-                            sourceMapsDisabled = false;
-                        }
-                        if ((state.emitFlags & EmitFlags.NoTrailingSourceMap) === 0
-                            && state.sourceMapRange.end >= 0) {
-                            emitSourcePos(state.sourceMapRange.source || sourceMapSource, state.sourceMapRange.end);
-                        }
-                    }
+                //     // Emit trailing sourcemap
+                //     if (state.sourceMapRange) {
+                //         if (state.emitFlags & EmitFlags.NoNestedSourceMaps) {
+                //             sourceMapsDisabled = false;
+                //         }
+                //         if ((state.emitFlags & EmitFlags.NoTrailingSourceMap) === 0
+                //             && state.sourceMapRange.end >= 0) {
+                //             emitSourcePos(state.sourceMapRange.source || sourceMapSource, state.sourceMapRange.end);
+                //         }
+                //     }
 
-                    // Emit trailing comments
-                    if (state.commentRange) {
-                        if (state.emitFlags & EmitFlags.NoNestedComments) {
-                            commentsDisabled = false;
-                        }
-                        emitTrailingCommentsOfNode(node, state.emitFlags, state.commentRange.pos, state.commentRange.end, state.containerPos, state.containerEnd, state.declarationListContainerEnd);
-                    }
+                //     // Emit trailing comments
+                //     if (state.commentRange) {
+                //         if (state.emitFlags & EmitFlags.NoNestedComments) {
+                //             commentsDisabled = false;
+                //         }
+                //         emitTrailingCommentsOfNode(node, state.emitFlags, state.commentRange.pos, state.commentRange.end, state.containerPos, state.containerEnd, state.declarationListContainerEnd);
+                //     }
 
-                    onAfterEmitNode?.(node);
+                //     onAfterEmitNode?.(node);
 
-                    preserveSourceNewlines = state.preserveSourceNewlines;
-                }
+                //     preserveSourceNewlines = state.preserveSourceNewlines;
+                // }
             }
 
             function maybeEmitExpression(next: Expression) {
                 // Push a new frame for binary expressions, otherwise emit all other expressions.
-                if (isBinaryExpression(next)) {
+                if (isBinaryExpression(next) && !shouldEmitComments(next) && !shouldEmitSourceMaps(next)) {
                     return next;
                 }
 

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1,6 +1,15 @@
 namespace ts {
     const brackets = createBracketsMap();
-    const syntheticParent: TextRange = { pos: -1, end: -1 };
+
+    /**
+     * For a BinaryExpression trampoline function, indicates
+     * which state of the trampoline we are currently in.
+     */
+    const enum BinaryExpressionState {
+        Left,
+        Right,
+        Finish
+    }
 
     /*@internal*/
     export function isBuildInfoFile(file: string) {
@@ -861,20 +870,11 @@ namespace ts {
         return outputFiles;
     }
 
-    const enum PipelinePhase {
-        Notification,
-        Substitution,
-        Comments,
-        SourceMaps,
-        Emit
-    }
-
     export function createPrinter(printerOptions: PrinterOptions = {}, handlers: PrintHandlers = {}): Printer {
         const {
             hasGlobalName,
-            onEmitNode = noEmitNotification,
-            isEmitNotificationEnabled,
-            substituteNode = noEmitSubstitution,
+            onBeforeEmitNode,
+            onAfterEmitNode,
             onBeforeEmitNodeArray,
             onAfterEmitNodeArray,
             onBeforeEmitToken,
@@ -923,9 +923,8 @@ namespace ts {
         let detachedCommentsInfo: { nodePos: number, detachedCommentEndPos: number}[] | undefined;
         let hasWrittenComment = false;
         let commentsDisabled = !!printerOptions.removeComments;
-        let lastNode: Node | undefined;
-        let lastSubstitution: Node | undefined;
         const { enter: enterComment, exit: exitComment } = performance.createTimerIf(extendedDiagnostics, "commentTime", "beforeComment", "afterComment");
+        const preprint = createPreprinter(handlers);
 
         reset();
         return {
@@ -1003,7 +1002,7 @@ namespace ts {
             if (sourceFile) {
                 setSourceFile(sourceFile);
             }
-            emitList(syntheticParent, nodes, format);
+            emitList(/*parentNode*/ undefined, nodes, format);
             reset();
             writer = previousWriter;
         }
@@ -1147,7 +1146,7 @@ namespace ts {
                 setSourceFile(sourceFile);
             }
 
-            pipelineEmit(hint, node);
+            emit(preprint(hint, node));
         }
 
         function setSourceFile(sourceFile: SourceFile | undefined) {
@@ -1179,8 +1178,6 @@ namespace ts {
             currentSourceFile = undefined!;
             currentLineMap = undefined!;
             detachedCommentsInfo = undefined;
-            lastNode = undefined;
-            lastSubstitution = undefined;
             setWriter(/*output*/ undefined, /*_sourceMapGenerator*/ undefined);
         }
 
@@ -1188,539 +1185,534 @@ namespace ts {
             return currentLineMap || (currentLineMap = getLineStarts(currentSourceFile!));
         }
 
-        function emit(node: Node): Node;
-        function emit(node: Node | undefined): Node | undefined;
+        function emit(node: Node): void;
+        function emit(node: Node | undefined): void;
         function emit(node: Node | undefined) {
             if (node === undefined) return;
-
             const prevSourceFileTextKind = recordBundleFileInternalSectionStart(node);
-            const substitute = pipelineEmit(EmitHint.Unspecified, node);
+
+            emitWithContext(node, emitWorker);
+
             recordBundleFileInternalSectionEnd(prevSourceFileTextKind);
-            return substitute;
         }
 
-        function emitIdentifierName(node: Identifier): Node;
-        function emitIdentifierName(node: Identifier | undefined): Node | undefined;
-        function emitIdentifierName(node: Identifier | undefined): Node | undefined {
-            if (node === undefined) return;
-            return pipelineEmit(EmitHint.IdentifierName, node);
+        function shouldEmitComments(node: Node) {
+            return !commentsDisabled && !isSourceFile(node);
         }
 
-        function emitExpression(node: Expression): Node;
-        function emitExpression(node: Expression | undefined): Node | undefined;
-        function emitExpression(node: Expression | undefined): Node | undefined {
-            if (node === undefined) return;
-            return pipelineEmit(EmitHint.Expression, node);
+        function shouldEmitSourceMaps(node: Node) {
+            return !sourceMapsDisabled &&
+                !isSourceFile(node) &&
+                !isInJsonFile(node) &&
+                !isUnparsedSource(node) &&
+                !isUnparsedPrepend(node);
         }
 
-        function emitJsxAttributeValue(node: StringLiteral | JsxExpression): Node {
-            return pipelineEmit(isStringLiteral(node) ? EmitHint.JsxAttributeValue : EmitHint.Unspecified, node);
-        }
+        function emitWithContext<T extends Node>(node: T, emitCallback: (node: T) => void) {
+            onBeforeEmitNode?.(node);
 
-        function pipelineEmit(emitHint: EmitHint, node: Node) {
-            const savedLastNode = lastNode;
-            const savedLastSubstitution = lastSubstitution;
             const savedPreserveSourceNewlines = preserveSourceNewlines;
-            lastNode = node;
-            lastSubstitution = undefined;
             if (preserveSourceNewlines && !!(getEmitFlags(node) & EmitFlags.IgnoreSourceNewlines)) {
                 preserveSourceNewlines = false;
             }
 
-            const pipelinePhase = getPipelinePhase(PipelinePhase.Notification, emitHint, node);
-            pipelinePhase(emitHint, node);
+            const savedContainerPos = containerPos;
+            const savedContainerEnd = containerEnd;
+            const savedDeclarationListContainerEnd = declarationListContainerEnd;
+            const emitFlags = getEmitFlags(node);
+            const commentRange = shouldEmitComments(node) ? getCommentRange(node) : undefined;
+            const sourceMapRange = shouldEmitSourceMaps(node) ? getSourceMapRange(node) : undefined;
 
-            Debug.assert(lastNode === node);
+            // Emit leading comments
+            if (commentRange) {
+                emitLeadingCommentsOfNode(node, emitFlags, commentRange.pos, commentRange.end);
+                if (emitFlags & EmitFlags.NoNestedComments) {
+                    commentsDisabled = true;
+                }
+            }
 
-            const substitute = lastSubstitution;
-            lastNode = savedLastNode;
-            lastSubstitution = savedLastSubstitution;
+            // Emit leading sourcemap
+            if (sourceMapRange) {
+                if (isUnparsedNode(node)) {
+                    Debug.assertIsDefined(node.parent, "UnparsedNodes must have parent pointers");
+                    const parsed = getParsedSourceMap(node.parent);
+                    if (parsed && sourceMapGenerator) {
+                        sourceMapGenerator.appendSourceMap(
+                            writer.getLine(),
+                            writer.getColumn(),
+                            parsed,
+                            node.parent.sourceMapPath!,
+                            node.parent.getLineAndCharacterOfPosition(node.pos),
+                            node.parent.getLineAndCharacterOfPosition(node.end)
+                        );
+                    }
+                }
+                else {
+                    const source = sourceMapRange.source || sourceMapSource;
+                    if (node.kind !== SyntaxKind.NotEmittedStatement
+                        && (emitFlags & EmitFlags.NoLeadingSourceMap) === 0
+                        && sourceMapRange.pos >= 0) {
+                        emitSourcePos(sourceMapRange.source || sourceMapSource, skipSourceTrivia(source, sourceMapRange.pos));
+                    }
+                    if (emitFlags & EmitFlags.NoNestedSourceMaps) {
+                        sourceMapsDisabled = true;
+                    }
+                }
+            }
+
+            emitCallback(node);
+
+            // Emit trailing sourcemap
+            if (sourceMapRange) {
+                if (!isUnparsedNode(node)) {
+                    if (emitFlags & EmitFlags.NoNestedSourceMaps) {
+                        sourceMapsDisabled = false;
+                    }
+                    if (node.kind !== SyntaxKind.NotEmittedStatement
+                        && (emitFlags & EmitFlags.NoTrailingSourceMap) === 0
+                        && sourceMapRange.end >= 0) {
+                        emitSourcePos(sourceMapRange.source || sourceMapSource, sourceMapRange.end);
+                    }
+                }
+            }
+
+            // Emit trailing comments
+            if (commentRange) {
+                if (emitFlags & EmitFlags.NoNestedComments) {
+                    commentsDisabled = false;
+                }
+                emitTrailingCommentsOfNode(node, emitFlags, commentRange.pos, commentRange.end, savedContainerPos, savedContainerEnd, savedDeclarationListContainerEnd);
+            }
+
+            onAfterEmitNode?.(node);
+
             preserveSourceNewlines = savedPreserveSourceNewlines;
-
-            return substitute || node;
         }
 
-        function getPipelinePhase(phase: PipelinePhase, emitHint: EmitHint, node: Node) {
-            switch (phase) {
-                case PipelinePhase.Notification:
-                    if (onEmitNode !== noEmitNotification && (!isEmitNotificationEnabled || isEmitNotificationEnabled(node))) {
-                        return pipelineEmitWithNotification;
-                    }
-                    // falls through
+        function emitWorker(node: Node): void {
+            switch (node.kind) {
+                // Literals
+                case SyntaxKind.NumericLiteral:
+                case SyntaxKind.BigIntLiteral:
+                    return emitNumericOrBigIntLiteral(<NumericLiteral | BigIntLiteral>node);
 
-                case PipelinePhase.Substitution:
-                    if (substituteNode !== noEmitSubstitution && (lastSubstitution = substituteNode(emitHint, node)) !== node) {
-                        return pipelineEmitWithSubstitution;
-                    }
-                    // falls through
+                case SyntaxKind.StringLiteral:
+                case SyntaxKind.RegularExpressionLiteral:
+                case SyntaxKind.NoSubstitutionTemplateLiteral:
+                    return emitLiteral(<LiteralExpression>node, /*jsxAttributeEscape*/ false);
 
-                case PipelinePhase.Comments:
-                    if (!commentsDisabled && node.kind !== SyntaxKind.SourceFile) {
-                        return pipelineEmitWithComments;
-                    }
-                    // falls through
+                case SyntaxKind.JsxText:
+                    return emitJsxText(<JsxText>node);
 
-                case PipelinePhase.SourceMaps:
-                    if (!sourceMapsDisabled && node.kind !== SyntaxKind.SourceFile && !isInJsonFile(node)) {
-                        return pipelineEmitWithSourceMap;
-                    }
-                    // falls through
+                // Pseudo-literals
+                case SyntaxKind.TemplateHead:
+                case SyntaxKind.TemplateMiddle:
+                case SyntaxKind.TemplateTail:
+                    return emitLiteral(<LiteralExpression>node, /*jsxAttributeEscape*/ false);
 
-                case PipelinePhase.Emit:
-                    return pipelineEmitWithHint;
+                // Identifiers and PrivateIdentifiers
+                case SyntaxKind.Identifier:
+                    return emitIdentifier(<Identifier>node);
+                case SyntaxKind.PrivateIdentifier:
+                    return emitPrivateIdentifier(node as PrivateIdentifier);
 
-                default:
-                    return Debug.assertNever(phase);
+                // Names
+                case SyntaxKind.QualifiedName:
+                    return emitQualifiedName(<QualifiedName>node);
+                case SyntaxKind.ComputedPropertyName:
+                    return emitComputedPropertyName(<ComputedPropertyName>node);
+
+                // Signature elements
+                case SyntaxKind.TypeParameter:
+                    return emitTypeParameter(<TypeParameterDeclaration>node);
+                case SyntaxKind.Parameter:
+                    return emitParameter(<ParameterDeclaration>node);
+                case SyntaxKind.Decorator:
+                    return emitDecorator(<Decorator>node);
+
+                // Type members
+                case SyntaxKind.PropertySignature:
+                    return emitPropertySignature(<PropertySignature>node);
+                case SyntaxKind.PropertyDeclaration:
+                    return emitPropertyDeclaration(<PropertyDeclaration>node);
+                case SyntaxKind.MethodSignature:
+                    return emitMethodSignature(<MethodSignature>node);
+                case SyntaxKind.MethodDeclaration:
+                    return emitMethodDeclaration(<MethodDeclaration>node);
+                case SyntaxKind.Constructor:
+                    return emitConstructor(<ConstructorDeclaration>node);
+                case SyntaxKind.GetAccessor:
+                case SyntaxKind.SetAccessor:
+                    return emitAccessorDeclaration(<AccessorDeclaration>node);
+                case SyntaxKind.CallSignature:
+                    return emitCallSignature(<CallSignatureDeclaration>node);
+                case SyntaxKind.ConstructSignature:
+                    return emitConstructSignature(<ConstructSignatureDeclaration>node);
+                case SyntaxKind.IndexSignature:
+                    return emitIndexSignature(<IndexSignatureDeclaration>node);
+
+                // Types
+                case SyntaxKind.TypePredicate:
+                    return emitTypePredicate(<TypePredicateNode>node);
+                case SyntaxKind.TypeReference:
+                    return emitTypeReference(<TypeReferenceNode>node);
+                case SyntaxKind.FunctionType:
+                    return emitFunctionType(<FunctionTypeNode>node);
+                case SyntaxKind.ConstructorType:
+                    return emitConstructorType(<ConstructorTypeNode>node);
+                case SyntaxKind.TypeQuery:
+                    return emitTypeQuery(<TypeQueryNode>node);
+                case SyntaxKind.TypeLiteral:
+                    return emitTypeLiteral(<TypeLiteralNode>node);
+                case SyntaxKind.ArrayType:
+                    return emitArrayType(<ArrayTypeNode>node);
+                case SyntaxKind.TupleType:
+                    return emitTupleType(<TupleTypeNode>node);
+                case SyntaxKind.OptionalType:
+                    return emitOptionalType(<OptionalTypeNode>node);
+                // SyntaxKind.RestType is handled below
+                case SyntaxKind.UnionType:
+                    return emitUnionType(<UnionTypeNode>node);
+                case SyntaxKind.IntersectionType:
+                    return emitIntersectionType(<IntersectionTypeNode>node);
+                case SyntaxKind.ConditionalType:
+                    return emitConditionalType(<ConditionalTypeNode>node);
+                case SyntaxKind.InferType:
+                    return emitInferType(<InferTypeNode>node);
+                case SyntaxKind.ParenthesizedType:
+                    return emitParenthesizedType(<ParenthesizedTypeNode>node);
+                case SyntaxKind.ThisType:
+                    return emitThisType();
+                case SyntaxKind.TypeOperator:
+                    return emitTypeOperator(<TypeOperatorNode>node);
+                case SyntaxKind.IndexedAccessType:
+                    return emitIndexedAccessType(<IndexedAccessTypeNode>node);
+                case SyntaxKind.MappedType:
+                    return emitMappedType(<MappedTypeNode>node);
+                case SyntaxKind.LiteralType:
+                    return emitLiteralType(<LiteralTypeNode>node);
+                case SyntaxKind.NamedTupleMember:
+                    return emitNamedTupleMember(node as NamedTupleMember);
+                case SyntaxKind.TemplateLiteralType:
+                    return emitTemplateType(<TemplateLiteralTypeNode>node);
+                case SyntaxKind.TemplateLiteralTypeSpan:
+                    return emitTemplateTypeSpan(<TemplateLiteralTypeSpan>node);
+                case SyntaxKind.ImportType:
+                    return emitImportTypeNode(<ImportTypeNode>node);
+
+                // Binding patterns
+                case SyntaxKind.ObjectBindingPattern:
+                    return emitObjectBindingPattern(<ObjectBindingPattern>node);
+                case SyntaxKind.ArrayBindingPattern:
+                    return emitArrayBindingPattern(<ArrayBindingPattern>node);
+                case SyntaxKind.BindingElement:
+                    return emitBindingElement(<BindingElement>node);
+
+                // Expressions
+                case SyntaxKind.ArrayLiteralExpression:
+                    return emitArrayLiteralExpression(<ArrayLiteralExpression>node);
+                case SyntaxKind.ObjectLiteralExpression:
+                    return emitObjectLiteralExpression(<ObjectLiteralExpression>node);
+                case SyntaxKind.PropertyAccessExpression:
+                    return emitPropertyAccessExpression(<PropertyAccessExpression>node);
+                case SyntaxKind.ElementAccessExpression:
+                    return emitElementAccessExpression(<ElementAccessExpression>node);
+                case SyntaxKind.CallExpression:
+                    return emitCallExpression(<CallExpression>node);
+                case SyntaxKind.NewExpression:
+                    return emitNewExpression(<NewExpression>node);
+                case SyntaxKind.TaggedTemplateExpression:
+                    return emitTaggedTemplateExpression(<TaggedTemplateExpression>node);
+                case SyntaxKind.TypeAssertionExpression:
+                    return emitTypeAssertionExpression(<TypeAssertion>node);
+                case SyntaxKind.ParenthesizedExpression:
+                    return emitParenthesizedExpression(<ParenthesizedExpression>node);
+                case SyntaxKind.FunctionExpression:
+                    return emitFunctionExpression(<FunctionExpression>node);
+                case SyntaxKind.ArrowFunction:
+                    return emitArrowFunction(<ArrowFunction>node);
+                case SyntaxKind.DeleteExpression:
+                    return emitDeleteExpression(<DeleteExpression>node);
+                case SyntaxKind.TypeOfExpression:
+                    return emitTypeOfExpression(<TypeOfExpression>node);
+                case SyntaxKind.VoidExpression:
+                    return emitVoidExpression(<VoidExpression>node);
+                case SyntaxKind.AwaitExpression:
+                    return emitAwaitExpression(<AwaitExpression>node);
+                case SyntaxKind.PrefixUnaryExpression:
+                    return emitPrefixUnaryExpression(<PrefixUnaryExpression>node);
+                case SyntaxKind.PostfixUnaryExpression:
+                    return emitPostfixUnaryExpression(<PostfixUnaryExpression>node);
+                case SyntaxKind.BinaryExpression:
+                    return emitBinaryExpression(<BinaryExpression>node);
+                case SyntaxKind.ConditionalExpression:
+                    return emitConditionalExpression(<ConditionalExpression>node);
+                case SyntaxKind.TemplateExpression:
+                    return emitTemplateExpression(<TemplateExpression>node);
+                case SyntaxKind.YieldExpression:
+                    return emitYieldExpression(<YieldExpression>node);
+                case SyntaxKind.SpreadElement:
+                    return emitSpreadExpression(<SpreadElement>node);
+                case SyntaxKind.ClassExpression:
+                    return emitClassExpression(<ClassExpression>node);
+                case SyntaxKind.OmittedExpression:
+                    return;
+                case SyntaxKind.ExpressionWithTypeArguments:
+                    return emitExpressionWithTypeArguments(<ExpressionWithTypeArguments>node);
+                case SyntaxKind.AsExpression:
+                    return emitAsExpression(<AsExpression>node);
+                case SyntaxKind.NonNullExpression:
+                    return emitNonNullExpression(<NonNullExpression>node);
+                case SyntaxKind.MetaProperty:
+                    return emitMetaProperty(<MetaProperty>node);
+                case SyntaxKind.SyntheticExpression:
+                    Debug.fail("SyntheticExpression should never be printed.");
+                    break;
+
+                // Misc
+                case SyntaxKind.TemplateSpan:
+                    return emitTemplateSpan(<TemplateSpan>node);
+                case SyntaxKind.SemicolonClassElement:
+                    return emitSemicolonClassElement();
+
+                // Element
+                case SyntaxKind.Block:
+                    return emitBlock(<Block>node);
+                case SyntaxKind.EmptyStatement:
+                    return emitEmptyStatement(/*isEmbeddedStatement*/ false);
+                case SyntaxKind.VariableStatement:
+                    return emitVariableStatement(<VariableStatement>node);
+                case SyntaxKind.ExpressionStatement:
+                    return emitExpressionStatement(<ExpressionStatement>node);
+                case SyntaxKind.IfStatement:
+                    return emitIfStatement(<IfStatement>node);
+                case SyntaxKind.DoStatement:
+                    return emitDoStatement(<DoStatement>node);
+                case SyntaxKind.WhileStatement:
+                    return emitWhileStatement(<WhileStatement>node);
+                case SyntaxKind.ForStatement:
+                    return emitForStatement(<ForStatement>node);
+                case SyntaxKind.ForInStatement:
+                    return emitForInStatement(<ForInStatement>node);
+                case SyntaxKind.ForOfStatement:
+                    return emitForOfStatement(<ForOfStatement>node);
+                case SyntaxKind.ContinueStatement:
+                    return emitContinueStatement(<ContinueStatement>node);
+                case SyntaxKind.BreakStatement:
+                    return emitBreakStatement(<BreakStatement>node);
+                case SyntaxKind.ReturnStatement:
+                    return emitReturnStatement(<ReturnStatement>node);
+                case SyntaxKind.WithStatement:
+                    return emitWithStatement(<WithStatement>node);
+                case SyntaxKind.SwitchStatement:
+                    return emitSwitchStatement(<SwitchStatement>node);
+                case SyntaxKind.LabeledStatement:
+                    return emitLabeledStatement(<LabeledStatement>node);
+                case SyntaxKind.ThrowStatement:
+                    return emitThrowStatement(<ThrowStatement>node);
+                case SyntaxKind.TryStatement:
+                    return emitTryStatement(<TryStatement>node);
+                case SyntaxKind.DebuggerStatement:
+                    return emitDebuggerStatement(<DebuggerStatement>node);
+
+                // Declarations
+                case SyntaxKind.VariableDeclaration:
+                    return emitVariableDeclaration(<VariableDeclaration>node);
+                case SyntaxKind.VariableDeclarationList:
+                    return emitVariableDeclarationList(<VariableDeclarationList>node);
+                case SyntaxKind.FunctionDeclaration:
+                    return emitFunctionDeclaration(<FunctionDeclaration>node);
+                case SyntaxKind.ClassDeclaration:
+                    return emitClassDeclaration(<ClassDeclaration>node);
+                case SyntaxKind.InterfaceDeclaration:
+                    return emitInterfaceDeclaration(<InterfaceDeclaration>node);
+                case SyntaxKind.TypeAliasDeclaration:
+                    return emitTypeAliasDeclaration(<TypeAliasDeclaration>node);
+                case SyntaxKind.EnumDeclaration:
+                    return emitEnumDeclaration(<EnumDeclaration>node);
+                case SyntaxKind.ModuleDeclaration:
+                    return emitModuleDeclaration(<ModuleDeclaration>node);
+                case SyntaxKind.ModuleBlock:
+                    return emitModuleBlock(<ModuleBlock>node);
+                case SyntaxKind.CaseBlock:
+                    return emitCaseBlock(<CaseBlock>node);
+                case SyntaxKind.NamespaceExportDeclaration:
+                    return emitNamespaceExportDeclaration(<NamespaceExportDeclaration>node);
+                case SyntaxKind.ImportEqualsDeclaration:
+                    return emitImportEqualsDeclaration(<ImportEqualsDeclaration>node);
+                case SyntaxKind.ImportDeclaration:
+                    return emitImportDeclaration(<ImportDeclaration>node);
+                case SyntaxKind.ImportClause:
+                    return emitImportClause(<ImportClause>node);
+                case SyntaxKind.NamespaceImport:
+                    return emitNamespaceImport(<NamespaceImport>node);
+                case SyntaxKind.NamedImports:
+                    return emitNamedImports(<NamedImports>node);
+                case SyntaxKind.ImportSpecifier:
+                    return emitImportSpecifier(<ImportSpecifier>node);
+                case SyntaxKind.ExportAssignment:
+                    return emitExportAssignment(<ExportAssignment>node);
+                case SyntaxKind.ExportDeclaration:
+                    return emitExportDeclaration(<ExportDeclaration>node);
+                case SyntaxKind.NamedExports:
+                    return emitNamedExports(<NamedExports>node);
+                case SyntaxKind.NamespaceExport:
+                    return emitNamespaceExport(<NamespaceExport>node);
+                case SyntaxKind.ExportSpecifier:
+                    return emitExportSpecifier(<ExportSpecifier>node);
+                case SyntaxKind.MissingDeclaration:
+                    return;
+
+                // Module references
+                case SyntaxKind.ExternalModuleReference:
+                    return emitExternalModuleReference(<ExternalModuleReference>node);
+
+                // JSX
+                case SyntaxKind.JsxElement:
+                    return emitJsxElement(<JsxElement>node);
+                case SyntaxKind.JsxSelfClosingElement:
+                    return emitJsxSelfClosingElement(<JsxSelfClosingElement>node);
+                case SyntaxKind.JsxFragment:
+                    return emitJsxFragment(<JsxFragment>node);
+                case SyntaxKind.JsxOpeningElement:
+                case SyntaxKind.JsxOpeningFragment:
+                    return emitJsxOpeningElementOrFragment(<JsxOpeningElement>node);
+                case SyntaxKind.JsxClosingElement:
+                case SyntaxKind.JsxClosingFragment:
+                    return emitJsxClosingElementOrFragment(<JsxClosingElement>node);
+                case SyntaxKind.JsxAttribute:
+                    return emitJsxAttribute(<JsxAttribute>node);
+                case SyntaxKind.JsxAttributes:
+                    return emitJsxAttributes(<JsxAttributes>node);
+                case SyntaxKind.JsxSpreadAttribute:
+                    return emitJsxSpreadAttribute(<JsxSpreadAttribute>node);
+                case SyntaxKind.JsxExpression:
+                    return emitJsxExpression(<JsxExpression>node);
+
+                // Clauses
+                case SyntaxKind.CaseClause:
+                    return emitCaseClause(<CaseClause>node);
+                case SyntaxKind.DefaultClause:
+                    return emitDefaultClause(<DefaultClause>node);
+                case SyntaxKind.HeritageClause:
+                    return emitHeritageClause(<HeritageClause>node);
+                case SyntaxKind.CatchClause:
+                    return emitCatchClause(<CatchClause>node);
+
+                // Property assignments
+                case SyntaxKind.PropertyAssignment:
+                    return emitPropertyAssignment(<PropertyAssignment>node);
+                case SyntaxKind.ShorthandPropertyAssignment:
+                    return emitShorthandPropertyAssignment(<ShorthandPropertyAssignment>node);
+                case SyntaxKind.SpreadAssignment:
+                    return emitSpreadAssignment(node as SpreadAssignment);
+
+                // Enum
+                case SyntaxKind.EnumMember:
+                    return emitEnumMember(<EnumMember>node);
+
+                // Unparsed
+                case SyntaxKind.UnparsedPrologue:
+                    return writeUnparsedNode(<UnparsedNode>node);
+                case SyntaxKind.UnparsedSource:
+                case SyntaxKind.UnparsedPrepend:
+                    return emitUnparsedSourceOrPrepend(<UnparsedSource>node);
+                case SyntaxKind.UnparsedText:
+                case SyntaxKind.UnparsedInternalText:
+                    return emitUnparsedTextLike(<UnparsedTextLike>node);
+                case SyntaxKind.UnparsedSyntheticReference:
+                    return emitUnparsedSyntheticReference(<UnparsedSyntheticReference>node);
+
+                // Top-level nodes
+                case SyntaxKind.SourceFile:
+                    return emitSourceFile(<SourceFile>node);
+                case SyntaxKind.Bundle:
+                    Debug.fail("Bundles should be printed using printBundle");
+                    break;
+                // SyntaxKind.UnparsedSource (handled above)
+                case SyntaxKind.InputFiles:
+                    Debug.fail("InputFiles should not be printed");
+                    break;
+
+                // JSDoc nodes (only used in codefixes currently)
+                case SyntaxKind.JSDocTypeExpression:
+                    return emitJSDocTypeExpression(node as JSDocTypeExpression);
+                case SyntaxKind.JSDocNameReference:
+                    return emitJSDocNameReference(node as JSDocNameReference);
+                case SyntaxKind.JSDocAllType:
+                    return writePunctuation("*");
+                case SyntaxKind.JSDocUnknownType:
+                    return writePunctuation("?");
+                case SyntaxKind.JSDocNullableType:
+                    return emitJSDocNullableType(node as JSDocNullableType);
+                case SyntaxKind.JSDocNonNullableType:
+                    return emitJSDocNonNullableType(node as JSDocNonNullableType);
+                case SyntaxKind.JSDocOptionalType:
+                    return emitJSDocOptionalType(node as JSDocOptionalType);
+                case SyntaxKind.JSDocFunctionType:
+                    return emitJSDocFunctionType(node as JSDocFunctionType);
+                case SyntaxKind.RestType:
+                case SyntaxKind.JSDocVariadicType:
+                    return emitRestOrJSDocVariadicType(node as RestTypeNode | JSDocVariadicType);
+                // SyntaxKind.JSDocNamepathType (missing)
+                case SyntaxKind.JSDocComment:
+                    return emitJSDoc(node as JSDoc);
+                case SyntaxKind.JSDocTypeLiteral:
+                    return emitJSDocTypeLiteral(node as JSDocTypeLiteral);
+                case SyntaxKind.JSDocSignature:
+                    return emitJSDocSignature(node as JSDocSignature);
+                case SyntaxKind.JSDocTag:
+                case SyntaxKind.JSDocClassTag:
+                    return emitJSDocSimpleTag(node as JSDocTag);
+                case SyntaxKind.JSDocAugmentsTag:
+                case SyntaxKind.JSDocImplementsTag:
+                    return emitJSDocHeritageTag(node as JSDocImplementsTag | JSDocAugmentsTag);
+                // SyntaxKind.JSDocAuthorTag (missing)
+                // SyntaxKind.JSDocDeprecatedTag (missing)
+                // SyntaxKind.JSDocClassTag (see JSDocTag, above)
+                // SyntaxKind.JSDocPublicTag (missing)
+                // SyntaxKind.JSDocPrivateTag (missing)
+                // SyntaxKind.JSDocProtectedTag (missing)
+                // SyntaxKind.JSDocReadonlyTag (missing)
+                case SyntaxKind.JSDocCallbackTag:
+                    return emitJSDocCallbackTag(node as JSDocCallbackTag);
+                // SyntaxKind.JSDocEnumTag (see below)
+                case SyntaxKind.JSDocParameterTag:
+                case SyntaxKind.JSDocPropertyTag:
+                    return emitJSDocPropertyLikeTag(node as JSDocPropertyLikeTag);
+                case SyntaxKind.JSDocEnumTag:
+                case SyntaxKind.JSDocReturnTag:
+                case SyntaxKind.JSDocThisTag:
+                case SyntaxKind.JSDocTypeTag:
+                    return emitJSDocSimpleTypedTag(node as JSDocTypeTag);
+                case SyntaxKind.JSDocTemplateTag:
+                    return emitJSDocTemplateTag(node as JSDocTemplateTag);
+                case SyntaxKind.JSDocTypedefTag:
+                    return emitJSDocTypedefTag(node as JSDocTypedefTag);
+                case SyntaxKind.JSDocSeeTag:
+                    return emitJSDocSeeTag(node as JSDocSeeTag);
+                // SyntaxKind.JSDocPropertyTag (see JSDocParameterTag, above)
+
+                // Synthesized list
+                case SyntaxKind.SyntaxList:
+                    Debug.fail("SyntaxList should not be printed");
+                    break;
+
+                // Transformation nodes
+                case SyntaxKind.NotEmittedStatement:
+                    break;
+                case SyntaxKind.PartiallyEmittedExpression:
+                    return emitPartiallyEmittedExpression(<PartiallyEmittedExpression>node);
+                case SyntaxKind.CommaListExpression:
+                    return emitCommaList(<CommaListExpression>node);
+                case SyntaxKind.MergeDeclarationMarker:
+                case SyntaxKind.EndOfDeclarationMarker:
+                    break;
+                case SyntaxKind.SyntheticReferenceExpression:
+                    Debug.fail("SyntheticReferenceExpression should not be printed");
             }
-        }
-
-        function getNextPipelinePhase(currentPhase: PipelinePhase, emitHint: EmitHint, node: Node) {
-            return getPipelinePhase(currentPhase + 1, emitHint, node);
-        }
-
-        function pipelineEmitWithNotification(hint: EmitHint, node: Node) {
-            Debug.assert(lastNode === node);
-            const pipelinePhase = getNextPipelinePhase(PipelinePhase.Notification, hint, node);
-            onEmitNode(hint, node, pipelinePhase);
-            Debug.assert(lastNode === node);
-        }
-
-        function pipelineEmitWithHint(hint: EmitHint, node: Node): void {
-            Debug.assert(lastNode === node || lastSubstitution === node);
-            if (hint === EmitHint.SourceFile) return emitSourceFile(cast(node, isSourceFile));
-            if (hint === EmitHint.IdentifierName) return emitIdentifier(cast(node, isIdentifier));
-            if (hint === EmitHint.JsxAttributeValue) return emitLiteral(cast(node, isStringLiteral), /*jsxAttributeEscape*/ true);
-            if (hint === EmitHint.MappedTypeParameter) return emitMappedTypeParameter(cast(node, isTypeParameterDeclaration));
-            if (hint === EmitHint.EmbeddedStatement) {
-                Debug.assertNode(node, isEmptyStatement);
-                return emitEmptyStatement(/*isEmbeddedStatement*/ true);
-            }
-            if (hint === EmitHint.Unspecified) {
-                if (isKeyword(node.kind)) return writeTokenNode(node, writeKeyword);
-
-                switch (node.kind) {
-                    // Pseudo-literals
-                    case SyntaxKind.TemplateHead:
-                    case SyntaxKind.TemplateMiddle:
-                    case SyntaxKind.TemplateTail:
-                        return emitLiteral(<LiteralExpression>node, /*jsxAttributeEscape*/ false);
-
-                    case SyntaxKind.UnparsedSource:
-                    case SyntaxKind.UnparsedPrepend:
-                        return emitUnparsedSourceOrPrepend(<UnparsedSource>node);
-
-                    case SyntaxKind.UnparsedPrologue:
-                        return writeUnparsedNode(<UnparsedNode>node);
-
-                    case SyntaxKind.UnparsedText:
-                    case SyntaxKind.UnparsedInternalText:
-                        return emitUnparsedTextLike(<UnparsedTextLike>node);
-
-                    case SyntaxKind.UnparsedSyntheticReference:
-                        return emitUnparsedSyntheticReference(<UnparsedSyntheticReference>node);
-
-
-                    // Identifiers
-                    case SyntaxKind.Identifier:
-                        return emitIdentifier(<Identifier>node);
-
-                    // PrivateIdentifiers
-                    case SyntaxKind.PrivateIdentifier:
-                        return emitPrivateIdentifier(node as PrivateIdentifier);
-
-                    // Parse tree nodes
-                    // Names
-                    case SyntaxKind.QualifiedName:
-                        return emitQualifiedName(<QualifiedName>node);
-                    case SyntaxKind.ComputedPropertyName:
-                        return emitComputedPropertyName(<ComputedPropertyName>node);
-
-                    // Signature elements
-                    case SyntaxKind.TypeParameter:
-                        return emitTypeParameter(<TypeParameterDeclaration>node);
-                    case SyntaxKind.Parameter:
-                        return emitParameter(<ParameterDeclaration>node);
-                    case SyntaxKind.Decorator:
-                        return emitDecorator(<Decorator>node);
-
-                    // Type members
-                    case SyntaxKind.PropertySignature:
-                        return emitPropertySignature(<PropertySignature>node);
-                    case SyntaxKind.PropertyDeclaration:
-                        return emitPropertyDeclaration(<PropertyDeclaration>node);
-                    case SyntaxKind.MethodSignature:
-                        return emitMethodSignature(<MethodSignature>node);
-                    case SyntaxKind.MethodDeclaration:
-                        return emitMethodDeclaration(<MethodDeclaration>node);
-                    case SyntaxKind.Constructor:
-                        return emitConstructor(<ConstructorDeclaration>node);
-                    case SyntaxKind.GetAccessor:
-                    case SyntaxKind.SetAccessor:
-                        return emitAccessorDeclaration(<AccessorDeclaration>node);
-                    case SyntaxKind.CallSignature:
-                        return emitCallSignature(<CallSignatureDeclaration>node);
-                    case SyntaxKind.ConstructSignature:
-                        return emitConstructSignature(<ConstructSignatureDeclaration>node);
-                    case SyntaxKind.IndexSignature:
-                        return emitIndexSignature(<IndexSignatureDeclaration>node);
-                    case SyntaxKind.TemplateLiteralTypeSpan:
-                        return emitTemplateTypeSpan(<TemplateLiteralTypeSpan>node);
-
-                    // Types
-                    case SyntaxKind.TypePredicate:
-                        return emitTypePredicate(<TypePredicateNode>node);
-                    case SyntaxKind.TypeReference:
-                        return emitTypeReference(<TypeReferenceNode>node);
-                    case SyntaxKind.FunctionType:
-                        return emitFunctionType(<FunctionTypeNode>node);
-                    case SyntaxKind.JSDocFunctionType:
-                        return emitJSDocFunctionType(node as JSDocFunctionType);
-                    case SyntaxKind.ConstructorType:
-                        return emitConstructorType(<ConstructorTypeNode>node);
-                    case SyntaxKind.TypeQuery:
-                        return emitTypeQuery(<TypeQueryNode>node);
-                    case SyntaxKind.TypeLiteral:
-                        return emitTypeLiteral(<TypeLiteralNode>node);
-                    case SyntaxKind.ArrayType:
-                        return emitArrayType(<ArrayTypeNode>node);
-                    case SyntaxKind.TupleType:
-                        return emitTupleType(<TupleTypeNode>node);
-                    case SyntaxKind.OptionalType:
-                        return emitOptionalType(<OptionalTypeNode>node);
-                    case SyntaxKind.UnionType:
-                        return emitUnionType(<UnionTypeNode>node);
-                    case SyntaxKind.IntersectionType:
-                        return emitIntersectionType(<IntersectionTypeNode>node);
-                    case SyntaxKind.ConditionalType:
-                        return emitConditionalType(<ConditionalTypeNode>node);
-                    case SyntaxKind.InferType:
-                        return emitInferType(<InferTypeNode>node);
-                    case SyntaxKind.ParenthesizedType:
-                        return emitParenthesizedType(<ParenthesizedTypeNode>node);
-                    case SyntaxKind.ExpressionWithTypeArguments:
-                        return emitExpressionWithTypeArguments(<ExpressionWithTypeArguments>node);
-                    case SyntaxKind.ThisType:
-                        return emitThisType();
-                    case SyntaxKind.TypeOperator:
-                        return emitTypeOperator(<TypeOperatorNode>node);
-                    case SyntaxKind.IndexedAccessType:
-                        return emitIndexedAccessType(<IndexedAccessTypeNode>node);
-                    case SyntaxKind.MappedType:
-                        return emitMappedType(<MappedTypeNode>node);
-                    case SyntaxKind.LiteralType:
-                        return emitLiteralType(<LiteralTypeNode>node);
-                    case SyntaxKind.TemplateLiteralType:
-                        return emitTemplateType(<TemplateLiteralTypeNode>node);
-                    case SyntaxKind.ImportType:
-                        return emitImportTypeNode(<ImportTypeNode>node);
-                    case SyntaxKind.JSDocAllType:
-                        writePunctuation("*");
-                        return;
-                    case SyntaxKind.JSDocUnknownType:
-                        writePunctuation("?");
-                        return;
-                    case SyntaxKind.JSDocNullableType:
-                        return emitJSDocNullableType(node as JSDocNullableType);
-                    case SyntaxKind.JSDocNonNullableType:
-                        return emitJSDocNonNullableType(node as JSDocNonNullableType);
-                    case SyntaxKind.JSDocOptionalType:
-                        return emitJSDocOptionalType(node as JSDocOptionalType);
-                    case SyntaxKind.RestType:
-                    case SyntaxKind.JSDocVariadicType:
-                        return emitRestOrJSDocVariadicType(node as RestTypeNode | JSDocVariadicType);
-                    case SyntaxKind.NamedTupleMember:
-                        return emitNamedTupleMember(node as NamedTupleMember);
-
-                    // Binding patterns
-                    case SyntaxKind.ObjectBindingPattern:
-                        return emitObjectBindingPattern(<ObjectBindingPattern>node);
-                    case SyntaxKind.ArrayBindingPattern:
-                        return emitArrayBindingPattern(<ArrayBindingPattern>node);
-                    case SyntaxKind.BindingElement:
-                        return emitBindingElement(<BindingElement>node);
-
-                    // Misc
-                    case SyntaxKind.TemplateSpan:
-                        return emitTemplateSpan(<TemplateSpan>node);
-                    case SyntaxKind.SemicolonClassElement:
-                        return emitSemicolonClassElement();
-
-                    // Statements
-                    case SyntaxKind.Block:
-                        return emitBlock(<Block>node);
-                    case SyntaxKind.VariableStatement:
-                        return emitVariableStatement(<VariableStatement>node);
-                    case SyntaxKind.EmptyStatement:
-                        return emitEmptyStatement(/*isEmbeddedStatement*/ false);
-                    case SyntaxKind.ExpressionStatement:
-                        return emitExpressionStatement(<ExpressionStatement>node);
-                    case SyntaxKind.IfStatement:
-                        return emitIfStatement(<IfStatement>node);
-                    case SyntaxKind.DoStatement:
-                        return emitDoStatement(<DoStatement>node);
-                    case SyntaxKind.WhileStatement:
-                        return emitWhileStatement(<WhileStatement>node);
-                    case SyntaxKind.ForStatement:
-                        return emitForStatement(<ForStatement>node);
-                    case SyntaxKind.ForInStatement:
-                        return emitForInStatement(<ForInStatement>node);
-                    case SyntaxKind.ForOfStatement:
-                        return emitForOfStatement(<ForOfStatement>node);
-                    case SyntaxKind.ContinueStatement:
-                        return emitContinueStatement(<ContinueStatement>node);
-                    case SyntaxKind.BreakStatement:
-                        return emitBreakStatement(<BreakStatement>node);
-                    case SyntaxKind.ReturnStatement:
-                        return emitReturnStatement(<ReturnStatement>node);
-                    case SyntaxKind.WithStatement:
-                        return emitWithStatement(<WithStatement>node);
-                    case SyntaxKind.SwitchStatement:
-                        return emitSwitchStatement(<SwitchStatement>node);
-                    case SyntaxKind.LabeledStatement:
-                        return emitLabeledStatement(<LabeledStatement>node);
-                    case SyntaxKind.ThrowStatement:
-                        return emitThrowStatement(<ThrowStatement>node);
-                    case SyntaxKind.TryStatement:
-                        return emitTryStatement(<TryStatement>node);
-                    case SyntaxKind.DebuggerStatement:
-                        return emitDebuggerStatement(<DebuggerStatement>node);
-
-                    // Declarations
-                    case SyntaxKind.VariableDeclaration:
-                        return emitVariableDeclaration(<VariableDeclaration>node);
-                    case SyntaxKind.VariableDeclarationList:
-                        return emitVariableDeclarationList(<VariableDeclarationList>node);
-                    case SyntaxKind.FunctionDeclaration:
-                        return emitFunctionDeclaration(<FunctionDeclaration>node);
-                    case SyntaxKind.ClassDeclaration:
-                        return emitClassDeclaration(<ClassDeclaration>node);
-                    case SyntaxKind.InterfaceDeclaration:
-                        return emitInterfaceDeclaration(<InterfaceDeclaration>node);
-                    case SyntaxKind.TypeAliasDeclaration:
-                        return emitTypeAliasDeclaration(<TypeAliasDeclaration>node);
-                    case SyntaxKind.EnumDeclaration:
-                        return emitEnumDeclaration(<EnumDeclaration>node);
-                    case SyntaxKind.ModuleDeclaration:
-                        return emitModuleDeclaration(<ModuleDeclaration>node);
-                    case SyntaxKind.ModuleBlock:
-                        return emitModuleBlock(<ModuleBlock>node);
-                    case SyntaxKind.CaseBlock:
-                        return emitCaseBlock(<CaseBlock>node);
-                    case SyntaxKind.NamespaceExportDeclaration:
-                        return emitNamespaceExportDeclaration(<NamespaceExportDeclaration>node);
-                    case SyntaxKind.ImportEqualsDeclaration:
-                        return emitImportEqualsDeclaration(<ImportEqualsDeclaration>node);
-                    case SyntaxKind.ImportDeclaration:
-                        return emitImportDeclaration(<ImportDeclaration>node);
-                    case SyntaxKind.ImportClause:
-                        return emitImportClause(<ImportClause>node);
-                    case SyntaxKind.NamespaceImport:
-                        return emitNamespaceImport(<NamespaceImport>node);
-                    case SyntaxKind.NamespaceExport:
-                        return emitNamespaceExport(<NamespaceExport>node);
-                    case SyntaxKind.NamedImports:
-                        return emitNamedImports(<NamedImports>node);
-                    case SyntaxKind.ImportSpecifier:
-                        return emitImportSpecifier(<ImportSpecifier>node);
-                    case SyntaxKind.ExportAssignment:
-                        return emitExportAssignment(<ExportAssignment>node);
-                    case SyntaxKind.ExportDeclaration:
-                        return emitExportDeclaration(<ExportDeclaration>node);
-                    case SyntaxKind.NamedExports:
-                        return emitNamedExports(<NamedExports>node);
-                    case SyntaxKind.ExportSpecifier:
-                        return emitExportSpecifier(<ExportSpecifier>node);
-                    case SyntaxKind.MissingDeclaration:
-                        return;
-
-                    // Module references
-                    case SyntaxKind.ExternalModuleReference:
-                        return emitExternalModuleReference(<ExternalModuleReference>node);
-
-                    // JSX (non-expression)
-                    case SyntaxKind.JsxText:
-                        return emitJsxText(<JsxText>node);
-                    case SyntaxKind.JsxOpeningElement:
-                    case SyntaxKind.JsxOpeningFragment:
-                        return emitJsxOpeningElementOrFragment(<JsxOpeningElement>node);
-                    case SyntaxKind.JsxClosingElement:
-                    case SyntaxKind.JsxClosingFragment:
-                        return emitJsxClosingElementOrFragment(<JsxClosingElement>node);
-                    case SyntaxKind.JsxAttribute:
-                        return emitJsxAttribute(<JsxAttribute>node);
-                    case SyntaxKind.JsxAttributes:
-                        return emitJsxAttributes(<JsxAttributes>node);
-                    case SyntaxKind.JsxSpreadAttribute:
-                        return emitJsxSpreadAttribute(<JsxSpreadAttribute>node);
-                    case SyntaxKind.JsxExpression:
-                        return emitJsxExpression(<JsxExpression>node);
-
-                    // Clauses
-                    case SyntaxKind.CaseClause:
-                        return emitCaseClause(<CaseClause>node);
-                    case SyntaxKind.DefaultClause:
-                        return emitDefaultClause(<DefaultClause>node);
-                    case SyntaxKind.HeritageClause:
-                        return emitHeritageClause(<HeritageClause>node);
-                    case SyntaxKind.CatchClause:
-                        return emitCatchClause(<CatchClause>node);
-
-                    // Property assignments
-                    case SyntaxKind.PropertyAssignment:
-                        return emitPropertyAssignment(<PropertyAssignment>node);
-                    case SyntaxKind.ShorthandPropertyAssignment:
-                        return emitShorthandPropertyAssignment(<ShorthandPropertyAssignment>node);
-                    case SyntaxKind.SpreadAssignment:
-                        return emitSpreadAssignment(node as SpreadAssignment);
-
-                    // Enum
-                    case SyntaxKind.EnumMember:
-                        return emitEnumMember(<EnumMember>node);
-
-                    // JSDoc nodes (only used in codefixes currently)
-                    case SyntaxKind.JSDocParameterTag:
-                    case SyntaxKind.JSDocPropertyTag:
-                        return emitJSDocPropertyLikeTag(node as JSDocPropertyLikeTag);
-                    case SyntaxKind.JSDocReturnTag:
-                    case SyntaxKind.JSDocTypeTag:
-                    case SyntaxKind.JSDocThisTag:
-                    case SyntaxKind.JSDocEnumTag:
-                        return emitJSDocSimpleTypedTag(node as JSDocTypeTag);
-                    case SyntaxKind.JSDocImplementsTag:
-                    case SyntaxKind.JSDocAugmentsTag:
-                        return emitJSDocHeritageTag(node as JSDocImplementsTag | JSDocAugmentsTag);
-                    case SyntaxKind.JSDocTemplateTag:
-                        return emitJSDocTemplateTag(node as JSDocTemplateTag);
-                    case SyntaxKind.JSDocTypedefTag:
-                        return emitJSDocTypedefTag(node as JSDocTypedefTag);
-                    case SyntaxKind.JSDocCallbackTag:
-                        return emitJSDocCallbackTag(node as JSDocCallbackTag);
-                    case SyntaxKind.JSDocSignature:
-                        return emitJSDocSignature(node as JSDocSignature);
-                    case SyntaxKind.JSDocTypeLiteral:
-                        return emitJSDocTypeLiteral(node as JSDocTypeLiteral);
-                    case SyntaxKind.JSDocClassTag:
-                    case SyntaxKind.JSDocTag:
-                        return emitJSDocSimpleTag(node as JSDocTag);
-                    case SyntaxKind.JSDocSeeTag:
-                        return emitJSDocSeeTag(node as JSDocSeeTag);
-                    case SyntaxKind.JSDocNameReference:
-                        return emitJSDocNameReference(node as JSDocNameReference);
-
-                    case SyntaxKind.JSDocComment:
-                        return emitJSDoc(node as JSDoc);
-
-                    // Transformation nodes (ignored)
-                }
-
-                if (isExpression(node)) {
-                    hint = EmitHint.Expression;
-                    if (substituteNode !== noEmitSubstitution) {
-                        lastSubstitution = node = substituteNode(hint, node);
-                    }
-                }
-                else if (isToken(node)) {
-                    return writeTokenNode(node, writePunctuation);
-                }
-            }
-            if (hint === EmitHint.Expression) {
-                switch (node.kind) {
-                    // Literals
-                    case SyntaxKind.NumericLiteral:
-                    case SyntaxKind.BigIntLiteral:
-                        return emitNumericOrBigIntLiteral(<NumericLiteral | BigIntLiteral>node);
-
-                    case SyntaxKind.StringLiteral:
-                    case SyntaxKind.RegularExpressionLiteral:
-                    case SyntaxKind.NoSubstitutionTemplateLiteral:
-                        return emitLiteral(<LiteralExpression>node, /*jsxAttributeEscape*/ false);
-
-                    // Identifiers
-                    case SyntaxKind.Identifier:
-                        return emitIdentifier(<Identifier>node);
-
-                    // Reserved words
-                    case SyntaxKind.FalseKeyword:
-                    case SyntaxKind.NullKeyword:
-                    case SyntaxKind.SuperKeyword:
-                    case SyntaxKind.TrueKeyword:
-                    case SyntaxKind.ThisKeyword:
-                    case SyntaxKind.ImportKeyword:
-                        writeTokenNode(node, writeKeyword);
-                        return;
-
-                    // Expressions
-                    case SyntaxKind.ArrayLiteralExpression:
-                        return emitArrayLiteralExpression(<ArrayLiteralExpression>node);
-                    case SyntaxKind.ObjectLiteralExpression:
-                        return emitObjectLiteralExpression(<ObjectLiteralExpression>node);
-                    case SyntaxKind.PropertyAccessExpression:
-                        return emitPropertyAccessExpression(<PropertyAccessExpression>node);
-                    case SyntaxKind.ElementAccessExpression:
-                        return emitElementAccessExpression(<ElementAccessExpression>node);
-                    case SyntaxKind.CallExpression:
-                        return emitCallExpression(<CallExpression>node);
-                    case SyntaxKind.NewExpression:
-                        return emitNewExpression(<NewExpression>node);
-                    case SyntaxKind.TaggedTemplateExpression:
-                        return emitTaggedTemplateExpression(<TaggedTemplateExpression>node);
-                    case SyntaxKind.TypeAssertionExpression:
-                        return emitTypeAssertionExpression(<TypeAssertion>node);
-                    case SyntaxKind.ParenthesizedExpression:
-                        return emitParenthesizedExpression(<ParenthesizedExpression>node);
-                    case SyntaxKind.FunctionExpression:
-                        return emitFunctionExpression(<FunctionExpression>node);
-                    case SyntaxKind.ArrowFunction:
-                        return emitArrowFunction(<ArrowFunction>node);
-                    case SyntaxKind.DeleteExpression:
-                        return emitDeleteExpression(<DeleteExpression>node);
-                    case SyntaxKind.TypeOfExpression:
-                        return emitTypeOfExpression(<TypeOfExpression>node);
-                    case SyntaxKind.VoidExpression:
-                        return emitVoidExpression(<VoidExpression>node);
-                    case SyntaxKind.AwaitExpression:
-                        return emitAwaitExpression(<AwaitExpression>node);
-                    case SyntaxKind.PrefixUnaryExpression:
-                        return emitPrefixUnaryExpression(<PrefixUnaryExpression>node);
-                    case SyntaxKind.PostfixUnaryExpression:
-                        return emitPostfixUnaryExpression(<PostfixUnaryExpression>node);
-                    case SyntaxKind.BinaryExpression:
-                        return emitBinaryExpression(<BinaryExpression>node);
-                    case SyntaxKind.ConditionalExpression:
-                        return emitConditionalExpression(<ConditionalExpression>node);
-                    case SyntaxKind.TemplateExpression:
-                        return emitTemplateExpression(<TemplateExpression>node);
-                    case SyntaxKind.YieldExpression:
-                        return emitYieldExpression(<YieldExpression>node);
-                    case SyntaxKind.SpreadElement:
-                        return emitSpreadExpression(<SpreadElement>node);
-                    case SyntaxKind.ClassExpression:
-                        return emitClassExpression(<ClassExpression>node);
-                    case SyntaxKind.OmittedExpression:
-                        return;
-                    case SyntaxKind.AsExpression:
-                        return emitAsExpression(<AsExpression>node);
-                    case SyntaxKind.NonNullExpression:
-                        return emitNonNullExpression(<NonNullExpression>node);
-                    case SyntaxKind.MetaProperty:
-                        return emitMetaProperty(<MetaProperty>node);
-
-                    // JSX
-                    case SyntaxKind.JsxElement:
-                        return emitJsxElement(<JsxElement>node);
-                    case SyntaxKind.JsxSelfClosingElement:
-                        return emitJsxSelfClosingElement(<JsxSelfClosingElement>node);
-                    case SyntaxKind.JsxFragment:
-                        return emitJsxFragment(<JsxFragment>node);
-
-                    // Transformation nodes
-                    case SyntaxKind.PartiallyEmittedExpression:
-                        return emitPartiallyEmittedExpression(<PartiallyEmittedExpression>node);
-
-                    case SyntaxKind.CommaListExpression:
-                        return emitCommaList(<CommaListExpression>node);
-                }
-            }
+            if (isKeyword(node.kind)) return writeTokenNode(node, writeKeyword);
+            if (isTokenKind(node.kind)) return writeTokenNode(node, writePunctuation);
         }
 
         function emitMappedTypeParameter(node: TypeParameterDeclaration): void {
@@ -1729,13 +1721,6 @@ namespace ts {
             writeKeyword("in");
             writeSpace();
             emit(node.constraint);
-        }
-
-        function pipelineEmitWithSubstitution(hint: EmitHint, node: Node) {
-            Debug.assert(lastNode === node || lastSubstitution === node);
-            const pipelinePhase = getNextPipelinePhase(PipelinePhase.Substitution, hint, node);
-            pipelinePhase(hint, lastSubstitution!);
-            Debug.assert(lastNode === node || lastSubstitution === node);
         }
 
         function getHelpersFromBundledSourceFiles(bundle: Bundle): string[] | undefined {
@@ -1844,6 +1829,10 @@ namespace ts {
             }
         }
 
+        function emitStringLiteralWithJsxAttributeEscape(node: StringLiteral) {
+            emitLiteral(node, /*jsxAttributeEscape*/ true);
+        }
+
         // SyntaxKind.UnparsedSource
         // SyntaxKind.UnparsedPrepend
         function emitUnparsedSourceOrPrepend(unparsed: UnparsedSource | UnparsedPrepend) {
@@ -1917,7 +1906,7 @@ namespace ts {
 
         function emitEntityName(node: EntityName) {
             if (node.kind === SyntaxKind.Identifier) {
-                emitExpression(node);
+                emit(node);
             }
             else {
                 emit(node);
@@ -1926,7 +1915,7 @@ namespace ts {
 
         function emitComputedPropertyName(node: ComputedPropertyName) {
             writePunctuation("[");
-            emitExpression(node.expression);
+            emit(node.expression);
             writePunctuation("]");
         }
 
@@ -1968,7 +1957,7 @@ namespace ts {
 
         function emitDecorator(decorator: Decorator) {
             writePunctuation("@");
-            emitExpression(decorator.expression);
+            emit(decorator.expression);
         }
 
         //
@@ -2261,7 +2250,7 @@ namespace ts {
             }
             writePunctuation("[");
 
-            pipelineEmit(EmitHint.MappedTypeParameter, node.typeParameter);
+            emitWithContext(node.typeParameter, emitMappedTypeParameter);
             if (node.nameType) {
                 writeSpace();
                 writeKeyword("as");
@@ -2291,7 +2280,7 @@ namespace ts {
         }
 
         function emitLiteralType(node: LiteralTypeNode) {
-            emitExpression(node.literal);
+            emit(node.literal);
         }
 
         function emitTemplateType(node: TemplateLiteralTypeNode) {
@@ -2349,7 +2338,7 @@ namespace ts {
         function emitArrayLiteralExpression(node: ArrayLiteralExpression) {
             const elements = node.elements;
             const preferNewLine = node.multiLine ? ListFormat.PreferNewLine : ListFormat.None;
-            emitExpressionList(node, elements, ListFormat.ArrayLiteralExpressionElements | preferNewLine);
+            emitList(node, elements, ListFormat.ArrayLiteralExpressionElements | preferNewLine);
         }
 
         function emitObjectLiteralExpression(node: ObjectLiteralExpression) {
@@ -2370,7 +2359,7 @@ namespace ts {
         }
 
         function emitPropertyAccessExpression(node: PropertyAccessExpression) {
-            const expression = cast(emitExpression(node.expression), isExpression);
+            emit(node.expression);
             const token = node.questionDotToken || setTextRangePosEnd(factory.createToken(SyntaxKind.DotToken) as DotToken, node.expression.end, node.name.pos);
             const linesBeforeDot = getLinesBetweenNodes(node, node.expression, token);
             const linesAfterDot = getLinesBetweenNodes(node, token, node.name);
@@ -2379,7 +2368,7 @@ namespace ts {
 
             const shouldEmitDotDot =
                 token.kind !== SyntaxKind.QuestionDotToken &&
-                mayNeedDotDotForPropertyAccess(expression) &&
+                mayNeedDotDotForPropertyAccess(node.expression) &&
                 !writer.hasTrailingComment() &&
                 !writer.hasTrailingWhitespace();
 
@@ -2419,46 +2408,46 @@ namespace ts {
         }
 
         function emitElementAccessExpression(node: ElementAccessExpression) {
-            emitExpression(node.expression);
+            emit(node.expression);
             emit(node.questionDotToken);
             emitTokenWithComment(SyntaxKind.OpenBracketToken, node.expression.end, writePunctuation, node);
-            emitExpression(node.argumentExpression);
+            emit(node.argumentExpression);
             emitTokenWithComment(SyntaxKind.CloseBracketToken, node.argumentExpression.end, writePunctuation, node);
         }
 
         function emitCallExpression(node: CallExpression) {
-            emitExpression(node.expression);
+            emit(node.expression);
             emit(node.questionDotToken);
             emitTypeArguments(node, node.typeArguments);
-            emitExpressionList(node, node.arguments, ListFormat.CallExpressionArguments);
+            emitList(node, node.arguments, ListFormat.CallExpressionArguments);
         }
 
         function emitNewExpression(node: NewExpression) {
             emitTokenWithComment(SyntaxKind.NewKeyword, node.pos, writeKeyword, node);
             writeSpace();
-            emitExpression(node.expression);
+            emit(node.expression);
             emitTypeArguments(node, node.typeArguments);
-            emitExpressionList(node, node.arguments, ListFormat.NewExpressionArguments);
+            emitList(node, node.arguments, ListFormat.NewExpressionArguments);
         }
 
         function emitTaggedTemplateExpression(node: TaggedTemplateExpression) {
-            emitExpression(node.tag);
+            emit(node.tag);
             emitTypeArguments(node, node.typeArguments);
             writeSpace();
-            emitExpression(node.template);
+            emit(node.template);
         }
 
         function emitTypeAssertionExpression(node: TypeAssertion) {
             writePunctuation("<");
             emit(node.type);
             writePunctuation(">");
-            emitExpression(node.expression);
+            emit(node.expression);
         }
 
         function emitParenthesizedExpression(node: ParenthesizedExpression) {
             const openParenPos = emitTokenWithComment(SyntaxKind.OpenParenToken, node.pos, writePunctuation, node);
             const indented = writeLineSeparatorsAndIndentBefore(node.expression, node);
-            emitExpression(node.expression);
+            emit(node.expression);
             writeLineSeparatorsAfter(node.expression, node);
             decreaseIndentIf(indented);
             emitTokenWithComment(SyntaxKind.CloseParenToken, node.expression ? node.expression.end : openParenPos, writePunctuation, node);
@@ -2486,25 +2475,25 @@ namespace ts {
         function emitDeleteExpression(node: DeleteExpression) {
             emitTokenWithComment(SyntaxKind.DeleteKeyword, node.pos, writeKeyword, node);
             writeSpace();
-            emitExpression(node.expression);
+            emit(node.expression);
         }
 
         function emitTypeOfExpression(node: TypeOfExpression) {
             emitTokenWithComment(SyntaxKind.TypeOfKeyword, node.pos, writeKeyword, node);
             writeSpace();
-            emitExpression(node.expression);
+            emit(node.expression);
         }
 
         function emitVoidExpression(node: VoidExpression) {
             emitTokenWithComment(SyntaxKind.VoidKeyword, node.pos, writeKeyword, node);
             writeSpace();
-            emitExpression(node.expression);
+            emit(node.expression);
         }
 
         function emitAwaitExpression(node: AwaitExpression) {
             emitTokenWithComment(SyntaxKind.AwaitKeyword, node.pos, writeKeyword, node);
             writeSpace();
-            emitExpression(node.expression);
+            emit(node.expression);
         }
 
         function emitPrefixUnaryExpression(node: PrefixUnaryExpression) {
@@ -2512,7 +2501,7 @@ namespace ts {
             if (shouldEmitWhitespaceBeforeOperand(node)) {
                 writeSpace();
             }
-            emitExpression(node.operand);
+            emit(node.operand);
         }
 
         function shouldEmitWhitespaceBeforeOperand(node: PrefixUnaryExpression) {
@@ -2535,14 +2524,8 @@ namespace ts {
         }
 
         function emitPostfixUnaryExpression(node: PostfixUnaryExpression) {
-            emitExpression(node.operand);
+            emit(node.operand);
             writeTokenText(node.operator, writeOperator);
-        }
-
-        const enum EmitBinaryExpressionState {
-            EmitLeft,
-            EmitRight,
-            FinishEmit
         }
 
         /**
@@ -2552,16 +2535,16 @@ namespace ts {
          */
         function emitBinaryExpression(node: BinaryExpression) {
             const nodeStack = [node];
-            const stateStack = [EmitBinaryExpressionState.EmitLeft];
+            const stateStack = [BinaryExpressionState.Left];
             let stackIndex = 0;
             while (stackIndex >= 0) {
                 node = nodeStack[stackIndex];
                 switch (stateStack[stackIndex]) {
-                    case EmitBinaryExpressionState.EmitLeft: {
+                    case BinaryExpressionState.Left: {
                         maybePipelineEmitExpression(node.left);
                         break;
                     }
-                    case EmitBinaryExpressionState.EmitRight: {
+                    case BinaryExpressionState.Right: {
                         const isCommaOperator = node.operatorToken.kind !== SyntaxKind.CommaToken;
                         const linesBeforeOperator = getLinesBetweenNodes(node, node.left, node.operatorToken);
                         const linesAfterOperator = getLinesBetweenNodes(node, node.operatorToken, node.right);
@@ -2573,7 +2556,7 @@ namespace ts {
                         maybePipelineEmitExpression(node.right);
                         break;
                     }
-                    case EmitBinaryExpressionState.FinishEmit: {
+                    case BinaryExpressionState.Finish: {
                         const linesBeforeOperator = getLinesBetweenNodes(node, node.left, node.operatorToken);
                         const linesAfterOperator = getLinesBetweenNodes(node, node.operatorToken, node.right);
                         decreaseIndentIf(linesBeforeOperator, linesAfterOperator);
@@ -2594,27 +2577,16 @@ namespace ts {
                 // binary expression handling, where possible, to the contained work queue
 
                 // #region trampolinePipelineEmit
-                const savedLastNode = lastNode;
-                const savedLastSubstitution = lastSubstitution;
-                lastNode = next;
-                lastSubstitution = undefined;
-
-                const pipelinePhase = getPipelinePhase(PipelinePhase.Notification, EmitHint.Expression, next);
-                if (pipelinePhase === pipelineEmitWithHint && isBinaryExpression(next)) {
+                if (!shouldEmitComments(next) && !shouldEmitSourceMaps(next) && isBinaryExpression(next)) {
                     // If the target pipeline phase is emit directly, and the next node's also a binary expression,
                     // skip all the intermediate indirection and push the expression directly onto the work stack
                     stackIndex++;
-                    stateStack[stackIndex] = EmitBinaryExpressionState.EmitLeft;
+                    stateStack[stackIndex] = BinaryExpressionState.Left;
                     nodeStack[stackIndex] = next;
                 }
                 else {
-                    pipelinePhase(EmitHint.Expression, next);
+                    emit(next);
                 }
-
-                Debug.assert(lastNode === next);
-
-                lastNode = savedLastNode;
-                lastSubstitution = savedLastSubstitution;
                 // #endregion trampolinePipelineEmit
             }
         }
@@ -2625,17 +2597,17 @@ namespace ts {
             const linesBeforeColon = getLinesBetweenNodes(node, node.whenTrue, node.colonToken);
             const linesAfterColon = getLinesBetweenNodes(node, node.colonToken, node.whenFalse);
 
-            emitExpression(node.condition);
+            emit(node.condition);
             writeLinesAndIndent(linesBeforeQuestion, /*writeSpaceIfNotIndenting*/ true);
             emit(node.questionToken);
             writeLinesAndIndent(linesAfterQuestion, /*writeSpaceIfNotIndenting*/ true);
-            emitExpression(node.whenTrue);
+            emit(node.whenTrue);
             decreaseIndentIf(linesBeforeQuestion, linesAfterQuestion);
 
             writeLinesAndIndent(linesBeforeColon, /*writeSpaceIfNotIndenting*/ true);
             emit(node.colonToken);
             writeLinesAndIndent(linesAfterColon, /*writeSpaceIfNotIndenting*/ true);
-            emitExpression(node.whenFalse);
+            emit(node.whenFalse);
             decreaseIndentIf(linesBeforeColon, linesAfterColon);
         }
 
@@ -2652,7 +2624,7 @@ namespace ts {
 
         function emitSpreadExpression(node: SpreadElement) {
             emitTokenWithComment(SyntaxKind.DotDotDotToken, node.pos, writePunctuation, node);
-            emitExpression(node.expression);
+            emit(node.expression);
         }
 
         function emitClassExpression(node: ClassExpression) {
@@ -2661,12 +2633,12 @@ namespace ts {
         }
 
         function emitExpressionWithTypeArguments(node: ExpressionWithTypeArguments) {
-            emitExpression(node.expression);
+            emit(node.expression);
             emitTypeArguments(node, node.typeArguments);
         }
 
         function emitAsExpression(node: AsExpression) {
-            emitExpression(node.expression);
+            emit(node.expression);
             if (node.type) {
                 writeSpace();
                 writeKeyword("as");
@@ -2676,7 +2648,7 @@ namespace ts {
         }
 
         function emitNonNullExpression(node: NonNullExpression) {
-            emitExpression(node.expression);
+            emit(node.expression);
             writeOperator("!");
         }
 
@@ -2691,7 +2663,7 @@ namespace ts {
         //
 
         function emitTemplateSpan(node: TemplateSpan) {
-            emitExpression(node.expression);
+            emit(node.expression);
             emit(node.literal);
         }
 
@@ -2727,9 +2699,12 @@ namespace ts {
             }
         }
 
+        function emitEmbeddedEmptyStatement(_node: EmptyStatement) {
+            emitEmptyStatement(/*isEmbeddedStatement*/ true);
+        }
 
         function emitExpressionStatement(node: ExpressionStatement) {
-            emitExpression(node.expression);
+            emit(node.expression);
             // Emit semicolon in non json files
             // or if json file that created synthesized expression(eg.define expression statement when --out and amd code generation)
             if (!isJsonSourceFile(currentSourceFile!) || nodeIsSynthesized(node.expression)) {
@@ -2741,7 +2716,7 @@ namespace ts {
             const openParenPos = emitTokenWithComment(SyntaxKind.IfKeyword, node.pos, writeKeyword, node);
             writeSpace();
             emitTokenWithComment(SyntaxKind.OpenParenToken, openParenPos, writePunctuation, node);
-            emitExpression(node.expression);
+            emit(node.expression);
             emitTokenWithComment(SyntaxKind.CloseParenToken, node.expression.end, writePunctuation, node);
             emitEmbeddedStatement(node, node.thenStatement);
             if (node.elseStatement) {
@@ -2761,7 +2736,7 @@ namespace ts {
             const openParenPos = emitTokenWithComment(SyntaxKind.WhileKeyword, startPos, writeKeyword, node);
             writeSpace();
             emitTokenWithComment(SyntaxKind.OpenParenToken, openParenPos, writePunctuation, node);
-            emitExpression(node.expression);
+            emit(node.expression);
             emitTokenWithComment(SyntaxKind.CloseParenToken, node.expression.end, writePunctuation, node);
         }
 
@@ -2805,7 +2780,7 @@ namespace ts {
             writeSpace();
             emitTokenWithComment(SyntaxKind.InKeyword, node.initializer.end, writeKeyword, node);
             writeSpace();
-            emitExpression(node.expression);
+            emit(node.expression);
             emitTokenWithComment(SyntaxKind.CloseParenToken, node.expression.end, writePunctuation, node);
             emitEmbeddedStatement(node, node.statement);
         }
@@ -2819,7 +2794,7 @@ namespace ts {
             writeSpace();
             emitTokenWithComment(SyntaxKind.OfKeyword, node.initializer.end, writeKeyword, node);
             writeSpace();
-            emitExpression(node.expression);
+            emit(node.expression);
             emitTokenWithComment(SyntaxKind.CloseParenToken, node.expression.end, writePunctuation, node);
             emitEmbeddedStatement(node, node.statement);
         }
@@ -2830,7 +2805,7 @@ namespace ts {
                     emit(node);
                 }
                 else {
-                    emitExpression(node);
+                    emit(node);
                 }
             }
         }
@@ -2882,7 +2857,7 @@ namespace ts {
             const openParenPos = emitTokenWithComment(SyntaxKind.WithKeyword, node.pos, writeKeyword, node);
             writeSpace();
             emitTokenWithComment(SyntaxKind.OpenParenToken, openParenPos, writePunctuation, node);
-            emitExpression(node.expression);
+            emit(node.expression);
             emitTokenWithComment(SyntaxKind.CloseParenToken, node.expression.end, writePunctuation, node);
             emitEmbeddedStatement(node, node.statement);
         }
@@ -2891,7 +2866,7 @@ namespace ts {
             const openParenPos = emitTokenWithComment(SyntaxKind.SwitchKeyword, node.pos, writeKeyword, node);
             writeSpace();
             emitTokenWithComment(SyntaxKind.OpenParenToken, openParenPos, writePunctuation, node);
-            emitExpression(node.expression);
+            emit(node.expression);
             emitTokenWithComment(SyntaxKind.CloseParenToken, node.expression.end, writePunctuation, node);
             writeSpace();
             emit(node.caseBlock);
@@ -2958,12 +2933,8 @@ namespace ts {
             writeKeyword("function");
             emit(node.asteriskToken);
             writeSpace();
-            emitIdentifierName(node.name);
+            emit(node.name);
             emitSignatureAndBody(node, emitSignatureHead);
-        }
-
-        function emitBlockCallback(_hint: EmitHint, body: Node): void {
-            emitBlockFunctionBody(<Block>body);
         }
 
         function emitSignatureAndBody(node: FunctionLikeDeclaration, emitSignatureHead: (node: SignatureDeclaration) => void) {
@@ -2980,12 +2951,7 @@ namespace ts {
                     generateNames(node.body);
 
                     emitSignatureHead(node);
-                    if (onEmitNode) {
-                        onEmitNode(EmitHint.Unspecified, body, emitBlockCallback);
-                    }
-                    else {
-                        emitBlockFunctionBody(body);
-                    }
+                    emitBlockFunctionBody(body);
                     popNameGenerationScope(node);
 
                     if (indentedFlag) {
@@ -2995,7 +2961,7 @@ namespace ts {
                 else {
                     emitSignatureHead(node);
                     writeSpace();
-                    emitExpression(body);
+                    emit(body);
                 }
             }
             else {
@@ -3050,6 +3016,7 @@ namespace ts {
         }
 
         function emitBlockFunctionBody(body: Block) {
+            onBeforeEmitNode?.(body);
             writeSpace();
             writePunctuation("{");
             increaseIndent();
@@ -3067,6 +3034,7 @@ namespace ts {
 
             decreaseIndent();
             writeToken(SyntaxKind.CloseBraceToken, body.statements.end, writePunctuation, body);
+            onAfterEmitNode?.(body);
         }
 
         function emitBlockFunctionBodyOnSingleLine(body: Block) {
@@ -3100,7 +3068,7 @@ namespace ts {
             writeKeyword("class");
             if (node.name) {
                 writeSpace();
-                emitIdentifierName(node.name);
+                emit(node.name);
             }
 
             const indentedFlag = getEmitFlags(node) & EmitFlags.Indented;
@@ -3212,7 +3180,7 @@ namespace ts {
 
         function emitModuleReference(node: ModuleReference) {
             if (node.kind === SyntaxKind.Identifier) {
-                emitExpression(node);
+                emit(node);
             }
             else {
                 emit(node);
@@ -3229,7 +3197,7 @@ namespace ts {
                 emitTokenWithComment(SyntaxKind.FromKeyword, node.importClause.end, writeKeyword, node);
                 writeSpace();
             }
-            emitExpression(node.moduleSpecifier);
+            emit(node.moduleSpecifier);
             writeTrailingSemicolon();
         }
 
@@ -3272,7 +3240,7 @@ namespace ts {
                 emitTokenWithComment(SyntaxKind.DefaultKeyword, nextPos, writeKeyword, node);
             }
             writeSpace();
-            emitExpression(node.expression);
+            emit(node.expression);
             writeTrailingSemicolon();
         }
 
@@ -3294,7 +3262,7 @@ namespace ts {
                 const fromPos = node.exportClause ? node.exportClause.end : nextPos;
                 emitTokenWithComment(SyntaxKind.FromKeyword, fromPos, writeKeyword, node);
                 writeSpace();
-                emitExpression(node.moduleSpecifier);
+                emit(node.moduleSpecifier);
             }
             writeTrailingSemicolon();
         }
@@ -3350,7 +3318,7 @@ namespace ts {
         function emitExternalModuleReference(node: ExternalModuleReference) {
             writeKeyword("require");
             writePunctuation("(");
-            emitExpression(node.expression);
+            emit(node.expression);
             writePunctuation(")");
         }
 
@@ -3413,6 +3381,11 @@ namespace ts {
             emitList(node, node.properties, ListFormat.JsxElementAttributes);
         }
 
+        function emitJsxAttributeValue(node: StringLiteral | JsxExpression): void {
+            const emitCallback = isStringLiteral(node) ? emitStringLiteralWithJsxAttributeEscape : emitWorker;
+            emitWithContext(node, emitCallback);
+        }
+
         function emitJsxAttribute(node: JsxAttribute) {
             emit(node.name);
             emitNodeWithPrefix("=", writePunctuation, node.initializer, emitJsxAttributeValue);
@@ -3420,7 +3393,7 @@ namespace ts {
 
         function emitJsxSpreadAttribute(node: JsxSpreadAttribute) {
             writePunctuation("{...");
-            emitExpression(node.expression);
+            emit(node.expression);
             writePunctuation("}");
         }
 
@@ -3448,7 +3421,7 @@ namespace ts {
                 }
                 const end = emitTokenWithComment(SyntaxKind.OpenBraceToken, node.pos, writePunctuation, node);
                 emit(node.dotDotDotToken);
-                emitExpression(node.expression);
+                emit(node.expression);
                 emitTokenWithComment(SyntaxKind.CloseBraceToken, node.expression?.end || end, writePunctuation, node);
                 if (isMultiline) {
                     writer.decreaseIndent();
@@ -3458,7 +3431,7 @@ namespace ts {
 
         function emitJsxTagName(node: JsxTagNameExpression) {
             if (node.kind === SyntaxKind.Identifier) {
-                emitExpression(node);
+                emit(node);
             }
             else {
                 emit(node);
@@ -3472,7 +3445,7 @@ namespace ts {
         function emitCaseClause(node: CaseClause) {
             emitTokenWithComment(SyntaxKind.CaseKeyword, node.pos, writeKeyword, node);
             writeSpace();
-            emitExpression(node.expression);
+            emit(node.expression);
 
             emitCaseOrDefaultClauseRest(node, node.statements, node.expression.end);
         }
@@ -3543,7 +3516,7 @@ namespace ts {
                 const commentRange = getCommentRange(initializer);
                 emitTrailingCommentsOfPosition(commentRange.pos);
             }
-            emitExpression(initializer);
+            emit(initializer);
         }
 
         function emitShorthandPropertyAssignment(node: ShorthandPropertyAssignment) {
@@ -3552,14 +3525,14 @@ namespace ts {
                 writeSpace();
                 writePunctuation("=");
                 writeSpace();
-                emitExpression(node.objectAssignmentInitializer);
+                emit(node.objectAssignmentInitializer);
             }
         }
 
         function emitSpreadAssignment(node: SpreadAssignment) {
             if (node.expression) {
                 emitTokenWithComment(SyntaxKind.DotDotDotToken, node.pos, writePunctuation, node);
-                emitExpression(node.expression);
+                emit(node.expression);
             }
         }
 
@@ -3826,11 +3799,11 @@ namespace ts {
         // Transformation nodes
 
         function emitPartiallyEmittedExpression(node: PartiallyEmittedExpression) {
-            emitExpression(node.expression);
+            emit(node.expression);
         }
 
         function emitCommaList(node: CommaListExpression) {
-            emitExpressionList(node, node.elements, ListFormat.CommaListElements);
+            emitList(node, node.elements, ListFormat.CommaListElements);
         }
 
         /**
@@ -3980,7 +3953,7 @@ namespace ts {
                 writeSpace();
                 emitTokenWithComment(SyntaxKind.EqualsToken, equalCommentStartPos, writeOperator, container);
                 writeSpace();
-                emitExpression(node);
+                emit(node);
             }
         }
 
@@ -4001,7 +3974,7 @@ namespace ts {
         function emitExpressionWithLeadingSpace(node: Expression | undefined) {
             if (node) {
                 writeSpace();
-                emitExpression(node);
+                emit(node);
             }
         }
 
@@ -4021,7 +3994,7 @@ namespace ts {
                 writeLine();
                 increaseIndent();
                 if (isEmptyStatement(node)) {
-                    pipelineEmit(EmitHint.EmbeddedStatement, node);
+                    emitWithContext(node, emitEmbeddedEmptyStatement);
                 }
                 else {
                     emit(node);
@@ -4080,14 +4053,6 @@ namespace ts {
             emitList(parentNode, parameters, ListFormat.IndexSignatureParameters);
         }
 
-        function emitList(parentNode: TextRange, children: NodeArray<Node> | undefined, format: ListFormat, start?: number, count?: number) {
-            emitNodeList(emit, parentNode, children, format, start, count);
-        }
-
-        function emitExpressionList(parentNode: TextRange, children: NodeArray<Node> | undefined, format: ListFormat, start?: number, count?: number) {
-            emitNodeList(emitExpression as (node: Node) => void, parentNode, children, format, start, count); // TODO: GH#18217
-        }
-
         function writeDelimiter(format: ListFormat) {
             switch (format & ListFormat.DelimitersMask) {
                 case ListFormat.None:
@@ -4111,7 +4076,7 @@ namespace ts {
             }
         }
 
-        function emitNodeList(emit: (node: Node) => void, parentNode: TextRange, children: NodeArray<Node> | undefined, format: ListFormat, start = 0, count = children ? children.length - start : 0) {
+        function emitList(parentNode: Node | undefined, children: NodeArray<Node> | undefined, format: ListFormat, start = 0, count = children ? children.length - start : 0) {
             const isUndefined = children === undefined;
             if (isUndefined && format & ListFormat.OptionalIfUndefined) {
                 return;
@@ -4130,9 +4095,8 @@ namespace ts {
 
             if (format & ListFormat.BracketsMask) {
                 writePunctuation(getOpeningBracket(format));
-                if (isEmpty && !isUndefined) {
-                    // TODO: GH#18217
-                    emitTrailingCommentsOfPosition(children!.pos, /*prefixSpace*/ true); // Emit comments within empty bracketed lists
+                if (isEmpty && children) {
+                    emitTrailingCommentsOfPosition(children.pos, /*prefixSpace*/ true); // Emit comments within empty bracketed lists
                 }
             }
 
@@ -4142,7 +4106,7 @@ namespace ts {
 
             if (isEmpty) {
                 // Write a line terminator if the parent node was multi-line
-                if (format & ListFormat.MultiLine && !(preserveSourceNewlines && rangeIsOnSingleLine(parentNode, currentSourceFile!))) {
+                if (format & ListFormat.MultiLine && !(preserveSourceNewlines && (!parentNode || rangeIsOnSingleLine(parentNode, currentSourceFile!)))) {
                     writeLine();
                 }
                 else if (format & ListFormat.SpaceBetweenBraces && !(format & ListFormat.NoSpaceIfEmpty)) {
@@ -4150,10 +4114,11 @@ namespace ts {
                 }
             }
             else {
+                Debug.type<NodeArray<Node>>(children);
                 // Write the opening line terminator or leading whitespace.
                 const mayEmitInterveningComments = (format & ListFormat.NoInterveningComments) === 0;
                 let shouldEmitInterveningComments = mayEmitInterveningComments;
-                const leadingLineTerminatorCount = getLeadingLineTerminatorCount(parentNode, children!, format); // TODO: GH#18217
+                const leadingLineTerminatorCount = getLeadingLineTerminatorCount(parentNode, children, format); // TODO: GH#18217
                 if (leadingLineTerminatorCount) {
                     writeLine(leadingLineTerminatorCount);
                     shouldEmitInterveningComments = false;
@@ -4172,7 +4137,7 @@ namespace ts {
                 let previousSourceFileTextKind: ReturnType<typeof recordBundleFileInternalSectionStart>;
                 let shouldDecreaseIndentAfterEmit = false;
                 for (let i = 0; i < count; i++) {
-                    const child = children![start + i];
+                    const child = children[start + i];
 
                     // Write the delimiter if this is not the first node.
                     if (format & ListFormat.AsteriskDelimited) {
@@ -4187,7 +4152,7 @@ namespace ts {
                         //          a
                         //          /* End of parameter a */ -> this comment isn't considered to be trailing comment of parameter "a" due to newline
                         //          ,
-                        if (format & ListFormat.DelimitersMask && previousSibling.end !== parentNode.end) {
+                        if (format & ListFormat.DelimitersMask && previousSibling.end !== (parentNode ? parentNode.end : -1)) {
                             emitLeadingCommentsOfPosition(previousSibling.end);
                         }
                         writeDelimiter(format);
@@ -4253,7 +4218,7 @@ namespace ts {
                 //          2
                 //          /* end of element 2 */
                 //       ];
-                if (previousSibling && parentNode.end !== previousSibling.end && (format & ListFormat.DelimitersMask) && !skipTrailingComments) {
+                if (previousSibling && (parentNode ? parentNode.end : -1) !== previousSibling.end && (format & ListFormat.DelimitersMask) && !skipTrailingComments) {
                     emitLeadingCommentsOfPosition(hasTrailingComma && children?.end ? children.end : previousSibling.end);
                 }
 
@@ -4265,7 +4230,7 @@ namespace ts {
                 recordBundleFileInternalSectionEnd(previousSourceFileTextKind);
 
                 // Write the closing line terminator or closing whitespace.
-                const closingLineTerminatorCount = getClosingLineTerminatorCount(parentNode, children!, format);
+                const closingLineTerminatorCount = getClosingLineTerminatorCount(parentNode, children, format);
                 if (closingLineTerminatorCount) {
                     writeLine(closingLineTerminatorCount);
                 }
@@ -4279,9 +4244,8 @@ namespace ts {
             }
 
             if (format & ListFormat.BracketsMask) {
-                if (isEmpty && !isUndefined) {
-                    // TODO: GH#18217
-                    emitLeadingCommentsOfPosition(children!.end); // Emit leading comments within empty lists
+                if (isEmpty && children) {
+                    emitLeadingCommentsOfPosition(children.end); // Emit leading comments within empty lists
                 }
                 writePunctuation(getClosingBracket(format));
             }
@@ -4428,7 +4392,7 @@ namespace ts {
             }
         }
 
-        function getLeadingLineTerminatorCount(parentNode: TextRange, children: readonly Node[], format: ListFormat): number {
+        function getLeadingLineTerminatorCount(parentNode: Node | undefined, children: readonly Node[], format: ListFormat): number {
             if (format & ListFormat.PreserveLines || preserveSourceNewlines) {
                 if (format & ListFormat.PreferNewLine) {
                     return 1;
@@ -4436,7 +4400,7 @@ namespace ts {
 
                 const firstChild = children[0];
                 if (firstChild === undefined) {
-                    return rangeIsOnSingleLine(parentNode, currentSourceFile!) ? 0 : 1;
+                    return !parentNode || rangeIsOnSingleLine(parentNode, currentSourceFile!) ? 0 : 1;
                 }
                 if (firstChild.pos === nextListElementPos) {
                     // If this child starts at the beginning of a list item in a parent list, its leading
@@ -4460,9 +4424,10 @@ namespace ts {
                     // JsxText will be written with its leading whitespace, so don't add more manually.
                     return 0;
                 }
-                if (!positionIsSynthesized(parentNode.pos) &&
+                if (parentNode &&
+                    !positionIsSynthesized(parentNode.pos) &&
                     !nodeIsSynthesized(firstChild) &&
-                    (!firstChild.parent || getOriginalNode(firstChild.parent) === getOriginalNode(parentNode as Node))
+                    (!firstChild.parent || getOriginalNode(firstChild.parent) === getOriginalNode(parentNode))
                 ) {
                     if (preserveSourceNewlines) {
                         return getEffectiveLines(
@@ -4490,8 +4455,8 @@ namespace ts {
                     // JsxText will be written with its leading whitespace, so don't add more manually.
                     return 0;
                 }
-                else if (!nodeIsSynthesized(previousNode) && !nodeIsSynthesized(nextNode) && previousNode.parent === nextNode.parent) {
-                    if (preserveSourceNewlines) {
+                else if (!nodeIsSynthesized(previousNode) && !nodeIsSynthesized(nextNode) && (!previousNode.parent || !nextNode.parent || previousNode.parent === nextNode.parent)) {
+                    if (preserveSourceNewlines && previousNode.parent && nextNode.parent) {
                         return getEffectiveLines(
                             includeComments => getLinesBetweenRangeEndAndRangeStart(
                                 previousNode,
@@ -4511,7 +4476,7 @@ namespace ts {
             return format & ListFormat.MultiLine ? 1 : 0;
         }
 
-        function getClosingLineTerminatorCount(parentNode: TextRange, children: readonly Node[], format: ListFormat): number {
+        function getClosingLineTerminatorCount(parentNode: Node | undefined, children: readonly Node[], format: ListFormat): number {
             if (format & ListFormat.PreserveLines || preserveSourceNewlines) {
                 if (format & ListFormat.PreferNewLine) {
                     return 1;
@@ -4519,9 +4484,9 @@ namespace ts {
 
                 const lastChild = lastOrUndefined(children);
                 if (lastChild === undefined) {
-                    return rangeIsOnSingleLine(parentNode, currentSourceFile!) ? 0 : 1;
+                    return !parentNode || rangeIsOnSingleLine(parentNode, currentSourceFile!) ? 0 : 1;
                 }
-                if (!positionIsSynthesized(parentNode.pos) && !nodeIsSynthesized(lastChild) && (!lastChild.parent || lastChild.parent === parentNode)) {
+                if (parentNode && !positionIsSynthesized(parentNode.pos) && !nodeIsSynthesized(lastChild) && (!lastChild.parent || lastChild.parent === parentNode)) {
                     if (preserveSourceNewlines) {
                         const end = isNodeArray(children) && !positionIsSynthesized(children.end) ? children.end : lastChild.end;
                         return getEffectiveLines(
@@ -5072,13 +5037,9 @@ namespace ts {
 
         // Comments
 
-        function pipelineEmitWithComments(hint: EmitHint, node: Node) {
-            Debug.assert(lastNode === node || lastSubstitution === node);
+        function emitLeadingCommentsOfNode(node: Node, emitFlags: EmitFlags, pos: number, end: number) {
             enterComment();
             hasWrittenComment = false;
-            const emitFlags = getEmitFlags(node);
-            const { pos, end } = getCommentRange(node);
-            const isEmittedNode = node.kind !== SyntaxKind.NotEmittedStatement;
 
             // We have to explicitly check that the node is JsxText because if the compilerOptions.jsx is "preserve" we will not do any transformation.
             // It is expensive to walk entire tree just to set one kind of node to have no comments.
@@ -5086,14 +5047,11 @@ namespace ts {
             const skipTrailingComments = end < 0 || (emitFlags & EmitFlags.NoTrailingComments) !== 0 || node.kind === SyntaxKind.JsxText;
 
             // Save current container state on the stack.
-            const savedContainerPos = containerPos;
-            const savedContainerEnd = containerEnd;
-            const savedDeclarationListContainerEnd = declarationListContainerEnd;
             if ((pos > 0 || end > 0) && pos !== end) {
                 // Emit leading comments if the position is not synthesized and the node
                 // has not opted out from emitting leading comments.
                 if (!skipLeadingComments) {
-                    emitLeadingComments(pos, isEmittedNode);
+                    emitLeadingComments(pos, /*isEmittedNode*/ node.kind !== SyntaxKind.NotEmittedStatement);
                 }
 
                 if (!skipLeadingComments || (pos >= 0 && (emitFlags & EmitFlags.NoLeadingComments) !== 0)) {
@@ -5114,18 +5072,11 @@ namespace ts {
             }
             forEach(getSyntheticLeadingComments(node), emitLeadingSynthesizedComment);
             exitComment();
+        }
 
-            const pipelinePhase = getNextPipelinePhase(PipelinePhase.Comments, hint, node);
-            if (emitFlags & EmitFlags.NoNestedComments) {
-                commentsDisabled = true;
-                pipelinePhase(hint, node);
-                commentsDisabled = false;
-            }
-            else {
-                pipelinePhase(hint, node);
-            }
-
+        function emitTrailingCommentsOfNode(node: Node, emitFlags: EmitFlags, pos: number, end: number, savedContainerPos: number, savedContainerEnd: number, savedDeclarationListContainerEnd: number) {
             enterComment();
+            const skipTrailingComments = end < 0 || (emitFlags & EmitFlags.NoTrailingComments) !== 0 || node.kind === SyntaxKind.JsxText;
             forEach(getSyntheticTrailingComments(node), emitTrailingSynthesizedComment);
             if ((pos > 0 || end > 0) && pos !== end) {
                 // Restore previous container state.
@@ -5135,12 +5086,11 @@ namespace ts {
 
                 // Emit trailing comments if the position is not synthesized and the node
                 // has not opted out from emitting leading comments and is an emitted node.
-                if (!skipTrailingComments && isEmittedNode) {
+                if (!skipTrailingComments && node.kind !== SyntaxKind.NotEmittedStatement) {
                     emitTrailingComments(end);
                 }
             }
             exitComment();
-            Debug.assert(lastNode === node || lastSubstitution === node);
         }
 
         function emitLeadingSynthesizedComment(comment: SynthesizedComment) {
@@ -5409,53 +5359,6 @@ namespace ts {
             return node.parsedSourceMap || undefined;
         }
 
-        function pipelineEmitWithSourceMap(hint: EmitHint, node: Node) {
-            Debug.assert(lastNode === node || lastSubstitution === node);
-            const pipelinePhase = getNextPipelinePhase(PipelinePhase.SourceMaps, hint, node);
-            if (isUnparsedSource(node) || isUnparsedPrepend(node)) {
-                pipelinePhase(hint, node);
-            }
-            else if (isUnparsedNode(node)) {
-                const parsed = getParsedSourceMap(node.parent);
-                if (parsed && sourceMapGenerator) {
-                    sourceMapGenerator.appendSourceMap(
-                        writer.getLine(),
-                        writer.getColumn(),
-                        parsed,
-                        node.parent.sourceMapPath!,
-                        node.parent.getLineAndCharacterOfPosition(node.pos),
-                        node.parent.getLineAndCharacterOfPosition(node.end)
-                    );
-                }
-                pipelinePhase(hint, node);
-            }
-            else {
-                const { pos, end, source = sourceMapSource } = getSourceMapRange(node);
-                const emitFlags = getEmitFlags(node);
-                if (node.kind !== SyntaxKind.NotEmittedStatement
-                    && (emitFlags & EmitFlags.NoLeadingSourceMap) === 0
-                    && pos >= 0) {
-                    emitSourcePos(source, skipSourceTrivia(source, pos));
-                }
-
-                if (emitFlags & EmitFlags.NoNestedSourceMaps) {
-                    sourceMapsDisabled = true;
-                    pipelinePhase(hint, node);
-                    sourceMapsDisabled = false;
-                }
-                else {
-                    pipelinePhase(hint, node);
-                }
-
-                if (node.kind !== SyntaxKind.NotEmittedStatement
-                    && (emitFlags & EmitFlags.NoTrailingSourceMap) === 0
-                    && end >= 0) {
-                    emitSourcePos(source, end);
-                }
-            }
-            Debug.assert(lastNode === node || lastSubstitution === node);
-        }
-
         /**
          * Skips trivia such as comments and white-space that can be optionally overridden by the source-map source
          */
@@ -5567,6 +5470,1239 @@ namespace ts {
         function isJsonSourceMapSource(sourceFile: SourceMapSource) {
             return fileExtensionIs(sourceFile.fileName, Extension.Json);
         }
+    }
+
+    const enum PreprintPipelinePhase {
+        Notification,
+        Substitution,
+        Visit
+    }
+
+    function createPreprinter(handlers: PrintHandlers) {
+        const {
+            substituteNode = noEmitSubstitution,
+            onEmitNode = noEmitNotification,
+            isEmitNotificationEnabled
+        } = handlers;
+
+        let pipelineResult: Node | undefined;
+
+        // Outer visitors
+        //
+        //   These visitors are invoked by inner visitors to re-enter the pipeline
+        //   for notification and substitution.
+
+        const visit = makeVisitor(pipelineVisitorForUnspecified);
+        const visitSourceFile = makeVisitor(pipelineVisitorForSourceFile, isSourceFile);
+        const visitIdentifierName = makeVisitor(pipelineVisitorForIdentifierName, isIdentifier);
+        const visitModuleName = makeVisitor(pipelineVisitorForIdentifierNameOrUnspecified, isModuleName);
+        const visitPropertyName = makeVisitor(pipelineVisitorForIdentifierNameOrUnspecified, isPropertyName);
+        const visitMemberName = makeVisitor(pipelineVisitorForIdentifierNameOrUnspecified, isMemberName);
+        const visitBindingName = makeVisitor(pipelineVisitorForIdentifierNameOrUnspecified, isBindingName);
+        const visitEntityName = makeVisitor(pipelineVisitorForIdentifierReferenceOrUnspecified, isEntityName);
+        const visitExpression = makeVisitor(pipelineVisitorForExpression, isExpression);
+        const visitForInitializer = makeVisitor(pipelineVisitorForForInitializer, isForInitializer);
+        const visitTypeNode = makeVisitor(pipelineVisitorForUnspecified, isTypeNode);
+        const visitEmbeddedStatement = makeVisitor(pipelineVisitorForEmbeddedStatement, isStatement, factory.liftToBlock);
+        const visitJsxAttributeValue = makeVisitor(pipelineVisitorForJsxAttributeValue, isStringLiteralOrJsxExpression);
+        const visitMappedTypeParameter = makeVisitor(pipelineVisitorForMappedTypeParameter, isTypeParameterDeclaration);
+        const visitConciseBody = makeVisitor(pipelineVisitorForConciseBody, isConciseBody);
+        const visitFunctionBody = makeVisitor(pipelineVisitorForUnspecified, isFunctionBody);
+        const visitList = makeListVisitor(pipelineVisitorForUnspecified);
+        const visitTypeNodeList = makeListVisitor(pipelineVisitorForUnspecified, isTypeNode);
+        const visitExpressionList = makeListVisitor(pipelineVisitorForExpression, isExpression);
+        const visitParameterList = makeListVisitor(pipelineVisitorForUnspecified, isParameter);
+
+        function makeVisitor<T extends Node>(outerVisitor: (node: Node) => Node | undefined, defaultTest?: (node: Node) => node is T, lift?: (nodes: readonly Node[]) => Node) {
+            function visit<U extends T>(node: T, test: (node: Node) => node is U): U;
+            function visit<U extends T>(node: T | undefined, test: (node: Node) => node is U): U | undefined;
+            function visit(node: T, test?: (node: Node) => node is T): T;
+            function visit(node: T | undefined, test?: (node: Node) => node is T): T | undefined;
+            function visit(node: Node | undefined, test?: (node: Node) => node is T): Node | undefined {
+                return visitNode(node, outerVisitor, test || defaultTest, lift);
+            }
+            return visit;
+        }
+
+        function makeListVisitor<T extends Node>(outerVisitor: (node: Node) => Node | undefined, defaultTest?: (node: Node) => node is T) {
+            function visitList<U extends T>(nodes: NodeArray<T>, test: (node: Node) => node is U): NodeArray<U>;
+            function visitList<U extends T>(nodes: NodeArray<T> | undefined, test: (node: Node) => node is U): NodeArray<U> | undefined;
+            function visitList(nodes: NodeArray<T>, test?: (node: Node) => boolean): NodeArray<T>;
+            function visitList(nodes: NodeArray<T> | undefined, test?: (node: Node) => boolean): NodeArray<T> | undefined;
+            function visitList(nodes: NodeArray<T> | undefined, test: (node: Node) => boolean = defaultTest || returnTrue): NodeArray<T> | undefined {
+                return visitNodes(nodes, outerVisitor, test);
+            }
+            return visitList;
+        }
+
+        // Pipeline Visitors
+        //
+        //   These visitors execute our existing pipeline logic for notification and substitution,
+        //   but adapted to our visitor pattern. In some cases, we refine the `EmitHint` we pass
+        //   to the `onEmitNode` and `substituteNode` APIs to ensure they receive the appropriate
+        //   context.
+        //
+        //   For example, the ConciseBody of an arrow function could be an Identifier, in which
+        //   case we would want to use `EmitHint.Expression` to ensure we treat the identifier
+        //   as an expression during substitution.
+
+        function pipelineVisitorForSourceFile(node: SourceFile) { return pipelineVisitorWorker(EmitHint.SourceFile, node); }
+        function pipelineVisitorForExpression(node: Expression) { return pipelineVisitorWorker(EmitHint.Expression, node); }
+        function pipelineVisitorForIdentifierName(node: Identifier) { return pipelineVisitorWorker(EmitHint.IdentifierName, node); }
+        function pipelineVisitorForIdentifierNameOrUnspecified(node: Node) { return pipelineVisitorWorker(isIdentifier(node) ? EmitHint.IdentifierName : EmitHint.Unspecified, node); }
+        function pipelineVisitorForIdentifierReferenceOrUnspecified(node: Node) { return pipelineVisitorWorker(isIdentifier(node) ? EmitHint.Expression : EmitHint.Unspecified, node); }
+        function pipelineVisitorForForInitializer(node: ForInitializer) { return pipelineVisitorWorker(isVariableDeclarationList(node) ? EmitHint.Unspecified : EmitHint.Expression, node); }
+        function pipelineVisitorForMappedTypeParameter(node: TypeParameterDeclaration) { return pipelineVisitorWorker(EmitHint.MappedTypeParameter, node); }
+        function pipelineVisitorForEmbeddedStatement(node: Statement) { return pipelineVisitorWorker(isEmptyStatement(node) ? EmitHint.EmbeddedStatement : EmitHint.Unspecified, node); }
+        function pipelineVisitorForJsxAttributeValue(node: StringLiteral | JsxExpression) { return pipelineVisitorWorker(isStringLiteral(node) ? EmitHint.JsxAttributeValue : EmitHint.Unspecified, node); }
+        function pipelineVisitorForConciseBody(node: ConciseBody) { return pipelineVisitorWorker(isBlock(node) ? EmitHint.Unspecified : EmitHint.Expression, node); }
+        function pipelineVisitorForUnspecified(node: Node) { return pipelineVisitorWorker(EmitHint.Unspecified, node); }
+
+        /**
+         * Adapts the emit pipeline API to work with the visitor API
+         */
+        function pipelineVisitorWorker(hint: EmitHint, node: Node) {
+            resetPipelineResult();
+            // Get the first supported pipeline phase for this node and evaluate it. We can skip several stack
+            // frames if we aren't doing emit notification, so we check for substitution and direct callbacks
+            // and execute those immediately.
+            const pipelinePhase = getPipelinePhase(PreprintPipelinePhase.Notification, node);
+            if (pipelinePhase === pipelineVisitDirect) {
+                return visitor(hint, node);
+            }
+
+            if (pipelinePhase === pipelineVisitWithSubstitution) {
+                // The next phase after substitution is always direct visitation, so we can reduce the call stack
+                // depth by calling the visitor directly.
+                return visitor(hint, substituteNode(hint, node));
+            }
+
+            pipelinePhase(hint, node);
+            Debug.assertIsDefined(pipelineResult);
+            const result = pipelineResult;
+            resetPipelineResult();
+            return result;
+        }
+
+        function resetPipelineResult() {
+            pipelineResult = undefined;
+        }
+
+        /**
+         * Gets the pipeline callback to pass to the relevant API (i.e., `substituteNode` or `onEmitNode`)
+         */
+        function getPipelinePhase(phase: PreprintPipelinePhase, node: Node) {
+            switch (phase) {
+                case PreprintPipelinePhase.Notification:
+                    if (onEmitNode !== noEmitNotification && (!isEmitNotificationEnabled || isEmitNotificationEnabled(node))) {
+                        return pipelineVisitWithNotification;
+                    }
+                    // falls through
+                case PreprintPipelinePhase.Substitution:
+                    if (substituteNode !== noEmitSubstitution) {
+                        return pipelineVisitWithSubstitution;
+                    }
+                    // falls through
+                default:
+                    return pipelineVisitDirect;
+            }
+        }
+
+        /**
+         * A callback that can be evaluated to trigger emit notification as part of the emit pipeline.
+         */
+        function pipelineVisitWithNotification(hint: EmitHint, node: Node) {
+            onEmitNode(hint, node, getPipelinePhase(PreprintPipelinePhase.Substitution, node));
+        }
+
+        /**
+         * A callback that can be evaluated to trigger JIT substitution as part of the emit pipeline.
+         */
+        function pipelineVisitWithSubstitution(hint: EmitHint, node: Node) {
+            // Next phase is always direct visitation, so we can reduce the call stack
+            // depth by calling the visitor directly.
+            pipelineResult = visitor(hint, substituteNode(hint, node));
+        }
+
+        /**
+         * A callback that can be evaluated to visit the subtree of a node.
+         */
+        function pipelineVisitDirect(hint: EmitHint, node: Node) {
+            pipelineResult = visitor(hint, node);
+        }
+
+        /**
+         * Re-enters the visitor pattern from the pipeline pattern to perform
+         * tree updates and trigger parenthesization rules.
+         */
+        function visitor(hint: EmitHint, node: Node): Node {
+            // This should align with the assertions in `pipelineEmitWithHint`.
+            if (hint === EmitHint.SourceFile) return preprintSourceFile(cast(node, isSourceFile));
+            if (hint === EmitHint.IdentifierName) return preprintIdentifier(cast(node, isIdentifier));
+            if (hint === EmitHint.JsxAttributeValue) return cast(node, isStringLiteral);
+            if (hint === EmitHint.MappedTypeParameter) return preprintTypeParameterDeclaration(cast(node, isTypeParameterDeclaration));
+            if (hint === EmitHint.EmbeddedStatement) return cast(node, isEmptyStatement);
+
+            const kind = node.kind;
+            // No need to visit nodes without children.
+            if ((kind > SyntaxKind.FirstToken && kind <= SyntaxKind.LastToken) || kind === SyntaxKind.ThisType) {
+                return node;
+            }
+
+            if (hint === EmitHint.Unspecified) {
+                if (isKeyword(node.kind)) return node;
+
+                switch (node.kind) {
+                    // Identifiers
+                    case SyntaxKind.Identifier:
+                        return preprintIdentifier(node as Identifier);
+
+                    // Names
+                    case SyntaxKind.QualifiedName:
+                        Debug.type<QualifiedName>(node);
+                        return factory.updateQualifiedName(node,
+                            visitEntityName(node.left),
+                            visitIdentifierName(node.right));
+
+                    case SyntaxKind.ComputedPropertyName:
+                        Debug.type<ComputedPropertyName>(node);
+                        return factory.updateComputedPropertyName(node,
+                            visitExpression(node.expression));
+
+                    // Signature elements
+                    case SyntaxKind.TypeParameter:
+                        return preprintTypeParameterDeclaration(node as TypeParameterDeclaration);
+
+                    case SyntaxKind.Parameter:
+                        Debug.type<ParameterDeclaration>(node);
+                        return factory.updateParameterDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visit(node.dotDotDotToken, isDotDotDotToken),
+                            visitBindingName(node.name),
+                            visit(node.questionToken, isQuestionToken),
+                            visitTypeNode(node.type),
+                            visitExpression(node.initializer));
+
+                    case SyntaxKind.Decorator:
+                        Debug.type<Decorator>(node);
+                        return factory.updateDecorator(node,
+                            visitExpression(node.expression));
+
+                    // Type members
+                    case SyntaxKind.PropertySignature:
+                        Debug.type<PropertySignature>(node);
+                        return factory.updatePropertySignature(node,
+                            visitList(node.modifiers, isModifier),
+                            visitPropertyName(node.name),
+                            visit(node.questionToken, isQuestionToken),
+                            visitTypeNode(node.type));
+
+                    case SyntaxKind.PropertyDeclaration:
+                        Debug.type<PropertyDeclaration>(node);
+                        return factory.updatePropertyDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visitPropertyName(node.name),
+                            visit(node.questionToken || node.exclamationToken, isQuestionOrExclamationToken),
+                            visitTypeNode(node.type),
+                            visitExpression(node.initializer));
+
+                    case SyntaxKind.MethodSignature:
+                        Debug.type<MethodSignature>(node);
+                        return factory.updateMethodSignature(node,
+                            visitList(node.modifiers, isModifier),
+                            visitPropertyName(node.name),
+                            visit(node.questionToken, isQuestionToken),
+                            visitList(node.typeParameters, isTypeParameterDeclaration),
+                            visitParameterList(node.parameters),
+                            visitTypeNode(node.type));
+
+                    case SyntaxKind.MethodDeclaration:
+                        Debug.type<MethodDeclaration>(node);
+                        return factory.updateMethodDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visit(node.asteriskToken, isAsteriskToken),
+                            visitPropertyName(node.name),
+                            visit(node.questionToken, isQuestionToken),
+                            visitList(node.typeParameters, isTypeParameterDeclaration),
+                            visitParameterList(node.parameters),
+                            visitTypeNode(node.type),
+                            visitFunctionBody(node.body));
+
+                    case SyntaxKind.Constructor:
+                        Debug.type<ConstructorDeclaration>(node);
+                        return factory.updateConstructorDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visitParameterList(node.parameters),
+                            visitFunctionBody(node.body));
+
+                    case SyntaxKind.GetAccessor:
+                        Debug.type<GetAccessorDeclaration>(node);
+                        return factory.updateGetAccessorDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visitPropertyName(node.name),
+                            visitParameterList(node.parameters),
+                            visitTypeNode(node.type),
+                            visitFunctionBody(node.body));
+
+                    case SyntaxKind.SetAccessor:
+                        Debug.type<SetAccessorDeclaration>(node);
+                        return factory.updateSetAccessorDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visitPropertyName(node.name),
+                            visitParameterList(node.parameters),
+                            visitFunctionBody(node.body));
+
+                    case SyntaxKind.CallSignature:
+                        Debug.type<CallSignatureDeclaration>(node);
+                        return factory.updateCallSignature(node,
+                            visitList(node.typeParameters, isTypeParameterDeclaration),
+                            visitParameterList(node.parameters),
+                            visitTypeNode(node.type));
+
+                    case SyntaxKind.ConstructSignature:
+                        Debug.type<ConstructSignatureDeclaration>(node);
+                        return factory.updateConstructSignature(node,
+                            visitList(node.typeParameters, isTypeParameterDeclaration),
+                            visitParameterList(node.parameters),
+                            visitTypeNode(node.type));
+
+                    case SyntaxKind.IndexSignature:
+                        Debug.type<IndexSignatureDeclaration>(node);
+                        return factory.updateIndexSignature(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visitParameterList(node.parameters),
+                            visitTypeNode(node.type));
+
+                    // Types
+                    case SyntaxKind.TypePredicate:
+                        Debug.type<TypePredicateNode>(node);
+                        return factory.updateTypePredicateNode(node,
+                            visit(node.assertsModifier, isAssertsKeyword),
+                            visit(node.parameterName, isIdentifierOrThisTypeNode),
+                            visitTypeNode(node.type));
+
+                    case SyntaxKind.TypeReference:
+                        Debug.type<TypeReferenceNode>(node);
+                        return factory.updateTypeReferenceNode(node,
+                            visitEntityName(node.typeName),
+                            visitTypeNodeList(node.typeArguments));
+
+                    case SyntaxKind.FunctionType:
+                        Debug.type<FunctionTypeNode>(node);
+                        return factory.updateFunctionTypeNode(node,
+                            visitList(node.typeParameters, isTypeParameterDeclaration),
+                            visitNodes(node.parameters, pipelineVisitorForUnspecified, isParameterDeclaration),
+                            visitTypeNode(node.type));
+
+                    case SyntaxKind.ConstructorType:
+                        Debug.type<ConstructorTypeNode>(node);
+                        return factory.updateConstructorTypeNode(node,
+                            visitNodes(node.modifiers, pipelineVisitorForUnspecified, isModifier),
+                            visitList(node.typeParameters, isTypeParameterDeclaration),
+                            visitParameterList(node.parameters),
+                            visitTypeNode(node.type));
+
+                    case SyntaxKind.TypeQuery:
+                        Debug.type<TypeQueryNode>(node);
+                        return factory.updateTypeQueryNode(node,
+                            visitEntityName(node.exprName));
+
+                    case SyntaxKind.TypeLiteral:
+                        Debug.type<TypeLiteralNode>(node);
+                        return factory.updateTypeLiteralNode(node,
+                            visitList(node.members, isTypeElement));
+
+                    case SyntaxKind.ArrayType:
+                        Debug.type<ArrayTypeNode>(node);
+                        return factory.updateArrayTypeNode(node,
+                            visitTypeNode(node.elementType));
+
+                    case SyntaxKind.TupleType:
+                        Debug.type<TupleTypeNode>(node);
+                        return factory.updateTupleTypeNode(node,
+                            visitTypeNodeList(node.elements));
+
+                    case SyntaxKind.OptionalType:
+                        Debug.type<OptionalTypeNode>(node);
+                        return factory.updateOptionalTypeNode(node,
+                            visitTypeNode(node.type));
+
+                    case SyntaxKind.RestType:
+                        Debug.type<RestTypeNode>(node);
+                        return factory.updateRestTypeNode(node,
+                            visitTypeNode(node.type));
+
+                    case SyntaxKind.UnionType:
+                        Debug.type<UnionTypeNode>(node);
+                        return factory.updateUnionTypeNode(node,
+                            visitTypeNodeList(node.types));
+
+                    case SyntaxKind.IntersectionType:
+                        Debug.type<IntersectionTypeNode>(node);
+                        return factory.updateIntersectionTypeNode(node,
+                            visitTypeNodeList(node.types));
+
+                    case SyntaxKind.ConditionalType:
+                        Debug.type<ConditionalTypeNode>(node);
+                        return factory.updateConditionalTypeNode(node,
+                            visitTypeNode(node.checkType),
+                            visitTypeNode(node.extendsType),
+                            visitTypeNode(node.trueType),
+                            visitTypeNode(node.falseType));
+
+                    case SyntaxKind.InferType:
+                        Debug.type<InferTypeNode>(node);
+                        return factory.updateInferTypeNode(node,
+                            visit(node.typeParameter, isTypeParameterDeclaration));
+
+                    case SyntaxKind.ImportType:
+                        Debug.type<ImportTypeNode>(node);
+                        return factory.updateImportTypeNode(node,
+                            visitTypeNode(node.argument),
+                            visitEntityName(node.qualifier),
+                            visitTypeNodeList(node.typeArguments),
+                            node.isTypeOf
+                        );
+
+                    case SyntaxKind.NamedTupleMember:
+                        Debug.type<NamedTupleMember>(node);
+                        return factory.updateNamedTupleMember(node,
+                            visit(node.dotDotDotToken, isDotDotDotToken),
+                            visitIdentifierName(node.name),
+                            visit(node.questionToken, isQuestionToken),
+                            visitTypeNode(node.type),
+                        );
+
+                    case SyntaxKind.ParenthesizedType:
+                        Debug.type<ParenthesizedTypeNode>(node);
+                        return factory.updateParenthesizedType(node,
+                            visitTypeNode(node.type));
+
+                    case SyntaxKind.ExpressionWithTypeArguments:
+                        Debug.type<ExpressionWithTypeArguments>(node);
+                        return factory.updateExpressionWithTypeArguments(node,
+                            visitExpression(node.expression),
+                            visitTypeNodeList(node.typeArguments));
+
+                    case SyntaxKind.TypeOperator:
+                        Debug.type<TypeOperatorNode>(node);
+                        return factory.updateTypeOperatorNode(node,
+                            visitTypeNode(node.type));
+
+                    case SyntaxKind.IndexedAccessType:
+                        Debug.type<IndexedAccessTypeNode>(node);
+                        return factory.updateIndexedAccessTypeNode(node,
+                            visitTypeNode(node.objectType),
+                            visitTypeNode(node.indexType));
+
+                    case SyntaxKind.MappedType:
+                        Debug.type<MappedTypeNode>(node);
+                        return factory.updateMappedTypeNode(node,
+                            visit(node.readonlyToken, isReadonlyKeywordOrPlusOrMinusToken),
+                            visitMappedTypeParameter(node.typeParameter),
+                            visitTypeNode(node.nameType),
+                            visit(node.questionToken, isQuestionOrPlusOrMinusToken),
+                            visitTypeNode(node.type));
+
+                    case SyntaxKind.LiteralType:
+                        Debug.type<LiteralTypeNode>(node);
+                        return factory.updateLiteralTypeNode(node,
+                            visitExpression(node.literal, isLiteralTypeLikeExpression));
+
+                    case SyntaxKind.TemplateLiteralType:
+                        Debug.type<TemplateLiteralTypeNode>(node);
+                        return factory.updateTemplateLiteralType(node,
+                            visit(node.head, isTemplateHead),
+                            visitList(node.templateSpans, isTemplateLiteralTypeSpan));
+
+                    case SyntaxKind.TemplateLiteralTypeSpan:
+                        Debug.type<TemplateLiteralTypeSpan>(node);
+                        return factory.updateTemplateLiteralTypeSpan(node,
+                            visitTypeNode(node.type),
+                            visit(node.literal, isTemplateMiddleOrTemplateTail));
+
+                    // Binding patterns
+                    case SyntaxKind.ObjectBindingPattern:
+                        Debug.type<ObjectBindingPattern>(node);
+                        return factory.updateObjectBindingPattern(node,
+                            visitList(node.elements, isBindingElement));
+
+                    case SyntaxKind.ArrayBindingPattern:
+                        Debug.type<ArrayBindingPattern>(node);
+                        return factory.updateArrayBindingPattern(node,
+                            visitList(node.elements, isArrayBindingElement));
+
+                    case SyntaxKind.BindingElement:
+                        Debug.type<BindingElement>(node);
+                        return factory.updateBindingElement(node,
+                            visit(node.dotDotDotToken, isDotDotDotToken),
+                            visitPropertyName(node.propertyName),
+                            visitBindingName(node.name),
+                            visitExpression(node.initializer));
+
+                    // Misc
+                    case SyntaxKind.TemplateSpan:
+                        Debug.type<TemplateSpan>(node);
+                        return factory.updateTemplateSpan(node,
+                            visitExpression(node.expression),
+                            visit(node.literal, isTemplateMiddleOrTemplateTail));
+
+                    // Element
+                    case SyntaxKind.Block:
+                        Debug.type<Block>(node);
+                        return factory.updateBlock(node,
+                            visitList(node.statements, isStatement));
+
+                    case SyntaxKind.VariableStatement:
+                        Debug.type<VariableStatement>(node);
+                        return factory.updateVariableStatement(node,
+                            visitList(node.modifiers, isModifier),
+                            visit(node.declarationList, isVariableDeclarationList));
+
+                    case SyntaxKind.ExpressionStatement:
+                        Debug.type<ExpressionStatement>(node);
+                        return factory.updateExpressionStatement(node,
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.IfStatement:
+                        Debug.type<IfStatement>(node);
+                        return factory.updateIfStatement(node,
+                            visitExpression(node.expression),
+                            visitEmbeddedStatement(node.thenStatement),
+                            visitEmbeddedStatement(node.elseStatement));
+
+                    case SyntaxKind.DoStatement:
+                        Debug.type<DoStatement>(node);
+                        return factory.updateDoStatement(node,
+                            visitEmbeddedStatement(node.statement),
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.WhileStatement:
+                        Debug.type<WhileStatement>(node);
+                        return factory.updateWhileStatement(node,
+                            visitExpression(node.expression),
+                            visitEmbeddedStatement(node.statement));
+
+                    case SyntaxKind.ForStatement:
+                        Debug.type<ForStatement>(node);
+                        return factory.updateForStatement(node,
+                            visitForInitializer(node.initializer),
+                            visitExpression(node.condition),
+                            visitExpression(node.incrementor),
+                            visitEmbeddedStatement(node.statement));
+
+                    case SyntaxKind.ForInStatement:
+                        Debug.type<ForInStatement>(node);
+                        return factory.updateForInStatement(node,
+                            visitForInitializer(node.initializer),
+                            visitExpression(node.expression),
+                            visitEmbeddedStatement(node.statement));
+
+                    case SyntaxKind.ForOfStatement:
+                        Debug.type<ForOfStatement>(node);
+                        return factory.updateForOfStatement(node,
+                            visit(node.awaitModifier, isAwaitKeyword),
+                            visitForInitializer(node.initializer),
+                            visitExpression(node.expression),
+                            visitEmbeddedStatement(node.statement));
+
+                    case SyntaxKind.ContinueStatement:
+                        Debug.type<ContinueStatement>(node);
+                        return factory.updateContinueStatement(node,
+                            visitIdentifierName(node.label));
+
+                    case SyntaxKind.BreakStatement:
+                        Debug.type<BreakStatement>(node);
+                        return factory.updateBreakStatement(node,
+                            visitIdentifierName(node.label));
+
+                    case SyntaxKind.ReturnStatement:
+                        Debug.type<ReturnStatement>(node);
+                        return factory.updateReturnStatement(node,
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.WithStatement:
+                        Debug.type<WithStatement>(node);
+                        return factory.updateWithStatement(node,
+                            visitExpression(node.expression),
+                            visitEmbeddedStatement(node.statement));
+
+                    case SyntaxKind.SwitchStatement:
+                        Debug.type<SwitchStatement>(node);
+                        return factory.updateSwitchStatement(node,
+                            visitExpression(node.expression),
+                            visit(node.caseBlock, isCaseBlock));
+
+                    case SyntaxKind.LabeledStatement:
+                        Debug.type<LabeledStatement>(node);
+                        return factory.updateLabeledStatement(node,
+                            visitIdentifierName(node.label),
+                            visitEmbeddedStatement(node.statement));
+
+                    case SyntaxKind.ThrowStatement:
+                        Debug.type<ThrowStatement>(node);
+                        return factory.updateThrowStatement(node,
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.TryStatement:
+                        Debug.type<TryStatement>(node);
+                        return factory.updateTryStatement(node,
+                            visit(node.tryBlock, isBlock),
+                            visit(node.catchClause, isCatchClause),
+                            visit(node.finallyBlock, isBlock));
+
+                    // Declarations
+                    case SyntaxKind.VariableDeclaration:
+                        Debug.type<VariableDeclaration>(node);
+                        return factory.updateVariableDeclaration(node,
+                            visitBindingName(node.name),
+                            visit(node.exclamationToken, isExclamationToken),
+                            visitTypeNode(node.type),
+                            visitExpression(node.initializer));
+
+                    case SyntaxKind.VariableDeclarationList:
+                        Debug.type<VariableDeclarationList>(node);
+                        return factory.updateVariableDeclarationList(node,
+                            visitList(node.declarations, isVariableDeclaration));
+
+                    case SyntaxKind.FunctionDeclaration:
+                        Debug.type<FunctionDeclaration>(node);
+                        return factory.updateFunctionDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visit(node.asteriskToken, isAsteriskToken),
+                            visitIdentifierName(node.name),
+                            visitList(node.typeParameters, isTypeParameterDeclaration),
+                            visitParameterList(node.parameters),
+                            visitTypeNode(node.type),
+                            visitFunctionBody(node.body));
+
+                    case SyntaxKind.ClassDeclaration:
+                        Debug.type<ClassDeclaration>(node);
+                        return factory.updateClassDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visitIdentifierName(node.name),
+                            visitList(node.typeParameters, isTypeParameterDeclaration),
+                            visitList(node.heritageClauses, isHeritageClause),
+                            visitList(node.members, isClassElement));
+
+                    case SyntaxKind.InterfaceDeclaration:
+                        Debug.type<InterfaceDeclaration>(node);
+                        return factory.updateInterfaceDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visitIdentifierName(node.name),
+                            visitList(node.typeParameters, isTypeParameterDeclaration),
+                            visitList(node.heritageClauses, isHeritageClause),
+                            visitList(node.members, isTypeElement));
+
+                    case SyntaxKind.TypeAliasDeclaration:
+                        Debug.type<TypeAliasDeclaration>(node);
+                        return factory.updateTypeAliasDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visitIdentifierName(node.name),
+                            visitList(node.typeParameters, isTypeParameterDeclaration),
+                            visitTypeNode(node.type));
+
+                    case SyntaxKind.EnumDeclaration:
+                        Debug.type<EnumDeclaration>(node);
+                        return factory.updateEnumDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visitIdentifierName(node.name),
+                            visitList(node.members, isEnumMember));
+
+                    case SyntaxKind.ModuleDeclaration:
+                        Debug.type<ModuleDeclaration>(node);
+                        return factory.updateModuleDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visitModuleName(node.name),
+                            visit(node.body, isModuleBody));
+
+                    case SyntaxKind.ModuleBlock:
+                        Debug.type<ModuleBlock>(node);
+                        return factory.updateModuleBlock(node,
+                            visitList(node.statements, isStatement));
+
+                    case SyntaxKind.CaseBlock:
+                        Debug.type<CaseBlock>(node);
+                        return factory.updateCaseBlock(node,
+                            visitList(node.clauses, isCaseOrDefaultClause));
+
+                    case SyntaxKind.NamespaceExportDeclaration:
+                        Debug.type<NamespaceExportDeclaration>(node);
+                        return factory.updateNamespaceExportDeclaration(node,
+                            visitIdentifierName(node.name));
+
+                    case SyntaxKind.ImportEqualsDeclaration:
+                        Debug.type<ImportEqualsDeclaration>(node);
+                        return factory.updateImportEqualsDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            node.isTypeOnly,
+                            visitIdentifierName(node.name),
+                            visit(node.moduleReference, isModuleReference));
+
+                    case SyntaxKind.ImportDeclaration:
+                        Debug.type<ImportDeclaration>(node);
+                        return factory.updateImportDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visit(node.importClause, isImportClause),
+                            visitExpression(node.moduleSpecifier));
+
+                    case SyntaxKind.ImportClause:
+                        Debug.type<ImportClause>(node);
+                        return factory.updateImportClause(node,
+                            node.isTypeOnly,
+                            visitIdentifierName(node.name),
+                            visit(node.namedBindings, isNamedImportBindings));
+
+                    case SyntaxKind.NamespaceImport:
+                        Debug.type<NamespaceImport>(node);
+                        return factory.updateNamespaceImport(node,
+                            visitIdentifierName(node.name));
+
+                    case SyntaxKind.NamespaceExport:
+                        Debug.type<NamespaceExport>(node);
+                        return factory.updateNamespaceExport(node,
+                            visitIdentifierName(node.name));
+
+                    case SyntaxKind.NamedImports:
+                        Debug.type<NamedImports>(node);
+                        return factory.updateNamedImports(node,
+                            visitList(node.elements, isImportSpecifier));
+
+                    case SyntaxKind.ImportSpecifier:
+                        Debug.type<ImportSpecifier>(node);
+                        return factory.updateImportSpecifier(node,
+                            visitIdentifierName(node.propertyName),
+                            visitIdentifierName(node.name));
+
+                    case SyntaxKind.ExportAssignment:
+                        Debug.type<ExportAssignment>(node);
+                        return factory.updateExportAssignment(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.ExportDeclaration:
+                        Debug.type<ExportDeclaration>(node);
+                        return factory.updateExportDeclaration(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            node.isTypeOnly,
+                            visit(node.exportClause, isNamedExportBindings),
+                            visitExpression(node.moduleSpecifier));
+
+                    case SyntaxKind.NamedExports:
+                        Debug.type<NamedExports>(node);
+                        return factory.updateNamedExports(node,
+                            visitList(node.elements, isExportSpecifier));
+
+                    case SyntaxKind.ExportSpecifier:
+                        Debug.type<ExportSpecifier>(node);
+                        return factory.updateExportSpecifier(node,
+                            visitIdentifierName(node.propertyName),
+                            visitIdentifierName(node.name));
+
+                    case SyntaxKind.MissingDeclaration:
+                        return node;
+
+                    // Module references
+                    case SyntaxKind.ExternalModuleReference:
+                        Debug.type<ExternalModuleReference>(node);
+                        return factory.updateExternalModuleReference(node,
+                            visitExpression(node.expression));
+
+                    // JSX (non-expression)
+                    case SyntaxKind.JsxOpeningElement:
+                        Debug.type<JsxOpeningElement>(node);
+                        return factory.updateJsxOpeningElement(node,
+                            visitExpression(node.tagName, isJsxTagNameExpression),
+                            visitList(node.typeArguments, isTypeNode),
+                            visit(node.attributes, isJsxAttributes));
+
+                    case SyntaxKind.JsxClosingElement:
+                        Debug.type<JsxClosingElement>(node);
+                        return factory.updateJsxClosingElement(node,
+                            visitExpression(node.tagName, isJsxTagNameExpression));
+
+                    case SyntaxKind.JsxAttribute:
+                        Debug.type<JsxAttribute>(node);
+                        return factory.updateJsxAttribute(node,
+                            visitIdentifierName(node.name),
+                            visitJsxAttributeValue(node.initializer));
+
+                    case SyntaxKind.JsxAttributes:
+                        Debug.type<JsxAttributes>(node);
+                        return factory.updateJsxAttributes(node,
+                            visitList(node.properties, isJsxAttributeLike));
+
+                    case SyntaxKind.JsxSpreadAttribute:
+                        Debug.type<JsxSpreadAttribute>(node);
+                        return factory.updateJsxSpreadAttribute(node,
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.JsxExpression:
+                        Debug.type<JsxExpression>(node);
+                        return factory.updateJsxExpression(node,
+                            visitExpression(node.expression));
+
+                    // Clauses
+                    case SyntaxKind.CaseClause:
+                        Debug.type<CaseClause>(node);
+                        return factory.updateCaseClause(node,
+                            visitExpression(node.expression),
+                            visitList(node.statements, isStatement));
+
+                    case SyntaxKind.DefaultClause:
+                        Debug.type<DefaultClause>(node);
+                        return factory.updateDefaultClause(node,
+                            visitList(node.statements, isStatement));
+
+                    case SyntaxKind.HeritageClause:
+                        Debug.type<HeritageClause>(node);
+                        return factory.updateHeritageClause(node,
+                            visitList(node.types, isExpressionWithTypeArguments));
+
+                    case SyntaxKind.CatchClause:
+                        Debug.type<CatchClause>(node);
+                        return factory.updateCatchClause(node,
+                            visit(node.variableDeclaration, isVariableDeclaration),
+                            visit(node.block, isBlock));
+
+                    // Property assignments
+                    case SyntaxKind.PropertyAssignment:
+                        Debug.type<PropertyAssignment>(node);
+                        return factory.updatePropertyAssignment(node,
+                            visitPropertyName(node.name),
+                            visitExpression(node.initializer));
+
+                    case SyntaxKind.ShorthandPropertyAssignment:
+                        Debug.type<ShorthandPropertyAssignment>(node);
+                        return factory.updateShorthandPropertyAssignment(node,
+                            visitIdentifierName(node.name, isIdentifier),
+                            visitExpression(node.objectAssignmentInitializer));
+
+                    case SyntaxKind.SpreadAssignment:
+                        Debug.type<SpreadAssignment>(node);
+                        return factory.updateSpreadAssignment(node,
+                            visitExpression(node.expression));
+
+                    // Enum
+                    case SyntaxKind.EnumMember:
+                        Debug.type<EnumMember>(node);
+                        return factory.updateEnumMember(node,
+                            visitPropertyName(node.name),
+                            visitExpression(node.initializer));
+
+                    // JSDoc nodes (only used in codefixes currently)
+                    case SyntaxKind.JSDocTypeExpression:
+                    case SyntaxKind.JSDocNameReference:
+                    case SyntaxKind.JSDocAllType:
+                    case SyntaxKind.JSDocUnknownType:
+                    case SyntaxKind.JSDocNullableType:
+                    case SyntaxKind.JSDocNonNullableType:
+                    case SyntaxKind.JSDocOptionalType:
+                    case SyntaxKind.JSDocFunctionType:
+                    case SyntaxKind.JSDocVariadicType:
+                    case SyntaxKind.JSDocNamepathType:
+                    case SyntaxKind.JSDocComment:
+                    case SyntaxKind.JSDocTypeLiteral:
+                    case SyntaxKind.JSDocSignature:
+                    case SyntaxKind.JSDocTag:
+                    case SyntaxKind.JSDocAugmentsTag:
+                    case SyntaxKind.JSDocImplementsTag:
+                    case SyntaxKind.JSDocAuthorTag:
+                    case SyntaxKind.JSDocDeprecatedTag:
+                    case SyntaxKind.JSDocClassTag:
+                    case SyntaxKind.JSDocPublicTag:
+                    case SyntaxKind.JSDocPrivateTag:
+                    case SyntaxKind.JSDocProtectedTag:
+                    case SyntaxKind.JSDocReadonlyTag:
+                    case SyntaxKind.JSDocCallbackTag:
+                    case SyntaxKind.JSDocEnumTag:
+                    case SyntaxKind.JSDocParameterTag:
+                    case SyntaxKind.JSDocPropertyTag:
+                    case SyntaxKind.JSDocReturnTag:
+                    case SyntaxKind.JSDocThisTag:
+                    case SyntaxKind.JSDocTypeTag:
+                    case SyntaxKind.JSDocTemplateTag:
+                    case SyntaxKind.JSDocTypedefTag:
+                    case SyntaxKind.JSDocSeeTag:
+                        return node;
+
+                    // Transformation nodes (ignored)
+                }
+
+                if (isExpression(node)) {
+                    // If this was an expression that was originally in an `Unspecified` hint,
+                    // re-trigger substitution using the correct hint.
+                    hint = EmitHint.Expression;
+                    if (substituteNode !== noEmitSubstitution) {
+                        node = substituteNode(hint, node);
+                    }
+                }
+                else if (isSourceFile(node)) {
+                    return preprintSourceFile(node);
+                }
+            }
+
+            if (hint === EmitHint.Expression) {
+                switch (node.kind) {
+                    // Identifiers
+                    case SyntaxKind.Identifier:
+                        return preprintIdentifier(node as Identifier);
+
+                    // Expression
+                    case SyntaxKind.ArrayLiteralExpression:
+                        Debug.type<ArrayLiteralExpression>(node);
+                        return factory.updateArrayLiteralExpression(node,
+                            visitExpressionList(node.elements));
+
+                    case SyntaxKind.ObjectLiteralExpression:
+                        Debug.type<ObjectLiteralExpression>(node);
+                        return factory.updateObjectLiteralExpression(node,
+                            visitList(node.properties, isObjectLiteralElementLike));
+
+                    case SyntaxKind.PropertyAccessExpression:
+                        if (node.flags & NodeFlags.OptionalChain) {
+                            Debug.type<PropertyAccessChain>(node);
+                            return factory.updatePropertyAccessChain(node,
+                                visitExpression(node.expression),
+                                visit(node.questionDotToken, isQuestionDotToken),
+                                visitMemberName(node.name));
+                        }
+                        Debug.type<PropertyAccessExpression>(node);
+                        return factory.updatePropertyAccessExpression(node,
+                            visitExpression(node.expression),
+                            visitMemberName(node.name));
+
+                    case SyntaxKind.ElementAccessExpression:
+                        if (node.flags & NodeFlags.OptionalChain) {
+                            Debug.type<ElementAccessChain>(node);
+                            return factory.updateElementAccessChain(node,
+                                visitExpression(node.expression),
+                                visit(node.questionDotToken, isQuestionDotToken),
+                                visitExpression(node.argumentExpression));
+                        }
+                        Debug.type<ElementAccessExpression>(node);
+                        return factory.updateElementAccessExpression(node,
+                            visitExpression(node.expression),
+                            visitExpression(node.argumentExpression));
+
+                    case SyntaxKind.CallExpression:
+                        if (node.flags & NodeFlags.OptionalChain) {
+                            Debug.type<CallChain>(node);
+                            return factory.updateCallChain(node,
+                                visitExpression(node.expression),
+                                visit(node.questionDotToken, isQuestionDotToken),
+                                visitTypeNodeList(node.typeArguments),
+                                visitExpressionList(node.arguments));
+                        }
+                        Debug.type<CallExpression>(node);
+                        return factory.updateCallExpression(node,
+                            visitExpression(node.expression),
+                            visitTypeNodeList(node.typeArguments),
+                            visitExpressionList(node.arguments));
+
+                    case SyntaxKind.NewExpression:
+                        Debug.type<NewExpression>(node);
+                        return factory.updateNewExpression(node,
+                            visitExpression(node.expression),
+                            visitTypeNodeList(node.typeArguments),
+                            visitExpressionList(node.arguments));
+
+                    case SyntaxKind.TaggedTemplateExpression:
+                        Debug.type<TaggedTemplateExpression>(node);
+                        return factory.updateTaggedTemplateExpression(node,
+                            visitExpression(node.tag),
+                            visitTypeNodeList(node.typeArguments),
+                            visitExpression(node.template, isTemplateLiteral));
+
+                    case SyntaxKind.TypeAssertionExpression:
+                        Debug.type<TypeAssertion>(node);
+                        return factory.updateTypeAssertion(node,
+                            visitTypeNode(node.type),
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.ParenthesizedExpression:
+                        Debug.type<ParenthesizedExpression>(node);
+                        return factory.updateParenthesizedExpression(node,
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.FunctionExpression:
+                        Debug.type<FunctionExpression>(node);
+                        return factory.updateFunctionExpression(node,
+                            visitList(node.modifiers, isModifier),
+                            visit(node.asteriskToken, isAsteriskToken),
+                            visitIdentifierName(node.name),
+                            visitList(node.typeParameters, isTypeParameterDeclaration),
+                            visitParameterList(node.parameters),
+                            visitTypeNode(node.type),
+                            visitFunctionBody(node.body));
+
+                    case SyntaxKind.ArrowFunction:
+                        Debug.type<ArrowFunction>(node);
+                        return factory.updateArrowFunction(node,
+                            visitList(node.modifiers, isModifier),
+                            visitList(node.typeParameters, isTypeParameterDeclaration),
+                            visitParameterList(node.parameters),
+                            visitTypeNode(node.type),
+                            visit(node.equalsGreaterThanToken, isEqualsGreaterThanToken),
+                            visitConciseBody(node.body));
+
+                    case SyntaxKind.DeleteExpression:
+                        Debug.type<DeleteExpression>(node);
+                        return factory.updateDeleteExpression(node,
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.TypeOfExpression:
+                        Debug.type<TypeOfExpression>(node);
+                        return factory.updateTypeOfExpression(node,
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.VoidExpression:
+                        Debug.type<VoidExpression>(node);
+                        return factory.updateVoidExpression(node,
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.AwaitExpression:
+                        Debug.type<AwaitExpression>(node);
+                        return factory.updateAwaitExpression(node,
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.PrefixUnaryExpression:
+                        Debug.type<PrefixUnaryExpression>(node);
+                        return factory.updatePrefixUnaryExpression(node,
+                            visitExpression(node.operand));
+
+                    case SyntaxKind.PostfixUnaryExpression:
+                        Debug.type<PostfixUnaryExpression>(node);
+                        return factory.updatePostfixUnaryExpression(node,
+                            visitExpression(node.operand));
+
+                    case SyntaxKind.BinaryExpression:
+                        return preprintBinaryExpression(node as BinaryExpression);
+
+                    case SyntaxKind.ConditionalExpression:
+                        Debug.type<ConditionalExpression>(node);
+                        return factory.updateConditionalExpression(node,
+                            visitExpression(node.condition),
+                            visit(node.questionToken, isQuestionToken),
+                            visitExpression(node.whenTrue),
+                            visit(node.colonToken, isColonToken),
+                            visitExpression(node.whenFalse));
+
+                    case SyntaxKind.TemplateExpression:
+                        Debug.type<TemplateExpression>(node);
+                        return factory.updateTemplateExpression(node,
+                            visit(node.head, isTemplateHead),
+                            visitList(node.templateSpans, isTemplateSpan));
+
+                    case SyntaxKind.YieldExpression:
+                        Debug.type<YieldExpression>(node);
+                        return factory.updateYieldExpression(node,
+                            visit(node.asteriskToken, isAsteriskToken),
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.SpreadElement:
+                        Debug.type<SpreadElement>(node);
+                        return factory.updateSpreadElement(node,
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.ClassExpression:
+                        Debug.type<ClassExpression>(node);
+                        return factory.updateClassExpression(node,
+                            visitList(node.decorators, isDecorator),
+                            visitList(node.modifiers, isModifier),
+                            visitIdentifierName(node.name),
+                            visitList(node.typeParameters, isTypeParameterDeclaration),
+                            visitList(node.heritageClauses, isHeritageClause),
+                            visitList(node.members, isClassElement));
+
+                    case SyntaxKind.AsExpression:
+                        Debug.type<AsExpression>(node);
+                        return factory.updateAsExpression(node,
+                            visitExpression(node.expression),
+                            visitTypeNode(node.type));
+
+                    case SyntaxKind.NonNullExpression:
+                        if (node.flags & NodeFlags.OptionalChain) {
+                            Debug.type<NonNullChain>(node);
+                            return factory.updateNonNullChain(node,
+                                visitExpression(node.expression));
+                        }
+                        Debug.type<NonNullExpression>(node);
+                        return factory.updateNonNullExpression(node,
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.MetaProperty:
+                        Debug.type<MetaProperty>(node);
+                        return factory.updateMetaProperty(node,
+                            visitIdentifierName(node.name));
+
+
+                    // JSX (expression only)
+                    case SyntaxKind.JsxElement:
+                        Debug.type<JsxElement>(node);
+                        return factory.updateJsxElement(node,
+                            visit(node.openingElement, isJsxOpeningElement),
+                            visitList(node.children, isJsxChild),
+                            visit(node.closingElement, isJsxClosingElement));
+
+                    case SyntaxKind.JsxSelfClosingElement:
+                        Debug.type<JsxSelfClosingElement>(node);
+                        return factory.updateJsxSelfClosingElement(node,
+                            visitExpression(node.tagName, isJsxTagNameExpression),
+                            visitList(node.typeArguments, isTypeNode),
+                            visit(node.attributes, isJsxAttributes));
+
+                    case SyntaxKind.JsxFragment:
+                        Debug.type<JsxFragment>(node);
+                        return factory.updateJsxFragment(node,
+                            visit(node.openingFragment, isJsxOpeningFragment),
+                            visitList(node.children, isJsxChild),
+                            visit(node.closingFragment, isJsxClosingFragment));
+
+                    // Transformation nodes
+                    case SyntaxKind.PartiallyEmittedExpression:
+                        Debug.type<PartiallyEmittedExpression>(node);
+                        return factory.updatePartiallyEmittedExpression(node,
+                            visitExpression(node.expression));
+
+                    case SyntaxKind.CommaListExpression:
+                        Debug.type<CommaListExpression>(node);
+                        return factory.updateCommaListExpression(node,
+                            visitExpressionList(node.elements, isExpression));
+                }
+            }
+
+            if (Debug.shouldAssert(AssertionLevel.Normal)) {
+                // Any other node should not have children or this list isn't up to date.
+                Debug.assertMissingNode(forEachChild(node, identity), `Expected ${Debug.formatSyntaxKind(node.kind)} to contain no children.`);
+            }
+
+            // No need to visit nodes with no children.
+            return node;
+        }
+
+        function preprintSourceFile(node: SourceFile) {
+            return factory.updateSourceFile(node,
+                visitList(node.statements, isStatement));
+        }
+
+        function preprintIdentifier(node: Identifier) {
+            return factory.updateIdentifier(node,
+                visitList(node.typeArguments, isTypeNodeOrTypeParameterDeclaration));
+        }
+
+        function preprintTypeParameterDeclaration(node: TypeParameterDeclaration) {
+            return factory.updateTypeParameterDeclaration(node,
+                visitIdentifierName(node.name),
+                visitTypeNode(node.constraint),
+                visitTypeNode(node.default));
+        }
+
+        function preprintBinaryExpression(node: BinaryExpression) {
+            // This emulates `emitBinaryExpression` in `createPrinter`, except that
+            // it handles tree transformation instead of printing.
+            const nodeStack = [node];
+            const leftStack = [node.left];
+            const operatorStack = [node.operatorToken];
+            const rightStack = [node.right];
+            const stateStack = [BinaryExpressionState.Left];
+            let stackIndex = 0;
+            while (stackIndex >= 0) {
+                node = nodeStack[stackIndex];
+                switch (stateStack[stackIndex]) {
+                    case BinaryExpressionState.Left: {
+                        maybeVisitExpression(node.left);
+                        break;
+                    }
+                    case BinaryExpressionState.Right: {
+                        operatorStack[stackIndex] = visit(node.operatorToken, isBinaryOperatorToken);
+                        maybeVisitExpression(node.right);
+                        break;
+                    }
+                    case BinaryExpressionState.Finish: {
+                        const left = leftStack[stackIndex];
+                        const right = rightStack[stackIndex];
+                        const updated = factory.updateBinaryExpression(node, left, node.operatorToken, right);
+                        stackIndex--;
+                        if (stackIndex >= 0) {
+                            const sideStack = stateStack[stackIndex] === BinaryExpressionState.Finish ? rightStack : leftStack;
+                            sideStack[stackIndex] = updated;
+                        }
+                        break;
+                    }
+                    default:
+                        Debug.fail(`Invalid state ${stateStack[stackIndex]} for preprintBinaryExpression`);
+                }
+            }
+
+            return factory.updateBinaryExpression(node, leftStack[0], operatorStack[0], rightStack[0]);
+
+            function maybeVisitExpression(next: Expression) {
+                // Advance the state of this unit of work,
+                const currentState = stateStack[stackIndex];
+                stateStack[stackIndex]++;
+                // Get the first supported pipeline phase for this node. We can skip several stack
+                // frames if we aren't doing emit notification, so we check for substitution and
+                // direct callbacks and execute those immediately.
+                let pipelinePhase = getPipelinePhase(PreprintPipelinePhase.Notification, next);
+                if (pipelinePhase === pipelineVisitWithSubstitution) {
+                    // The next phase after substitution is always direct visitation, so we can reduce the call stack
+                    // depth by proceding to the direct visitor.
+                    next = cast(substituteNode(EmitHint.Expression, next), isExpression);
+                    pipelinePhase = pipelineVisitDirect;
+                }
+                if (pipelinePhase === pipelineVisitDirect && isBinaryExpression(next)) {
+                    // If we are visiting directly and the next node is a BinaryExpression, we can
+                    // add it to the stack and continue the trampoline.
+                    stackIndex++;
+                    stateStack[stackIndex] = BinaryExpressionState.Left;
+                    nodeStack[stackIndex] = next;
+                    leftStack[stackIndex] = next.left;
+                    rightStack[stackIndex] = next.right;
+                }
+                else {
+                    // Visit the expression and store the result on whichever side we are currently visiting.
+                    const sideStack = currentState === BinaryExpressionState.Left ? leftStack : rightStack;
+                    sideStack[stackIndex] = visitExpression(next, isExpression);
+                }
+            }
+        }
+
+        function preprint(hint: EmitHint, node: Node) {
+            // If we're not performing substitution or notification, we have no work to do here.
+            if (substituteNode === noEmitSubstitution &&
+                onEmitNode === noEmitNotification) {
+                return node;
+            }
+            switch (hint) {
+                case EmitHint.SourceFile: return visitSourceFile(cast(node, isSourceFile));
+                case EmitHint.Expression: return visitExpression(cast(node, isExpression));
+                case EmitHint.IdentifierName: return visitIdentifierName(cast(node, isIdentifier));
+                case EmitHint.MappedTypeParameter: return visitMappedTypeParameter(cast(node, isTypeParameterDeclaration));
+                case EmitHint.EmbeddedStatement: return visitEmbeddedStatement(cast(node, isStatement));
+                case EmitHint.JsxAttributeValue: return visitJsxAttributeValue(cast(node, isStringLiteralOrJsxExpression));
+                default: return visit(node);
+            }
+        }
+
+        return preprint;
     }
 
     function createBracketsMap() {

--- a/src/compiler/factory/nodeTests.ts
+++ b/src/compiler/factory/nodeTests.ts
@@ -39,10 +39,104 @@ namespace ts {
         return node.kind === SyntaxKind.TemplateTail;
     }
 
+    // Punctuation
+
+    export function isDotDotDotToken(node: Node): node is DotDotDotToken {
+        return node.kind === SyntaxKind.DotDotDotToken;
+    }
+
+    /*@internal*/
+    export function isCommaToken(node: Node): node is Token<SyntaxKind.CommaToken> {
+        return node.kind === SyntaxKind.CommaToken;
+    }
+
+    export function isPlusToken(node: Node): node is PlusToken {
+        return node.kind === SyntaxKind.PlusToken;
+    }
+
+    export function isMinusToken(node: Node): node is MinusToken {
+        return node.kind === SyntaxKind.MinusToken;
+    }
+
+    export function isAsteriskToken(node: Node): node is AsteriskToken {
+        return node.kind === SyntaxKind.AsteriskToken;
+    }
+
+    /*@internal*/
+    export function isExclamationToken(node: Node): node is ExclamationToken {
+        return node.kind === SyntaxKind.ExclamationToken;
+    }
+
+    /*@internal*/
+    export function isQuestionToken(node: Node): node is QuestionToken {
+        return node.kind === SyntaxKind.QuestionToken;
+    }
+
+    /*@internal*/
+    export function isColonToken(node: Node): node is ColonToken {
+        return node.kind === SyntaxKind.ColonToken;
+    }
+
+    /*@internal*/
+    export function isQuestionDotToken(node: Node): node is QuestionDotToken {
+        return node.kind === SyntaxKind.QuestionDotToken;
+    }
+
+    /*@internal*/
+    export function isEqualsGreaterThanToken(node: Node): node is EqualsGreaterThanToken {
+        return node.kind === SyntaxKind.EqualsGreaterThanToken;
+    }
+
     // Identifiers
 
     export function isIdentifier(node: Node): node is Identifier {
         return node.kind === SyntaxKind.Identifier;
+    }
+
+    export function isPrivateIdentifier(node: Node): node is PrivateIdentifier {
+        return node.kind === SyntaxKind.PrivateIdentifier;
+    }
+
+    // Reserved Words
+
+    /* @internal */
+    export function isExportModifier(node: Node): node is ExportKeyword {
+        return node.kind === SyntaxKind.ExportKeyword;
+    }
+
+    /* @internal */
+    export function isAsyncModifier(node: Node): node is AsyncKeyword {
+        return node.kind === SyntaxKind.AsyncKeyword;
+    }
+
+    /* @internal */
+    export function isAssertsKeyword(node: Node): node is AssertsKeyword {
+        return node.kind === SyntaxKind.AssertsKeyword;
+    }
+
+    /* @internal */
+    export function isAwaitKeyword(node: Node): node is AwaitKeyword {
+        return node.kind === SyntaxKind.AwaitKeyword;
+    }
+
+    /* @internal */
+    export function isReadonlyKeyword(node: Node): node is ReadonlyKeyword {
+        return node.kind === SyntaxKind.ReadonlyKeyword;
+    }
+
+    /* @internal */
+    export function isStaticModifier(node: Node): node is StaticKeyword {
+        return node.kind === SyntaxKind.StaticKeyword;
+    }
+
+    /*@internal*/
+    export function isSuperKeyword(node: Node): node is SuperExpression {
+        return node.kind === SyntaxKind.SuperKeyword;
+    }
+
+    /*@internal*/
+    export function isImportKeyword(node: Node): node is ImportExpression {
+        return node.kind === SyntaxKind.ImportKeyword;
     }
 
     // Names
@@ -53,37 +147,6 @@ namespace ts {
 
     export function isComputedPropertyName(node: Node): node is ComputedPropertyName {
         return node.kind === SyntaxKind.ComputedPropertyName;
-    }
-
-    export function isPrivateIdentifier(node: Node): node is PrivateIdentifier {
-        return node.kind === SyntaxKind.PrivateIdentifier;
-    }
-
-    // Tokens
-
-    /*@internal*/
-    export function isSuperKeyword(node: Node): node is Token<SyntaxKind.SuperKeyword> {
-        return node.kind === SyntaxKind.SuperKeyword;
-    }
-
-    /*@internal*/
-    export function isImportKeyword(node: Node): node is Token<SyntaxKind.ImportKeyword> {
-        return node.kind === SyntaxKind.ImportKeyword;
-    }
-
-    /*@internal*/
-    export function isCommaToken(node: Node): node is Token<SyntaxKind.CommaToken> {
-        return node.kind === SyntaxKind.CommaToken;
-    }
-
-    /*@internal*/
-    export function isQuestionToken(node: Node): node is Token<SyntaxKind.QuestionToken> {
-        return node.kind === SyntaxKind.QuestionToken;
-    }
-
-    /*@internal*/
-    export function isExclamationToken(node: Node): node is Token<SyntaxKind.ExclamationToken> {
-        return node.kind === SyntaxKind.ExclamationToken;
     }
 
     // Signature elements

--- a/src/compiler/factory/utilities.ts
+++ b/src/compiler/factory/utilities.ts
@@ -1047,7 +1047,7 @@ namespace ts {
 
         function pushStack<TState>(stackIndex: number, stateStack: BinaryExpressionState[], nodeStack: BinaryExpression[], userStateStack: TState[], node: BinaryExpression) {
             stackIndex++;
-            stateStack[stackIndex] = BinaryExpressionState.enter;
+            stateStack[stackIndex] = enter;
             nodeStack[stackIndex] = node;
             userStateStack[stackIndex] = undefined!;
             return stackIndex;

--- a/src/compiler/factory/utilities.ts
+++ b/src/compiler/factory/utilities.ts
@@ -1009,8 +1009,10 @@ namespace ts {
             const result = machine.onExit(nodeStack[stackIndex], userStateStack[stackIndex]);
             if (stackIndex > 0) {
                 stackIndex--;
-                const side = stateStack[stackIndex] === exit ? "right" : "left";
-                userStateStack[stackIndex] = machine.foldState(userStateStack[stackIndex], result, side);
+                if (machine.foldState) {
+                    const side = stateStack[stackIndex] === exit ? "right" : "left";
+                    userStateStack[stackIndex] = machine.foldState(userStateStack[stackIndex], result, side);
+                }
             }
             else {
                 resultHolder.value = result;
@@ -1073,7 +1075,7 @@ namespace ts {
             readonly onOperator: ((operatorToken: BinaryOperatorToken, userState: TState, node: BinaryExpression) => void) | undefined,
             readonly onRight: ((right: Expression, userState: TState, node: BinaryExpression) => BinaryExpression | void) | undefined,
             readonly onExit: (node: BinaryExpression, userState: TState) => TResult,
-            readonly foldState: (userState: TState, result: TResult, side: "left" | "right") => TState,
+            readonly foldState: ((userState: TState, result: TResult, side: "left" | "right") => TState) | undefined,
         ) {
         }
     }
@@ -1093,7 +1095,7 @@ namespace ts {
         onOperator: ((operatorToken: BinaryOperatorToken, userState: TState, node: BinaryExpression) => void) | undefined,
         onRight: ((right: Expression, userState: TState, node: BinaryExpression) => BinaryExpression | void) | undefined,
         onExit: (node: BinaryExpression, userState: TState) => TResult,
-        foldState: (userState: TState, result: TResult, side: "left" | "right") => TState,
+        foldState: ((userState: TState, result: TResult, side: "left" | "right") => TState) | undefined,
     ) {
         const machine = new BinaryExpressionStateMachine(onEnter, onLeft, onOperator, onRight, onExit, foldState);
         return (node: BinaryExpression) => {

--- a/src/compiler/factory/utilities.ts
+++ b/src/compiler/factory/utilities.ts
@@ -929,4 +929,181 @@ namespace ts {
     export function isBinaryOperatorToken(node: Node): node is BinaryOperatorToken {
         return isBinaryOperator(node.kind);
     }
+
+    type BinaryExpressionState = <TState, TResult>(machine: BinaryExpressionStateMachine<TState, TResult>, frame: BinaryExpressionStateMachineFrame<TState, TResult>) => BinaryExpressionStateMachineFrame<TState, TResult>;
+
+    namespace BinaryExpressionState {
+        /**
+         * Handles walking into a `BinaryExpression`.
+         * @param machine State machine handler functions
+         * @param frame The current frame
+         * @returns The new frame
+         */
+        export function enter<TState, TResult>(machine: BinaryExpressionStateMachine<TState, TResult>, frame: BinaryExpressionStateMachineFrame<TState, TResult>): BinaryExpressionStateMachineFrame<TState, TResult> {
+            Debug.assertEqual(frame.state, enter);
+            frame.userState = machine.onEnter(frame.node, frame.prev?.userState);
+            frame.state = nextState(machine, enter);
+            return frame;
+        }
+
+        /**
+         * Handles walking the `left` side of a `BinaryExpression`.
+         * @param machine State machine handler functions
+         * @param frame The current frame
+         * @returns The new frame
+         */
+        export function left<TState, TResult>(machine: BinaryExpressionStateMachine<TState, TResult>, frame: BinaryExpressionStateMachineFrame<TState, TResult>): BinaryExpressionStateMachineFrame<TState, TResult> {
+            Debug.assertEqual(frame.state, left);
+            Debug.assertIsDefined(machine.onLeft);
+            frame.state = nextState(machine, left);
+            const nextNode = machine.onLeft(frame.node.left, frame.userState, frame.node);
+            if (nextNode) {
+                checkCircularity(frame, nextNode);
+                return new BinaryExpressionStateMachineFrame(frame, nextNode);
+            }
+            return frame;
+        }
+
+        /**
+         * Handles walking the `operatorToken` of a `BinaryExpression`.
+         * @param machine State machine handler functions
+         * @param frame The current frame
+         * @returns The new frame
+         */
+        export function operator<TState, TResult>(machine: BinaryExpressionStateMachine<TState, TResult>, frame: BinaryExpressionStateMachineFrame<TState, TResult>): BinaryExpressionStateMachineFrame<TState, TResult> {
+            Debug.assertEqual(frame.state, operator);
+            Debug.assertIsDefined(machine.onOperator);
+            frame.state = nextState(machine, operator);
+            machine.onOperator(frame.node.operatorToken, frame.userState, frame.node);
+            return frame;
+        }
+
+        /**
+         * Handles walking the `right` side of a `BinaryExpression`.
+         * @param machine State machine handler functions
+         * @param frame The current frame
+         * @returns The new frame
+         */
+        export function right<TState, TResult>(machine: BinaryExpressionStateMachine<TState, TResult>, frame: BinaryExpressionStateMachineFrame<TState, TResult>): BinaryExpressionStateMachineFrame<TState, TResult> {
+            Debug.assertEqual(frame.state, right);
+            Debug.assertIsDefined(machine.onRight);
+            frame.state = nextState(machine, right);
+            const nextNode = machine.onRight(frame.node.right, frame.userState, frame.node);
+            if (nextNode) {
+                checkCircularity(frame, nextNode);
+                return new BinaryExpressionStateMachineFrame(frame, nextNode);
+            }
+            return frame;
+        }
+
+        /**
+         * Handles walking out of a `BinaryExpression`.
+         * @param machine State machine handler functions
+         * @param frame The current frame
+         * @returns The new frame
+         */
+        export function exit<TState, TResult>(machine: BinaryExpressionStateMachine<TState, TResult>, frame: BinaryExpressionStateMachineFrame<TState, TResult>): BinaryExpressionStateMachineFrame<TState, TResult> {
+            Debug.assertEqual(frame.state, exit);
+            frame.state = nextState(machine, exit);
+            frame.result = machine.onExit(frame.node, frame.userState);
+            if (frame.prev) {
+                const side = frame.prev.state === exit ? "right" : "left";
+                frame.prev.userState = machine.foldState(frame.prev.userState, frame.result, side);
+                return frame.prev;
+            }
+            return frame;
+        }
+
+        /**
+         * Handles a frame that is already done.
+         * @returns The `done` state.
+         */
+        export function done<TState, TResult>(_machine: BinaryExpressionStateMachine<TState, TResult>, frame: BinaryExpressionStateMachineFrame<TState, TResult>): BinaryExpressionStateMachineFrame<TState, TResult> {
+            Debug.assertEqual(frame.state, done);
+            return frame;
+        }
+
+        export function nextState<TState, TResult>(machine: BinaryExpressionStateMachine<TState, TResult>, currentState: BinaryExpressionState) {
+            switch (currentState) {
+                case enter:
+                    if (machine.onLeft) return left;
+                    // falls through
+                case left:
+                    if (machine.onOperator) return operator;
+                    // falls through
+                case operator:
+                    if (machine.onRight) return right;
+                    // falls through
+                case right: return exit;
+                case exit: return done;
+                case done: return done;
+                default: Debug.fail("Invalid state");
+            }
+        }
+
+        function checkCircularity<TState, TResult>(frame: BinaryExpressionStateMachineFrame<TState, TResult> | undefined, node: BinaryExpression) {
+            if (Debug.shouldAssert(AssertionLevel.Aggressive)) {
+                while (frame) {
+                    Debug.assert(frame.node !== node, "Circular traversal detected.");
+                    frame = frame.prev;
+                }
+            }
+        }
+    }
+
+    /**
+     * Holds state machine handler functions
+     */
+    class BinaryExpressionStateMachine<TState, TResult> {
+        constructor(
+            readonly onEnter: (node: BinaryExpression, prev: TState | undefined) => TState,
+            readonly onLeft: ((left: Expression, userState: TState, node: BinaryExpression) => BinaryExpression | void) | undefined,
+            readonly onOperator: ((operatorToken: BinaryOperatorToken, userState: TState, node: BinaryExpression) => void) | undefined,
+            readonly onRight: ((right: Expression, userState: TState, node: BinaryExpression) => BinaryExpression | void) | undefined,
+            readonly onExit: (node: BinaryExpression, userState: TState) => TResult,
+            readonly foldState: (userState: TState, result: TResult, side: "left" | "right") => TState,
+        ) {
+        }
+    }
+
+    /**
+     * Holds the current frame for the state machine
+     */
+    class BinaryExpressionStateMachineFrame<TState, TResult> {
+        public state: BinaryExpressionState = BinaryExpressionState.enter;
+        public userState: TState = undefined!;
+        public result: TResult = undefined!;
+        constructor(
+            public prev: BinaryExpressionStateMachineFrame<TState, TResult> | undefined,
+            public node: BinaryExpression
+        ) {
+        }
+    }
+
+    /**
+     * Creates a state machine that walks a `BinaryExpression` using the heap to reduce call-stack depth on a large tree.
+     * @param onEnter Callback evaluated when entering a `BinaryExpression`. Returns new user-defined state to associate with the node while walking.
+     * @param onLeft Callback evaluated when walking the left side of a `BinaryExpression`. Return a `BinaryExpression` to continue walking, or `void` to advance to the right side.
+     * @param onRight Callback evaluated when walking the right side of a `BinaryExpression`. Return a `BinaryExpression` to continue walking, or `void` to advance to the end of the node.
+     * @param onExit Callback evaluated when exiting a `BinaryExpression`. The result returned will either be folded into the parent's state, or returned from the walker if at the top frame.
+     * @param foldState Callback evaluated when the result from a nested `onExit` should be folded into the state of that node's parent.
+     * @returns A function that walks a `BinaryExpression` node using the above callbacks, returning the result of the call to `onExit` from the outermost `BinaryExpression` node.
+     */
+    export function createBinaryExpressionWalker<TState, TResult>(
+        onEnter: (node: BinaryExpression, prev: TState | undefined) => TState,
+        onLeft: ((left: Expression, userState: TState, node: BinaryExpression) => BinaryExpression | void) | undefined,
+        onOperator: ((operatorToken: BinaryOperatorToken, userState: TState, node: BinaryExpression) => void) | undefined,
+        onRight: ((right: Expression, userState: TState, node: BinaryExpression) => BinaryExpression | void) | undefined,
+        onExit: (node: BinaryExpression, userState: TState) => TResult,
+        foldState: (userState: TState, result: TResult, side: "left" | "right") => TState,
+    ) {
+        const machine = new BinaryExpressionStateMachine(onEnter, onLeft, onOperator, onRight, onExit, foldState);
+        return (node: BinaryExpression) => {
+            let frame = new BinaryExpressionStateMachineFrame<TState, TResult>(/*prev*/ undefined, node);
+            while (frame.state !== BinaryExpressionState.done) {
+                frame = frame.state(machine, frame);
+            }
+            return frame.result;
+        };
+    }
 }

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -1864,17 +1864,22 @@ namespace ts {
                 if (exportedNames) {
                     let expression: Expression = node.kind === SyntaxKind.PostfixUnaryExpression
                         ? setTextRange(
-                            factory.createBinaryExpression(
-                                node.operand,
-                                factory.createToken(node.operator === SyntaxKind.PlusPlusToken ? SyntaxKind.PlusEqualsToken : SyntaxKind.MinusEqualsToken),
-                                factory.createNumericLiteral(1)
+                            factory.createPrefixUnaryExpression(
+                                node.operator,
+                                node.operand
                             ),
                             /*location*/ node)
                         : node;
                     for (const exportName of exportedNames) {
                         // Mark the node to prevent triggering this rule again.
                         noSubstitution[getNodeId(expression)] = true;
-                        expression = factory.createParenthesizedExpression(createExportExpression(exportName, expression));
+                        expression = createExportExpression(exportName, expression);
+                    }
+                    if (node.kind === SyntaxKind.PostfixUnaryExpression) {
+                        noSubstitution[getNodeId(expression)] = true;
+                        expression = node.operator === SyntaxKind.PlusPlusToken
+                            ? factory.createSubtract(expression, factory.createNumericLiteral(1))
+                            : factory.createAdd(expression, factory.createNumericLiteral(1));
                     }
                     return expression;
                 }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -361,17 +361,14 @@ namespace ts {
         // JSDoc nodes
         JSDocTypeExpression,
         JSDocNameReference,
-        // The * type
-        JSDocAllType,
-        // The ? type
-        JSDocUnknownType,
+        JSDocAllType, // The * type
+        JSDocUnknownType, // The ? type
         JSDocNullableType,
         JSDocNonNullableType,
         JSDocOptionalType,
         JSDocFunctionType,
         JSDocVariadicType,
-        // https://jsdoc.app/about-namepaths.html
-        JSDocNamepathType,
+        JSDocNamepathType, // https://jsdoc.app/about-namepaths.html
         JSDocComment,
         JSDocTypeLiteral,
         JSDocSignature,
@@ -1117,6 +1114,8 @@ namespace ts {
     export type EntityName = Identifier | QualifiedName;
 
     export type PropertyName = Identifier | StringLiteral | NumericLiteral | ComputedPropertyName | PrivateIdentifier;
+
+    export type MemberName = Identifier | PrivateIdentifier;
 
     export type DeclarationName =
         | Identifier
@@ -2224,7 +2223,7 @@ namespace ts {
         readonly kind: SyntaxKind.PropertyAccessExpression;
         readonly expression: LeftHandSideExpression;
         readonly questionDotToken?: QuestionDotToken;
-        readonly name: Identifier | PrivateIdentifier;
+        readonly name: MemberName;
     }
 
     /*@internal*/
@@ -2234,7 +2233,7 @@ namespace ts {
 
     export interface PropertyAccessChain extends PropertyAccessExpression {
         _optionalChainBrand: any;
-        readonly name: Identifier | PrivateIdentifier;
+        readonly name: MemberName;
     }
 
     /* @internal */
@@ -4130,9 +4129,9 @@ namespace ts {
          */
         /* @internal */ tryGetMemberInModuleExportsAndProperties(memberName: string, moduleSymbol: Symbol): Symbol | undefined;
         getApparentType(type: Type): Type;
-        /* @internal */ getSuggestedSymbolForNonexistentProperty(name: Identifier | PrivateIdentifier | string, containingType: Type): Symbol | undefined;
+        /* @internal */ getSuggestedSymbolForNonexistentProperty(name: MemberName | string, containingType: Type): Symbol | undefined;
         /* @internal */ getSuggestedSymbolForNonexistentJSXAttribute(name: Identifier | string, containingType: Type): Symbol | undefined;
-        /* @internal */ getSuggestionForNonexistentProperty(name: Identifier | PrivateIdentifier | string, containingType: Type): string | undefined;
+        /* @internal */ getSuggestionForNonexistentProperty(name: MemberName | string, containingType: Type): string | undefined;
         /* @internal */ getSuggestedSymbolForNonexistentSymbol(location: Node, name: string, meaning: SymbolFlags): Symbol | undefined;
         /* @internal */ getSuggestionForNonexistentSymbol(location: Node, name: string, meaning: SymbolFlags): string | undefined;
         /* @internal */ getSuggestedSymbolForNonexistentModule(node: Identifier, target: Symbol): Symbol | undefined;
@@ -6570,7 +6569,7 @@ namespace ts {
         /*@internal*/ IgnoreSourceNewlines = 1 << 27,   // Overrides `printerOptions.preserveSourceNewlines` to print this node (and all descendants) with default whitespace.
     }
 
-    export interface EmitHelper {
+    export interface EmitHelperBase {
         readonly name: string;                                          // A unique name for this helper.
         readonly scoped: boolean;                                       // Indicates whether the helper MUST be emitted in the current scope.
         readonly text: string | ((node: EmitHelperUniqueNameCallback) => string);  // ES3-compatible raw script text, or a function yielding such a string
@@ -6578,12 +6577,18 @@ namespace ts {
         readonly dependencies?: EmitHelper[]
     }
 
-    export interface UnscopedEmitHelper extends EmitHelper {
+    export interface ScopedEmitHelper extends EmitHelperBase {
+        readonly scoped: true;
+    }
+
+    export interface UnscopedEmitHelper extends EmitHelperBase {
         readonly scoped: false;                                         // Indicates whether the helper MUST be emitted in the current scope.
         /* @internal */
         readonly importName?: string;                                   // The name of the helper to use when importing via `--importHelpers`.
         readonly text: string;                                          // ES3-compatible raw script text, or a function yielding such a string
     }
+
+    export type EmitHelper = ScopedEmitHelper | UnscopedEmitHelper;
 
     /* @internal */
     export type UniqueNameHandler = (baseName: string, checkFn?: (name: string) => boolean, optimistic?: boolean) => string;
@@ -6943,10 +6948,10 @@ namespace ts {
         updateArrayLiteralExpression(node: ArrayLiteralExpression, elements: readonly Expression[]): ArrayLiteralExpression;
         createObjectLiteralExpression(properties?: readonly ObjectLiteralElementLike[], multiLine?: boolean): ObjectLiteralExpression;
         updateObjectLiteralExpression(node: ObjectLiteralExpression, properties: readonly ObjectLiteralElementLike[]): ObjectLiteralExpression;
-        createPropertyAccessExpression(expression: Expression, name: string | Identifier | PrivateIdentifier): PropertyAccessExpression;
-        updatePropertyAccessExpression(node: PropertyAccessExpression, expression: Expression, name: Identifier | PrivateIdentifier): PropertyAccessExpression;
-        createPropertyAccessChain(expression: Expression, questionDotToken: QuestionDotToken | undefined, name: string | Identifier | PrivateIdentifier): PropertyAccessChain;
-        updatePropertyAccessChain(node: PropertyAccessChain, expression: Expression, questionDotToken: QuestionDotToken | undefined, name: Identifier | PrivateIdentifier): PropertyAccessChain;
+        createPropertyAccessExpression(expression: Expression, name: string | MemberName): PropertyAccessExpression;
+        updatePropertyAccessExpression(node: PropertyAccessExpression, expression: Expression, name: MemberName): PropertyAccessExpression;
+        createPropertyAccessChain(expression: Expression, questionDotToken: QuestionDotToken | undefined, name: string | MemberName): PropertyAccessChain;
+        updatePropertyAccessChain(node: PropertyAccessChain, expression: Expression, questionDotToken: QuestionDotToken | undefined, name: MemberName): PropertyAccessChain;
         createElementAccessExpression(expression: Expression, index: number | Expression): ElementAccessExpression;
         updateElementAccessExpression(node: ElementAccessExpression, expression: Expression, argumentExpression: Expression): ElementAccessExpression;
         createElementAccessChain(expression: Expression, questionDotToken: QuestionDotToken | undefined, index: number | Expression): ElementAccessChain;
@@ -7782,13 +7787,13 @@ namespace ts {
          * });
          * ```
          */
-        onEmitNode?(hint: EmitHint, node: Node | undefined, emitCallback: (hint: EmitHint, node: Node | undefined) => void): void;
+        onEmitNode?(hint: EmitHint, node: Node, emitCallback: (hint: EmitHint, node: Node) => void): void;
 
         /**
          * A hook used to check if an emit notification is required for a node.
          * @param node The node to emit.
          */
-        isEmitNotificationEnabled?(node: Node | undefined): boolean;
+        isEmitNotificationEnabled?(node: Node): boolean;
         /**
          * A hook used by the Printer to perform just-in-time substitution of a node. This is
          * primarily used by node transformations that need to substitute one node for another,
@@ -7810,6 +7815,8 @@ namespace ts {
         /*@internal*/ onEmitSourceMapOfToken?: (node: Node | undefined, token: SyntaxKind, writer: (s: string) => void, pos: number, emitCallback: (token: SyntaxKind, writer: (s: string) => void, pos: number) => number) => number;
         /*@internal*/ onEmitSourceMapOfPosition?: (pos: number) => void;
         /*@internal*/ onSetSourceFile?: (node: SourceFile) => void;
+        /*@internal*/ onBeforeEmitNode?: (node: Node | undefined) => void;
+        /*@internal*/ onAfterEmitNode?: (node: Node | undefined) => void;
         /*@internal*/ onBeforeEmitNodeArray?: (nodes: NodeArray<any> | undefined) => void;
         /*@internal*/ onAfterEmitNodeArray?: (nodes: NodeArray<any> | undefined) => void;
         /*@internal*/ onBeforeEmitToken?: (node: Node) => void;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3210,11 +3210,11 @@ namespace ts {
         }
     }
     export function getTextOfIdentifierOrLiteral(node: PropertyNameLiteral): string {
-        return isIdentifierOrPrivateIdentifier(node) ? idText(node) : node.text;
+        return isMemberName(node) ? idText(node) : node.text;
     }
 
     export function getEscapedTextOfIdentifierOrLiteral(node: PropertyNameLiteral): __String {
-        return isIdentifierOrPrivateIdentifier(node) ? node.escapedText : escapeLeadingUnderscores(node.text);
+        return isMemberName(node) ? node.escapedText : escapeLeadingUnderscores(node.text);
     }
 
     export function getPropertyNameForUniqueESSymbol(symbol: Symbol): __String {
@@ -3602,6 +3602,7 @@ namespace ts {
             case SyntaxKind.TaggedTemplateExpression:
             case SyntaxKind.PropertyAccessExpression:
             case SyntaxKind.ElementAccessExpression:
+            case SyntaxKind.MetaProperty:
                 return OperatorPrecedence.Member;
 
             case SyntaxKind.AsExpression:

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -930,7 +930,7 @@ namespace ts {
 
     // #region
 
-    export function isIdentifierOrPrivateIdentifier(node: Node): node is Identifier | PrivateIdentifier {
+    export function isMemberName(node: Node): node is MemberName {
         return node.kind === SyntaxKind.Identifier || node.kind === SyntaxKind.PrivateIdentifier;
     }
 
@@ -1056,12 +1056,21 @@ namespace ts {
     }
 
     /**
+     * True if kind is of some token syntax kind.
+     * For example, this is true for an IfKeyword but not for an IfStatement.
+     * Literals are considered tokens, except TemplateLiteral, but does include TemplateHead/Middle/Tail.
+     */
+    export function isTokenKind(kind: SyntaxKind): boolean {
+        return kind >= SyntaxKind.FirstToken && kind <= SyntaxKind.LastToken;
+    }
+
+    /**
      * True if node is of some token syntax kind.
      * For example, this is true for an IfKeyword but not for an IfStatement.
      * Literals are considered tokens, except TemplateLiteral, but does include TemplateHead/Middle/Tail.
      */
     export function isToken(n: Node): boolean {
-        return n.kind >= SyntaxKind.FirstToken && n.kind <= SyntaxKind.LastToken;
+        return isTokenKind(n.kind);
     }
 
     // Node Arrays

--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -1,6 +1,4 @@
 namespace ts {
-    const isTypeNodeOrTypeParameterDeclaration = or(isTypeNode, isTypeParameterDeclaration);
-
     /**
      * Visits a Node using the supplied visitor, possibly returning a new Node in its place.
      *
@@ -350,755 +348,889 @@ namespace ts {
             // Names
 
             case SyntaxKind.Identifier:
-                return factory.updateIdentifier(<Identifier>node,
-                    nodesVisitor((<Identifier>node).typeArguments, visitor, isTypeNodeOrTypeParameterDeclaration));
+                Debug.type<Identifier>(node);
+                return factory.updateIdentifier(node,
+                    nodesVisitor(node.typeArguments, visitor, isTypeNodeOrTypeParameterDeclaration));
 
             case SyntaxKind.QualifiedName:
-                return factory.updateQualifiedName(<QualifiedName>node,
-                    nodeVisitor((<QualifiedName>node).left, visitor, isEntityName),
-                    nodeVisitor((<QualifiedName>node).right, visitor, isIdentifier));
+                Debug.type<QualifiedName>(node);
+                return factory.updateQualifiedName(node,
+                    nodeVisitor(node.left, visitor, isEntityName),
+                    nodeVisitor(node.right, visitor, isIdentifier));
 
             case SyntaxKind.ComputedPropertyName:
-                return factory.updateComputedPropertyName(<ComputedPropertyName>node,
-                    nodeVisitor((<ComputedPropertyName>node).expression, visitor, isExpression));
+                Debug.type<ComputedPropertyName>(node);
+                return factory.updateComputedPropertyName(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             // Signature elements
             case SyntaxKind.TypeParameter:
-                return factory.updateTypeParameterDeclaration(<TypeParameterDeclaration>node,
-                    nodeVisitor((<TypeParameterDeclaration>node).name, visitor, isIdentifier),
-                    nodeVisitor((<TypeParameterDeclaration>node).constraint, visitor, isTypeNode),
-                    nodeVisitor((<TypeParameterDeclaration>node).default, visitor, isTypeNode));
+                Debug.type<TypeParameterDeclaration>(node);
+                return factory.updateTypeParameterDeclaration(node,
+                    nodeVisitor(node.name, visitor, isIdentifier),
+                    nodeVisitor(node.constraint, visitor, isTypeNode),
+                    nodeVisitor(node.default, visitor, isTypeNode));
 
             case SyntaxKind.Parameter:
-                return factory.updateParameterDeclaration(<ParameterDeclaration>node,
-                    nodesVisitor((<ParameterDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<ParameterDeclaration>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<ParameterDeclaration>node).dotDotDotToken, tokenVisitor, isToken),
-                    nodeVisitor((<ParameterDeclaration>node).name, visitor, isBindingName),
-                    nodeVisitor((<ParameterDeclaration>node).questionToken, tokenVisitor, isToken),
-                    nodeVisitor((<ParameterDeclaration>node).type, visitor, isTypeNode),
-                    nodeVisitor((<ParameterDeclaration>node).initializer, visitor, isExpression));
+                Debug.type<ParameterDeclaration>(node);
+                return factory.updateParameterDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.dotDotDotToken, tokenVisitor, isDotDotDotToken),
+                    nodeVisitor(node.name, visitor, isBindingName),
+                    nodeVisitor(node.questionToken, tokenVisitor, isQuestionToken),
+                    nodeVisitor(node.type, visitor, isTypeNode),
+                    nodeVisitor(node.initializer, visitor, isExpression));
 
             case SyntaxKind.Decorator:
-                return factory.updateDecorator(<Decorator>node,
-                    nodeVisitor((<Decorator>node).expression, visitor, isExpression));
+                Debug.type<Decorator>(node);
+                return factory.updateDecorator(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             // Type elements
             case SyntaxKind.PropertySignature:
-                return factory.updatePropertySignature((<PropertySignature>node),
-                    nodesVisitor((<PropertySignature>node).modifiers, visitor, isToken),
-                    nodeVisitor((<PropertySignature>node).name, visitor, isPropertyName),
-                    nodeVisitor((<PropertySignature>node).questionToken, tokenVisitor, isToken),
-                    nodeVisitor((<PropertySignature>node).type, visitor, isTypeNode));
+                Debug.type<PropertySignature>(node);
+                return factory.updatePropertySignature(node,
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.name, visitor, isPropertyName),
+                    nodeVisitor(node.questionToken, tokenVisitor, isToken),
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             case SyntaxKind.PropertyDeclaration:
-                return factory.updatePropertyDeclaration(<PropertyDeclaration>node,
-                    nodesVisitor((<PropertyDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<PropertyDeclaration>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<PropertyDeclaration>node).name, visitor, isPropertyName),
+                Debug.type<PropertyDeclaration>(node);
+                return factory.updatePropertyDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.name, visitor, isPropertyName),
                     // QuestionToken and ExclamationToken is uniqued in Property Declaration and the signature of 'updateProperty' is that too
-                    nodeVisitor((<PropertyDeclaration>node).questionToken || (<PropertyDeclaration>node).exclamationToken, tokenVisitor, isToken),
-                    nodeVisitor((<PropertyDeclaration>node).type, visitor, isTypeNode),
-                    nodeVisitor((<PropertyDeclaration>node).initializer, visitor, isExpression));
+                    nodeVisitor(node.questionToken || node.exclamationToken, tokenVisitor, isQuestionOrExclamationToken),
+                    nodeVisitor(node.type, visitor, isTypeNode),
+                    nodeVisitor(node.initializer, visitor, isExpression));
 
             case SyntaxKind.MethodSignature:
-                return factory.updateMethodSignature(<MethodSignature>node,
-                    nodesVisitor((<ParameterDeclaration>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<MethodSignature>node).name, visitor, isPropertyName),
-                    nodeVisitor((<MethodSignature>node).questionToken, tokenVisitor, isToken),
-                    nodesVisitor((<MethodSignature>node).typeParameters, visitor, isTypeParameterDeclaration),
-                    nodesVisitor((<MethodSignature>node).parameters, visitor, isParameterDeclaration),
-                    nodeVisitor((<MethodSignature>node).type, visitor, isTypeNode));
+                Debug.type<MethodSignature>(node);
+                return factory.updateMethodSignature(node,
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.name, visitor, isPropertyName),
+                    nodeVisitor(node.questionToken, tokenVisitor, isQuestionToken),
+                    nodesVisitor(node.typeParameters, visitor, isTypeParameterDeclaration),
+                    nodesVisitor(node.parameters, visitor, isParameterDeclaration),
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             case SyntaxKind.MethodDeclaration:
-                return factory.updateMethodDeclaration(<MethodDeclaration>node,
-                    nodesVisitor((<MethodDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<MethodDeclaration>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<MethodDeclaration>node).asteriskToken, tokenVisitor, isToken),
-                    nodeVisitor((<MethodDeclaration>node).name, visitor, isPropertyName),
-                    nodeVisitor((<MethodDeclaration>node).questionToken, tokenVisitor, isToken),
-                    nodesVisitor((<MethodDeclaration>node).typeParameters, visitor, isTypeParameterDeclaration),
-                    visitParameterList((<MethodDeclaration>node).parameters, visitor, context, nodesVisitor),
-                    nodeVisitor((<MethodDeclaration>node).type, visitor, isTypeNode),
-                    visitFunctionBody((<MethodDeclaration>node).body!, visitor, context, nodeVisitor));
+                Debug.type<MethodDeclaration>(node);
+                return factory.updateMethodDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.asteriskToken, tokenVisitor, isAsteriskToken),
+                    nodeVisitor(node.name, visitor, isPropertyName),
+                    nodeVisitor(node.questionToken, tokenVisitor, isQuestionToken),
+                    nodesVisitor(node.typeParameters, visitor, isTypeParameterDeclaration),
+                    visitParameterList(node.parameters, visitor, context, nodesVisitor),
+                    nodeVisitor(node.type, visitor, isTypeNode),
+                    visitFunctionBody(node.body!, visitor, context, nodeVisitor));
 
             case SyntaxKind.Constructor:
-                return factory.updateConstructorDeclaration(<ConstructorDeclaration>node,
-                    nodesVisitor((<ConstructorDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<ConstructorDeclaration>node).modifiers, visitor, isModifier),
-                    visitParameterList((<ConstructorDeclaration>node).parameters, visitor, context, nodesVisitor),
-                    visitFunctionBody((<ConstructorDeclaration>node).body!, visitor, context, nodeVisitor));
+                Debug.type<ConstructorDeclaration>(node);
+                return factory.updateConstructorDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    visitParameterList(node.parameters, visitor, context, nodesVisitor),
+                    visitFunctionBody(node.body!, visitor, context, nodeVisitor));
 
             case SyntaxKind.GetAccessor:
-                return factory.updateGetAccessorDeclaration(<GetAccessorDeclaration>node,
-                    nodesVisitor((<GetAccessorDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<GetAccessorDeclaration>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<GetAccessorDeclaration>node).name, visitor, isPropertyName),
-                    visitParameterList((<GetAccessorDeclaration>node).parameters, visitor, context, nodesVisitor),
-                    nodeVisitor((<GetAccessorDeclaration>node).type, visitor, isTypeNode),
-                    visitFunctionBody((<GetAccessorDeclaration>node).body!, visitor, context, nodeVisitor));
+                Debug.type<GetAccessorDeclaration>(node);
+                return factory.updateGetAccessorDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.name, visitor, isPropertyName),
+                    visitParameterList(node.parameters, visitor, context, nodesVisitor),
+                    nodeVisitor(node.type, visitor, isTypeNode),
+                    visitFunctionBody(node.body!, visitor, context, nodeVisitor));
 
             case SyntaxKind.SetAccessor:
-                return factory.updateSetAccessorDeclaration(<SetAccessorDeclaration>node,
-                    nodesVisitor((<SetAccessorDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<SetAccessorDeclaration>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<SetAccessorDeclaration>node).name, visitor, isPropertyName),
-                    visitParameterList((<SetAccessorDeclaration>node).parameters, visitor, context, nodesVisitor),
-                    visitFunctionBody((<SetAccessorDeclaration>node).body!, visitor, context, nodeVisitor));
+                Debug.type<SetAccessorDeclaration>(node);
+                return factory.updateSetAccessorDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.name, visitor, isPropertyName),
+                    visitParameterList(node.parameters, visitor, context, nodesVisitor),
+                    visitFunctionBody(node.body!, visitor, context, nodeVisitor));
 
             case SyntaxKind.CallSignature:
-                return factory.updateCallSignature(<CallSignatureDeclaration>node,
-                    nodesVisitor((<CallSignatureDeclaration>node).typeParameters, visitor, isTypeParameterDeclaration),
-                    nodesVisitor((<CallSignatureDeclaration>node).parameters, visitor, isParameterDeclaration),
-                    nodeVisitor((<CallSignatureDeclaration>node).type, visitor, isTypeNode));
+                Debug.type<CallSignatureDeclaration>(node);
+                return factory.updateCallSignature(node,
+                    nodesVisitor(node.typeParameters, visitor, isTypeParameterDeclaration),
+                    nodesVisitor(node.parameters, visitor, isParameterDeclaration),
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             case SyntaxKind.ConstructSignature:
-                return factory.updateConstructSignature(<ConstructSignatureDeclaration>node,
-                    nodesVisitor((<ConstructSignatureDeclaration>node).typeParameters, visitor, isTypeParameterDeclaration),
-                    nodesVisitor((<ConstructSignatureDeclaration>node).parameters, visitor, isParameterDeclaration),
-                    nodeVisitor((<ConstructSignatureDeclaration>node).type, visitor, isTypeNode));
+                Debug.type<ConstructSignatureDeclaration>(node);
+                return factory.updateConstructSignature(node,
+                    nodesVisitor(node.typeParameters, visitor, isTypeParameterDeclaration),
+                    nodesVisitor(node.parameters, visitor, isParameterDeclaration),
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             case SyntaxKind.IndexSignature:
-                return factory.updateIndexSignature(<IndexSignatureDeclaration>node,
-                    nodesVisitor((<IndexSignatureDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<IndexSignatureDeclaration>node).modifiers, visitor, isModifier),
-                    nodesVisitor((<IndexSignatureDeclaration>node).parameters, visitor, isParameterDeclaration),
-                    nodeVisitor((<IndexSignatureDeclaration>node).type, visitor, isTypeNode));
+                Debug.type<IndexSignatureDeclaration>(node);
+                return factory.updateIndexSignature(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodesVisitor(node.parameters, visitor, isParameterDeclaration),
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             // Types
             case SyntaxKind.TypePredicate:
-                return factory.updateTypePredicateNode(<TypePredicateNode>node,
-                    nodeVisitor((<TypePredicateNode>node).assertsModifier, visitor),
-                    nodeVisitor((<TypePredicateNode>node).parameterName, visitor),
-                    nodeVisitor((<TypePredicateNode>node).type, visitor, isTypeNode));
+                Debug.type<TypePredicateNode>(node);
+                return factory.updateTypePredicateNode(node,
+                    nodeVisitor(node.assertsModifier, visitor, isAssertsKeyword),
+                    nodeVisitor(node.parameterName, visitor, isIdentifierOrThisTypeNode),
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             case SyntaxKind.TypeReference:
-                return factory.updateTypeReferenceNode(<TypeReferenceNode>node,
-                    nodeVisitor((<TypeReferenceNode>node).typeName, visitor, isEntityName),
-                    nodesVisitor((<TypeReferenceNode>node).typeArguments, visitor, isTypeNode));
+                Debug.type<TypeReferenceNode>(node);
+                return factory.updateTypeReferenceNode(node,
+                    nodeVisitor(node.typeName, visitor, isEntityName),
+                    nodesVisitor(node.typeArguments, visitor, isTypeNode));
 
             case SyntaxKind.FunctionType:
-                return factory.updateFunctionTypeNode(<FunctionTypeNode>node,
-                    nodesVisitor((<FunctionTypeNode>node).typeParameters, visitor, isTypeParameterDeclaration),
-                    nodesVisitor((<FunctionTypeNode>node).parameters, visitor, isParameterDeclaration),
-                    nodeVisitor((<FunctionTypeNode>node).type, visitor, isTypeNode));
+                Debug.type<FunctionTypeNode>(node);
+                return factory.updateFunctionTypeNode(node,
+                    nodesVisitor(node.typeParameters, visitor, isTypeParameterDeclaration),
+                    nodesVisitor(node.parameters, visitor, isParameterDeclaration),
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             case SyntaxKind.ConstructorType:
-                return factory.updateConstructorTypeNode(<ConstructorTypeNode>node,
-                    nodesVisitor((<ConstructorTypeNode>node).modifiers, visitor, isModifier),
-                    nodesVisitor((<ConstructorTypeNode>node).typeParameters, visitor, isTypeParameterDeclaration),
-                    nodesVisitor((<ConstructorTypeNode>node).parameters, visitor, isParameterDeclaration),
-                    nodeVisitor((<ConstructorTypeNode>node).type, visitor, isTypeNode));
+                Debug.type<ConstructorTypeNode>(node);
+                return factory.updateConstructorTypeNode(node,
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodesVisitor(node.typeParameters, visitor, isTypeParameterDeclaration),
+                    nodesVisitor(node.parameters, visitor, isParameterDeclaration),
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             case SyntaxKind.TypeQuery:
-                return factory.updateTypeQueryNode((<TypeQueryNode>node),
-                    nodeVisitor((<TypeQueryNode>node).exprName, visitor, isEntityName));
+                Debug.type<TypeQueryNode>(node);
+                return factory.updateTypeQueryNode(node,
+                    nodeVisitor(node.exprName, visitor, isEntityName));
 
             case SyntaxKind.TypeLiteral:
-                return factory.updateTypeLiteralNode((<TypeLiteralNode>node),
-                    nodesVisitor((<TypeLiteralNode>node).members, visitor, isTypeElement));
+                Debug.type<TypeLiteralNode>(node);
+                return factory.updateTypeLiteralNode(node,
+                    nodesVisitor(node.members, visitor, isTypeElement));
 
             case SyntaxKind.ArrayType:
-                return factory.updateArrayTypeNode(<ArrayTypeNode>node,
-                    nodeVisitor((<ArrayTypeNode>node).elementType, visitor, isTypeNode));
+                Debug.type<ArrayTypeNode>(node);
+                return factory.updateArrayTypeNode(node,
+                    nodeVisitor(node.elementType, visitor, isTypeNode));
 
             case SyntaxKind.TupleType:
-                return factory.updateTupleTypeNode((<TupleTypeNode>node),
-                    nodesVisitor((<TupleTypeNode>node).elements, visitor, isTypeNode));
+                Debug.type<TupleTypeNode>(node);
+                return factory.updateTupleTypeNode(node,
+                    nodesVisitor(node.elements, visitor, isTypeNode));
 
             case SyntaxKind.OptionalType:
-                return factory.updateOptionalTypeNode((<OptionalTypeNode>node),
-                    nodeVisitor((<OptionalTypeNode>node).type, visitor, isTypeNode));
+                Debug.type<OptionalTypeNode>(node);
+                return factory.updateOptionalTypeNode(node,
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             case SyntaxKind.RestType:
-                return factory.updateRestTypeNode((<RestTypeNode>node),
-                    nodeVisitor((<RestTypeNode>node).type, visitor, isTypeNode));
+                Debug.type<RestTypeNode>(node);
+                return factory.updateRestTypeNode(node,
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             case SyntaxKind.UnionType:
-                return factory.updateUnionTypeNode(<UnionTypeNode>node,
-                    nodesVisitor((<UnionTypeNode>node).types, visitor, isTypeNode));
+                Debug.type<UnionTypeNode>(node);
+                return factory.updateUnionTypeNode(node,
+                    nodesVisitor(node.types, visitor, isTypeNode));
 
             case SyntaxKind.IntersectionType:
-                return factory.updateIntersectionTypeNode(<IntersectionTypeNode>node,
-                    nodesVisitor((<IntersectionTypeNode>node).types, visitor, isTypeNode));
+                Debug.type<IntersectionTypeNode>(node);
+                return factory.updateIntersectionTypeNode(node,
+                    nodesVisitor(node.types, visitor, isTypeNode));
 
             case SyntaxKind.ConditionalType:
-                return factory.updateConditionalTypeNode(<ConditionalTypeNode>node,
-                    nodeVisitor((<ConditionalTypeNode>node).checkType, visitor, isTypeNode),
-                    nodeVisitor((<ConditionalTypeNode>node).extendsType, visitor, isTypeNode),
-                    nodeVisitor((<ConditionalTypeNode>node).trueType, visitor, isTypeNode),
-                    nodeVisitor((<ConditionalTypeNode>node).falseType, visitor, isTypeNode));
+                Debug.type<ConditionalTypeNode>(node);
+                return factory.updateConditionalTypeNode(node,
+                    nodeVisitor(node.checkType, visitor, isTypeNode),
+                    nodeVisitor(node.extendsType, visitor, isTypeNode),
+                    nodeVisitor(node.trueType, visitor, isTypeNode),
+                    nodeVisitor(node.falseType, visitor, isTypeNode));
 
             case SyntaxKind.InferType:
-                return factory.updateInferTypeNode(<InferTypeNode>node,
-                    nodeVisitor((<InferTypeNode>node).typeParameter, visitor, isTypeParameterDeclaration));
+                Debug.type<InferTypeNode>(node);
+                return factory.updateInferTypeNode(node,
+                    nodeVisitor(node.typeParameter, visitor, isTypeParameterDeclaration));
 
             case SyntaxKind.ImportType:
-                return factory.updateImportTypeNode(<ImportTypeNode>node,
-                    nodeVisitor((<ImportTypeNode>node).argument, visitor, isTypeNode),
-                    nodeVisitor((<ImportTypeNode>node).qualifier, visitor, isEntityName),
-                    visitNodes((<ImportTypeNode>node).typeArguments, visitor, isTypeNode),
-                    (<ImportTypeNode>node).isTypeOf
+                Debug.type<ImportTypeNode>(node);
+                return factory.updateImportTypeNode(node,
+                    nodeVisitor(node.argument, visitor, isTypeNode),
+                    nodeVisitor(node.qualifier, visitor, isEntityName),
+                    visitNodes(node.typeArguments, visitor, isTypeNode),
+                    node.isTypeOf
                 );
 
             case SyntaxKind.NamedTupleMember:
-                return factory.updateNamedTupleMember(<NamedTupleMember>node,
-                    visitNode((<NamedTupleMember>node).dotDotDotToken, visitor, isToken),
-                    visitNode((<NamedTupleMember>node).name, visitor, isIdentifier),
-                    visitNode((<NamedTupleMember>node).questionToken, visitor, isToken),
-                    visitNode((<NamedTupleMember>node).type, visitor, isTypeNode),
+                Debug.type<NamedTupleMember>(node);
+                return factory.updateNamedTupleMember(node,
+                    visitNode(node.dotDotDotToken, visitor, isDotDotDotToken),
+                    visitNode(node.name, visitor, isIdentifier),
+                    visitNode(node.questionToken, visitor, isQuestionToken),
+                    visitNode(node.type, visitor, isTypeNode),
                 );
 
             case SyntaxKind.ParenthesizedType:
-                return factory.updateParenthesizedType(<ParenthesizedTypeNode>node,
-                    nodeVisitor((<ParenthesizedTypeNode>node).type, visitor, isTypeNode));
+                Debug.type<ParenthesizedTypeNode>(node);
+                return factory.updateParenthesizedType(node,
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             case SyntaxKind.TypeOperator:
-                return factory.updateTypeOperatorNode(<TypeOperatorNode>node,
-                    nodeVisitor((<TypeOperatorNode>node).type, visitor, isTypeNode));
+                Debug.type<TypeOperatorNode>(node);
+                return factory.updateTypeOperatorNode(node,
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             case SyntaxKind.IndexedAccessType:
-                return factory.updateIndexedAccessTypeNode((<IndexedAccessTypeNode>node),
-                    nodeVisitor((<IndexedAccessTypeNode>node).objectType, visitor, isTypeNode),
-                    nodeVisitor((<IndexedAccessTypeNode>node).indexType, visitor, isTypeNode));
+                Debug.type<IndexedAccessTypeNode>(node);
+                return factory.updateIndexedAccessTypeNode(node,
+                    nodeVisitor(node.objectType, visitor, isTypeNode),
+                    nodeVisitor(node.indexType, visitor, isTypeNode));
 
             case SyntaxKind.MappedType:
-                return factory.updateMappedTypeNode((<MappedTypeNode>node),
-                    nodeVisitor((<MappedTypeNode>node).readonlyToken, tokenVisitor, isToken),
-                    nodeVisitor((<MappedTypeNode>node).typeParameter, visitor, isTypeParameterDeclaration),
-                    nodeVisitor((<MappedTypeNode>node).nameType, visitor, isTypeNode),
-                    nodeVisitor((<MappedTypeNode>node).questionToken, tokenVisitor, isToken),
-                    nodeVisitor((<MappedTypeNode>node).type, visitor, isTypeNode));
+                Debug.type<MappedTypeNode>(node);
+                return factory.updateMappedTypeNode(node,
+                    nodeVisitor(node.readonlyToken, tokenVisitor, isReadonlyKeywordOrPlusOrMinusToken),
+                    nodeVisitor(node.typeParameter, visitor, isTypeParameterDeclaration),
+                    nodeVisitor(node.nameType, visitor, isTypeNode),
+                    nodeVisitor(node.questionToken, tokenVisitor, isQuestionOrPlusOrMinusToken),
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             case SyntaxKind.LiteralType:
-                return factory.updateLiteralTypeNode(<LiteralTypeNode>node,
-                    nodeVisitor((<LiteralTypeNode>node).literal, visitor, isExpression));
+                Debug.type<LiteralTypeNode>(node);
+                return factory.updateLiteralTypeNode(node,
+                    nodeVisitor(node.literal, visitor, isExpression));
 
             case SyntaxKind.TemplateLiteralType:
-                return factory.updateTemplateLiteralType(<TemplateLiteralTypeNode>node,
-                    nodeVisitor((<TemplateLiteralTypeNode>node).head, visitor, isTemplateHead),
-                    nodesVisitor((<TemplateLiteralTypeNode>node).templateSpans, visitor, isTemplateLiteralTypeSpan));
+                Debug.type<TemplateLiteralTypeNode>(node);
+                return factory.updateTemplateLiteralType(node,
+                    nodeVisitor(node.head, visitor, isTemplateHead),
+                    nodesVisitor(node.templateSpans, visitor, isTemplateLiteralTypeSpan));
 
             case SyntaxKind.TemplateLiteralTypeSpan:
-                return factory.updateTemplateLiteralTypeSpan(<TemplateLiteralTypeSpan>node,
-                    nodeVisitor((<TemplateLiteralTypeSpan>node).type, visitor, isTypeNode),
-                    nodeVisitor((<TemplateLiteralTypeSpan>node).literal, visitor, isTemplateMiddleOrTemplateTail));
+                Debug.type<TemplateLiteralTypeSpan>(node);
+                return factory.updateTemplateLiteralTypeSpan(node,
+                    nodeVisitor(node.type, visitor, isTypeNode),
+                    nodeVisitor(node.literal, visitor, isTemplateMiddleOrTemplateTail));
 
             // Binding patterns
             case SyntaxKind.ObjectBindingPattern:
-                return factory.updateObjectBindingPattern(<ObjectBindingPattern>node,
-                    nodesVisitor((<ObjectBindingPattern>node).elements, visitor, isBindingElement));
+                Debug.type<ObjectBindingPattern>(node);
+                return factory.updateObjectBindingPattern(node,
+                    nodesVisitor(node.elements, visitor, isBindingElement));
 
             case SyntaxKind.ArrayBindingPattern:
-                return factory.updateArrayBindingPattern(<ArrayBindingPattern>node,
-                    nodesVisitor((<ArrayBindingPattern>node).elements, visitor, isArrayBindingElement));
+                Debug.type<ArrayBindingPattern>(node);
+                return factory.updateArrayBindingPattern(node,
+                    nodesVisitor(node.elements, visitor, isArrayBindingElement));
 
             case SyntaxKind.BindingElement:
-                return factory.updateBindingElement(<BindingElement>node,
-                    nodeVisitor((<BindingElement>node).dotDotDotToken, tokenVisitor, isToken),
-                    nodeVisitor((<BindingElement>node).propertyName, visitor, isPropertyName),
-                    nodeVisitor((<BindingElement>node).name, visitor, isBindingName),
-                    nodeVisitor((<BindingElement>node).initializer, visitor, isExpression));
+                Debug.type<BindingElement>(node);
+                return factory.updateBindingElement(node,
+                    nodeVisitor(node.dotDotDotToken, tokenVisitor, isDotDotDotToken),
+                    nodeVisitor(node.propertyName, visitor, isPropertyName),
+                    nodeVisitor(node.name, visitor, isBindingName),
+                    nodeVisitor(node.initializer, visitor, isExpression));
 
             // Expression
             case SyntaxKind.ArrayLiteralExpression:
-                return factory.updateArrayLiteralExpression(<ArrayLiteralExpression>node,
-                    nodesVisitor((<ArrayLiteralExpression>node).elements, visitor, isExpression));
+                Debug.type<ArrayLiteralExpression>(node);
+                return factory.updateArrayLiteralExpression(node,
+                    nodesVisitor(node.elements, visitor, isExpression));
 
             case SyntaxKind.ObjectLiteralExpression:
-                return factory.updateObjectLiteralExpression(<ObjectLiteralExpression>node,
-                    nodesVisitor((<ObjectLiteralExpression>node).properties, visitor, isObjectLiteralElementLike));
+                Debug.type<ObjectLiteralExpression>(node);
+                return factory.updateObjectLiteralExpression(node,
+                    nodesVisitor(node.properties, visitor, isObjectLiteralElementLike));
 
             case SyntaxKind.PropertyAccessExpression:
                 if (node.flags & NodeFlags.OptionalChain) {
-                    return factory.updatePropertyAccessChain(<PropertyAccessChain>node,
-                        nodeVisitor((<PropertyAccessChain>node).expression, visitor, isExpression),
-                        nodeVisitor((<PropertyAccessChain>node).questionDotToken, tokenVisitor, isToken),
-                        nodeVisitor((<PropertyAccessChain>node).name, visitor, isIdentifier));
+                    Debug.type<PropertyAccessChain>(node);
+                    return factory.updatePropertyAccessChain(node,
+                        nodeVisitor(node.expression, visitor, isExpression),
+                        nodeVisitor(node.questionDotToken, tokenVisitor, isQuestionDotToken),
+                        nodeVisitor(node.name, visitor, isMemberName));
                 }
-                return factory.updatePropertyAccessExpression(<PropertyAccessExpression>node,
-                    nodeVisitor((<PropertyAccessExpression>node).expression, visitor, isExpression),
-                    nodeVisitor((<PropertyAccessExpression>node).name, visitor, isIdentifierOrPrivateIdentifier));
+                Debug.type<PropertyAccessExpression>(node);
+                return factory.updatePropertyAccessExpression(node,
+                    nodeVisitor(node.expression, visitor, isExpression),
+                    nodeVisitor(node.name, visitor, isMemberName));
 
             case SyntaxKind.ElementAccessExpression:
                 if (node.flags & NodeFlags.OptionalChain) {
-                    return factory.updateElementAccessChain(<ElementAccessChain>node,
-                        nodeVisitor((<ElementAccessChain>node).expression, visitor, isExpression),
-                        nodeVisitor((<ElementAccessChain>node).questionDotToken, tokenVisitor, isToken),
-                        nodeVisitor((<ElementAccessChain>node).argumentExpression, visitor, isExpression));
+                    Debug.type<ElementAccessChain>(node);
+                    return factory.updateElementAccessChain(node,
+                        nodeVisitor(node.expression, visitor, isExpression),
+                        nodeVisitor(node.questionDotToken, tokenVisitor, isQuestionDotToken),
+                        nodeVisitor(node.argumentExpression, visitor, isExpression));
                 }
-                return factory.updateElementAccessExpression(<ElementAccessExpression>node,
-                    nodeVisitor((<ElementAccessExpression>node).expression, visitor, isExpression),
-                    nodeVisitor((<ElementAccessExpression>node).argumentExpression, visitor, isExpression));
+                Debug.type<ElementAccessExpression>(node);
+                return factory.updateElementAccessExpression(node,
+                    nodeVisitor(node.expression, visitor, isExpression),
+                    nodeVisitor(node.argumentExpression, visitor, isExpression));
 
             case SyntaxKind.CallExpression:
                 if (node.flags & NodeFlags.OptionalChain) {
-                    return factory.updateCallChain(<CallChain>node,
-                        nodeVisitor((<CallChain>node).expression, visitor, isExpression),
-                        nodeVisitor((<CallChain>node).questionDotToken, tokenVisitor, isToken),
-                        nodesVisitor((<CallChain>node).typeArguments, visitor, isTypeNode),
-                        nodesVisitor((<CallChain>node).arguments, visitor, isExpression));
+                    Debug.type<CallChain>(node);
+                    return factory.updateCallChain(node,
+                        nodeVisitor(node.expression, visitor, isExpression),
+                        nodeVisitor(node.questionDotToken, tokenVisitor, isQuestionDotToken),
+                        nodesVisitor(node.typeArguments, visitor, isTypeNode),
+                        nodesVisitor(node.arguments, visitor, isExpression));
                 }
-                return factory.updateCallExpression(<CallExpression>node,
-                    nodeVisitor((<CallExpression>node).expression, visitor, isExpression),
-                    nodesVisitor((<CallExpression>node).typeArguments, visitor, isTypeNode),
-                    nodesVisitor((<CallExpression>node).arguments, visitor, isExpression));
+                Debug.type<CallExpression>(node);
+                return factory.updateCallExpression(node,
+                    nodeVisitor(node.expression, visitor, isExpression),
+                    nodesVisitor(node.typeArguments, visitor, isTypeNode),
+                    nodesVisitor(node.arguments, visitor, isExpression));
 
             case SyntaxKind.NewExpression:
-                return factory.updateNewExpression(<NewExpression>node,
-                    nodeVisitor((<NewExpression>node).expression, visitor, isExpression),
-                    nodesVisitor((<NewExpression>node).typeArguments, visitor, isTypeNode),
-                    nodesVisitor((<NewExpression>node).arguments, visitor, isExpression));
+                Debug.type<NewExpression>(node);
+                return factory.updateNewExpression(node,
+                    nodeVisitor(node.expression, visitor, isExpression),
+                    nodesVisitor(node.typeArguments, visitor, isTypeNode),
+                    nodesVisitor(node.arguments, visitor, isExpression));
 
             case SyntaxKind.TaggedTemplateExpression:
-                return factory.updateTaggedTemplateExpression(<TaggedTemplateExpression>node,
-                    nodeVisitor((<TaggedTemplateExpression>node).tag, visitor, isExpression),
-                    visitNodes((<TaggedTemplateExpression>node).typeArguments, visitor, isExpression),
-                    nodeVisitor((<TaggedTemplateExpression>node).template, visitor, isTemplateLiteral));
+                Debug.type<TaggedTemplateExpression>(node);
+                return factory.updateTaggedTemplateExpression(node,
+                    nodeVisitor(node.tag, visitor, isExpression),
+                    visitNodes(node.typeArguments, visitor, isTypeNode),
+                    nodeVisitor(node.template, visitor, isTemplateLiteral));
 
             case SyntaxKind.TypeAssertionExpression:
-                return factory.updateTypeAssertion(<TypeAssertion>node,
-                    nodeVisitor((<TypeAssertion>node).type, visitor, isTypeNode),
-                    nodeVisitor((<TypeAssertion>node).expression, visitor, isExpression));
+                Debug.type<TypeAssertion>(node);
+                return factory.updateTypeAssertion(node,
+                    nodeVisitor(node.type, visitor, isTypeNode),
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.ParenthesizedExpression:
-                return factory.updateParenthesizedExpression(<ParenthesizedExpression>node,
-                    nodeVisitor((<ParenthesizedExpression>node).expression, visitor, isExpression));
+                Debug.type<ParenthesizedExpression>(node);
+                return factory.updateParenthesizedExpression(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.FunctionExpression:
-                return factory.updateFunctionExpression(<FunctionExpression>node,
-                    nodesVisitor((<FunctionExpression>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<FunctionExpression>node).asteriskToken, tokenVisitor, isToken),
-                    nodeVisitor((<FunctionExpression>node).name, visitor, isIdentifier),
-                    nodesVisitor((<FunctionExpression>node).typeParameters, visitor, isTypeParameterDeclaration),
-                    visitParameterList((<FunctionExpression>node).parameters, visitor, context, nodesVisitor),
-                    nodeVisitor((<FunctionExpression>node).type, visitor, isTypeNode),
-                    visitFunctionBody((<FunctionExpression>node).body, visitor, context, nodeVisitor));
+                Debug.type<FunctionExpression>(node);
+                return factory.updateFunctionExpression(node,
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.asteriskToken, tokenVisitor, isAsteriskToken),
+                    nodeVisitor(node.name, visitor, isIdentifier),
+                    nodesVisitor(node.typeParameters, visitor, isTypeParameterDeclaration),
+                    visitParameterList(node.parameters, visitor, context, nodesVisitor),
+                    nodeVisitor(node.type, visitor, isTypeNode),
+                    visitFunctionBody(node.body, visitor, context, nodeVisitor));
 
             case SyntaxKind.ArrowFunction:
-                return factory.updateArrowFunction(<ArrowFunction>node,
-                    nodesVisitor((<ArrowFunction>node).modifiers, visitor, isModifier),
-                    nodesVisitor((<ArrowFunction>node).typeParameters, visitor, isTypeParameterDeclaration),
-                    visitParameterList((<ArrowFunction>node).parameters, visitor, context, nodesVisitor),
-                    nodeVisitor((<ArrowFunction>node).type, visitor, isTypeNode),
-                    nodeVisitor((<ArrowFunction>node).equalsGreaterThanToken, tokenVisitor, isToken),
-                    visitFunctionBody((<ArrowFunction>node).body, visitor, context, nodeVisitor));
+                Debug.type<ArrowFunction>(node);
+                return factory.updateArrowFunction(node,
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodesVisitor(node.typeParameters, visitor, isTypeParameterDeclaration),
+                    visitParameterList(node.parameters, visitor, context, nodesVisitor),
+                    nodeVisitor(node.type, visitor, isTypeNode),
+                    nodeVisitor(node.equalsGreaterThanToken, tokenVisitor, isEqualsGreaterThanToken),
+                    visitFunctionBody(node.body, visitor, context, nodeVisitor));
 
             case SyntaxKind.DeleteExpression:
-                return factory.updateDeleteExpression(<DeleteExpression>node,
-                    nodeVisitor((<DeleteExpression>node).expression, visitor, isExpression));
+                Debug.type<DeleteExpression>(node);
+                return factory.updateDeleteExpression(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.TypeOfExpression:
-                return factory.updateTypeOfExpression(<TypeOfExpression>node,
-                    nodeVisitor((<TypeOfExpression>node).expression, visitor, isExpression));
+                Debug.type<TypeOfExpression>(node);
+                return factory.updateTypeOfExpression(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.VoidExpression:
-                return factory.updateVoidExpression(<VoidExpression>node,
-                    nodeVisitor((<VoidExpression>node).expression, visitor, isExpression));
+                Debug.type<VoidExpression>(node);
+                return factory.updateVoidExpression(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.AwaitExpression:
-                return factory.updateAwaitExpression(<AwaitExpression>node,
-                    nodeVisitor((<AwaitExpression>node).expression, visitor, isExpression));
+                Debug.type<AwaitExpression>(node);
+                return factory.updateAwaitExpression(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.PrefixUnaryExpression:
-                return factory.updatePrefixUnaryExpression(<PrefixUnaryExpression>node,
-                    nodeVisitor((<PrefixUnaryExpression>node).operand, visitor, isExpression));
+                Debug.type<PrefixUnaryExpression>(node);
+                return factory.updatePrefixUnaryExpression(node,
+                    nodeVisitor(node.operand, visitor, isExpression));
 
             case SyntaxKind.PostfixUnaryExpression:
-                return factory.updatePostfixUnaryExpression(<PostfixUnaryExpression>node,
-                    nodeVisitor((<PostfixUnaryExpression>node).operand, visitor, isExpression));
+                Debug.type<PostfixUnaryExpression>(node);
+                return factory.updatePostfixUnaryExpression(node,
+                    nodeVisitor(node.operand, visitor, isExpression));
 
             case SyntaxKind.BinaryExpression:
-                return factory.updateBinaryExpression(<BinaryExpression>node,
-                    nodeVisitor((<BinaryExpression>node).left, visitor, isExpression),
-                    nodeVisitor((<BinaryExpression>node).operatorToken, tokenVisitor, isToken),
-                    nodeVisitor((<BinaryExpression>node).right, visitor, isExpression));
+                Debug.type<BinaryExpression>(node);
+                return factory.updateBinaryExpression(node,
+                    nodeVisitor(node.left, visitor, isExpression),
+                    nodeVisitor(node.operatorToken, tokenVisitor, isBinaryOperatorToken),
+                    nodeVisitor(node.right, visitor, isExpression));
 
             case SyntaxKind.ConditionalExpression:
-                return factory.updateConditionalExpression(<ConditionalExpression>node,
-                    nodeVisitor((<ConditionalExpression>node).condition, visitor, isExpression),
-                    nodeVisitor((<ConditionalExpression>node).questionToken, tokenVisitor, isToken),
-                    nodeVisitor((<ConditionalExpression>node).whenTrue, visitor, isExpression),
-                    nodeVisitor((<ConditionalExpression>node).colonToken, tokenVisitor, isToken),
-                    nodeVisitor((<ConditionalExpression>node).whenFalse, visitor, isExpression));
+                Debug.type<ConditionalExpression>(node);
+                return factory.updateConditionalExpression(node,
+                    nodeVisitor(node.condition, visitor, isExpression),
+                    nodeVisitor(node.questionToken, tokenVisitor, isQuestionToken),
+                    nodeVisitor(node.whenTrue, visitor, isExpression),
+                    nodeVisitor(node.colonToken, tokenVisitor, isColonToken),
+                    nodeVisitor(node.whenFalse, visitor, isExpression));
 
             case SyntaxKind.TemplateExpression:
-                return factory.updateTemplateExpression(<TemplateExpression>node,
-                    nodeVisitor((<TemplateExpression>node).head, visitor, isTemplateHead),
-                    nodesVisitor((<TemplateExpression>node).templateSpans, visitor, isTemplateSpan));
+                Debug.type<TemplateExpression>(node);
+                return factory.updateTemplateExpression(node,
+                    nodeVisitor(node.head, visitor, isTemplateHead),
+                    nodesVisitor(node.templateSpans, visitor, isTemplateSpan));
 
             case SyntaxKind.YieldExpression:
-                return factory.updateYieldExpression(<YieldExpression>node,
-                    nodeVisitor((<YieldExpression>node).asteriskToken, tokenVisitor, isToken),
-                    nodeVisitor((<YieldExpression>node).expression, visitor, isExpression));
+                Debug.type<YieldExpression>(node);
+                return factory.updateYieldExpression(node,
+                    nodeVisitor(node.asteriskToken, tokenVisitor, isAsteriskToken),
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.SpreadElement:
-                return factory.updateSpreadElement(<SpreadElement>node,
-                    nodeVisitor((<SpreadElement>node).expression, visitor, isExpression));
+                Debug.type<SpreadElement>(node);
+                return factory.updateSpreadElement(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.ClassExpression:
-                return factory.updateClassExpression(<ClassExpression>node,
-                    nodesVisitor((<ClassExpression>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<ClassExpression>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<ClassExpression>node).name, visitor, isIdentifier),
-                    nodesVisitor((<ClassExpression>node).typeParameters, visitor, isTypeParameterDeclaration),
-                    nodesVisitor((<ClassExpression>node).heritageClauses, visitor, isHeritageClause),
-                    nodesVisitor((<ClassExpression>node).members, visitor, isClassElement));
+                Debug.type<ClassExpression>(node);
+                return factory.updateClassExpression(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.name, visitor, isIdentifier),
+                    nodesVisitor(node.typeParameters, visitor, isTypeParameterDeclaration),
+                    nodesVisitor(node.heritageClauses, visitor, isHeritageClause),
+                    nodesVisitor(node.members, visitor, isClassElement));
 
             case SyntaxKind.ExpressionWithTypeArguments:
-                return factory.updateExpressionWithTypeArguments(<ExpressionWithTypeArguments>node,
-                    nodeVisitor((<ExpressionWithTypeArguments>node).expression, visitor, isExpression),
-                    nodesVisitor((<ExpressionWithTypeArguments>node).typeArguments, visitor, isTypeNode));
+                Debug.type<ExpressionWithTypeArguments>(node);
+                return factory.updateExpressionWithTypeArguments(node,
+                    nodeVisitor(node.expression, visitor, isExpression),
+                    nodesVisitor(node.typeArguments, visitor, isTypeNode));
 
             case SyntaxKind.AsExpression:
-                return factory.updateAsExpression(<AsExpression>node,
-                    nodeVisitor((<AsExpression>node).expression, visitor, isExpression),
-                    nodeVisitor((<AsExpression>node).type, visitor, isTypeNode));
+                Debug.type<AsExpression>(node);
+                return factory.updateAsExpression(node,
+                    nodeVisitor(node.expression, visitor, isExpression),
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             case SyntaxKind.NonNullExpression:
                 if (node.flags & NodeFlags.OptionalChain) {
-                    return factory.updateNonNullChain(<NonNullChain>node,
-                        nodeVisitor((<NonNullChain>node).expression, visitor, isExpression));
+                    Debug.type<NonNullChain>(node);
+                    return factory.updateNonNullChain(node,
+                        nodeVisitor(node.expression, visitor, isExpression));
                 }
-                return factory.updateNonNullExpression(<NonNullExpression>node,
-                    nodeVisitor((<NonNullExpression>node).expression, visitor, isExpression));
+                Debug.type<NonNullExpression>(node);
+                return factory.updateNonNullExpression(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.MetaProperty:
-                return factory.updateMetaProperty(<MetaProperty>node,
-                    nodeVisitor((<MetaProperty>node).name, visitor, isIdentifier));
+                Debug.type<MetaProperty>(node);
+                return factory.updateMetaProperty(node,
+                    nodeVisitor(node.name, visitor, isIdentifier));
 
             // Misc
             case SyntaxKind.TemplateSpan:
-                return factory.updateTemplateSpan(<TemplateSpan>node,
-                    nodeVisitor((<TemplateSpan>node).expression, visitor, isExpression),
-                    nodeVisitor((<TemplateSpan>node).literal, visitor, isTemplateMiddleOrTemplateTail));
+                Debug.type<TemplateSpan>(node);
+                return factory.updateTemplateSpan(node,
+                    nodeVisitor(node.expression, visitor, isExpression),
+                    nodeVisitor(node.literal, visitor, isTemplateMiddleOrTemplateTail));
 
             // Element
             case SyntaxKind.Block:
-                return factory.updateBlock(<Block>node,
-                    nodesVisitor((<Block>node).statements, visitor, isStatement));
+                Debug.type<Block>(node);
+                return factory.updateBlock(node,
+                    nodesVisitor(node.statements, visitor, isStatement));
 
             case SyntaxKind.VariableStatement:
-                return factory.updateVariableStatement(<VariableStatement>node,
-                    nodesVisitor((<VariableStatement>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<VariableStatement>node).declarationList, visitor, isVariableDeclarationList));
+                Debug.type<VariableStatement>(node);
+                return factory.updateVariableStatement(node,
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.declarationList, visitor, isVariableDeclarationList));
 
             case SyntaxKind.ExpressionStatement:
-                return factory.updateExpressionStatement(<ExpressionStatement>node,
-                    nodeVisitor((<ExpressionStatement>node).expression, visitor, isExpression));
+                Debug.type<ExpressionStatement>(node);
+                return factory.updateExpressionStatement(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.IfStatement:
-                return factory.updateIfStatement(<IfStatement>node,
-                    nodeVisitor((<IfStatement>node).expression, visitor, isExpression),
-                    nodeVisitor((<IfStatement>node).thenStatement, visitor, isStatement, factory.liftToBlock),
-                    nodeVisitor((<IfStatement>node).elseStatement, visitor, isStatement, factory.liftToBlock));
+                Debug.type<IfStatement>(node);
+                return factory.updateIfStatement(node,
+                    nodeVisitor(node.expression, visitor, isExpression),
+                    nodeVisitor(node.thenStatement, visitor, isStatement, factory.liftToBlock),
+                    nodeVisitor(node.elseStatement, visitor, isStatement, factory.liftToBlock));
 
             case SyntaxKind.DoStatement:
-                return factory.updateDoStatement(<DoStatement>node,
-                    nodeVisitor((<DoStatement>node).statement, visitor, isStatement, factory.liftToBlock),
-                    nodeVisitor((<DoStatement>node).expression, visitor, isExpression));
+                Debug.type<DoStatement>(node);
+                return factory.updateDoStatement(node,
+                    nodeVisitor(node.statement, visitor, isStatement, factory.liftToBlock),
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.WhileStatement:
-                return factory.updateWhileStatement(<WhileStatement>node,
-                    nodeVisitor((<WhileStatement>node).expression, visitor, isExpression),
-                    nodeVisitor((<WhileStatement>node).statement, visitor, isStatement, factory.liftToBlock));
+                Debug.type<WhileStatement>(node);
+                return factory.updateWhileStatement(node,
+                    nodeVisitor(node.expression, visitor, isExpression),
+                    nodeVisitor(node.statement, visitor, isStatement, factory.liftToBlock));
 
             case SyntaxKind.ForStatement:
-                return factory.updateForStatement(<ForStatement>node,
-                    nodeVisitor((<ForStatement>node).initializer, visitor, isForInitializer),
-                    nodeVisitor((<ForStatement>node).condition, visitor, isExpression),
-                    nodeVisitor((<ForStatement>node).incrementor, visitor, isExpression),
-                    nodeVisitor((<ForStatement>node).statement, visitor, isStatement, factory.liftToBlock));
+                Debug.type<ForStatement>(node);
+                return factory.updateForStatement(node,
+                    nodeVisitor(node.initializer, visitor, isForInitializer),
+                    nodeVisitor(node.condition, visitor, isExpression),
+                    nodeVisitor(node.incrementor, visitor, isExpression),
+                    nodeVisitor(node.statement, visitor, isStatement, factory.liftToBlock));
 
             case SyntaxKind.ForInStatement:
-                return factory.updateForInStatement(<ForInStatement>node,
-                    nodeVisitor((<ForInStatement>node).initializer, visitor, isForInitializer),
-                    nodeVisitor((<ForInStatement>node).expression, visitor, isExpression),
-                    nodeVisitor((<ForInStatement>node).statement, visitor, isStatement, factory.liftToBlock));
+                Debug.type<ForInStatement>(node);
+                return factory.updateForInStatement(node,
+                    nodeVisitor(node.initializer, visitor, isForInitializer),
+                    nodeVisitor(node.expression, visitor, isExpression),
+                    nodeVisitor(node.statement, visitor, isStatement, factory.liftToBlock));
 
             case SyntaxKind.ForOfStatement:
-                return factory.updateForOfStatement(<ForOfStatement>node,
-                    nodeVisitor((<ForOfStatement>node).awaitModifier, tokenVisitor, isToken),
-                    nodeVisitor((<ForOfStatement>node).initializer, visitor, isForInitializer),
-                    nodeVisitor((<ForOfStatement>node).expression, visitor, isExpression),
-                    nodeVisitor((<ForOfStatement>node).statement, visitor, isStatement, factory.liftToBlock));
+                Debug.type<ForOfStatement>(node);
+                return factory.updateForOfStatement(node,
+                    nodeVisitor(node.awaitModifier, tokenVisitor, isAwaitKeyword),
+                    nodeVisitor(node.initializer, visitor, isForInitializer),
+                    nodeVisitor(node.expression, visitor, isExpression),
+                    nodeVisitor(node.statement, visitor, isStatement, factory.liftToBlock));
 
             case SyntaxKind.ContinueStatement:
-                return factory.updateContinueStatement(<ContinueStatement>node,
-                    nodeVisitor((<ContinueStatement>node).label, visitor, isIdentifier));
+                Debug.type<ContinueStatement>(node);
+                return factory.updateContinueStatement(node,
+                    nodeVisitor(node.label, visitor, isIdentifier));
 
             case SyntaxKind.BreakStatement:
-                return factory.updateBreakStatement(<BreakStatement>node,
-                    nodeVisitor((<BreakStatement>node).label, visitor, isIdentifier));
+                Debug.type<BreakStatement>(node);
+                return factory.updateBreakStatement(node,
+                    nodeVisitor(node.label, visitor, isIdentifier));
 
             case SyntaxKind.ReturnStatement:
-                return factory.updateReturnStatement(<ReturnStatement>node,
-                    nodeVisitor((<ReturnStatement>node).expression, visitor, isExpression));
+                Debug.type<ReturnStatement>(node);
+                return factory.updateReturnStatement(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.WithStatement:
-                return factory.updateWithStatement(<WithStatement>node,
-                    nodeVisitor((<WithStatement>node).expression, visitor, isExpression),
-                    nodeVisitor((<WithStatement>node).statement, visitor, isStatement, factory.liftToBlock));
+                Debug.type<WithStatement>(node);
+                return factory.updateWithStatement(node,
+                    nodeVisitor(node.expression, visitor, isExpression),
+                    nodeVisitor(node.statement, visitor, isStatement, factory.liftToBlock));
 
             case SyntaxKind.SwitchStatement:
-                return factory.updateSwitchStatement(<SwitchStatement>node,
-                    nodeVisitor((<SwitchStatement>node).expression, visitor, isExpression),
-                    nodeVisitor((<SwitchStatement>node).caseBlock, visitor, isCaseBlock));
+                Debug.type<SwitchStatement>(node);
+                return factory.updateSwitchStatement(node,
+                    nodeVisitor(node.expression, visitor, isExpression),
+                    nodeVisitor(node.caseBlock, visitor, isCaseBlock));
 
             case SyntaxKind.LabeledStatement:
-                return factory.updateLabeledStatement(<LabeledStatement>node,
-                    nodeVisitor((<LabeledStatement>node).label, visitor, isIdentifier),
-                    nodeVisitor((<LabeledStatement>node).statement, visitor, isStatement, factory.liftToBlock));
+                Debug.type<LabeledStatement>(node);
+                return factory.updateLabeledStatement(node,
+                    nodeVisitor(node.label, visitor, isIdentifier),
+                    nodeVisitor(node.statement, visitor, isStatement, factory.liftToBlock));
 
             case SyntaxKind.ThrowStatement:
-                return factory.updateThrowStatement(<ThrowStatement>node,
-                    nodeVisitor((<ThrowStatement>node).expression, visitor, isExpression));
+                Debug.type<ThrowStatement>(node);
+                return factory.updateThrowStatement(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.TryStatement:
-                return factory.updateTryStatement(<TryStatement>node,
-                    nodeVisitor((<TryStatement>node).tryBlock, visitor, isBlock),
-                    nodeVisitor((<TryStatement>node).catchClause, visitor, isCatchClause),
-                    nodeVisitor((<TryStatement>node).finallyBlock, visitor, isBlock));
+                Debug.type<TryStatement>(node);
+                return factory.updateTryStatement(node,
+                    nodeVisitor(node.tryBlock, visitor, isBlock),
+                    nodeVisitor(node.catchClause, visitor, isCatchClause),
+                    nodeVisitor(node.finallyBlock, visitor, isBlock));
 
             case SyntaxKind.VariableDeclaration:
-                return factory.updateVariableDeclaration(<VariableDeclaration>node,
-                    nodeVisitor((<VariableDeclaration>node).name, visitor, isBindingName),
-                    nodeVisitor((<VariableDeclaration>node).exclamationToken, tokenVisitor, isToken),
-                    nodeVisitor((<VariableDeclaration>node).type, visitor, isTypeNode),
-                    nodeVisitor((<VariableDeclaration>node).initializer, visitor, isExpression));
+                Debug.type<VariableDeclaration>(node);
+                return factory.updateVariableDeclaration(node,
+                    nodeVisitor(node.name, visitor, isBindingName),
+                    nodeVisitor(node.exclamationToken, tokenVisitor, isExclamationToken),
+                    nodeVisitor(node.type, visitor, isTypeNode),
+                    nodeVisitor(node.initializer, visitor, isExpression));
 
             case SyntaxKind.VariableDeclarationList:
-                return factory.updateVariableDeclarationList(<VariableDeclarationList>node,
-                    nodesVisitor((<VariableDeclarationList>node).declarations, visitor, isVariableDeclaration));
+                Debug.type<VariableDeclarationList>(node);
+                return factory.updateVariableDeclarationList(node,
+                    nodesVisitor(node.declarations, visitor, isVariableDeclaration));
 
             case SyntaxKind.FunctionDeclaration:
-                return factory.updateFunctionDeclaration(<FunctionDeclaration>node,
-                    nodesVisitor((<FunctionDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<FunctionDeclaration>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<FunctionDeclaration>node).asteriskToken, tokenVisitor, isToken),
-                    nodeVisitor((<FunctionDeclaration>node).name, visitor, isIdentifier),
-                    nodesVisitor((<FunctionDeclaration>node).typeParameters, visitor, isTypeParameterDeclaration),
-                    visitParameterList((<FunctionDeclaration>node).parameters, visitor, context, nodesVisitor),
-                    nodeVisitor((<FunctionDeclaration>node).type, visitor, isTypeNode),
-                    visitFunctionBody((<FunctionExpression>node).body, visitor, context, nodeVisitor));
+                Debug.type<FunctionDeclaration>(node);
+                return factory.updateFunctionDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.asteriskToken, tokenVisitor, isAsteriskToken),
+                    nodeVisitor(node.name, visitor, isIdentifier),
+                    nodesVisitor(node.typeParameters, visitor, isTypeParameterDeclaration),
+                    visitParameterList(node.parameters, visitor, context, nodesVisitor),
+                    nodeVisitor(node.type, visitor, isTypeNode),
+                    visitFunctionBody(node.body, visitor, context, nodeVisitor));
 
             case SyntaxKind.ClassDeclaration:
-                return factory.updateClassDeclaration(<ClassDeclaration>node,
-                    nodesVisitor((<ClassDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<ClassDeclaration>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<ClassDeclaration>node).name, visitor, isIdentifier),
-                    nodesVisitor((<ClassDeclaration>node).typeParameters, visitor, isTypeParameterDeclaration),
-                    nodesVisitor((<ClassDeclaration>node).heritageClauses, visitor, isHeritageClause),
-                    nodesVisitor((<ClassDeclaration>node).members, visitor, isClassElement));
+                Debug.type<ClassDeclaration>(node);
+                return factory.updateClassDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.name, visitor, isIdentifier),
+                    nodesVisitor(node.typeParameters, visitor, isTypeParameterDeclaration),
+                    nodesVisitor(node.heritageClauses, visitor, isHeritageClause),
+                    nodesVisitor(node.members, visitor, isClassElement));
 
             case SyntaxKind.InterfaceDeclaration:
-                return factory.updateInterfaceDeclaration(<InterfaceDeclaration>node,
-                    nodesVisitor((<InterfaceDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<InterfaceDeclaration>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<InterfaceDeclaration>node).name, visitor, isIdentifier),
-                    nodesVisitor((<InterfaceDeclaration>node).typeParameters, visitor, isTypeParameterDeclaration),
-                    nodesVisitor((<InterfaceDeclaration>node).heritageClauses, visitor, isHeritageClause),
-                    nodesVisitor((<InterfaceDeclaration>node).members, visitor, isTypeElement));
+                Debug.type<InterfaceDeclaration>(node);
+                return factory.updateInterfaceDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.name, visitor, isIdentifier),
+                    nodesVisitor(node.typeParameters, visitor, isTypeParameterDeclaration),
+                    nodesVisitor(node.heritageClauses, visitor, isHeritageClause),
+                    nodesVisitor(node.members, visitor, isTypeElement));
 
             case SyntaxKind.TypeAliasDeclaration:
-                return factory.updateTypeAliasDeclaration(<TypeAliasDeclaration>node,
-                    nodesVisitor((<TypeAliasDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<TypeAliasDeclaration>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<TypeAliasDeclaration>node).name, visitor, isIdentifier),
-                    nodesVisitor((<TypeAliasDeclaration>node).typeParameters, visitor, isTypeParameterDeclaration),
-                    nodeVisitor((<TypeAliasDeclaration>node).type, visitor, isTypeNode));
+                Debug.type<TypeAliasDeclaration>(node);
+                return factory.updateTypeAliasDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.name, visitor, isIdentifier),
+                    nodesVisitor(node.typeParameters, visitor, isTypeParameterDeclaration),
+                    nodeVisitor(node.type, visitor, isTypeNode));
 
             case SyntaxKind.EnumDeclaration:
-                return factory.updateEnumDeclaration(<EnumDeclaration>node,
-                    nodesVisitor((<EnumDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<EnumDeclaration>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<EnumDeclaration>node).name, visitor, isIdentifier),
-                    nodesVisitor((<EnumDeclaration>node).members, visitor, isEnumMember));
+                Debug.type<EnumDeclaration>(node);
+                return factory.updateEnumDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.name, visitor, isIdentifier),
+                    nodesVisitor(node.members, visitor, isEnumMember));
 
             case SyntaxKind.ModuleDeclaration:
-                return factory.updateModuleDeclaration(<ModuleDeclaration>node,
-                    nodesVisitor((<ModuleDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<ModuleDeclaration>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<ModuleDeclaration>node).name, visitor, isIdentifier),
-                    nodeVisitor((<ModuleDeclaration>node).body, visitor, isModuleBody));
+                Debug.type<ModuleDeclaration>(node);
+                return factory.updateModuleDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.name, visitor, isModuleName),
+                    nodeVisitor(node.body, visitor, isModuleBody));
 
             case SyntaxKind.ModuleBlock:
-                return factory.updateModuleBlock(<ModuleBlock>node,
-                    nodesVisitor((<ModuleBlock>node).statements, visitor, isStatement));
+                Debug.type<ModuleBlock>(node);
+                return factory.updateModuleBlock(node,
+                    nodesVisitor(node.statements, visitor, isStatement));
 
             case SyntaxKind.CaseBlock:
-                return factory.updateCaseBlock(<CaseBlock>node,
-                    nodesVisitor((<CaseBlock>node).clauses, visitor, isCaseOrDefaultClause));
+                Debug.type<CaseBlock>(node);
+                return factory.updateCaseBlock(node,
+                    nodesVisitor(node.clauses, visitor, isCaseOrDefaultClause));
 
             case SyntaxKind.NamespaceExportDeclaration:
-                return factory.updateNamespaceExportDeclaration(<NamespaceExportDeclaration>node,
-                    nodeVisitor((<NamespaceExportDeclaration>node).name, visitor, isIdentifier));
+                Debug.type<NamespaceExportDeclaration>(node);
+                return factory.updateNamespaceExportDeclaration(node,
+                    nodeVisitor(node.name, visitor, isIdentifier));
 
             case SyntaxKind.ImportEqualsDeclaration:
-                return factory.updateImportEqualsDeclaration(<ImportEqualsDeclaration>node,
-                    nodesVisitor((<ImportEqualsDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<ImportEqualsDeclaration>node).modifiers, visitor, isModifier),
-                    (<ImportEqualsDeclaration>node).isTypeOnly,
-                    nodeVisitor((<ImportEqualsDeclaration>node).name, visitor, isIdentifier),
-                    nodeVisitor((<ImportEqualsDeclaration>node).moduleReference, visitor, isModuleReference));
+                Debug.type<ImportEqualsDeclaration>(node);
+                return factory.updateImportEqualsDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    node.isTypeOnly,
+                    nodeVisitor(node.name, visitor, isIdentifier),
+                    nodeVisitor(node.moduleReference, visitor, isModuleReference));
 
             case SyntaxKind.ImportDeclaration:
-                return factory.updateImportDeclaration(<ImportDeclaration>node,
-                    nodesVisitor((<ImportDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<ImportDeclaration>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<ImportDeclaration>node).importClause, visitor, isImportClause),
-                    nodeVisitor((<ImportDeclaration>node).moduleSpecifier, visitor, isExpression));
+                Debug.type<ImportDeclaration>(node);
+                return factory.updateImportDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.importClause, visitor, isImportClause),
+                    nodeVisitor(node.moduleSpecifier, visitor, isExpression));
 
             case SyntaxKind.ImportClause:
-                return factory.updateImportClause(<ImportClause>node,
-                    (<ImportClause>node).isTypeOnly,
-                    nodeVisitor((<ImportClause>node).name, visitor, isIdentifier),
-                    nodeVisitor((<ImportClause>node).namedBindings, visitor, isNamedImportBindings));
+                Debug.type<ImportClause>(node);
+                return factory.updateImportClause(node,
+                    node.isTypeOnly,
+                    nodeVisitor(node.name, visitor, isIdentifier),
+                    nodeVisitor(node.namedBindings, visitor, isNamedImportBindings));
 
             case SyntaxKind.NamespaceImport:
-                return factory.updateNamespaceImport(<NamespaceImport>node,
-                    nodeVisitor((<NamespaceImport>node).name, visitor, isIdentifier));
+                Debug.type<NamespaceImport>(node);
+                return factory.updateNamespaceImport(node,
+                    nodeVisitor(node.name, visitor, isIdentifier));
 
             case SyntaxKind.NamespaceExport:
-                    return factory.updateNamespaceExport(<NamespaceExport>node,
-                        nodeVisitor((<NamespaceExport>node).name, visitor, isIdentifier));
+                    Debug.type<NamespaceExport>(node);
+                    return factory.updateNamespaceExport(node,
+                        nodeVisitor(node.name, visitor, isIdentifier));
 
             case SyntaxKind.NamedImports:
-                return factory.updateNamedImports(<NamedImports>node,
-                    nodesVisitor((<NamedImports>node).elements, visitor, isImportSpecifier));
+                Debug.type<NamedImports>(node);
+                return factory.updateNamedImports(node,
+                    nodesVisitor(node.elements, visitor, isImportSpecifier));
 
             case SyntaxKind.ImportSpecifier:
-                return factory.updateImportSpecifier(<ImportSpecifier>node,
-                    nodeVisitor((<ImportSpecifier>node).propertyName, visitor, isIdentifier),
-                    nodeVisitor((<ImportSpecifier>node).name, visitor, isIdentifier));
+                Debug.type<ImportSpecifier>(node);
+                return factory.updateImportSpecifier(node,
+                    nodeVisitor(node.propertyName, visitor, isIdentifier),
+                    nodeVisitor(node.name, visitor, isIdentifier));
 
             case SyntaxKind.ExportAssignment:
-                return factory.updateExportAssignment(<ExportAssignment>node,
-                    nodesVisitor((<ExportAssignment>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<ExportAssignment>node).modifiers, visitor, isModifier),
-                    nodeVisitor((<ExportAssignment>node).expression, visitor, isExpression));
+                Debug.type<ExportAssignment>(node);
+                return factory.updateExportAssignment(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.ExportDeclaration:
-                return factory.updateExportDeclaration(<ExportDeclaration>node,
-                    nodesVisitor((<ExportDeclaration>node).decorators, visitor, isDecorator),
-                    nodesVisitor((<ExportDeclaration>node).modifiers, visitor, isModifier),
-                    (<ExportDeclaration>node).isTypeOnly,
-                    nodeVisitor((<ExportDeclaration>node).exportClause, visitor, isNamedExportBindings),
-                    nodeVisitor((<ExportDeclaration>node).moduleSpecifier, visitor, isExpression));
+                Debug.type<ExportDeclaration>(node);
+                return factory.updateExportDeclaration(node,
+                    nodesVisitor(node.decorators, visitor, isDecorator),
+                    nodesVisitor(node.modifiers, visitor, isModifier),
+                    node.isTypeOnly,
+                    nodeVisitor(node.exportClause, visitor, isNamedExportBindings),
+                    nodeVisitor(node.moduleSpecifier, visitor, isExpression));
 
             case SyntaxKind.NamedExports:
-                return factory.updateNamedExports(<NamedExports>node,
-                    nodesVisitor((<NamedExports>node).elements, visitor, isExportSpecifier));
+                Debug.type<NamedExports>(node);
+                return factory.updateNamedExports(node,
+                    nodesVisitor(node.elements, visitor, isExportSpecifier));
 
             case SyntaxKind.ExportSpecifier:
-                return factory.updateExportSpecifier(<ExportSpecifier>node,
-                    nodeVisitor((<ExportSpecifier>node).propertyName, visitor, isIdentifier),
-                    nodeVisitor((<ExportSpecifier>node).name, visitor, isIdentifier));
+                Debug.type<ExportSpecifier>(node);
+                return factory.updateExportSpecifier(node,
+                    nodeVisitor(node.propertyName, visitor, isIdentifier),
+                    nodeVisitor(node.name, visitor, isIdentifier));
 
             // Module references
             case SyntaxKind.ExternalModuleReference:
-                return factory.updateExternalModuleReference(<ExternalModuleReference>node,
-                    nodeVisitor((<ExternalModuleReference>node).expression, visitor, isExpression));
+                Debug.type<ExternalModuleReference>(node);
+                return factory.updateExternalModuleReference(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             // JSX
             case SyntaxKind.JsxElement:
-                return factory.updateJsxElement(<JsxElement>node,
-                    nodeVisitor((<JsxElement>node).openingElement, visitor, isJsxOpeningElement),
-                    nodesVisitor((<JsxElement>node).children, visitor, isJsxChild),
-                    nodeVisitor((<JsxElement>node).closingElement, visitor, isJsxClosingElement));
+                Debug.type<JsxElement>(node);
+                return factory.updateJsxElement(node,
+                    nodeVisitor(node.openingElement, visitor, isJsxOpeningElement),
+                    nodesVisitor(node.children, visitor, isJsxChild),
+                    nodeVisitor(node.closingElement, visitor, isJsxClosingElement));
 
             case SyntaxKind.JsxSelfClosingElement:
-                return factory.updateJsxSelfClosingElement(<JsxSelfClosingElement>node,
-                    nodeVisitor((<JsxSelfClosingElement>node).tagName, visitor, isJsxTagNameExpression),
-                    nodesVisitor((<JsxSelfClosingElement>node).typeArguments, visitor, isTypeNode),
-                    nodeVisitor((<JsxSelfClosingElement>node).attributes, visitor, isJsxAttributes));
+                Debug.type<JsxSelfClosingElement>(node);
+                return factory.updateJsxSelfClosingElement(node,
+                    nodeVisitor(node.tagName, visitor, isJsxTagNameExpression),
+                    nodesVisitor(node.typeArguments, visitor, isTypeNode),
+                    nodeVisitor(node.attributes, visitor, isJsxAttributes));
 
             case SyntaxKind.JsxOpeningElement:
-                return factory.updateJsxOpeningElement(<JsxOpeningElement>node,
-                    nodeVisitor((<JsxOpeningElement>node).tagName, visitor, isJsxTagNameExpression),
-                    nodesVisitor((<JsxSelfClosingElement>node).typeArguments, visitor, isTypeNode),
-                    nodeVisitor((<JsxOpeningElement>node).attributes, visitor, isJsxAttributes));
+                Debug.type<JsxOpeningElement>(node);
+                return factory.updateJsxOpeningElement(node,
+                    nodeVisitor(node.tagName, visitor, isJsxTagNameExpression),
+                    nodesVisitor(node.typeArguments, visitor, isTypeNode),
+                    nodeVisitor(node.attributes, visitor, isJsxAttributes));
 
             case SyntaxKind.JsxClosingElement:
-                return factory.updateJsxClosingElement(<JsxClosingElement>node,
-                    nodeVisitor((<JsxClosingElement>node).tagName, visitor, isJsxTagNameExpression));
+                Debug.type<JsxClosingElement>(node);
+                return factory.updateJsxClosingElement(node,
+                    nodeVisitor(node.tagName, visitor, isJsxTagNameExpression));
 
             case SyntaxKind.JsxFragment:
-                return factory.updateJsxFragment(<JsxFragment>node,
-                    nodeVisitor((<JsxFragment>node).openingFragment, visitor, isJsxOpeningFragment),
-                    nodesVisitor((<JsxFragment>node).children, visitor, isJsxChild),
-                    nodeVisitor((<JsxFragment>node).closingFragment, visitor, isJsxClosingFragment));
+                Debug.type<JsxFragment>(node);
+                return factory.updateJsxFragment(node,
+                    nodeVisitor(node.openingFragment, visitor, isJsxOpeningFragment),
+                    nodesVisitor(node.children, visitor, isJsxChild),
+                    nodeVisitor(node.closingFragment, visitor, isJsxClosingFragment));
 
             case SyntaxKind.JsxAttribute:
-                return factory.updateJsxAttribute(<JsxAttribute>node,
-                    nodeVisitor((<JsxAttribute>node).name, visitor, isIdentifier),
-                    nodeVisitor((<JsxAttribute>node).initializer, visitor, isStringLiteralOrJsxExpression));
+                Debug.type<JsxAttribute>(node);
+                return factory.updateJsxAttribute(node,
+                    nodeVisitor(node.name, visitor, isIdentifier),
+                    nodeVisitor(node.initializer, visitor, isStringLiteralOrJsxExpression));
 
             case SyntaxKind.JsxAttributes:
-                return factory.updateJsxAttributes(<JsxAttributes>node,
-                    nodesVisitor((<JsxAttributes>node).properties, visitor, isJsxAttributeLike));
+                Debug.type<JsxAttributes>(node);
+                return factory.updateJsxAttributes(node,
+                    nodesVisitor(node.properties, visitor, isJsxAttributeLike));
 
             case SyntaxKind.JsxSpreadAttribute:
-                return factory.updateJsxSpreadAttribute(<JsxSpreadAttribute>node,
-                    nodeVisitor((<JsxSpreadAttribute>node).expression, visitor, isExpression));
+                Debug.type<JsxSpreadAttribute>(node);
+                return factory.updateJsxSpreadAttribute(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.JsxExpression:
-                return factory.updateJsxExpression(<JsxExpression>node,
-                    nodeVisitor((<JsxExpression>node).expression, visitor, isExpression));
+                Debug.type<JsxExpression>(node);
+                return factory.updateJsxExpression(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             // Clauses
             case SyntaxKind.CaseClause:
-                return factory.updateCaseClause(<CaseClause>node,
-                    nodeVisitor((<CaseClause>node).expression, visitor, isExpression),
-                    nodesVisitor((<CaseClause>node).statements, visitor, isStatement));
+                Debug.type<CaseClause>(node);
+                return factory.updateCaseClause(node,
+                    nodeVisitor(node.expression, visitor, isExpression),
+                    nodesVisitor(node.statements, visitor, isStatement));
 
             case SyntaxKind.DefaultClause:
-                return factory.updateDefaultClause(<DefaultClause>node,
-                    nodesVisitor((<DefaultClause>node).statements, visitor, isStatement));
+                Debug.type<DefaultClause>(node);
+                return factory.updateDefaultClause(node,
+                    nodesVisitor(node.statements, visitor, isStatement));
 
             case SyntaxKind.HeritageClause:
-                return factory.updateHeritageClause(<HeritageClause>node,
-                    nodesVisitor((<HeritageClause>node).types, visitor, isExpressionWithTypeArguments));
+                Debug.type<HeritageClause>(node);
+                return factory.updateHeritageClause(node,
+                    nodesVisitor(node.types, visitor, isExpressionWithTypeArguments));
 
             case SyntaxKind.CatchClause:
-                return factory.updateCatchClause(<CatchClause>node,
-                    nodeVisitor((<CatchClause>node).variableDeclaration, visitor, isVariableDeclaration),
-                    nodeVisitor((<CatchClause>node).block, visitor, isBlock));
+                Debug.type<CatchClause>(node);
+                return factory.updateCatchClause(node,
+                    nodeVisitor(node.variableDeclaration, visitor, isVariableDeclaration),
+                    nodeVisitor(node.block, visitor, isBlock));
 
             // Property assignments
             case SyntaxKind.PropertyAssignment:
-                return factory.updatePropertyAssignment(<PropertyAssignment>node,
-                    nodeVisitor((<PropertyAssignment>node).name, visitor, isPropertyName),
-                    nodeVisitor((<PropertyAssignment>node).initializer, visitor, isExpression));
+                Debug.type<PropertyAssignment>(node);
+                return factory.updatePropertyAssignment(node,
+                    nodeVisitor(node.name, visitor, isPropertyName),
+                    nodeVisitor(node.initializer, visitor, isExpression));
 
             case SyntaxKind.ShorthandPropertyAssignment:
-                return factory.updateShorthandPropertyAssignment(<ShorthandPropertyAssignment>node,
-                    nodeVisitor((<ShorthandPropertyAssignment>node).name, visitor, isIdentifier),
-                    nodeVisitor((<ShorthandPropertyAssignment>node).objectAssignmentInitializer, visitor, isExpression));
+                Debug.type<ShorthandPropertyAssignment>(node);
+                return factory.updateShorthandPropertyAssignment(node,
+                    nodeVisitor(node.name, visitor, isIdentifier),
+                    nodeVisitor(node.objectAssignmentInitializer, visitor, isExpression));
 
             case SyntaxKind.SpreadAssignment:
-                return factory.updateSpreadAssignment(<SpreadAssignment>node,
-                    nodeVisitor((<SpreadAssignment>node).expression, visitor, isExpression));
+                Debug.type<SpreadAssignment>(node);
+                return factory.updateSpreadAssignment(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             // Enum
             case SyntaxKind.EnumMember:
-                return factory.updateEnumMember(<EnumMember>node,
-                    nodeVisitor((<EnumMember>node).name, visitor, isPropertyName),
-                    nodeVisitor((<EnumMember>node).initializer, visitor, isExpression));
+                Debug.type<EnumMember>(node);
+                return factory.updateEnumMember(node,
+                    nodeVisitor(node.name, visitor, isPropertyName),
+                    nodeVisitor(node.initializer, visitor, isExpression));
 
             // Top-level nodes
             case SyntaxKind.SourceFile:
-                return factory.updateSourceFile(<SourceFile>node,
-                    visitLexicalEnvironment((<SourceFile>node).statements, visitor, context));
+                Debug.type<SourceFile>(node);
+                return factory.updateSourceFile(node,
+                    visitLexicalEnvironment(node.statements, visitor, context));
 
             // Transformation nodes
             case SyntaxKind.PartiallyEmittedExpression:
-                return factory.updatePartiallyEmittedExpression(<PartiallyEmittedExpression>node,
-                    nodeVisitor((<PartiallyEmittedExpression>node).expression, visitor, isExpression));
+                Debug.type<PartiallyEmittedExpression>(node);
+                return factory.updatePartiallyEmittedExpression(node,
+                    nodeVisitor(node.expression, visitor, isExpression));
 
             case SyntaxKind.CommaListExpression:
-                return factory.updateCommaListExpression(<CommaListExpression>node,
-                    nodesVisitor((<CommaListExpression>node).elements, visitor, isExpression));
+                Debug.type<CommaListExpression>(node);
+                return factory.updateCommaListExpression(node,
+                    nodesVisitor(node.elements, visitor, isExpression));
 
             default:
                 // No need to visit nodes with no children.

--- a/src/deprecatedCompat/deprecations.ts
+++ b/src/deprecatedCompat/deprecations.ts
@@ -1354,4 +1354,24 @@ namespace ts {
     export interface Map<T> extends ESMap<string, T> { }
 
     // #endregion
+
+    // DEPRECATION: Renamed node tests
+    // DEPRECATION PLAN:
+    //     - soft: 4.2
+    //     - warn: 4.3
+    //     - error: TBD
+    // #region Renamed node Tests
+
+    /**
+     * @deprecated Use `isMemberName` instead.
+     */
+    export const isIdentifierOrPrivateIdentifier = Debug.deprecate(function isIdentifierOrPrivateIdentifier(node: Node): node is MemberName {
+        return isMemberName(node);
+    }, {
+        since: "4.2",
+        warnAfter: "4.3",
+        message: "Use `isMemberName` instead."
+    });
+
+    // #endregion Renamed node Tests
 }

--- a/src/services/codefixes/fixSpelling.ts
+++ b/src/services/codefixes/fixSpelling.ts
@@ -46,7 +46,7 @@ namespace ts.codefix {
 
         let suggestedSymbol: Symbol | undefined;
         if (isPropertyAccessExpression(parent) && parent.name === node) {
-            Debug.assert(isIdentifierOrPrivateIdentifier(node), "Expected an identifier for spelling (property access)");
+            Debug.assert(isMemberName(node), "Expected an identifier for spelling (property access)");
             let containingType = checker.getTypeAtLocation(parent.expression);
             if (parent.flags & NodeFlags.OptionalChain) {
                 containingType = checker.getNonNullableType(containingType);

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -941,7 +941,7 @@ namespace ts.Completions {
 
         // Check if the caret is at the end of an identifier; this is a partial identifier that we want to complete: e.g. a.toS|
         // Skip this partial identifier and adjust the contextToken to the token that precedes it.
-        if (contextToken && position <= contextToken.end && (isIdentifierOrPrivateIdentifier(contextToken) || isKeyword(contextToken.kind))) {
+        if (contextToken && position <= contextToken.end && (isMemberName(contextToken) || isKeyword(contextToken.kind))) {
             const start = timestamp();
             contextToken = findPrecedingToken(contextToken.getFullStart(), sourceFile, /*startNode*/ undefined)!; // TODO: GH#18217
             log("getCompletionData: Get previous token 2: " + (timestamp() - start));

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -1037,11 +1037,12 @@ namespace ts.textChanges {
         let lastNonTriviaPosition = 0;
 
         const writer = createTextWriter(newLine);
-        const onEmitNode: PrintHandlers["onEmitNode"] = (hint, node, printCallback) => {
+        const onBeforeEmitNode: PrintHandlers["onBeforeEmitNode"] = node => {
             if (node) {
                 setPos(node, lastNonTriviaPosition);
             }
-            printCallback(hint, node);
+        };
+        const onAfterEmitNode: PrintHandlers["onAfterEmitNode"] = node => {
             if (node) {
                 setEnd(node, lastNonTriviaPosition);
             }
@@ -1163,7 +1164,8 @@ namespace ts.textChanges {
         }
 
         return {
-            onEmitNode,
+            onBeforeEmitNode,
+            onAfterEmitNode,
             onBeforeEmitNodeArray,
             onAfterEmitNodeArray,
             onBeforeEmitToken,

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -638,6 +638,7 @@ declare namespace ts {
     }
     export type EntityName = Identifier | QualifiedName;
     export type PropertyName = Identifier | StringLiteral | NumericLiteral | ComputedPropertyName | PrivateIdentifier;
+    export type MemberName = Identifier | PrivateIdentifier;
     export type DeclarationName = Identifier | PrivateIdentifier | StringLiteralLike | NumericLiteral | ComputedPropertyName | ElementAccessExpression | BindingPattern | EntityNameExpression;
     export interface Declaration extends Node {
         _declarationBrand: any;
@@ -1216,11 +1217,11 @@ declare namespace ts {
         readonly kind: SyntaxKind.PropertyAccessExpression;
         readonly expression: LeftHandSideExpression;
         readonly questionDotToken?: QuestionDotToken;
-        readonly name: Identifier | PrivateIdentifier;
+        readonly name: MemberName;
     }
     export interface PropertyAccessChain extends PropertyAccessExpression {
         _optionalChainBrand: any;
-        readonly name: Identifier | PrivateIdentifier;
+        readonly name: MemberName;
     }
     export interface SuperPropertyAccessExpression extends PropertyAccessExpression {
         readonly expression: SuperExpression;
@@ -3128,17 +3129,21 @@ declare namespace ts {
         Iterator = 8388608,
         NoAsciiEscaping = 16777216,
     }
-    export interface EmitHelper {
+    export interface EmitHelperBase {
         readonly name: string;
         readonly scoped: boolean;
         readonly text: string | ((node: EmitHelperUniqueNameCallback) => string);
         readonly priority?: number;
         readonly dependencies?: EmitHelper[];
     }
-    export interface UnscopedEmitHelper extends EmitHelper {
+    export interface ScopedEmitHelper extends EmitHelperBase {
+        readonly scoped: true;
+    }
+    export interface UnscopedEmitHelper extends EmitHelperBase {
         readonly scoped: false;
         readonly text: string;
     }
+    export type EmitHelper = ScopedEmitHelper | UnscopedEmitHelper;
     export type EmitHelperUniqueNameCallback = (name: string) => string;
     export enum EmitHint {
         SourceFile = 0,
@@ -3284,10 +3289,10 @@ declare namespace ts {
         updateArrayLiteralExpression(node: ArrayLiteralExpression, elements: readonly Expression[]): ArrayLiteralExpression;
         createObjectLiteralExpression(properties?: readonly ObjectLiteralElementLike[], multiLine?: boolean): ObjectLiteralExpression;
         updateObjectLiteralExpression(node: ObjectLiteralExpression, properties: readonly ObjectLiteralElementLike[]): ObjectLiteralExpression;
-        createPropertyAccessExpression(expression: Expression, name: string | Identifier | PrivateIdentifier): PropertyAccessExpression;
-        updatePropertyAccessExpression(node: PropertyAccessExpression, expression: Expression, name: Identifier | PrivateIdentifier): PropertyAccessExpression;
-        createPropertyAccessChain(expression: Expression, questionDotToken: QuestionDotToken | undefined, name: string | Identifier | PrivateIdentifier): PropertyAccessChain;
-        updatePropertyAccessChain(node: PropertyAccessChain, expression: Expression, questionDotToken: QuestionDotToken | undefined, name: Identifier | PrivateIdentifier): PropertyAccessChain;
+        createPropertyAccessExpression(expression: Expression, name: string | MemberName): PropertyAccessExpression;
+        updatePropertyAccessExpression(node: PropertyAccessExpression, expression: Expression, name: MemberName): PropertyAccessExpression;
+        createPropertyAccessChain(expression: Expression, questionDotToken: QuestionDotToken | undefined, name: string | MemberName): PropertyAccessChain;
+        updatePropertyAccessChain(node: PropertyAccessChain, expression: Expression, questionDotToken: QuestionDotToken | undefined, name: MemberName): PropertyAccessChain;
         createElementAccessExpression(expression: Expression, index: number | Expression): ElementAccessExpression;
         updateElementAccessExpression(node: ElementAccessExpression, expression: Expression, argumentExpression: Expression): ElementAccessExpression;
         createElementAccessChain(expression: Expression, questionDotToken: QuestionDotToken | undefined, index: number | Expression): ElementAccessChain;
@@ -3748,12 +3753,12 @@ declare namespace ts {
          * });
          * ```
          */
-        onEmitNode?(hint: EmitHint, node: Node | undefined, emitCallback: (hint: EmitHint, node: Node | undefined) => void): void;
+        onEmitNode?(hint: EmitHint, node: Node, emitCallback: (hint: EmitHint, node: Node) => void): void;
         /**
          * A hook used to check if an emit notification is required for a node.
          * @param node The node to emit.
          */
-        isEmitNotificationEnabled?(node: Node | undefined): boolean;
+        isEmitNotificationEnabled?(node: Node): boolean;
         /**
          * A hook used by the Printer to perform just-in-time substitution of a node. This is
          * primarily used by node transformations that need to substitute one node for another,
@@ -4189,7 +4194,7 @@ declare namespace ts {
      */
     function getEffectiveTypeParameterDeclarations(node: DeclarationWithTypeParameters): readonly TypeParameterDeclaration[];
     function getEffectiveConstraintOfTypeParameter(node: TypeParameterDeclaration): TypeNode | undefined;
-    function isIdentifierOrPrivateIdentifier(node: Node): node is Identifier | PrivateIdentifier;
+    function isMemberName(node: Node): node is MemberName;
     function isPropertyAccessChain(node: Node): node is PropertyAccessChain;
     function isElementAccessChain(node: Node): node is ElementAccessChain;
     function isCallChain(node: Node): node is CallChain;
@@ -4204,6 +4209,12 @@ declare namespace ts {
     function isUnparsedTextLike(node: Node): node is UnparsedTextLike;
     function isUnparsedNode(node: Node): node is UnparsedNode;
     function isJSDocPropertyLikeTag(node: Node): node is JSDocPropertyLikeTag;
+    /**
+     * True if kind is of some token syntax kind.
+     * For example, this is true for an IfKeyword but not for an IfStatement.
+     * Literals are considered tokens, except TemplateLiteral, but does include TemplateHead/Middle/Tail.
+     */
+    function isTokenKind(kind: SyntaxKind): boolean;
     /**
      * True if node is of some token syntax kind.
      * For example, this is true for an IfKeyword but not for an IfStatement.
@@ -4346,10 +4357,14 @@ declare namespace ts {
     function isTemplateHead(node: Node): node is TemplateHead;
     function isTemplateMiddle(node: Node): node is TemplateMiddle;
     function isTemplateTail(node: Node): node is TemplateTail;
+    function isDotDotDotToken(node: Node): node is DotDotDotToken;
+    function isPlusToken(node: Node): node is PlusToken;
+    function isMinusToken(node: Node): node is MinusToken;
+    function isAsteriskToken(node: Node): node is AsteriskToken;
     function isIdentifier(node: Node): node is Identifier;
+    function isPrivateIdentifier(node: Node): node is PrivateIdentifier;
     function isQualifiedName(node: Node): node is QualifiedName;
     function isComputedPropertyName(node: Node): node is ComputedPropertyName;
-    function isPrivateIdentifier(node: Node): node is PrivateIdentifier;
     function isTypeParameterDeclaration(node: Node): node is TypeParameterDeclaration;
     function isParameter(node: Node): node is ParameterDeclaration;
     function isDecorator(node: Node): node is Decorator;
@@ -10306,13 +10321,13 @@ declare namespace ts {
     /** @deprecated Use `factory.updateObjectLiteralExpression` or the factory supplied by your transformation context instead. */
     const updateObjectLiteral: (node: ObjectLiteralExpression, properties: readonly ObjectLiteralElementLike[]) => ObjectLiteralExpression;
     /** @deprecated Use `factory.createPropertyAccessExpression` or the factory supplied by your transformation context instead. */
-    const createPropertyAccess: (expression: Expression, name: string | Identifier | PrivateIdentifier) => PropertyAccessExpression;
+    const createPropertyAccess: (expression: Expression, name: string | MemberName) => PropertyAccessExpression;
     /** @deprecated Use `factory.updatePropertyAccessExpression` or the factory supplied by your transformation context instead. */
-    const updatePropertyAccess: (node: PropertyAccessExpression, expression: Expression, name: Identifier | PrivateIdentifier) => PropertyAccessExpression;
+    const updatePropertyAccess: (node: PropertyAccessExpression, expression: Expression, name: MemberName) => PropertyAccessExpression;
     /** @deprecated Use `factory.createPropertyAccessChain` or the factory supplied by your transformation context instead. */
-    const createPropertyAccessChain: (expression: Expression, questionDotToken: QuestionDotToken | undefined, name: string | Identifier | PrivateIdentifier) => PropertyAccessChain;
+    const createPropertyAccessChain: (expression: Expression, questionDotToken: QuestionDotToken | undefined, name: string | MemberName) => PropertyAccessChain;
     /** @deprecated Use `factory.updatePropertyAccessChain` or the factory supplied by your transformation context instead. */
-    const updatePropertyAccessChain: (node: PropertyAccessChain, expression: Expression, questionDotToken: QuestionDotToken | undefined, name: Identifier | PrivateIdentifier) => PropertyAccessChain;
+    const updatePropertyAccessChain: (node: PropertyAccessChain, expression: Expression, questionDotToken: QuestionDotToken | undefined, name: MemberName) => PropertyAccessChain;
     /** @deprecated Use `factory.createElementAccessExpression` or the factory supplied by your transformation context instead. */
     const createElementAccess: (expression: Expression, index: number | Expression) => ElementAccessExpression;
     /** @deprecated Use `factory.updateElementAccessExpression` or the factory supplied by your transformation context instead. */
@@ -10882,6 +10897,10 @@ declare namespace ts {
      */
     interface Map<T> extends ESMap<string, T> {
     }
+    /**
+     * @deprecated Use `isMemberName` instead.
+     */
+    const isIdentifierOrPrivateIdentifier: (node: Node) => node is MemberName;
 }
 
 export = ts;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -638,6 +638,7 @@ declare namespace ts {
     }
     export type EntityName = Identifier | QualifiedName;
     export type PropertyName = Identifier | StringLiteral | NumericLiteral | ComputedPropertyName | PrivateIdentifier;
+    export type MemberName = Identifier | PrivateIdentifier;
     export type DeclarationName = Identifier | PrivateIdentifier | StringLiteralLike | NumericLiteral | ComputedPropertyName | ElementAccessExpression | BindingPattern | EntityNameExpression;
     export interface Declaration extends Node {
         _declarationBrand: any;
@@ -1216,11 +1217,11 @@ declare namespace ts {
         readonly kind: SyntaxKind.PropertyAccessExpression;
         readonly expression: LeftHandSideExpression;
         readonly questionDotToken?: QuestionDotToken;
-        readonly name: Identifier | PrivateIdentifier;
+        readonly name: MemberName;
     }
     export interface PropertyAccessChain extends PropertyAccessExpression {
         _optionalChainBrand: any;
-        readonly name: Identifier | PrivateIdentifier;
+        readonly name: MemberName;
     }
     export interface SuperPropertyAccessExpression extends PropertyAccessExpression {
         readonly expression: SuperExpression;
@@ -3128,17 +3129,21 @@ declare namespace ts {
         Iterator = 8388608,
         NoAsciiEscaping = 16777216,
     }
-    export interface EmitHelper {
+    export interface EmitHelperBase {
         readonly name: string;
         readonly scoped: boolean;
         readonly text: string | ((node: EmitHelperUniqueNameCallback) => string);
         readonly priority?: number;
         readonly dependencies?: EmitHelper[];
     }
-    export interface UnscopedEmitHelper extends EmitHelper {
+    export interface ScopedEmitHelper extends EmitHelperBase {
+        readonly scoped: true;
+    }
+    export interface UnscopedEmitHelper extends EmitHelperBase {
         readonly scoped: false;
         readonly text: string;
     }
+    export type EmitHelper = ScopedEmitHelper | UnscopedEmitHelper;
     export type EmitHelperUniqueNameCallback = (name: string) => string;
     export enum EmitHint {
         SourceFile = 0,
@@ -3284,10 +3289,10 @@ declare namespace ts {
         updateArrayLiteralExpression(node: ArrayLiteralExpression, elements: readonly Expression[]): ArrayLiteralExpression;
         createObjectLiteralExpression(properties?: readonly ObjectLiteralElementLike[], multiLine?: boolean): ObjectLiteralExpression;
         updateObjectLiteralExpression(node: ObjectLiteralExpression, properties: readonly ObjectLiteralElementLike[]): ObjectLiteralExpression;
-        createPropertyAccessExpression(expression: Expression, name: string | Identifier | PrivateIdentifier): PropertyAccessExpression;
-        updatePropertyAccessExpression(node: PropertyAccessExpression, expression: Expression, name: Identifier | PrivateIdentifier): PropertyAccessExpression;
-        createPropertyAccessChain(expression: Expression, questionDotToken: QuestionDotToken | undefined, name: string | Identifier | PrivateIdentifier): PropertyAccessChain;
-        updatePropertyAccessChain(node: PropertyAccessChain, expression: Expression, questionDotToken: QuestionDotToken | undefined, name: Identifier | PrivateIdentifier): PropertyAccessChain;
+        createPropertyAccessExpression(expression: Expression, name: string | MemberName): PropertyAccessExpression;
+        updatePropertyAccessExpression(node: PropertyAccessExpression, expression: Expression, name: MemberName): PropertyAccessExpression;
+        createPropertyAccessChain(expression: Expression, questionDotToken: QuestionDotToken | undefined, name: string | MemberName): PropertyAccessChain;
+        updatePropertyAccessChain(node: PropertyAccessChain, expression: Expression, questionDotToken: QuestionDotToken | undefined, name: MemberName): PropertyAccessChain;
         createElementAccessExpression(expression: Expression, index: number | Expression): ElementAccessExpression;
         updateElementAccessExpression(node: ElementAccessExpression, expression: Expression, argumentExpression: Expression): ElementAccessExpression;
         createElementAccessChain(expression: Expression, questionDotToken: QuestionDotToken | undefined, index: number | Expression): ElementAccessChain;
@@ -3748,12 +3753,12 @@ declare namespace ts {
          * });
          * ```
          */
-        onEmitNode?(hint: EmitHint, node: Node | undefined, emitCallback: (hint: EmitHint, node: Node | undefined) => void): void;
+        onEmitNode?(hint: EmitHint, node: Node, emitCallback: (hint: EmitHint, node: Node) => void): void;
         /**
          * A hook used to check if an emit notification is required for a node.
          * @param node The node to emit.
          */
-        isEmitNotificationEnabled?(node: Node | undefined): boolean;
+        isEmitNotificationEnabled?(node: Node): boolean;
         /**
          * A hook used by the Printer to perform just-in-time substitution of a node. This is
          * primarily used by node transformations that need to substitute one node for another,
@@ -4189,7 +4194,7 @@ declare namespace ts {
      */
     function getEffectiveTypeParameterDeclarations(node: DeclarationWithTypeParameters): readonly TypeParameterDeclaration[];
     function getEffectiveConstraintOfTypeParameter(node: TypeParameterDeclaration): TypeNode | undefined;
-    function isIdentifierOrPrivateIdentifier(node: Node): node is Identifier | PrivateIdentifier;
+    function isMemberName(node: Node): node is MemberName;
     function isPropertyAccessChain(node: Node): node is PropertyAccessChain;
     function isElementAccessChain(node: Node): node is ElementAccessChain;
     function isCallChain(node: Node): node is CallChain;
@@ -4204,6 +4209,12 @@ declare namespace ts {
     function isUnparsedTextLike(node: Node): node is UnparsedTextLike;
     function isUnparsedNode(node: Node): node is UnparsedNode;
     function isJSDocPropertyLikeTag(node: Node): node is JSDocPropertyLikeTag;
+    /**
+     * True if kind is of some token syntax kind.
+     * For example, this is true for an IfKeyword but not for an IfStatement.
+     * Literals are considered tokens, except TemplateLiteral, but does include TemplateHead/Middle/Tail.
+     */
+    function isTokenKind(kind: SyntaxKind): boolean;
     /**
      * True if node is of some token syntax kind.
      * For example, this is true for an IfKeyword but not for an IfStatement.
@@ -4346,10 +4357,14 @@ declare namespace ts {
     function isTemplateHead(node: Node): node is TemplateHead;
     function isTemplateMiddle(node: Node): node is TemplateMiddle;
     function isTemplateTail(node: Node): node is TemplateTail;
+    function isDotDotDotToken(node: Node): node is DotDotDotToken;
+    function isPlusToken(node: Node): node is PlusToken;
+    function isMinusToken(node: Node): node is MinusToken;
+    function isAsteriskToken(node: Node): node is AsteriskToken;
     function isIdentifier(node: Node): node is Identifier;
+    function isPrivateIdentifier(node: Node): node is PrivateIdentifier;
     function isQualifiedName(node: Node): node is QualifiedName;
     function isComputedPropertyName(node: Node): node is ComputedPropertyName;
-    function isPrivateIdentifier(node: Node): node is PrivateIdentifier;
     function isTypeParameterDeclaration(node: Node): node is TypeParameterDeclaration;
     function isParameter(node: Node): node is ParameterDeclaration;
     function isDecorator(node: Node): node is Decorator;
@@ -6641,13 +6656,13 @@ declare namespace ts {
     /** @deprecated Use `factory.updateObjectLiteralExpression` or the factory supplied by your transformation context instead. */
     const updateObjectLiteral: (node: ObjectLiteralExpression, properties: readonly ObjectLiteralElementLike[]) => ObjectLiteralExpression;
     /** @deprecated Use `factory.createPropertyAccessExpression` or the factory supplied by your transformation context instead. */
-    const createPropertyAccess: (expression: Expression, name: string | Identifier | PrivateIdentifier) => PropertyAccessExpression;
+    const createPropertyAccess: (expression: Expression, name: string | MemberName) => PropertyAccessExpression;
     /** @deprecated Use `factory.updatePropertyAccessExpression` or the factory supplied by your transformation context instead. */
-    const updatePropertyAccess: (node: PropertyAccessExpression, expression: Expression, name: Identifier | PrivateIdentifier) => PropertyAccessExpression;
+    const updatePropertyAccess: (node: PropertyAccessExpression, expression: Expression, name: MemberName) => PropertyAccessExpression;
     /** @deprecated Use `factory.createPropertyAccessChain` or the factory supplied by your transformation context instead. */
-    const createPropertyAccessChain: (expression: Expression, questionDotToken: QuestionDotToken | undefined, name: string | Identifier | PrivateIdentifier) => PropertyAccessChain;
+    const createPropertyAccessChain: (expression: Expression, questionDotToken: QuestionDotToken | undefined, name: string | MemberName) => PropertyAccessChain;
     /** @deprecated Use `factory.updatePropertyAccessChain` or the factory supplied by your transformation context instead. */
-    const updatePropertyAccessChain: (node: PropertyAccessChain, expression: Expression, questionDotToken: QuestionDotToken | undefined, name: Identifier | PrivateIdentifier) => PropertyAccessChain;
+    const updatePropertyAccessChain: (node: PropertyAccessChain, expression: Expression, questionDotToken: QuestionDotToken | undefined, name: MemberName) => PropertyAccessChain;
     /** @deprecated Use `factory.createElementAccessExpression` or the factory supplied by your transformation context instead. */
     const createElementAccess: (expression: Expression, index: number | Expression) => ElementAccessExpression;
     /** @deprecated Use `factory.updateElementAccessExpression` or the factory supplied by your transformation context instead. */
@@ -7217,6 +7232,10 @@ declare namespace ts {
      */
     interface Map<T> extends ESMap<string, T> {
     }
+    /**
+     * @deprecated Use `isMemberName` instead.
+     */
+    const isIdentifierOrPrivateIdentifier: (node: Node) => node is MemberName;
 }
 
 export = ts;

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.js
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.js
@@ -32,6 +32,6 @@ exports.buzz = buzz;
 exports.buzz = buzz += 3;
 var bizz = 8;
 exports.bizz = bizz;
-(exports.bizz = bizz += 1); // compiles to exports.bizz = bizz += 1
-(exports.bizz = bizz -= 1); // similarly
-(exports.bizz = ++bizz); // compiles to exports.bizz = ++bizz
+(exports.bizz = ++bizz) - 1; // compiles to exports.bizz = bizz += 1
+(exports.bizz = --bizz) + 1; // similarly
+exports.bizz = ++bizz; // compiles to exports.bizz = ++bizz

--- a/tests/baselines/reference/importMeta(module=commonjs,target=es5).js
+++ b/tests/baselines/reference/importMeta(module=commonjs,target=es5).js
@@ -101,8 +101,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.z = exports.y = exports.x = void 0;
-exports.x = (import.meta);
-exports.y = (import.metal);
+exports.x = import.meta;
+exports.y = import.metal;
 exports.z = import.import.import.malkovich;
 //// [scriptLookingFile01.js]
 "use strict";

--- a/tests/baselines/reference/importMeta(module=commonjs,target=esnext).js
+++ b/tests/baselines/reference/importMeta(module=commonjs,target=esnext).js
@@ -55,8 +55,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.z = exports.y = exports.x = void 0;
-exports.x = (import.meta);
-exports.y = (import.metal);
+exports.x = import.meta;
+exports.y = import.metal;
 exports.z = import.import.import.malkovich;
 //// [scriptLookingFile01.js]
 "use strict";

--- a/tests/baselines/reference/importMeta(module=system,target=es5).js
+++ b/tests/baselines/reference/importMeta(module=system,target=es5).js
@@ -112,8 +112,8 @@ System.register([], function (exports_1, context_1) {
     return {
         setters: [],
         execute: function () {
-            exports_1("x", x = (context_1.meta));
-            exports_1("y", y = (import.metal));
+            exports_1("x", x = context_1.meta);
+            exports_1("y", y = import.metal);
             exports_1("z", z = import.import.import.malkovich);
         }
     };
@@ -126,8 +126,8 @@ System.register([], function (exports_1, context_1) {
     return {
         setters: [],
         execute: function () {
-            globalA = (context_1.meta);
-            globalB = (import.metal);
+            globalA = context_1.meta;
+            globalB = import.metal;
             globalC = import.import.import.malkovich;
         }
     };

--- a/tests/baselines/reference/importMeta(module=system,target=esnext).js
+++ b/tests/baselines/reference/importMeta(module=system,target=esnext).js
@@ -66,8 +66,8 @@ System.register([], function (exports_1, context_1) {
     return {
         setters: [],
         execute: function () {
-            exports_1("x", x = (context_1.meta));
-            exports_1("y", y = (import.metal));
+            exports_1("x", x = context_1.meta);
+            exports_1("y", y = import.metal);
             exports_1("z", z = import.import.import.malkovich);
         }
     };
@@ -80,8 +80,8 @@ System.register([], function (exports_1, context_1) {
     return {
         setters: [],
         execute: function () {
-            globalA = (context_1.meta);
-            globalB = (import.metal);
+            globalA = context_1.meta;
+            globalB = import.metal;
             globalC = import.import.import.malkovich;
         }
     };

--- a/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.js
+++ b/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.js
@@ -161,6 +161,4 @@ var _brokenTree = renderer_1.dom(component_1.MySFC, { x: 1, y: 2 },
     renderer_1.dom(component_1.MyClass, { x: 3, y: 4 }),
     renderer_1.dom(component_1.MyClass, { x: 5, y: 6 }));
 // Should fail, nondom isn't allowed as children of dom
-var _brokenTree2 = renderer_1.dom(DOMSFC, { x: 1, y: 2 },
-    component_1.tree,
-    component_1.tree);
+var _brokenTree2 = renderer_1.dom(DOMSFC, { x: 1, y: 2 }, component_1.tree, component_1.tree);

--- a/tests/baselines/reference/jsxCheckJsxNoTypeArgumentsAllowed.js
+++ b/tests/baselines/reference/jsxCheckJsxNoTypeArgumentsAllowed.js
@@ -23,5 +23,5 @@ let x = <MyComp<Prop> a={10} b="hi" />; // error, no type arguments in js
 exports.__esModule = true;
 var component_1 = require("./component");
 var React = require("react");
-var x = <component_1.MyComp />, <Prop> a={10} b="hi" />; // error, no type arguments in js
-</>;
+var x = (<component_1.MyComp />, <Prop> a={10} b="hi" />; // error, no type arguments in js
+</>);

--- a/tests/baselines/reference/moduleExportsUnaryExpression.js
+++ b/tests/baselines/reference/moduleExportsUnaryExpression.js
@@ -23,17 +23,17 @@ exports.x = exports.foo = void 0;
 var x = 1;
 exports.x = x;
 function foo(y) {
-    if (y <= (exports.x = x += 1))
-        return y <= (exports.x = x += 1);
-    if (y <= (exports.x = x -= 1))
-        return y <= (exports.x = x -= 1);
+    if (y <= (exports.x = ++x) - 1)
+        return y <= (exports.x = ++x) - 1;
+    if (y <= (exports.x = --x) + 1)
+        return y <= (exports.x = --x) + 1;
     if (y <= (exports.x = ++x))
         return y <= (exports.x = ++x);
     if (y <= (exports.x = --x))
         return y <= (exports.x = --x);
-    (exports.x = x += 1);
-    (exports.x = x -= 1);
-    (exports.x = ++x);
-    (exports.x = --x);
+    (exports.x = ++x) - 1;
+    (exports.x = --x) + 1;
+    exports.x = ++x;
+    exports.x = --x;
 }
 exports.foo = foo;

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.js
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.js
@@ -35,8 +35,7 @@ var y = {
     "typeof": 
 };
 var x = (_a = {
-        a: a,
-        : .b,
+        a: a, : .b,
         a: a
     },
     _a["ss"] = ,

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesErrorWithModule.js
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesErrorWithModule.js
@@ -25,8 +25,7 @@ var n;
 (function (n) {
     var z = 10000;
     n.y = {
-        m: m,
-        : .x // error
+        m: m, : .x // error
     };
 })(n || (n = {}));
 m.y.x;

--- a/tests/baselines/reference/objectTypesWithOptionalProperties2.js
+++ b/tests/baselines/reference/objectTypesWithOptionalProperties2.js
@@ -42,6 +42,5 @@ var C2 = /** @class */ (function () {
     return C2;
 }());
 var b = {
-    x: function () { },
-    1:  // error
+    x: function () { }, 1:  // error
 };

--- a/tests/baselines/reference/parserErrorRecovery_ObjectLiteral2.js
+++ b/tests/baselines/reference/parserErrorRecovery_ObjectLiteral2.js
@@ -3,4 +3,5 @@ var v = { a
 return;
 
 //// [parserErrorRecovery_ObjectLiteral2.js]
-var v = { a: a, "return":  };
+var v = { a: a,
+    "return":  };


### PR DESCRIPTION
#41156 was only a temporary fix for #39022 as it *always* wraps the expression in parentheses, even when they are not needed. It has been a longstanding issue that emit substitution does not trigger our auto-parenthesization logic because we don't recreate the node as we emit.

To address this, I've pulled out the logic in the printer that handles our JIT substitution into its own transformation. As a result, substitution now uses the Node Factory and correctly handles auto-parenthesization. This has a number of other benefits as well:

- The entire emit notification/substitution flow can be skipped when it isn't needed (i.e., `typeToTypeNode`, refactors, etc.).
- The stack depth for printing has been reduced significantly.
- Printing is more straightforward (the "emit pipeline" has been drastically simplified).

Fixes #39022
