### PR TITLE
Base signatures resolve only the type parameters local to the signatue

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5552,6 +5552,8 @@ namespace ts {
         /* @internal */
         canonicalSignatureCache?: Signature; // Canonical version of signature (deferred)
         /* @internal */
+        baseSignatureCache?: Signature;      // Base version of signature (deferred)
+        /* @internal */
         optionalCallSignatureCache?: { inner?: Signature, outer?: Signature }; // Optional chained call version of signature (deferred)
         /* @internal */
         isolatedSignatureType?: ObjectType; // A manufactured type that just contains the signature for purposes of signature comparison

--- a/tests/baselines/reference/conditionalTypeGenericInSignatureTypeParameterConstraint.js
+++ b/tests/baselines/reference/conditionalTypeGenericInSignatureTypeParameterConstraint.js
@@ -1,0 +1,7 @@
+//// [conditionalTypeGenericInSignatureTypeParameterConstraint.ts]
+// should be x
+type H_inline1<x> = (<o extends x>() => o) extends (() => infer o) ? o : never;
+
+type Result = H_inline1<string>; // should be `string`
+
+//// [conditionalTypeGenericInSignatureTypeParameterConstraint.js]

--- a/tests/baselines/reference/conditionalTypeGenericInSignatureTypeParameterConstraint.symbols
+++ b/tests/baselines/reference/conditionalTypeGenericInSignatureTypeParameterConstraint.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/conditionalTypeGenericInSignatureTypeParameterConstraint.ts ===
+// should be x
+type H_inline1<x> = (<o extends x>() => o) extends (() => infer o) ? o : never;
+>H_inline1 : Symbol(H_inline1, Decl(conditionalTypeGenericInSignatureTypeParameterConstraint.ts, 0, 0))
+>x : Symbol(x, Decl(conditionalTypeGenericInSignatureTypeParameterConstraint.ts, 1, 15))
+>o : Symbol(o, Decl(conditionalTypeGenericInSignatureTypeParameterConstraint.ts, 1, 22))
+>x : Symbol(x, Decl(conditionalTypeGenericInSignatureTypeParameterConstraint.ts, 1, 15))
+>o : Symbol(o, Decl(conditionalTypeGenericInSignatureTypeParameterConstraint.ts, 1, 22))
+>o : Symbol(o, Decl(conditionalTypeGenericInSignatureTypeParameterConstraint.ts, 1, 63))
+>o : Symbol(o, Decl(conditionalTypeGenericInSignatureTypeParameterConstraint.ts, 1, 63))
+
+type Result = H_inline1<string>; // should be `string`
+>Result : Symbol(Result, Decl(conditionalTypeGenericInSignatureTypeParameterConstraint.ts, 1, 79))
+>H_inline1 : Symbol(H_inline1, Decl(conditionalTypeGenericInSignatureTypeParameterConstraint.ts, 0, 0))
+

--- a/tests/baselines/reference/conditionalTypeGenericInSignatureTypeParameterConstraint.types
+++ b/tests/baselines/reference/conditionalTypeGenericInSignatureTypeParameterConstraint.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/conditionalTypeGenericInSignatureTypeParameterConstraint.ts ===
+// should be x
+type H_inline1<x> = (<o extends x>() => o) extends (() => infer o) ? o : never;
+>H_inline1 : x
+
+type Result = H_inline1<string>; // should be `string`
+>Result : string
+

--- a/tests/cases/compiler/conditionalTypeGenericInSignatureTypeParameterConstraint.ts
+++ b/tests/cases/compiler/conditionalTypeGenericInSignatureTypeParameterConstraint.ts
@@ -1,0 +1,4 @@
+// should be x
+type H_inline1<x> = (<o extends x>() => o) extends (() => infer o) ? o : never;
+
+type Result = H_inline1<string>; // should be `string`


### PR DESCRIPTION
Rather than _all_ type parameters referred to in the signature's type parameter list, as was done by using `getBaseConstraintOfType`.


Fixes #42495
