### PR TITLE
Pin Node version for Volta users (like me)

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,5 +127,8 @@
         "source-map-support": false,
         "inspector": false
     },
+    "volta": {
+        "node": "14.15.5"
+    },
     "dependencies": {}
 }


### PR DESCRIPTION
While trying to patch a version of TypeScript 3.1, it was fairly tough to build because the dev-time Node dependency wasn't explicitly listed anywhere. I don't want to have to deal with that again. By adding this field, we can let a version switched like Volta know that it needs to run on Node 14. The only tradeoff is that it can fall out of date if not everyone in the team is using it.
