### PR TITLE
fix: add loading attribute

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -7104,6 +7104,10 @@ interface HTMLIFrameElement extends HTMLElement {
      */
     height: string;
     /**
+     * Sets or retrieves the loading strategy of the object.
+     */
+    loading: string;
+    /**
      * Sets or retrieves a URI to a long description of the object.
      */
     /** @deprecated */
@@ -7189,6 +7193,9 @@ interface HTMLImageElement extends HTMLElement {
      * Sets or retrieves whether the image is a server-side image map.
      */
     isMap: boolean;
+    /**
+     * Sets or retrieves the loading strategy of the object.
+     */
     loading: string;
     /**
      * Sets or retrieves a Uniform Resource Identifier (URI) to a long description of the object.


### PR DESCRIPTION
Update the type definitions for `HTMLImageElement` and `HTMLIframeElement` according to the [spec](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element).

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

