### PR TITLE
Type lookup in getIntrinsicAttributestypeFromJsxOpeningLikeElement should match getIntrinsicTagSymbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25881,11 +25881,11 @@ namespace ts {
             if (!links.resolvedJsxElementAttributesType) {
                 const symbol = getIntrinsicTagSymbol(node);
                 if (links.jsxFlags & JsxFlags.IntrinsicNamedElement) {
-                    return links.resolvedJsxElementAttributesType = getTypeOfSymbol(symbol);
+                    return links.resolvedJsxElementAttributesType = getTypeOfSymbol(symbol) || errorType;
                 }
                 else if (links.jsxFlags & JsxFlags.IntrinsicIndexedElement) {
                     return links.resolvedJsxElementAttributesType =
-                        getIndexTypeOfType(getDeclaredTypeOfSymbol(symbol), IndexKind.String)!;
+                        getIndexTypeOfType(getJsxType(JsxNames.IntrinsicElements, node), IndexKind.String) || errorType;
                 }
                 else {
                     return links.resolvedJsxElementAttributesType = errorType;

--- a/tests/baselines/reference/jsxLocalNamespaceIndexSignatureNoCrash.js
+++ b/tests/baselines/reference/jsxLocalNamespaceIndexSignatureNoCrash.js
@@ -1,0 +1,35 @@
+//// [index.tsx]
+export class X {
+    static jsx() {
+        return document.createElement('p');
+    }
+}
+
+export namespace X {
+    export namespace JSX {
+        export type IntrinsicElements = {
+            [other: string]: any;
+        };
+    }
+}
+
+function A() {
+    return (<p>Hello</p>);
+}
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+exports.X = void 0;
+var X = /** @class */ (function () {
+    function X() {
+    }
+    X.jsx = function () {
+        return document.createElement('p');
+    };
+    return X;
+}());
+exports.X = X;
+function A() {
+    return (X.jsx("p", null, "Hello"));
+}

--- a/tests/baselines/reference/jsxLocalNamespaceIndexSignatureNoCrash.symbols
+++ b/tests/baselines/reference/jsxLocalNamespaceIndexSignatureNoCrash.symbols
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/index.tsx ===
+export class X {
+>X : Symbol(X, Decl(index.tsx, 0, 0), Decl(index.tsx, 4, 1))
+
+    static jsx() {
+>jsx : Symbol(X.jsx, Decl(index.tsx, 0, 16))
+
+        return document.createElement('p');
+>document.createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+    }
+}
+
+export namespace X {
+>X : Symbol(X, Decl(index.tsx, 0, 0), Decl(index.tsx, 4, 1))
+
+    export namespace JSX {
+>JSX : Symbol(JSX, Decl(index.tsx, 6, 20))
+
+        export type IntrinsicElements = {
+>IntrinsicElements : Symbol(IntrinsicElements, Decl(index.tsx, 7, 26))
+
+            [other: string]: any;
+>other : Symbol(other, Decl(index.tsx, 9, 13))
+
+        };
+    }
+}
+
+function A() {
+>A : Symbol(A, Decl(index.tsx, 12, 1))
+
+    return (<p>Hello</p>);
+>p : Symbol(__type, Decl(index.tsx, 8, 39))
+>p : Symbol(__type, Decl(index.tsx, 8, 39))
+}

--- a/tests/baselines/reference/jsxLocalNamespaceIndexSignatureNoCrash.types
+++ b/tests/baselines/reference/jsxLocalNamespaceIndexSignatureNoCrash.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/index.tsx ===
+export class X {
+>X : X
+
+    static jsx() {
+>jsx : () => HTMLParagraphElement
+
+        return document.createElement('p');
+>document.createElement('p') : HTMLParagraphElement
+>document.createElement : { <K extends keyof HTMLElementTagNameMap>(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; <K extends keyof HTMLElementDeprecatedTagNameMap>(tagName: K, options?: ElementCreationOptions): HTMLElementDeprecatedTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>document : Document
+>createElement : { <K extends keyof HTMLElementTagNameMap>(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; <K extends keyof HTMLElementDeprecatedTagNameMap>(tagName: K, options?: ElementCreationOptions): HTMLElementDeprecatedTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>'p' : "p"
+    }
+}
+
+export namespace X {
+    export namespace JSX {
+        export type IntrinsicElements = {
+>IntrinsicElements : IntrinsicElements
+
+            [other: string]: any;
+>other : string
+
+        };
+    }
+}
+
+function A() {
+>A : () => any
+
+    return (<p>Hello</p>);
+>(<p>Hello</p>) : error
+><p>Hello</p> : error
+>p : any
+>p : any
+}

--- a/tests/cases/compiler/jsxLocalNamespaceIndexSignatureNoCrash.tsx
+++ b/tests/cases/compiler/jsxLocalNamespaceIndexSignatureNoCrash.tsx
@@ -1,0 +1,21 @@
+// @jsx: react
+// @jsxFactory: X.jsx
+// @filename: index.tsx
+
+export class X {
+    static jsx() {
+        return document.createElement('p');
+    }
+}
+
+export namespace X {
+    export namespace JSX {
+        export type IntrinsicElements = {
+            [other: string]: any;
+        };
+    }
+}
+
+function A() {
+    return (<p>Hello</p>);
+}


### PR DESCRIPTION
(`getDeclaredTypeOfSymbol` does not do what we want on type aliases.)

Additionally, removes the assertion and conservatively adds an `|| errorType` to satisfy the typechecker instead (while so long as the lookups methods match between `getIntrinsicAttributestypeFromJsxOpeningLikeElement` and `getIntrinsicTagSymbol`, it should never be `undefined`, if they ever drift again, returning the `errorType` here is better for follow-on issues than quietly leaking `undefined`).

Fixes #42753
