### PR TITLE
Fix for crash on call expression with private identifiers.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21978,7 +21978,16 @@ namespace ts {
                         const type = getTypeOfDottedName((<PropertyAccessExpression>node).expression, diagnostic);
                         if (type) {
                             const name = (<PropertyAccessExpression>node).name;
-                            const prop = getPropertyOfType(type, isPrivateIdentifier(name) ? getSymbolNameForPrivateIdentifier(type.symbol, name.escapedText) : name.escapedText);
+                            let prop: Symbol | undefined;
+                            if (isPrivateIdentifier(name)) {
+                                if (!type.symbol) {
+                                    return undefined;
+                                }
+                                prop = getPropertyOfType(type, getSymbolNameForPrivateIdentifier(type.symbol, name.escapedText));
+                            }
+                            else {
+                                prop = getPropertyOfType(type, name.escapedText);
+                            }
                             return prop && getExplicitTypeOfSymbol(prop, diagnostic);
                         }
                         return undefined;

--- a/tests/baselines/reference/privateNameAndAny.errors.txt
+++ b/tests/baselines/reference/privateNameAndAny.errors.txt
@@ -1,7 +1,14 @@
 tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts(5,15): error TS2339: Property '#bar' does not exist on type 'any'.
+tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts(9,9): error TS2571: Object is of type 'unknown'.
+tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts(10,9): error TS2571: Object is of type 'unknown'.
+tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts(10,15): error TS2339: Property '#bar' does not exist on type 'any'.
+tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts(11,9): error TS2571: Object is of type 'unknown'.
+tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts(14,15): error TS2339: Property '#foo' does not exist on type 'never'.
+tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts(15,15): error TS2339: Property '#bar' does not exist on type 'never'.
+tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts(16,15): error TS2339: Property '#foo' does not exist on type 'never'.
 
 
-==== tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts (1 errors) ====
+==== tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts (8 errors) ====
     class A {
         #foo = true; 
         method(thing: any) {
@@ -9,6 +16,31 @@ tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts(5,15):
             thing.#bar; // Error
                   ~~~~
 !!! error TS2339: Property '#bar' does not exist on type 'any'.
+            thing.#foo();
+        }
+        methodU(thing: unknown) {
+            thing.#foo;
+            ~~~~~
+!!! error TS2571: Object is of type 'unknown'.
+            thing.#bar;
+            ~~~~~
+!!! error TS2571: Object is of type 'unknown'.
+                  ~~~~
+!!! error TS2339: Property '#bar' does not exist on type 'any'.
+            thing.#foo();
+            ~~~~~
+!!! error TS2571: Object is of type 'unknown'.
+        }
+        methodN(thing: never) {
+            thing.#foo;
+                  ~~~~
+!!! error TS2339: Property '#foo' does not exist on type 'never'.
+            thing.#bar;
+                  ~~~~
+!!! error TS2339: Property '#bar' does not exist on type 'never'.
+            thing.#foo();
+                  ~~~~
+!!! error TS2339: Property '#foo' does not exist on type 'never'.
         }
     };
     

--- a/tests/baselines/reference/privateNameAndAny.js
+++ b/tests/baselines/reference/privateNameAndAny.js
@@ -4,6 +4,17 @@ class A {
     method(thing: any) {
         thing.#foo; // OK
         thing.#bar; // Error
+        thing.#foo();
+    }
+    methodU(thing: unknown) {
+        thing.#foo;
+        thing.#bar;
+        thing.#foo();
+    }
+    methodN(thing: never) {
+        thing.#foo;
+        thing.#bar;
+        thing.#foo();
     }
 };
 
@@ -24,6 +35,18 @@ class A {
     method(thing) {
         __classPrivateFieldGet(thing, _foo); // OK
         thing.; // Error
+        __classPrivateFieldGet(thing, _foo).call(// Error
+        thing);
+    }
+    methodU(thing) {
+        __classPrivateFieldGet(thing, _foo);
+        thing.;
+        __classPrivateFieldGet(thing, _foo).call(thing);
+    }
+    methodN(thing) {
+        __classPrivateFieldGet(thing, _foo);
+        thing.;
+        __classPrivateFieldGet(thing, _foo).call(thing);
     }
 }
 _foo = new WeakMap();

--- a/tests/baselines/reference/privateNameAndAny.symbols
+++ b/tests/baselines/reference/privateNameAndAny.symbols
@@ -14,6 +14,35 @@ class A {
 
         thing.#bar; // Error
 >thing : Symbol(thing, Decl(privateNameAndAny.ts, 2, 11))
+
+        thing.#foo();
+>thing : Symbol(thing, Decl(privateNameAndAny.ts, 2, 11))
+    }
+    methodU(thing: unknown) {
+>methodU : Symbol(A.methodU, Decl(privateNameAndAny.ts, 6, 5))
+>thing : Symbol(thing, Decl(privateNameAndAny.ts, 7, 12))
+
+        thing.#foo;
+>thing : Symbol(thing, Decl(privateNameAndAny.ts, 7, 12))
+
+        thing.#bar;
+>thing : Symbol(thing, Decl(privateNameAndAny.ts, 7, 12))
+
+        thing.#foo();
+>thing : Symbol(thing, Decl(privateNameAndAny.ts, 7, 12))
+    }
+    methodN(thing: never) {
+>methodN : Symbol(A.methodN, Decl(privateNameAndAny.ts, 11, 5))
+>thing : Symbol(thing, Decl(privateNameAndAny.ts, 12, 12))
+
+        thing.#foo;
+>thing : Symbol(thing, Decl(privateNameAndAny.ts, 12, 12))
+
+        thing.#bar;
+>thing : Symbol(thing, Decl(privateNameAndAny.ts, 12, 12))
+
+        thing.#foo();
+>thing : Symbol(thing, Decl(privateNameAndAny.ts, 12, 12))
     }
 };
 

--- a/tests/baselines/reference/privateNameAndAny.types
+++ b/tests/baselines/reference/privateNameAndAny.types
@@ -17,6 +17,45 @@ class A {
         thing.#bar; // Error
 >thing.#bar : any
 >thing : any
+
+        thing.#foo();
+>thing.#foo() : any
+>thing.#foo : any
+>thing : any
+    }
+    methodU(thing: unknown) {
+>methodU : (thing: unknown) => void
+>thing : unknown
+
+        thing.#foo;
+>thing.#foo : any
+>thing : unknown
+
+        thing.#bar;
+>thing.#bar : any
+>thing : unknown
+
+        thing.#foo();
+>thing.#foo() : any
+>thing.#foo : any
+>thing : unknown
+    }
+    methodN(thing: never) {
+>methodN : (thing: never) => void
+>thing : never
+
+        thing.#foo;
+>thing.#foo : any
+>thing : never
+
+        thing.#bar;
+>thing.#bar : any
+>thing : never
+
+        thing.#foo();
+>thing.#foo() : any
+>thing.#foo : any
+>thing : never
     }
 };
 

--- a/tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts
@@ -6,5 +6,16 @@ class A {
     method(thing: any) {
         thing.#foo; // OK
         thing.#bar; // Error
+        thing.#foo();
+    }
+    methodU(thing: unknown) {
+        thing.#foo;
+        thing.#bar;
+        thing.#foo();
+    }
+    methodN(thing: never) {
+        thing.#foo;
+        thing.#bar;
+        thing.#foo();
     }
 };


### PR DESCRIPTION
Fix for crash when using ca call expression on private identifier coming from an any typed variable.


Fixes #42860
