### PR TITLE
Add missing MetaProperty stuffs

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -885,11 +885,11 @@ namespace ts {
         }
 
         function isNarrowableReference(expr: Expression): boolean {
-            return expr.kind === SyntaxKind.Identifier || expr.kind === SyntaxKind.PrivateIdentifier || expr.kind === SyntaxKind.ThisKeyword || expr.kind === SyntaxKind.SuperKeyword ||
-                (isPropertyAccessExpression(expr) || isNonNullExpression(expr) || isParenthesizedExpression(expr)) && isNarrowableReference(expr.expression) ||
-                isBinaryExpression(expr) && expr.operatorToken.kind === SyntaxKind.CommaToken && isNarrowableReference(expr.right) ||
-                isElementAccessExpression(expr) && isStringOrNumericLiteralLike(expr.argumentExpression) && isNarrowableReference(expr.expression) ||
-                isAssignmentExpression(expr) && isNarrowableReference(expr.left);
+            return isDottedName(expr)
+                || (isPropertyAccessExpression(expr) || isNonNullExpression(expr) || isParenthesizedExpression(expr)) && isNarrowableReference(expr.expression)
+                || isBinaryExpression(expr) && expr.operatorToken.kind === SyntaxKind.CommaToken && isNarrowableReference(expr.right)
+                || isElementAccessExpression(expr) && isStringOrNumericLiteralLike(expr.argumentExpression) && isNarrowableReference(expr.expression)
+                || isAssignmentExpression(expr) && isNarrowableReference(expr.left);
         }
 
         function containsNarrowableReference(expr: Expression): boolean {
@@ -1372,7 +1372,7 @@ namespace ts {
             // is potentially an assertion and is therefore included in the control flow.
             if (node.kind === SyntaxKind.CallExpression) {
                 const call = <CallExpression>node;
-                if (isDottedName(call.expression) && call.expression.kind !== SyntaxKind.SuperKeyword) {
+                if (call.expression.kind !== SyntaxKind.SuperKeyword && isDottedName(call.expression)) {
                     currentFlow = createFlowCall(currentFlow, call);
                 }
             }
@@ -2545,6 +2545,7 @@ namespace ts {
                         node.flowNode = currentFlow;
                     }
                     break;
+                case SyntaxKind.MetaProperty:
                 case SyntaxKind.SuperKeyword:
                     node.flowNode = currentFlow;
                     break;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21277,10 +21277,8 @@ namespace ts {
             switch (source.kind) {
                 case SyntaxKind.MetaProperty:
                     return target.kind === SyntaxKind.MetaProperty
-                        && (source as MetaProperty).keywordToken === SyntaxKind.ImportKeyword
-                        && (target as MetaProperty).keywordToken === SyntaxKind.ImportKeyword
-                        && (source as MetaProperty).name.escapedText === "meta"
-                        && (target as MetaProperty).name.escapedText === "meta";
+                        && (source as MetaProperty).keywordToken === (target as MetaProperty).keywordToken
+                        && (source as MetaProperty).name.escapedText === (target as MetaProperty).name.escapedText;
                 case SyntaxKind.Identifier:
                 case SyntaxKind.PrivateIdentifier:
                     return target.kind === SyntaxKind.Identifier && getResolvedSymbol(<Identifier>source) === getResolvedSymbol(<Identifier>target) ||

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21275,6 +21275,12 @@ namespace ts {
                         (isBinaryExpression(target) && target.operatorToken.kind === SyntaxKind.CommaToken && isMatchingReference(source, target.right));
             }
             switch (source.kind) {
+                case SyntaxKind.MetaProperty:
+                    return target.kind === SyntaxKind.MetaProperty
+                        && (source as MetaProperty).keywordToken === SyntaxKind.ImportKeyword
+                        && (target as MetaProperty).keywordToken === SyntaxKind.ImportKeyword
+                        && (source as MetaProperty).name.escapedText === "meta"
+                        && (target as MetaProperty).name.escapedText === "meta";
                 case SyntaxKind.Identifier:
                 case SyntaxKind.PrivateIdentifier:
                     return target.kind === SyntaxKind.Identifier && getResolvedSymbol(<Identifier>source) === getResolvedSymbol(<Identifier>target) ||

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4861,9 +4861,12 @@ namespace ts {
     }
 
     export function isDottedName(node: Expression): boolean {
-        return node.kind === SyntaxKind.Identifier || node.kind === SyntaxKind.ThisKeyword || node.kind === SyntaxKind.SuperKeyword ||
-            node.kind === SyntaxKind.PropertyAccessExpression && isDottedName((<PropertyAccessExpression>node).expression) ||
-            node.kind === SyntaxKind.ParenthesizedExpression && isDottedName((<ParenthesizedExpression>node).expression);
+        return node.kind === SyntaxKind.Identifier
+            || node.kind === SyntaxKind.ThisKeyword
+            || node.kind === SyntaxKind.SuperKeyword
+            || node.kind === SyntaxKind.MetaProperty
+            || node.kind === SyntaxKind.PropertyAccessExpression && isDottedName((<PropertyAccessExpression>node).expression)
+            || node.kind === SyntaxKind.ParenthesizedExpression && isDottedName((<ParenthesizedExpression>node).expression);
     }
 
     export function isPropertyAccessEntityNameExpression(node: Node): node is PropertyAccessEntityNameExpression {

--- a/tests/baselines/reference/importMetaNarrowing(module=es2020).js
+++ b/tests/baselines/reference/importMetaNarrowing(module=es2020).js
@@ -1,0 +1,14 @@
+//// [importMetaNarrowing.ts]
+declare global { interface ImportMeta {foo?: () => void} };
+
+if (import.meta.foo) {
+  import.meta.foo();
+}
+
+
+//// [importMetaNarrowing.js]
+;
+if (import.meta.foo) {
+    import.meta.foo();
+}
+export {};

--- a/tests/baselines/reference/importMetaNarrowing(module=es2020).symbols
+++ b/tests/baselines/reference/importMetaNarrowing(module=es2020).symbols
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/es2019/importMeta/importMetaNarrowing.ts ===
+declare global { interface ImportMeta {foo?: () => void} };
+>global : Symbol(global, Decl(importMetaNarrowing.ts, 0, 0))
+>ImportMeta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(importMetaNarrowing.ts, 0, 16))
+>foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+
+if (import.meta.foo) {
+>import.meta.foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+>foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+
+  import.meta.foo();
+>import.meta.foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+>foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+}
+

--- a/tests/baselines/reference/importMetaNarrowing(module=es2020).types
+++ b/tests/baselines/reference/importMetaNarrowing(module=es2020).types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/es2019/importMeta/importMetaNarrowing.ts ===
+declare global { interface ImportMeta {foo?: () => void} };
+>global : any
+>foo : (() => void) | undefined
+
+if (import.meta.foo) {
+>import.meta.foo : (() => void) | undefined
+>import.meta : ImportMeta
+>meta : any
+>foo : (() => void) | undefined
+
+  import.meta.foo();
+>import.meta.foo() : void
+>import.meta.foo : () => void
+>import.meta : ImportMeta
+>meta : any
+>foo : () => void
+}
+

--- a/tests/baselines/reference/importMetaNarrowing(module=esnext).js
+++ b/tests/baselines/reference/importMetaNarrowing(module=esnext).js
@@ -1,0 +1,14 @@
+//// [importMetaNarrowing.ts]
+declare global { interface ImportMeta {foo?: () => void} };
+
+if (import.meta.foo) {
+  import.meta.foo();
+}
+
+
+//// [importMetaNarrowing.js]
+;
+if (import.meta.foo) {
+    import.meta.foo();
+}
+export {};

--- a/tests/baselines/reference/importMetaNarrowing(module=esnext).symbols
+++ b/tests/baselines/reference/importMetaNarrowing(module=esnext).symbols
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/es2019/importMeta/importMetaNarrowing.ts ===
+declare global { interface ImportMeta {foo?: () => void} };
+>global : Symbol(global, Decl(importMetaNarrowing.ts, 0, 0))
+>ImportMeta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(importMetaNarrowing.ts, 0, 16))
+>foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+
+if (import.meta.foo) {
+>import.meta.foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+>foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+
+  import.meta.foo();
+>import.meta.foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+>foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+}
+

--- a/tests/baselines/reference/importMetaNarrowing(module=esnext).types
+++ b/tests/baselines/reference/importMetaNarrowing(module=esnext).types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/es2019/importMeta/importMetaNarrowing.ts ===
+declare global { interface ImportMeta {foo?: () => void} };
+>global : any
+>foo : (() => void) | undefined
+
+if (import.meta.foo) {
+>import.meta.foo : (() => void) | undefined
+>import.meta : ImportMeta
+>meta : any
+>foo : (() => void) | undefined
+
+  import.meta.foo();
+>import.meta.foo() : void
+>import.meta.foo : () => void
+>import.meta : ImportMeta
+>meta : any
+>foo : () => void
+}
+

--- a/tests/baselines/reference/importMetaNarrowing(module=system).js
+++ b/tests/baselines/reference/importMetaNarrowing(module=system).js
@@ -1,0 +1,22 @@
+//// [importMetaNarrowing.ts]
+declare global { interface ImportMeta {foo?: () => void} };
+
+if (import.meta.foo) {
+  import.meta.foo();
+}
+
+
+//// [importMetaNarrowing.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            ;
+            if (context_1.meta.foo) {
+                context_1.meta.foo();
+            }
+        }
+    };
+});

--- a/tests/baselines/reference/importMetaNarrowing(module=system).symbols
+++ b/tests/baselines/reference/importMetaNarrowing(module=system).symbols
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/es2019/importMeta/importMetaNarrowing.ts ===
+declare global { interface ImportMeta {foo?: () => void} };
+>global : Symbol(global, Decl(importMetaNarrowing.ts, 0, 0))
+>ImportMeta : Symbol(ImportMeta, Decl(lib.es5.d.ts, --, --), Decl(lib.dom.d.ts, --, --), Decl(importMetaNarrowing.ts, 0, 16))
+>foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+
+if (import.meta.foo) {
+>import.meta.foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+>foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+
+  import.meta.foo();
+>import.meta.foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+>foo : Symbol(ImportMeta.foo, Decl(importMetaNarrowing.ts, 0, 39))
+}
+

--- a/tests/baselines/reference/importMetaNarrowing(module=system).types
+++ b/tests/baselines/reference/importMetaNarrowing(module=system).types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/es2019/importMeta/importMetaNarrowing.ts ===
+declare global { interface ImportMeta {foo?: () => void} };
+>global : any
+>foo : (() => void) | undefined
+
+if (import.meta.foo) {
+>import.meta.foo : (() => void) | undefined
+>import.meta : ImportMeta
+>meta : any
+>foo : (() => void) | undefined
+
+  import.meta.foo();
+>import.meta.foo() : void
+>import.meta.foo : () => void
+>import.meta : ImportMeta
+>meta : any
+>foo : () => void
+}
+

--- a/tests/baselines/reference/newTargetNarrowing.js
+++ b/tests/baselines/reference/newTargetNarrowing.js
@@ -1,0 +1,21 @@
+//// [newTargetNarrowing.ts]
+function foo(x: true) { }
+
+function f() {
+  if (new.target.marked === true) {
+    foo(new.target.marked);
+  }
+}
+
+f.marked = true;
+
+
+//// [newTargetNarrowing.js]
+"use strict";
+function foo(x) { }
+function f() {
+    if (new.target.marked === true) {
+        foo(new.target.marked);
+    }
+}
+f.marked = true;

--- a/tests/baselines/reference/newTargetNarrowing.symbols
+++ b/tests/baselines/reference/newTargetNarrowing.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/conformance/es6/newTarget/newTargetNarrowing.ts ===
+function foo(x: true) { }
+>foo : Symbol(foo, Decl(newTargetNarrowing.ts, 0, 0))
+>x : Symbol(x, Decl(newTargetNarrowing.ts, 0, 13))
+
+function f() {
+>f : Symbol(f, Decl(newTargetNarrowing.ts, 0, 25), Decl(newTargetNarrowing.ts, 6, 1))
+
+  if (new.target.marked === true) {
+>new.target.marked : Symbol(f.marked, Decl(newTargetNarrowing.ts, 6, 1))
+>marked : Symbol(f.marked, Decl(newTargetNarrowing.ts, 6, 1))
+
+    foo(new.target.marked);
+>foo : Symbol(foo, Decl(newTargetNarrowing.ts, 0, 0))
+>new.target.marked : Symbol(f.marked, Decl(newTargetNarrowing.ts, 6, 1))
+>marked : Symbol(f.marked, Decl(newTargetNarrowing.ts, 6, 1))
+  }
+}
+
+f.marked = true;
+>f.marked : Symbol(f.marked, Decl(newTargetNarrowing.ts, 6, 1))
+>f : Symbol(f, Decl(newTargetNarrowing.ts, 0, 25), Decl(newTargetNarrowing.ts, 6, 1))
+>marked : Symbol(f.marked, Decl(newTargetNarrowing.ts, 6, 1))
+

--- a/tests/baselines/reference/newTargetNarrowing.types
+++ b/tests/baselines/reference/newTargetNarrowing.types
@@ -1,0 +1,34 @@
+=== tests/cases/conformance/es6/newTarget/newTargetNarrowing.ts ===
+function foo(x: true) { }
+>foo : (x: true) => void
+>x : true
+>true : true
+
+function f() {
+>f : typeof f
+
+  if (new.target.marked === true) {
+>new.target.marked === true : boolean
+>new.target.marked : boolean
+>new.target : typeof f
+>target : any
+>marked : boolean
+>true : true
+
+    foo(new.target.marked);
+>foo(new.target.marked) : void
+>foo : (x: true) => void
+>new.target.marked : true
+>new.target : typeof f
+>target : any
+>marked : true
+  }
+}
+
+f.marked = true;
+>f.marked = true : true
+>f.marked : boolean
+>f : typeof f
+>marked : boolean
+>true : true
+

--- a/tests/cases/conformance/es2019/importMeta/importMetaNarrowing.ts
+++ b/tests/cases/conformance/es2019/importMeta/importMetaNarrowing.ts
@@ -1,0 +1,8 @@
+// @module: esnext,system,es2020
+// @strict: true
+
+declare global { interface ImportMeta {foo?: () => void} };
+
+if (import.meta.foo) {
+  import.meta.foo();
+}

--- a/tests/cases/conformance/es6/newTarget/newTargetNarrowing.ts
+++ b/tests/cases/conformance/es6/newTarget/newTargetNarrowing.ts
@@ -1,0 +1,12 @@
+// @target: es6
+// @strict: true
+
+function foo(x: true) { }
+
+function f() {
+  if (new.target.marked === true) {
+    foo(new.target.marked);
+  }
+}
+
+f.marked = true;


### PR DESCRIPTION
Add missing parts in the binder and the checker to enable narrowing of
`import.meta` values.

Fixes #41468
