### PR TITLE
Never-reducing intersections are not untyped function call targets

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28359,7 +28359,7 @@ namespace ts {
         function isUntypedFunctionCall(funcType: Type, apparentFuncType: Type, numCallSignatures: number, numConstructSignatures: number): boolean {
             // We exclude union types because we may have a union of function types that happen to have no common signatures.
             return isTypeAny(funcType) || isTypeAny(apparentFuncType) && !!(funcType.flags & TypeFlags.TypeParameter) ||
-                !numCallSignatures && !numConstructSignatures && !(getReducedType(apparentFuncType).flags & (TypeFlags.Union | TypeFlags.Never)) && isTypeAssignableTo(funcType, globalFunctionType);
+                !numCallSignatures && !numConstructSignatures && !(apparentFuncType.flags & TypeFlags.Union) && !(getReducedType(apparentFuncType).flags & TypeFlags.Never) && isTypeAssignableTo(funcType, globalFunctionType);
         }
 
         function resolveNewExpression(node: NewExpression, candidatesOutArray: Signature[] | undefined, checkMode: CheckMode): Signature {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28359,7 +28359,7 @@ namespace ts {
         function isUntypedFunctionCall(funcType: Type, apparentFuncType: Type, numCallSignatures: number, numConstructSignatures: number): boolean {
             // We exclude union types because we may have a union of function types that happen to have no common signatures.
             return isTypeAny(funcType) || isTypeAny(apparentFuncType) && !!(funcType.flags & TypeFlags.TypeParameter) ||
-                !numCallSignatures && !numConstructSignatures && !(apparentFuncType.flags & (TypeFlags.Union | TypeFlags.Never)) && isTypeAssignableTo(funcType, globalFunctionType);
+                !numCallSignatures && !numConstructSignatures && !(getReducedType(apparentFuncType).flags & (TypeFlags.Union | TypeFlags.Never)) && isTypeAssignableTo(funcType, globalFunctionType);
         }
 
         function resolveNewExpression(node: NewExpression, candidatesOutArray: Signature[] | undefined, checkMode: CheckMode): Signature {

--- a/tests/baselines/reference/neverIntersectionNotCallable.errors.txt
+++ b/tests/baselines/reference/neverIntersectionNotCallable.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/conformance/types/never/neverIntersectionNotCallable.ts(2,1): error TS2349: This expression is not callable.
+  Type 'never' has no call signatures.
+
+
+==== tests/cases/conformance/types/never/neverIntersectionNotCallable.ts (1 errors) ====
+    declare const f: { (x: string): number, a: "" } & { a: number }
+    f()
+    ~
+!!! error TS2349: This expression is not callable.
+!!! error TS2349:   Type 'never' has no call signatures.
+    

--- a/tests/baselines/reference/neverIntersectionNotCallable.js
+++ b/tests/baselines/reference/neverIntersectionNotCallable.js
@@ -1,0 +1,7 @@
+//// [neverIntersectionNotCallable.ts]
+declare const f: { (x: string): number, a: "" } & { a: number }
+f()
+
+
+//// [neverIntersectionNotCallable.js]
+f();

--- a/tests/baselines/reference/neverIntersectionNotCallable.symbols
+++ b/tests/baselines/reference/neverIntersectionNotCallable.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/conformance/types/never/neverIntersectionNotCallable.ts ===
+declare const f: { (x: string): number, a: "" } & { a: number }
+>f : Symbol(f, Decl(neverIntersectionNotCallable.ts, 0, 13))
+>x : Symbol(x, Decl(neverIntersectionNotCallable.ts, 0, 20))
+>a : Symbol(a, Decl(neverIntersectionNotCallable.ts, 0, 39))
+>a : Symbol(a, Decl(neverIntersectionNotCallable.ts, 0, 51))
+
+f()
+>f : Symbol(f, Decl(neverIntersectionNotCallable.ts, 0, 13))
+

--- a/tests/baselines/reference/neverIntersectionNotCallable.types
+++ b/tests/baselines/reference/neverIntersectionNotCallable.types
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/types/never/neverIntersectionNotCallable.ts ===
+declare const f: { (x: string): number, a: "" } & { a: number }
+>f : never
+>x : string
+>a : ""
+>a : number
+
+f()
+>f() : any
+>f : never
+

--- a/tests/cases/conformance/types/never/neverIntersectionNotCallable.ts
+++ b/tests/cases/conformance/types/never/neverIntersectionNotCallable.ts
@@ -1,0 +1,2 @@
+declare const f: { (x: string): number, a: "" } & { a: number }
+f()


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #42859 
