### PR TITLE
fix(42923): Provide go-to-definition on unresolved shorthand properties

### DIFF
--- a/tests/cases/fourslash/goToDefinitionShorthandProperty04.ts
+++ b/tests/cases/fourslash/goToDefinitionShorthandProperty04.ts
@@ -1,0 +1,11 @@
+/// <reference path="./fourslash.ts"/>
+
+////interface Foo {
+////    /*2*/foo(): void
+////}
+////
+////let x: Foo = {
+////    [|f/*1*/oo|]
+////}
+
+verify.goToDefinition("1", "2");

--- a/tests/cases/fourslash/goToDefinitionShorthandProperty05.ts
+++ b/tests/cases/fourslash/goToDefinitionShorthandProperty05.ts
@@ -1,0 +1,11 @@
+/// <reference path="./fourslash.ts"/>
+
+////interface Foo {
+////    /*3*/foo(): void
+////}
+////const /*2*/foo = 1;
+////let x: Foo = {
+////    [|f/*1*/oo|]
+////}
+
+verify.goToDefinition("1", ["2", "3"]);

--- a/tests/cases/fourslash/goToDefinitionShorthandProperty06.ts
+++ b/tests/cases/fourslash/goToDefinitionShorthandProperty06.ts
@@ -1,0 +1,11 @@
+/// <reference path="./fourslash.ts"/>
+
+////interface Foo {
+////    /*2*/foo(): void
+////}
+////const foo = 1;
+////let x: Foo = {
+////    [|f/*1*/oo|]()
+////}
+
+verify.goToDefinition("1", "2");


### PR DESCRIPTION
Fixes #42923