### PR TITLE
fix(42605): support refactoring for export default assignment without equal

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1180,7 +1180,9 @@ namespace ts.FindAllReferences {
             for (const indirectUser of indirectUsers) {
                 for (const node of getPossibleSymbolReferenceNodes(indirectUser, isDefaultExport ? "default" : exportName)) {
                     // Import specifiers should be handled by importSearches
-                    if (isIdentifier(node) && !isImportOrExportSpecifier(node.parent) && checker.getSymbolAtLocation(node) === exportSymbol) {
+                    const symbol = checker.getSymbolAtLocation(node);
+                    const hasExportAssignmentDeclaration = some(symbol?.declarations, d => tryCast(d, isExportAssignment) ? true : false);
+                    if (isIdentifier(node) && !isImportOrExportSpecifier(node.parent) && (symbol === exportSymbol || hasExportAssignmentDeclaration)) {
                         cb(node);
                     }
                 }

--- a/tests/cases/fourslash/refactorConvertExport_defaultToNamed2.ts
+++ b/tests/cases/fourslash/refactorConvertExport_defaultToNamed2.ts
@@ -1,0 +1,44 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.ts
+////const f = () => {};
+/////*a*/export default f;/*b*/
+
+// @Filename: /b.ts
+////import f from "./a";
+////import { default as f } from "./a";
+////import { default as g } from "./a";
+////import f, * as a from "./a";
+////
+////export { default } from "./a";
+////export { default as f } from "./a";
+////export { default as i } from "./a";
+////
+////import * as a from "./a";
+////a.default();
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Convert export",
+    actionName: "Convert default export to named export",
+    actionDescription: "Convert default export to named export",
+    newContent: {
+        "/a.ts":
+`const f = () => {};
+export { f };`,
+
+        "/b.ts":
+`import { f } from "./a";
+import { f } from "./a";
+import { f as g } from "./a";
+import * as a from "./a";
+import { f } from "./a";
+
+export { f as default } from "./a";
+export { f } from "./a";
+export { f as i } from "./a";
+
+import * as a from "./a";
+a.f();`,
+},
+});


### PR DESCRIPTION
Fixes [#42605](https://github.com/microsoft/TypeScript/issues/42605)

The original issue pointed that `Convert default export to named export` refactoring is not available when it has specific format below.

1. export default identifier:
  ```
    const foo = () => {};
    export default foo;
  ```
2. anonymous function:
`export default () => {}`

I can confirm the first situation is a bug, since we support `export default function foo () {}` refactoring currently.
But for second situation, I think it may be a feature not a bug, because `export default function() {}` is also not supported, and I traced the original relevant PR, this situation is not supported at very beginning.

So I just fix the bug part, as for feature part, I am not quite sure.