### PR TITLE
Properly handle duplicate enum types in type inference

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13460,7 +13460,7 @@ namespace ts {
                 if (t.flags & TypeFlags.Union) {
                     const origin = (<UnionType>t).origin;
                     if (t.aliasSymbol || origin && !(origin.flags & TypeFlags.Union)) {
-                        namedUnions.push(t);
+                        pushIfUnique(namedUnions, t);
                     }
                     else if (origin && origin.flags & TypeFlags.Union) {
                         addNamedUnions(namedUnions, (<UnionType>origin).types);

--- a/tests/baselines/reference/unionOfEnumInference.js
+++ b/tests/baselines/reference/unionOfEnumInference.js
@@ -1,0 +1,29 @@
+//// [unionOfEnumInference.ts]
+// Repro from #42932
+
+enum Enum { A, B, C }
+
+interface Interface<T extends Enum> {
+	type: T;
+}
+
+function foo<T extends Enum>(x: Interface<T>) { }
+
+function bar(x: Interface<Enum.A | Enum.B> | Interface<Enum.C>) {
+	foo(x);
+}
+
+
+//// [unionOfEnumInference.js]
+"use strict";
+// Repro from #42932
+var Enum;
+(function (Enum) {
+    Enum[Enum["A"] = 0] = "A";
+    Enum[Enum["B"] = 1] = "B";
+    Enum[Enum["C"] = 2] = "C";
+})(Enum || (Enum = {}));
+function foo(x) { }
+function bar(x) {
+    foo(x);
+}

--- a/tests/baselines/reference/unionOfEnumInference.symbols
+++ b/tests/baselines/reference/unionOfEnumInference.symbols
@@ -1,0 +1,44 @@
+=== tests/cases/compiler/unionOfEnumInference.ts ===
+// Repro from #42932
+
+enum Enum { A, B, C }
+>Enum : Symbol(Enum, Decl(unionOfEnumInference.ts, 0, 0))
+>A : Symbol(Enum.A, Decl(unionOfEnumInference.ts, 2, 11))
+>B : Symbol(Enum.B, Decl(unionOfEnumInference.ts, 2, 14))
+>C : Symbol(Enum.C, Decl(unionOfEnumInference.ts, 2, 17))
+
+interface Interface<T extends Enum> {
+>Interface : Symbol(Interface, Decl(unionOfEnumInference.ts, 2, 21))
+>T : Symbol(T, Decl(unionOfEnumInference.ts, 4, 20))
+>Enum : Symbol(Enum, Decl(unionOfEnumInference.ts, 0, 0))
+
+	type: T;
+>type : Symbol(Interface.type, Decl(unionOfEnumInference.ts, 4, 37))
+>T : Symbol(T, Decl(unionOfEnumInference.ts, 4, 20))
+}
+
+function foo<T extends Enum>(x: Interface<T>) { }
+>foo : Symbol(foo, Decl(unionOfEnumInference.ts, 6, 1))
+>T : Symbol(T, Decl(unionOfEnumInference.ts, 8, 13))
+>Enum : Symbol(Enum, Decl(unionOfEnumInference.ts, 0, 0))
+>x : Symbol(x, Decl(unionOfEnumInference.ts, 8, 29))
+>Interface : Symbol(Interface, Decl(unionOfEnumInference.ts, 2, 21))
+>T : Symbol(T, Decl(unionOfEnumInference.ts, 8, 13))
+
+function bar(x: Interface<Enum.A | Enum.B> | Interface<Enum.C>) {
+>bar : Symbol(bar, Decl(unionOfEnumInference.ts, 8, 49))
+>x : Symbol(x, Decl(unionOfEnumInference.ts, 10, 13))
+>Interface : Symbol(Interface, Decl(unionOfEnumInference.ts, 2, 21))
+>Enum : Symbol(Enum, Decl(unionOfEnumInference.ts, 0, 0))
+>A : Symbol(Enum.A, Decl(unionOfEnumInference.ts, 2, 11))
+>Enum : Symbol(Enum, Decl(unionOfEnumInference.ts, 0, 0))
+>B : Symbol(Enum.B, Decl(unionOfEnumInference.ts, 2, 14))
+>Interface : Symbol(Interface, Decl(unionOfEnumInference.ts, 2, 21))
+>Enum : Symbol(Enum, Decl(unionOfEnumInference.ts, 0, 0))
+>C : Symbol(Enum.C, Decl(unionOfEnumInference.ts, 2, 17))
+
+	foo(x);
+>foo : Symbol(foo, Decl(unionOfEnumInference.ts, 6, 1))
+>x : Symbol(x, Decl(unionOfEnumInference.ts, 10, 13))
+}
+

--- a/tests/baselines/reference/unionOfEnumInference.types
+++ b/tests/baselines/reference/unionOfEnumInference.types
@@ -1,0 +1,31 @@
+=== tests/cases/compiler/unionOfEnumInference.ts ===
+// Repro from #42932
+
+enum Enum { A, B, C }
+>Enum : Enum
+>A : Enum.A
+>B : Enum.B
+>C : Enum.C
+
+interface Interface<T extends Enum> {
+	type: T;
+>type : T
+}
+
+function foo<T extends Enum>(x: Interface<T>) { }
+>foo : <T extends Enum>(x: Interface<T>) => void
+>x : Interface<T>
+
+function bar(x: Interface<Enum.A | Enum.B> | Interface<Enum.C>) {
+>bar : (x: Interface<Enum.A | Enum.B> | Interface<Enum.C>) => void
+>x : Interface<Enum.A | Enum.B> | Interface<Enum.C>
+>Enum : any
+>Enum : any
+>Enum : any
+
+	foo(x);
+>foo(x) : void
+>foo : <T extends Enum>(x: Interface<T>) => void
+>x : Interface<Enum.A | Enum.B> | Interface<Enum.C>
+}
+

--- a/tests/cases/compiler/unionOfEnumInference.ts
+++ b/tests/cases/compiler/unionOfEnumInference.ts
@@ -1,0 +1,15 @@
+// @strict: true
+
+// Repro from #42932
+
+enum Enum { A, B, C }
+
+interface Interface<T extends Enum> {
+	type: T;
+}
+
+function foo<T extends Enum>(x: Interface<T>) { }
+
+function bar(x: Interface<Enum.A | Enum.B> | Interface<Enum.C>) {
+	foo(x);
+}


### PR DESCRIPTION
Fixes #42932.