### PR TITLE
Infer type of method parameter from base class

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24600,12 +24600,8 @@ namespace ts {
                 return undefined;
             }
 
-            const signatures = getSignaturesOfType(methodDeclType, SignatureKind.Call);
-            if (signatures.length > 1) {
-                return undefined;
-            }
-            const signature = first(signatures);
-            if (signature.typeParameters || signature.flags & SignatureFlags.HasRestParameter) {
+            const signature = getSingleCallSignature(methodDeclType);
+            if (!signature || signature.typeParameters || signature.flags & SignatureFlags.HasRestParameter) {
                 return undefined;
             }
 
@@ -24617,14 +24613,9 @@ namespace ts {
             if (!baseMethodType) {
                 return undefined;
             }
-
-            const baseSignatures = getSignaturesOfType(baseMethodType, SignatureKind.Call);
-            if (baseSignatures.length > 1) {
-                return undefined;
-            }
-
-            const baseSignature = first(baseSignatures);
-            if (baseSignature.typeParameters || baseSignature.flags & SignatureFlags.HasRestParameter) {
+            
+            const baseSignature = getSingleCallSignature(baseMethodType);
+            if (!baseSignature || baseSignature.typeParameters || baseSignature.flags & SignatureFlags.HasRestParameter) {
                 return undefined;
             }
 
@@ -24643,7 +24634,7 @@ namespace ts {
             const newSignatureParameters: Symbol[] = [];
             for (let i = 0; i < signature.parameters.length; ++i) {
                 const parameter = signature.parameters[i];
-                const parameterDeclaration = isParameter(parameter.valueDeclaration) && parameter.valueDeclaration
+                const parameterDeclaration = isParameter(parameter.valueDeclaration) && parameter.valueDeclaration;
                 if (!parameterDeclaration || parameterDeclaration.initializer || i >= baseSignature.parameters.length || getEffectiveTypeAnnotationNode(parameterDeclaration)) {
                     newSignatureParameters.push(parameter);
                     continue;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24591,10 +24591,10 @@ namespace ts {
             }
 
             const container = cast(node.parent, isClassLike);
-            const heritageElement = getClassExtendsHeritageElement(container);
-            Debug.assertIsDefined(heritageElement);
+            const baseTypeNode = getEffectiveBaseTypeNode(container);
+            Debug.assertIsDefined(baseTypeNode);
 
-            const baseType = getTypeFromTypeReference(heritageElement);
+            const baseType = getTypeOfNode(baseTypeNode);
             if (baseType === errorType) {
                 return undefined;
             }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1491,6 +1491,14 @@ namespace ts {
         return node && node.kind === SyntaxKind.MethodDeclaration && node.parent.kind === SyntaxKind.ObjectLiteralExpression;
     }
 
+    export function isClassMethodInSubClass(node: Node): node is MethodDeclaration {
+        if (!node || !isMethodDeclaration(node) || !isClassLike(node.parent)) {
+            return false;
+        }
+
+        return !!getClassExtendsHeritageElement(node.parent);
+    }
+
     export function isObjectLiteralOrClassExpressionMethod(node: Node): node is MethodDeclaration {
         return node.kind === SyntaxKind.MethodDeclaration &&
             (node.parent.kind === SyntaxKind.ObjectLiteralExpression ||

--- a/tests/baselines/reference/contextualClassMethodParameter1.js
+++ b/tests/baselines/reference/contextualClassMethodParameter1.js
@@ -1,0 +1,40 @@
+//// [contextualClassMethodParameter1.ts]
+class Base {
+    method(x: number) { }
+}
+
+class Derived extends Base {
+    method(x) { }
+}
+
+
+//// [contextualClassMethodParameter1.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter1.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter1.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter1.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter1.ts, 0, 0))
+
+    method(x: number) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter1.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter1.ts, 1, 11))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter1.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter1.ts, 0, 0))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter1.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter1.ts, 5, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter1.types
+++ b/tests/baselines/reference/contextualClassMethodParameter1.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter1.ts ===
+class Base {
+>Base : Base
+
+    method(x: number) { }
+>method : (x: number) => void
+>x : number
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x) { }
+>method : (x: number) => void
+>x : number
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter10.js
+++ b/tests/baselines/reference/contextualClassMethodParameter10.js
@@ -1,0 +1,40 @@
+//// [contextualClassMethodParameter10.ts]
+class Base {
+    method(x: number) { }
+}
+
+class Derived<T> extends Base {
+    method(x) { }
+}
+
+
+//// [contextualClassMethodParameter10.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter10.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter10.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter10.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter10.ts, 0, 0))
+
+    method(x: number) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter10.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter10.ts, 1, 11))
+}
+
+class Derived<T> extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter10.ts, 2, 1))
+>T : Symbol(T, Decl(contextualClassMethodParameter10.ts, 4, 14))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter10.ts, 0, 0))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter10.ts, 4, 31))
+>x : Symbol(x, Decl(contextualClassMethodParameter10.ts, 5, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter10.types
+++ b/tests/baselines/reference/contextualClassMethodParameter10.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter10.ts ===
+class Base {
+>Base : Base
+
+    method(x: number) { }
+>method : (x: number) => void
+>x : number
+}
+
+class Derived<T> extends Base {
+>Derived : Derived<T>
+>Base : Base
+
+    method(x) { }
+>method : (x: number) => void
+>x : number
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter11.js
+++ b/tests/baselines/reference/contextualClassMethodParameter11.js
@@ -1,0 +1,40 @@
+//// [contextualClassMethodParameter11.ts]
+class Base<T> {
+    method(x: T) { }
+}
+
+class Derived extends Base<string> {
+    method(x) { }
+}
+
+
+//// [contextualClassMethodParameter11.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter11.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter11.symbols
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter11.ts ===
+class Base<T> {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter11.ts, 0, 0))
+>T : Symbol(T, Decl(contextualClassMethodParameter11.ts, 0, 11))
+
+    method(x: T) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter11.ts, 0, 15))
+>x : Symbol(x, Decl(contextualClassMethodParameter11.ts, 1, 11))
+>T : Symbol(T, Decl(contextualClassMethodParameter11.ts, 0, 11))
+}
+
+class Derived extends Base<string> {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter11.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter11.ts, 0, 0))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter11.ts, 4, 36))
+>x : Symbol(x, Decl(contextualClassMethodParameter11.ts, 5, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter11.types
+++ b/tests/baselines/reference/contextualClassMethodParameter11.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter11.ts ===
+class Base<T> {
+>Base : Base<T>
+
+    method(x: T) { }
+>method : (x: T) => void
+>x : T
+}
+
+class Derived extends Base<string> {
+>Derived : Derived
+>Base : Base<string>
+
+    method(x) { }
+>method : (x: string) => void
+>x : string
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter12.js
+++ b/tests/baselines/reference/contextualClassMethodParameter12.js
@@ -1,0 +1,40 @@
+//// [contextualClassMethodParameter12.ts]
+class Base<T> {
+    method(x: T) { }
+}
+
+class Derived<T> extends Base<T> {
+    method(x) { }
+}
+
+
+//// [contextualClassMethodParameter12.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter12.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter12.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter12.ts ===
+class Base<T> {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter12.ts, 0, 0))
+>T : Symbol(T, Decl(contextualClassMethodParameter12.ts, 0, 11))
+
+    method(x: T) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter12.ts, 0, 15))
+>x : Symbol(x, Decl(contextualClassMethodParameter12.ts, 1, 11))
+>T : Symbol(T, Decl(contextualClassMethodParameter12.ts, 0, 11))
+}
+
+class Derived<T> extends Base<T> {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter12.ts, 2, 1))
+>T : Symbol(T, Decl(contextualClassMethodParameter12.ts, 4, 14))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter12.ts, 0, 0))
+>T : Symbol(T, Decl(contextualClassMethodParameter12.ts, 4, 14))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter12.ts, 4, 34))
+>x : Symbol(x, Decl(contextualClassMethodParameter12.ts, 5, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter12.types
+++ b/tests/baselines/reference/contextualClassMethodParameter12.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter12.ts ===
+class Base<T> {
+>Base : Base<T>
+
+    method(x: T) { }
+>method : (x: T) => void
+>x : T
+}
+
+class Derived<T> extends Base<T> {
+>Derived : Derived<T>
+>Base : Base<T>
+
+    method(x) { }
+>method : (x: T) => void
+>x : T
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter13.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter13.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter13.ts(4,12): error TS7006: Parameter 'x' implicitly has an 'any' type.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter13.ts (1 errors) ====
+    declare const Base: any
+    
+    class Derived extends Base {
+        method(x) { }
+               ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+    }
+    

--- a/tests/baselines/reference/contextualClassMethodParameter13.js
+++ b/tests/baselines/reference/contextualClassMethodParameter13.js
@@ -1,0 +1,32 @@
+//// [contextualClassMethodParameter13.ts]
+declare const Base: any
+
+class Derived extends Base {
+    method(x) { }
+}
+
+
+//// [contextualClassMethodParameter13.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter13.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter13.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter13.ts ===
+declare const Base: any
+>Base : Symbol(Base, Decl(contextualClassMethodParameter13.ts, 0, 13))
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter13.ts, 0, 23))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter13.ts, 0, 13))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter13.ts, 2, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter13.ts, 3, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter13.types
+++ b/tests/baselines/reference/contextualClassMethodParameter13.types
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter13.ts ===
+declare const Base: any
+>Base : any
+
+class Derived extends Base {
+>Derived : Derived
+>Base : any
+
+    method(x) { }
+>method : (x: any) => void
+>x : any
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter14.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter14.errors.txt
@@ -1,0 +1,16 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter14.ts(5,23): error TS2507: Type '{ method(x: string): void; }' is not a constructor function type.
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter14.ts(6,12): error TS7006: Parameter 'x' implicitly has an 'any' type.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter14.ts (2 errors) ====
+    declare const Base: {
+        method(x: string): void
+    }
+    
+    class Derived extends Base {
+                          ~~~~
+!!! error TS2507: Type '{ method(x: string): void; }' is not a constructor function type.
+        method(x) { }
+               ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+    }

--- a/tests/baselines/reference/contextualClassMethodParameter14.js
+++ b/tests/baselines/reference/contextualClassMethodParameter14.js
@@ -1,0 +1,33 @@
+//// [contextualClassMethodParameter14.ts]
+declare const Base: {
+    method(x: string): void
+}
+
+class Derived extends Base {
+    method(x) { }
+}
+
+//// [contextualClassMethodParameter14.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter14.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter14.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter14.ts ===
+declare const Base: {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter14.ts, 0, 13))
+
+    method(x: string): void
+>method : Symbol(method, Decl(contextualClassMethodParameter14.ts, 0, 21))
+>x : Symbol(x, Decl(contextualClassMethodParameter14.ts, 1, 11))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter14.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter14.ts, 0, 13))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter14.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter14.ts, 5, 11))
+}

--- a/tests/baselines/reference/contextualClassMethodParameter14.types
+++ b/tests/baselines/reference/contextualClassMethodParameter14.types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter14.ts ===
+declare const Base: {
+>Base : { method(x: string): void; }
+
+    method(x: string): void
+>method : (x: string) => void
+>x : string
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : { method(x: string): void; }
+
+    method(x) { }
+>method : (x: any) => void
+>x : any
+}

--- a/tests/baselines/reference/contextualClassMethodParameter15.js
+++ b/tests/baselines/reference/contextualClassMethodParameter15.js
@@ -1,0 +1,39 @@
+//// [contextualClassMethodParameter15.ts]
+type BaseProtytype = {
+    new(): BaseProtytype
+    method(x: string): void
+}
+
+declare const Base: {
+    new(): BaseProtytype
+}
+
+class Derived extends Base {
+    method(x) { }
+}
+
+
+//// [contextualClassMethodParameter15.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter15.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter15.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter15.ts ===
+type BaseProtytype = {
+>BaseProtytype : Symbol(BaseProtytype, Decl(contextualClassMethodParameter15.ts, 0, 0))
+
+    new(): BaseProtytype
+>BaseProtytype : Symbol(BaseProtytype, Decl(contextualClassMethodParameter15.ts, 0, 0))
+
+    method(x: string): void
+>method : Symbol(method, Decl(contextualClassMethodParameter15.ts, 1, 24))
+>x : Symbol(x, Decl(contextualClassMethodParameter15.ts, 2, 11))
+}
+
+declare const Base: {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter15.ts, 5, 13))
+
+    new(): BaseProtytype
+>BaseProtytype : Symbol(BaseProtytype, Decl(contextualClassMethodParameter15.ts, 0, 0))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter15.ts, 7, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter15.ts, 5, 13))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter15.ts, 9, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter15.ts, 10, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter15.types
+++ b/tests/baselines/reference/contextualClassMethodParameter15.types
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter15.ts ===
+type BaseProtytype = {
+>BaseProtytype : BaseProtytype
+
+    new(): BaseProtytype
+    method(x: string): void
+>method : (x: string) => void
+>x : string
+}
+
+declare const Base: {
+>Base : new () => BaseProtytype
+
+    new(): BaseProtytype
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : BaseProtytype
+
+    method(x) { }
+>method : (x: string) => void
+>x : string
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter16.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter16.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter16.ts(6,15): error TS7006: Parameter 'x' implicitly has an 'any' type.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter16.ts (1 errors) ====
+    class Base {
+        method (x: number) { }
+    }
+    
+    class Derived extends Base {
+        method = (x) => { }
+                  ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+    }
+    

--- a/tests/baselines/reference/contextualClassMethodParameter16.js
+++ b/tests/baselines/reference/contextualClassMethodParameter16.js
@@ -1,0 +1,41 @@
+//// [contextualClassMethodParameter16.ts]
+class Base {
+    method (x: number) { }
+}
+
+class Derived extends Base {
+    method = (x) => { }
+}
+
+
+//// [contextualClassMethodParameter16.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        var _this = _super !== null && _super.apply(this, arguments) || this;
+        _this.method = function (x) { };
+        return _this;
+    }
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter16.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter16.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter16.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter16.ts, 0, 0))
+
+    method (x: number) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter16.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter16.ts, 1, 12))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter16.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter16.ts, 0, 0))
+
+    method = (x) => { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter16.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter16.ts, 5, 14))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter16.types
+++ b/tests/baselines/reference/contextualClassMethodParameter16.types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter16.ts ===
+class Base {
+>Base : Base
+
+    method (x: number) { }
+>method : (x: number) => void
+>x : number
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method = (x) => { }
+>method : (x: any) => void
+>(x) => { } : (x: any) => void
+>x : any
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter17.js
+++ b/tests/baselines/reference/contextualClassMethodParameter17.js
@@ -1,0 +1,40 @@
+//// [contextualClassMethodParameter17.ts]
+class Base {
+    method(x: number, y: string) { }
+}
+
+class Derived extends Base {
+    method(x) { }
+}
+
+
+//// [contextualClassMethodParameter17.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x, y) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter17.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter17.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter17.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter17.ts, 0, 0))
+
+    method(x: number, y: string) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter17.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter17.ts, 1, 11))
+>y : Symbol(y, Decl(contextualClassMethodParameter17.ts, 1, 21))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter17.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter17.ts, 0, 0))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter17.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter17.ts, 5, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter17.types
+++ b/tests/baselines/reference/contextualClassMethodParameter17.types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter17.ts ===
+class Base {
+>Base : Base
+
+    method(x: number, y: string) { }
+>method : (x: number, y: string) => void
+>x : number
+>y : string
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x) { }
+>method : (x: number) => void
+>x : number
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter18.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter18.errors.txt
@@ -1,11 +1,8 @@
 tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts(6,5): error TS2416: Property 'method' in type 'Derived' is not assignable to the same property in base type 'Base'.
-  Type '(x: any, y: any, z: any) => void' is not assignable to type '(x: number, y: string) => void'.
-tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts(6,12): error TS7006: Parameter 'x' implicitly has an 'any' type.
-tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts(6,15): error TS7006: Parameter 'y' implicitly has an 'any' type.
-tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts(6,18): error TS7006: Parameter 'z' implicitly has an 'any' type.
+  Type '(x: number, y: string, z: any) => void' is not assignable to type '(x: number, y: string) => void'.
 
 
-==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts (4 errors) ====
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts (1 errors) ====
     class Base {
         method(x: number, y: string) { }
     }
@@ -14,12 +11,6 @@ tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMe
         method(x, y, z) { }
         ~~~~~~
 !!! error TS2416: Property 'method' in type 'Derived' is not assignable to the same property in base type 'Base'.
-!!! error TS2416:   Type '(x: any, y: any, z: any) => void' is not assignable to type '(x: number, y: string) => void'.
-               ~
-!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
-                  ~
-!!! error TS7006: Parameter 'y' implicitly has an 'any' type.
-                     ~
-!!! error TS7006: Parameter 'z' implicitly has an 'any' type.
+!!! error TS2416:   Type '(x: number, y: string, z: any) => void' is not assignable to type '(x: number, y: string) => void'.
     }
     

--- a/tests/baselines/reference/contextualClassMethodParameter18.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter18.errors.txt
@@ -1,0 +1,25 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts(6,5): error TS2416: Property 'method' in type 'Derived' is not assignable to the same property in base type 'Base'.
+  Type '(x: any, y: any, z: any) => void' is not assignable to type '(x: number, y: string) => void'.
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts(6,12): error TS7006: Parameter 'x' implicitly has an 'any' type.
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts(6,15): error TS7006: Parameter 'y' implicitly has an 'any' type.
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts(6,18): error TS7006: Parameter 'z' implicitly has an 'any' type.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts (4 errors) ====
+    class Base {
+        method(x: number, y: string) { }
+    }
+    
+    class Derived extends Base {
+        method(x, y, z) { }
+        ~~~~~~
+!!! error TS2416: Property 'method' in type 'Derived' is not assignable to the same property in base type 'Base'.
+!!! error TS2416:   Type '(x: any, y: any, z: any) => void' is not assignable to type '(x: number, y: string) => void'.
+               ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+                  ~
+!!! error TS7006: Parameter 'y' implicitly has an 'any' type.
+                     ~
+!!! error TS7006: Parameter 'z' implicitly has an 'any' type.
+    }
+    

--- a/tests/baselines/reference/contextualClassMethodParameter18.js
+++ b/tests/baselines/reference/contextualClassMethodParameter18.js
@@ -1,0 +1,40 @@
+//// [contextualClassMethodParameter18.ts]
+class Base {
+    method(x: number, y: string) { }
+}
+
+class Derived extends Base {
+    method(x, y, z) { }
+}
+
+
+//// [contextualClassMethodParameter18.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x, y) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x, y, z) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter18.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter18.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter18.ts, 0, 0))
+
+    method(x: number, y: string) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter18.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter18.ts, 1, 11))
+>y : Symbol(y, Decl(contextualClassMethodParameter18.ts, 1, 21))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter18.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter18.ts, 0, 0))
+
+    method(x, y, z) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter18.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter18.ts, 5, 11))
+>y : Symbol(y, Decl(contextualClassMethodParameter18.ts, 5, 13))
+>z : Symbol(z, Decl(contextualClassMethodParameter18.ts, 5, 16))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter18.types
+++ b/tests/baselines/reference/contextualClassMethodParameter18.types
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts ===
+class Base {
+>Base : Base
+
+    method(x: number, y: string) { }
+>method : (x: number, y: string) => void
+>x : number
+>y : string
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x, y, z) { }
+>method : (x: any, y: any, z: any) => void
+>x : any
+>y : any
+>z : any
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter18.types
+++ b/tests/baselines/reference/contextualClassMethodParameter18.types
@@ -13,9 +13,9 @@ class Derived extends Base {
 >Base : Base
 
     method(x, y, z) { }
->method : (x: any, y: any, z: any) => void
->x : any
->y : any
+>method : (x: number, y: string, z: any) => void
+>x : number
+>y : string
 >z : any
 }
 

--- a/tests/baselines/reference/contextualClassMethodParameter19.js
+++ b/tests/baselines/reference/contextualClassMethodParameter19.js
@@ -1,0 +1,40 @@
+//// [contextualClassMethodParameter19.ts]
+class Base {
+    method(x: number) { }
+}
+
+class Derived extends Base {
+    method(x) { }
+}
+
+
+//// [contextualClassMethodParameter19.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter19.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter19.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter19.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter19.ts, 0, 0))
+
+    method(x: number) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter19.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter19.ts, 1, 11))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter19.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter19.ts, 0, 0))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter19.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter19.ts, 5, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter19.types
+++ b/tests/baselines/reference/contextualClassMethodParameter19.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter19.ts ===
+class Base {
+>Base : Base
+
+    method(x: number) { }
+>method : (x: number) => void
+>x : number
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x) { }
+>method : (x: any) => void
+>x : any
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter2.js
+++ b/tests/baselines/reference/contextualClassMethodParameter2.js
@@ -1,0 +1,40 @@
+//// [contextualClassMethodParameter2.ts]
+class Base {
+    method(x: number, y: string) { }
+}
+
+class Derived extends Base {
+    method(x, y) { }
+}
+
+
+//// [contextualClassMethodParameter2.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x, y) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x, y) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter2.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter2.symbols
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter2.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter2.ts, 0, 0))
+
+    method(x: number, y: string) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter2.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter2.ts, 1, 11))
+>y : Symbol(y, Decl(contextualClassMethodParameter2.ts, 1, 21))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter2.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter2.ts, 0, 0))
+
+    method(x, y) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter2.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter2.ts, 5, 11))
+>y : Symbol(y, Decl(contextualClassMethodParameter2.ts, 5, 13))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter2.types
+++ b/tests/baselines/reference/contextualClassMethodParameter2.types
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter2.ts ===
+class Base {
+>Base : Base
+
+    method(x: number, y: string) { }
+>method : (x: number, y: string) => void
+>x : number
+>y : string
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x, y) { }
+>method : (x: number, y: string) => void
+>x : number
+>y : string
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter20.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter20.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter20.ts(6,15): error TS7006: Parameter 'x' implicitly has an 'any' type.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter20.ts (1 errors) ====
+    class Base {
+        method = (x: number) => { }
+    }
+    
+    class Derived extends Base {
+        method = (x) => { }
+                  ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+    }
+    

--- a/tests/baselines/reference/contextualClassMethodParameter20.js
+++ b/tests/baselines/reference/contextualClassMethodParameter20.js
@@ -1,0 +1,41 @@
+//// [contextualClassMethodParameter20.ts]
+class Base {
+    method = (x: number) => { }
+}
+
+class Derived extends Base {
+    method = (x) => { }
+}
+
+
+//// [contextualClassMethodParameter20.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+        this.method = function (x) { };
+    }
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        var _this = _super !== null && _super.apply(this, arguments) || this;
+        _this.method = function (x) { };
+        return _this;
+    }
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter20.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter20.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter20.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter20.ts, 0, 0))
+
+    method = (x: number) => { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter20.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter20.ts, 1, 14))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter20.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter20.ts, 0, 0))
+
+    method = (x) => { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter20.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter20.ts, 5, 14))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter20.types
+++ b/tests/baselines/reference/contextualClassMethodParameter20.types
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter20.ts ===
+class Base {
+>Base : Base
+
+    method = (x: number) => { }
+>method : (x: number) => void
+>(x: number) => { } : (x: number) => void
+>x : number
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method = (x) => { }
+>method : (x: any) => void
+>(x) => { } : (x: any) => void
+>x : any
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter21.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter21.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter21.ts(6,12): error TS7006: Parameter 'x' implicitly has an 'any' type.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter21.ts (1 errors) ====
+    class Base {
+        method<T>(x: T) { }
+    }
+    
+    class Derived extends Base {
+        method(x) { }
+               ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+    }
+    

--- a/tests/baselines/reference/contextualClassMethodParameter21.js
+++ b/tests/baselines/reference/contextualClassMethodParameter21.js
@@ -1,15 +1,14 @@
-//// [contextualClassMethodParameter6.ts]
+//// [contextualClassMethodParameter21.ts]
 class Base {
-    method(x: "a" | "b") { }
+    method<T>(x: T) { }
 }
 
 class Derived extends Base {
-    method(y = "a") { }
+    method(x) { }
 }
 
 
-
-//// [contextualClassMethodParameter6.js]
+//// [contextualClassMethodParameter21.js]
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
@@ -36,8 +35,6 @@ var Derived = /** @class */ (function (_super) {
     function Derived() {
         return _super !== null && _super.apply(this, arguments) || this;
     }
-    Derived.prototype.method = function (y) {
-        if (y === void 0) { y = "a"; }
-    };
+    Derived.prototype.method = function (x) { };
     return Derived;
 }(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter21.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter21.symbols
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter21.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter21.ts, 0, 0))
+
+    method<T>(x: T) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter21.ts, 0, 12))
+>T : Symbol(T, Decl(contextualClassMethodParameter21.ts, 1, 11))
+>x : Symbol(x, Decl(contextualClassMethodParameter21.ts, 1, 14))
+>T : Symbol(T, Decl(contextualClassMethodParameter21.ts, 1, 11))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter21.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter21.ts, 0, 0))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter21.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter21.ts, 5, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter21.types
+++ b/tests/baselines/reference/contextualClassMethodParameter21.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter21.ts ===
+class Base {
+>Base : Base
+
+    method<T>(x: T) { }
+>method : <T>(x: T) => void
+>x : T
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x) { }
+>method : (x: any) => void
+>x : any
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter22.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter22.errors.txt
@@ -1,0 +1,16 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter22.ts(6,12): error TS7006: Parameter 'x' implicitly has an 'any' type.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter22.ts (1 errors) ====
+    class Base {
+        method(x: number) { }
+    }
+    
+    class Derived extends Base {
+        method(x): x is number {
+               ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+            return true
+        }
+    }
+    

--- a/tests/baselines/reference/contextualClassMethodParameter22.js
+++ b/tests/baselines/reference/contextualClassMethodParameter22.js
@@ -1,15 +1,16 @@
-//// [contextualClassMethodParameter6.ts]
+//// [contextualClassMethodParameter22.ts]
 class Base {
-    method(x: "a" | "b") { }
+    method(x: number) { }
 }
 
 class Derived extends Base {
-    method(y = "a") { }
+    method(x): x is number {
+        return true
+    }
 }
 
 
-
-//// [contextualClassMethodParameter6.js]
+//// [contextualClassMethodParameter22.js]
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
@@ -36,8 +37,8 @@ var Derived = /** @class */ (function (_super) {
     function Derived() {
         return _super !== null && _super.apply(this, arguments) || this;
     }
-    Derived.prototype.method = function (y) {
-        if (y === void 0) { y = "a"; }
+    Derived.prototype.method = function (x) {
+        return true;
     };
     return Derived;
 }(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter22.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter22.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter22.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter22.ts, 0, 0))
+
+    method(x: number) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter22.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter22.ts, 1, 11))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter22.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter22.ts, 0, 0))
+
+    method(x): x is number {
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter22.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter22.ts, 5, 11))
+>x : Symbol(x, Decl(contextualClassMethodParameter22.ts, 5, 11))
+
+        return true
+    }
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter22.types
+++ b/tests/baselines/reference/contextualClassMethodParameter22.types
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter22.ts ===
+class Base {
+>Base : Base
+
+    method(x: number) { }
+>method : (x: number) => void
+>x : number
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x): x is number {
+>method : (x: any) => x is number
+>x : any
+
+        return true
+>true : true
+    }
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter23.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter23.errors.txt
@@ -1,0 +1,20 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter23.ts(8,5): error TS2416: Property 'method' in type 'Derived' is not assignable to the same property in base type 'Base'.
+  Type '(x: number) => void' is not assignable to type '(x: number) => x is number'.
+    Signature '(x: number): void' must be a type predicate.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter23.ts (1 errors) ====
+    class Base {
+        method(x: number): x is number {
+            return true
+        }
+    }
+    
+    class Derived extends Base {
+        method(x) { }
+        ~~~~~~
+!!! error TS2416: Property 'method' in type 'Derived' is not assignable to the same property in base type 'Base'.
+!!! error TS2416:   Type '(x: number) => void' is not assignable to type '(x: number) => x is number'.
+!!! error TS2416:     Signature '(x: number): void' must be a type predicate.
+    }
+    

--- a/tests/baselines/reference/contextualClassMethodParameter23.js
+++ b/tests/baselines/reference/contextualClassMethodParameter23.js
@@ -1,15 +1,16 @@
-//// [contextualClassMethodParameter6.ts]
+//// [contextualClassMethodParameter23.ts]
 class Base {
-    method(x: "a" | "b") { }
+    method(x: number): x is number {
+        return true
+    }
 }
 
 class Derived extends Base {
-    method(y = "a") { }
+    method(x) { }
 }
 
 
-
-//// [contextualClassMethodParameter6.js]
+//// [contextualClassMethodParameter23.js]
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
@@ -28,7 +29,9 @@ var __extends = (this && this.__extends) || (function () {
 var Base = /** @class */ (function () {
     function Base() {
     }
-    Base.prototype.method = function (x) { };
+    Base.prototype.method = function (x) {
+        return true;
+    };
     return Base;
 }());
 var Derived = /** @class */ (function (_super) {
@@ -36,8 +39,6 @@ var Derived = /** @class */ (function (_super) {
     function Derived() {
         return _super !== null && _super.apply(this, arguments) || this;
     }
-    Derived.prototype.method = function (y) {
-        if (y === void 0) { y = "a"; }
-    };
+    Derived.prototype.method = function (x) { };
     return Derived;
 }(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter23.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter23.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter23.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter23.ts, 0, 0))
+
+    method(x: number): x is number {
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter23.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter23.ts, 1, 11))
+>x : Symbol(x, Decl(contextualClassMethodParameter23.ts, 1, 11))
+
+        return true
+    }
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter23.ts, 4, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter23.ts, 0, 0))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter23.ts, 6, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter23.ts, 7, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter23.types
+++ b/tests/baselines/reference/contextualClassMethodParameter23.types
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter23.ts ===
+class Base {
+>Base : Base
+
+    method(x: number): x is number {
+>method : (x: number) => x is number
+>x : number
+
+        return true
+>true : true
+    }
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x) { }
+>method : (x: number) => void
+>x : number
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter24.js
+++ b/tests/baselines/reference/contextualClassMethodParameter24.js
@@ -1,15 +1,16 @@
-//// [contextualClassMethodParameter6.ts]
+//// [contextualClassMethodParameter24.ts]
 class Base {
-    method(x: "a" | "b") { }
+    method(x: number) { }
 }
 
 class Derived extends Base {
-    method(y = "a") { }
+    method(x): true {
+        return true
+    }
 }
 
 
-
-//// [contextualClassMethodParameter6.js]
+//// [contextualClassMethodParameter24.js]
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
@@ -36,8 +37,8 @@ var Derived = /** @class */ (function (_super) {
     function Derived() {
         return _super !== null && _super.apply(this, arguments) || this;
     }
-    Derived.prototype.method = function (y) {
-        if (y === void 0) { y = "a"; }
+    Derived.prototype.method = function (x) {
+        return true;
     };
     return Derived;
 }(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter24.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter24.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter24.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter24.ts, 0, 0))
+
+    method(x: number) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter24.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter24.ts, 1, 11))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter24.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter24.ts, 0, 0))
+
+    method(x): true {
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter24.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter24.ts, 5, 11))
+
+        return true
+    }
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter24.types
+++ b/tests/baselines/reference/contextualClassMethodParameter24.types
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter24.ts ===
+class Base {
+>Base : Base
+
+    method(x: number) { }
+>method : (x: number) => void
+>x : number
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x): true {
+>method : (x: number) => true
+>x : number
+>true : true
+
+        return true
+>true : true
+    }
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter25.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter25.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter25.ts(6,12): error TS7006: Parameter 'x' implicitly has an 'any' type.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter25.ts (1 errors) ====
+    class Base {
+        method(x: number, ...v: any[]) { }
+    }
+    
+    class Derived extends Base {
+        method(x) { }
+               ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+    }
+    

--- a/tests/baselines/reference/contextualClassMethodParameter25.js
+++ b/tests/baselines/reference/contextualClassMethodParameter25.js
@@ -1,15 +1,14 @@
-//// [contextualClassMethodParameter6.ts]
+//// [contextualClassMethodParameter25.ts]
 class Base {
-    method(x: "a" | "b") { }
+    method(x: number, ...v: any[]) { }
 }
 
 class Derived extends Base {
-    method(y = "a") { }
+    method(x) { }
 }
 
 
-
-//// [contextualClassMethodParameter6.js]
+//// [contextualClassMethodParameter25.js]
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
@@ -28,7 +27,12 @@ var __extends = (this && this.__extends) || (function () {
 var Base = /** @class */ (function () {
     function Base() {
     }
-    Base.prototype.method = function (x) { };
+    Base.prototype.method = function (x) {
+        var v = [];
+        for (var _i = 1; _i < arguments.length; _i++) {
+            v[_i - 1] = arguments[_i];
+        }
+    };
     return Base;
 }());
 var Derived = /** @class */ (function (_super) {
@@ -36,8 +40,6 @@ var Derived = /** @class */ (function (_super) {
     function Derived() {
         return _super !== null && _super.apply(this, arguments) || this;
     }
-    Derived.prototype.method = function (y) {
-        if (y === void 0) { y = "a"; }
-    };
+    Derived.prototype.method = function (x) { };
     return Derived;
 }(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter25.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter25.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter25.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter25.ts, 0, 0))
+
+    method(x: number, ...v: any[]) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter25.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter25.ts, 1, 11))
+>v : Symbol(v, Decl(contextualClassMethodParameter25.ts, 1, 21))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter25.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter25.ts, 0, 0))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter25.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter25.ts, 5, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter25.types
+++ b/tests/baselines/reference/contextualClassMethodParameter25.types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter25.ts ===
+class Base {
+>Base : Base
+
+    method(x: number, ...v: any[]) { }
+>method : (x: number, ...v: any[]) => void
+>x : number
+>v : any[]
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x) { }
+>method : (x: any) => void
+>x : any
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter26.js
+++ b/tests/baselines/reference/contextualClassMethodParameter26.js
@@ -1,15 +1,17 @@
-//// [contextualClassMethodParameter6.ts]
+//// [contextualClassMethodParameter26.ts]
 class Base {
-    method(x: "a" | "b") { }
+    method(x: number) { }
 }
 
 class Derived extends Base {
-    method(y = "a") { }
+    method(x) { }
 }
 
+class DD extends Derived {
+    method (x) { }
+}
 
-
-//// [contextualClassMethodParameter6.js]
+//// [contextualClassMethodParameter26.js]
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
@@ -36,8 +38,14 @@ var Derived = /** @class */ (function (_super) {
     function Derived() {
         return _super !== null && _super.apply(this, arguments) || this;
     }
-    Derived.prototype.method = function (y) {
-        if (y === void 0) { y = "a"; }
-    };
+    Derived.prototype.method = function (x) { };
     return Derived;
 }(Base));
+var DD = /** @class */ (function (_super) {
+    __extends(DD, _super);
+    function DD() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    DD.prototype.method = function (x) { };
+    return DD;
+}(Derived));

--- a/tests/baselines/reference/contextualClassMethodParameter26.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter26.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter26.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter26.ts, 0, 0))
+
+    method(x: number) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter26.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter26.ts, 1, 11))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter26.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter26.ts, 0, 0))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter26.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter26.ts, 5, 11))
+}
+
+class DD extends Derived {
+>DD : Symbol(DD, Decl(contextualClassMethodParameter26.ts, 6, 1))
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter26.ts, 2, 1))
+
+    method (x) { }
+>method : Symbol(DD.method, Decl(contextualClassMethodParameter26.ts, 8, 26))
+>x : Symbol(x, Decl(contextualClassMethodParameter26.ts, 9, 12))
+}

--- a/tests/baselines/reference/contextualClassMethodParameter26.types
+++ b/tests/baselines/reference/contextualClassMethodParameter26.types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter26.ts ===
+class Base {
+>Base : Base
+
+    method(x: number) { }
+>method : (x: number) => void
+>x : number
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x) { }
+>method : (x: number) => void
+>x : number
+}
+
+class DD extends Derived {
+>DD : DD
+>Derived : Derived
+
+    method (x) { }
+>method : (x: number) => void
+>x : number
+}

--- a/tests/baselines/reference/contextualClassMethodParameter27.js
+++ b/tests/baselines/reference/contextualClassMethodParameter27.js
@@ -1,15 +1,18 @@
-//// [contextualClassMethodParameter6.ts]
+//// [contextualClassMethodParameter27.ts]
 class Base {
-    method(x: "a" | "b") { }
+    method(x: number) { }
 }
 
 class Derived extends Base {
-    method(y = "a") { }
+    method(x: 42 | 12) { }
+}
+
+class DD extends Derived {
+    method (x) { }
 }
 
 
-
-//// [contextualClassMethodParameter6.js]
+//// [contextualClassMethodParameter27.js]
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
@@ -36,8 +39,14 @@ var Derived = /** @class */ (function (_super) {
     function Derived() {
         return _super !== null && _super.apply(this, arguments) || this;
     }
-    Derived.prototype.method = function (y) {
-        if (y === void 0) { y = "a"; }
-    };
+    Derived.prototype.method = function (x) { };
     return Derived;
 }(Base));
+var DD = /** @class */ (function (_super) {
+    __extends(DD, _super);
+    function DD() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    DD.prototype.method = function (x) { };
+    return DD;
+}(Derived));

--- a/tests/baselines/reference/contextualClassMethodParameter27.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter27.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter27.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter27.ts, 0, 0))
+
+    method(x: number) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter27.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter27.ts, 1, 11))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter27.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter27.ts, 0, 0))
+
+    method(x: 42 | 12) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter27.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter27.ts, 5, 11))
+}
+
+class DD extends Derived {
+>DD : Symbol(DD, Decl(contextualClassMethodParameter27.ts, 6, 1))
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter27.ts, 2, 1))
+
+    method (x) { }
+>method : Symbol(DD.method, Decl(contextualClassMethodParameter27.ts, 8, 26))
+>x : Symbol(x, Decl(contextualClassMethodParameter27.ts, 9, 12))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter27.types
+++ b/tests/baselines/reference/contextualClassMethodParameter27.types
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter27.ts ===
+class Base {
+>Base : Base
+
+    method(x: number) { }
+>method : (x: number) => void
+>x : number
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x: 42 | 12) { }
+>method : (x: 42 | 12) => void
+>x : 42 | 12
+}
+
+class DD extends Derived {
+>DD : DD
+>Derived : Derived
+
+    method (x) { }
+>method : (x: 42 | 12) => void
+>x : 42 | 12
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter28.js
+++ b/tests/baselines/reference/contextualClassMethodParameter28.js
@@ -1,15 +1,15 @@
-//// [contextualClassMethodParameter6.ts]
+//// [contextualClassMethodParameter28.ts]
 class Base {
-    method(x: "a" | "b") { }
+    method(x: number): void
+    method(x: number | string): void { }
 }
 
 class Derived extends Base {
-    method(y = "a") { }
+    method(x) { }
 }
 
 
-
-//// [contextualClassMethodParameter6.js]
+//// [contextualClassMethodParameter28.js]
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
@@ -36,8 +36,6 @@ var Derived = /** @class */ (function (_super) {
     function Derived() {
         return _super !== null && _super.apply(this, arguments) || this;
     }
-    Derived.prototype.method = function (y) {
-        if (y === void 0) { y = "a"; }
-    };
+    Derived.prototype.method = function (x) { };
     return Derived;
 }(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter28.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter28.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter28.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter28.ts, 0, 0))
+
+    method(x: number): void
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter28.ts, 0, 12), Decl(contextualClassMethodParameter28.ts, 1, 27))
+>x : Symbol(x, Decl(contextualClassMethodParameter28.ts, 1, 11))
+
+    method(x: number | string): void { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter28.ts, 0, 12), Decl(contextualClassMethodParameter28.ts, 1, 27))
+>x : Symbol(x, Decl(contextualClassMethodParameter28.ts, 2, 11))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter28.ts, 3, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter28.ts, 0, 0))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter28.ts, 5, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter28.ts, 6, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter28.types
+++ b/tests/baselines/reference/contextualClassMethodParameter28.types
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter28.ts ===
+class Base {
+>Base : Base
+
+    method(x: number): void
+>method : (x: number) => void
+>x : number
+
+    method(x: number | string): void { }
+>method : (x: number) => void
+>x : string | number
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x) { }
+>method : (x: number) => void
+>x : number
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter29.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter29.errors.txt
@@ -1,0 +1,20 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter29.ts(7,5): error TS2394: This overload signature is not compatible with its implementation signature.
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter29.ts(8,12): error TS7006: Parameter 'x' implicitly has an 'any' type.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter29.ts (2 errors) ====
+    class Base {
+        method(x: number): void
+        method(x: number | string): void { }
+    }
+    
+    class Derived extends Base {
+        method(): void
+        ~~~~~~
+!!! error TS2394: This overload signature is not compatible with its implementation signature.
+!!! related TS2750 tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter29.ts:8:5: The implementation signature is declared here.
+        method(x) { }
+               ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+    }
+    

--- a/tests/baselines/reference/contextualClassMethodParameter29.js
+++ b/tests/baselines/reference/contextualClassMethodParameter29.js
@@ -1,15 +1,16 @@
-//// [contextualClassMethodParameter6.ts]
+//// [contextualClassMethodParameter29.ts]
 class Base {
-    method(x: "a" | "b") { }
+    method(x: number): void
+    method(x: number | string): void { }
 }
 
 class Derived extends Base {
-    method(y = "a") { }
+    method(): void
+    method(x) { }
 }
 
 
-
-//// [contextualClassMethodParameter6.js]
+//// [contextualClassMethodParameter29.js]
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
@@ -36,8 +37,6 @@ var Derived = /** @class */ (function (_super) {
     function Derived() {
         return _super !== null && _super.apply(this, arguments) || this;
     }
-    Derived.prototype.method = function (y) {
-        if (y === void 0) { y = "a"; }
-    };
+    Derived.prototype.method = function (x) { };
     return Derived;
 }(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter29.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter29.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter29.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter29.ts, 0, 0))
+
+    method(x: number): void
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter29.ts, 0, 12), Decl(contextualClassMethodParameter29.ts, 1, 27))
+>x : Symbol(x, Decl(contextualClassMethodParameter29.ts, 1, 11))
+
+    method(x: number | string): void { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter29.ts, 0, 12), Decl(contextualClassMethodParameter29.ts, 1, 27))
+>x : Symbol(x, Decl(contextualClassMethodParameter29.ts, 2, 11))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter29.ts, 3, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter29.ts, 0, 0))
+
+    method(): void
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter29.ts, 5, 28), Decl(contextualClassMethodParameter29.ts, 6, 18))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter29.ts, 5, 28), Decl(contextualClassMethodParameter29.ts, 6, 18))
+>x : Symbol(x, Decl(contextualClassMethodParameter29.ts, 7, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter29.types
+++ b/tests/baselines/reference/contextualClassMethodParameter29.types
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter29.ts ===
+class Base {
+>Base : Base
+
+    method(x: number): void
+>method : (x: number) => void
+>x : number
+
+    method(x: number | string): void { }
+>method : (x: number) => void
+>x : string | number
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(): void
+>method : () => void
+
+    method(x) { }
+>method : () => void
+>x : any
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter3.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter3.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter3.ts(6,12): error TS7006: Parameter 'x' implicitly has an 'any' type.
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter3.ts(6,15): error TS7019: Rest parameter 'y' implicitly has an 'any[]' type.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter3.ts (2 errors) ====
+    class Base {
+        method(x: number, y: string, z: boolean) { }
+    }
+    
+    class Derived extends Base {
+        method(x, ...y) { }
+               ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+                  ~~~~
+!!! error TS7019: Rest parameter 'y' implicitly has an 'any[]' type.
+    }
+    

--- a/tests/baselines/reference/contextualClassMethodParameter3.js
+++ b/tests/baselines/reference/contextualClassMethodParameter3.js
@@ -1,0 +1,45 @@
+//// [contextualClassMethodParameter3.ts]
+class Base {
+    method(x: number, y: string, z: boolean) { }
+}
+
+class Derived extends Base {
+    method(x, ...y) { }
+}
+
+
+//// [contextualClassMethodParameter3.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x, y, z) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) {
+        var y = [];
+        for (var _i = 1; _i < arguments.length; _i++) {
+            y[_i - 1] = arguments[_i];
+        }
+    };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter3.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter3.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter3.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter3.ts, 0, 0))
+
+    method(x: number, y: string, z: boolean) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter3.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter3.ts, 1, 11))
+>y : Symbol(y, Decl(contextualClassMethodParameter3.ts, 1, 21))
+>z : Symbol(z, Decl(contextualClassMethodParameter3.ts, 1, 32))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter3.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter3.ts, 0, 0))
+
+    method(x, ...y) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter3.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter3.ts, 5, 11))
+>y : Symbol(y, Decl(contextualClassMethodParameter3.ts, 5, 13))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter3.types
+++ b/tests/baselines/reference/contextualClassMethodParameter3.types
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter3.ts ===
+class Base {
+>Base : Base
+
+    method(x: number, y: string, z: boolean) { }
+>method : (x: number, y: string, z: boolean) => void
+>x : number
+>y : string
+>z : boolean
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x, ...y) { }
+>method : (x: number, y: string, z: boolean) => void
+>x : number
+>y : [y: string, z: boolean]
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter3.types
+++ b/tests/baselines/reference/contextualClassMethodParameter3.types
@@ -14,8 +14,8 @@ class Derived extends Base {
 >Base : Base
 
     method(x, ...y) { }
->method : (x: number, y: string, z: boolean) => void
->x : number
->y : [y: string, z: boolean]
+>method : (x: any, ...y: any[]) => void
+>x : any
+>y : any[]
 }
 

--- a/tests/baselines/reference/contextualClassMethodParameter4.js
+++ b/tests/baselines/reference/contextualClassMethodParameter4.js
@@ -1,0 +1,40 @@
+//// [contextualClassMethodParameter4.ts]
+class Base {
+    method(x: number, y: string, z: boolean) { }
+}
+
+class Derived extends Base {
+    method(x: number, y, z: boolean) { }
+}
+
+
+//// [contextualClassMethodParameter4.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x, y, z) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x, y, z) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter4.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter4.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter4.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter4.ts, 0, 0))
+
+    method(x: number, y: string, z: boolean) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter4.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter4.ts, 1, 11))
+>y : Symbol(y, Decl(contextualClassMethodParameter4.ts, 1, 21))
+>z : Symbol(z, Decl(contextualClassMethodParameter4.ts, 1, 32))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter4.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter4.ts, 0, 0))
+
+    method(x: number, y, z: boolean) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter4.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter4.ts, 5, 11))
+>y : Symbol(y, Decl(contextualClassMethodParameter4.ts, 5, 21))
+>z : Symbol(z, Decl(contextualClassMethodParameter4.ts, 5, 24))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter4.types
+++ b/tests/baselines/reference/contextualClassMethodParameter4.types
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter4.ts ===
+class Base {
+>Base : Base
+
+    method(x: number, y: string, z: boolean) { }
+>method : (x: number, y: string, z: boolean) => void
+>x : number
+>y : string
+>z : boolean
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x: number, y, z: boolean) { }
+>method : (x: number, y: string, z: boolean) => void
+>x : number
+>y : string
+>z : boolean
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter5.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter5.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter5.ts(6,5): error TS2425: Class 'Base' defines instance member property 'method', but extended class 'Derived' defines it as instance member function.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter5.ts (1 errors) ====
+    class Base {
+        method = (x: number) => { }
+    }
+    
+    class Derived extends Base {
+        method(x) { }
+        ~~~~~~
+!!! error TS2425: Class 'Base' defines instance member property 'method', but extended class 'Derived' defines it as instance member function.
+    }

--- a/tests/baselines/reference/contextualClassMethodParameter5.js
+++ b/tests/baselines/reference/contextualClassMethodParameter5.js
@@ -1,0 +1,39 @@
+//// [contextualClassMethodParameter5.ts]
+class Base {
+    method = (x: number) => { }
+}
+
+class Derived extends Base {
+    method(x) { }
+}
+
+//// [contextualClassMethodParameter5.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+        this.method = function (x) { };
+    }
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter5.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter5.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter5.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter5.ts, 0, 0))
+
+    method = (x: number) => { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter5.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter5.ts, 1, 14))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter5.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter5.ts, 0, 0))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter5.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter5.ts, 5, 11))
+}

--- a/tests/baselines/reference/contextualClassMethodParameter5.types
+++ b/tests/baselines/reference/contextualClassMethodParameter5.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter5.ts ===
+class Base {
+>Base : Base
+
+    method = (x: number) => { }
+>method : (x: number) => void
+>(x: number) => { } : (x: number) => void
+>x : number
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x) { }
+>method : (x: number) => void
+>x : number
+}

--- a/tests/baselines/reference/contextualClassMethodParameter6.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter6.errors.txt
@@ -1,0 +1,15 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter6.ts(6,12): error TS7022: 'y' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter6.ts (1 errors) ====
+    class Base {
+        method(x: "a" | "b") { }
+    }
+    
+    class Derived extends Base {
+        method(y = "a") { }
+               ~~~~~~~
+!!! error TS7022: 'y' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+    }
+    
+    

--- a/tests/baselines/reference/contextualClassMethodParameter6.js
+++ b/tests/baselines/reference/contextualClassMethodParameter6.js
@@ -1,0 +1,42 @@
+//// [contextualClassMethodParameter6.ts]
+class Base {
+    method(x: "a" | "b") { }
+}
+
+class Derived extends Base {
+    method(x = "a") { }
+}
+
+
+//// [contextualClassMethodParameter6.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) {
+        if (x === void 0) { x = "a"; }
+    };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter6.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter6.symbols
@@ -11,8 +11,9 @@ class Derived extends Base {
 >Derived : Symbol(Derived, Decl(contextualClassMethodParameter6.ts, 2, 1))
 >Base : Symbol(Base, Decl(contextualClassMethodParameter6.ts, 0, 0))
 
-    method(x = "a") { }
+    method(y = "a") { }
 >method : Symbol(Derived.method, Decl(contextualClassMethodParameter6.ts, 4, 28))
->x : Symbol(x, Decl(contextualClassMethodParameter6.ts, 5, 11))
+>y : Symbol(y, Decl(contextualClassMethodParameter6.ts, 5, 11))
 }
+
 

--- a/tests/baselines/reference/contextualClassMethodParameter6.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter6.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter6.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter6.ts, 0, 0))
+
+    method(x: "a" | "b") { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter6.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter6.ts, 1, 11))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter6.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter6.ts, 0, 0))
+
+    method(x = "a") { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter6.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter6.ts, 5, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter6.types
+++ b/tests/baselines/reference/contextualClassMethodParameter6.types
@@ -11,9 +11,10 @@ class Derived extends Base {
 >Derived : Derived
 >Base : Base
 
-    method(x = "a") { }
->method : (x?: "a" | "b") => void
->x : "a" | "b"
+    method(y = "a") { }
+>method : (y?: any) => void
+>y : any
 >"a" : "a"
 }
+
 

--- a/tests/baselines/reference/contextualClassMethodParameter6.types
+++ b/tests/baselines/reference/contextualClassMethodParameter6.types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter6.ts ===
+class Base {
+>Base : Base
+
+    method(x: "a" | "b") { }
+>method : (x: "a" | "b") => void
+>x : "a" | "b"
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x = "a") { }
+>method : (x?: "a" | "b") => void
+>x : "a" | "b"
+>"a" : "a"
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter7.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter7.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter7.ts(6,12): error TS2322: Type '"c"' is not assignable to type '"a" | "b"'.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter7.ts (1 errors) ====
+    class Base {
+        method(x: "a" | "b") { }
+    }
+    
+    class Derived extends Base {
+        method(x = "c") { }
+               ~~~~~~~
+!!! error TS2322: Type '"c"' is not assignable to type '"a" | "b"'.
+    }
+    

--- a/tests/baselines/reference/contextualClassMethodParameter7.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter7.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter7.ts(6,12): error TS2322: Type '"c"' is not assignable to type '"a" | "b"'.
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter7.ts(6,12): error TS7022: 'y' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
 
 
 ==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter7.ts (1 errors) ====
@@ -7,8 +7,8 @@ tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMe
     }
     
     class Derived extends Base {
-        method(x = "c") { }
+        method(y = "c") { }
                ~~~~~~~
-!!! error TS2322: Type '"c"' is not assignable to type '"a" | "b"'.
+!!! error TS7022: 'y' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
     }
     

--- a/tests/baselines/reference/contextualClassMethodParameter7.js
+++ b/tests/baselines/reference/contextualClassMethodParameter7.js
@@ -4,7 +4,7 @@ class Base {
 }
 
 class Derived extends Base {
-    method(x = "c") { }
+    method(y = "c") { }
 }
 
 
@@ -35,8 +35,8 @@ var Derived = /** @class */ (function (_super) {
     function Derived() {
         return _super !== null && _super.apply(this, arguments) || this;
     }
-    Derived.prototype.method = function (x) {
-        if (x === void 0) { x = "c"; }
+    Derived.prototype.method = function (y) {
+        if (y === void 0) { y = "c"; }
     };
     return Derived;
 }(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter7.js
+++ b/tests/baselines/reference/contextualClassMethodParameter7.js
@@ -1,0 +1,42 @@
+//// [contextualClassMethodParameter7.ts]
+class Base {
+    method(x: "a" | "b") { }
+}
+
+class Derived extends Base {
+    method(x = "c") { }
+}
+
+
+//// [contextualClassMethodParameter7.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) {
+        if (x === void 0) { x = "c"; }
+    };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter7.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter7.symbols
@@ -11,8 +11,8 @@ class Derived extends Base {
 >Derived : Symbol(Derived, Decl(contextualClassMethodParameter7.ts, 2, 1))
 >Base : Symbol(Base, Decl(contextualClassMethodParameter7.ts, 0, 0))
 
-    method(x = "c") { }
+    method(y = "c") { }
 >method : Symbol(Derived.method, Decl(contextualClassMethodParameter7.ts, 4, 28))
->x : Symbol(x, Decl(contextualClassMethodParameter7.ts, 5, 11))
+>y : Symbol(y, Decl(contextualClassMethodParameter7.ts, 5, 11))
 }
 

--- a/tests/baselines/reference/contextualClassMethodParameter7.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter7.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter7.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter7.ts, 0, 0))
+
+    method(x: "a" | "b") { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter7.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter7.ts, 1, 11))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter7.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter7.ts, 0, 0))
+
+    method(x = "c") { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter7.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter7.ts, 5, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter7.types
+++ b/tests/baselines/reference/contextualClassMethodParameter7.types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter7.ts ===
+class Base {
+>Base : Base
+
+    method(x: "a" | "b") { }
+>method : (x: "a" | "b") => void
+>x : "a" | "b"
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x = "c") { }
+>method : (x?: "a" | "b") => void
+>x : "a" | "b"
+>"c" : "c"
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter7.types
+++ b/tests/baselines/reference/contextualClassMethodParameter7.types
@@ -11,9 +11,9 @@ class Derived extends Base {
 >Derived : Derived
 >Base : Base
 
-    method(x = "c") { }
->method : (x?: "a" | "b") => void
->x : "a" | "b"
+    method(y = "c") { }
+>method : (y?: any) => void
+>y : any
 >"c" : "c"
 }
 

--- a/tests/baselines/reference/contextualClassMethodParameter8.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter8.errors.txt
@@ -1,14 +1,11 @@
-tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter8.ts(2,24): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter8.ts(6,5): error TS2416: Property 'method' in type 'Derived' is not assignable to the same property in base type 'Base'.
   Type '(x: number) => void' is not assignable to type '(x: number) => true'.
     Type 'void' is not assignable to type 'true'.
 
 
-==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter8.ts (2 errors) ====
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter8.ts (1 errors) ====
     class Base {
-        method(x: number): true { }
-                           ~~~~
-!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
+        method(x: number): true { return true }
     }
     
     class Derived extends Base {

--- a/tests/baselines/reference/contextualClassMethodParameter8.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter8.errors.txt
@@ -1,0 +1,21 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter8.ts(2,24): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter8.ts(6,5): error TS2416: Property 'method' in type 'Derived' is not assignable to the same property in base type 'Base'.
+  Type '(x: number) => void' is not assignable to type '(x: number) => true'.
+    Type 'void' is not assignable to type 'true'.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter8.ts (2 errors) ====
+    class Base {
+        method(x: number): true { }
+                           ~~~~
+!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
+    }
+    
+    class Derived extends Base {
+        method(x) { }
+        ~~~~~~
+!!! error TS2416: Property 'method' in type 'Derived' is not assignable to the same property in base type 'Base'.
+!!! error TS2416:   Type '(x: number) => void' is not assignable to type '(x: number) => true'.
+!!! error TS2416:     Type 'void' is not assignable to type 'true'.
+    }
+    

--- a/tests/baselines/reference/contextualClassMethodParameter8.js
+++ b/tests/baselines/reference/contextualClassMethodParameter8.js
@@ -1,6 +1,6 @@
 //// [contextualClassMethodParameter8.ts]
 class Base {
-    method(x: number): true { }
+    method(x: number): true { return true }
 }
 
 class Derived extends Base {
@@ -27,7 +27,7 @@ var __extends = (this && this.__extends) || (function () {
 var Base = /** @class */ (function () {
     function Base() {
     }
-    Base.prototype.method = function (x) { };
+    Base.prototype.method = function (x) { return true; };
     return Base;
 }());
 var Derived = /** @class */ (function (_super) {

--- a/tests/baselines/reference/contextualClassMethodParameter8.js
+++ b/tests/baselines/reference/contextualClassMethodParameter8.js
@@ -1,0 +1,40 @@
+//// [contextualClassMethodParameter8.ts]
+class Base {
+    method(x: number): true { }
+}
+
+class Derived extends Base {
+    method(x) { }
+}
+
+
+//// [contextualClassMethodParameter8.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter8.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter8.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter8.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter8.ts, 0, 0))
+
+    method(x: number): true { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter8.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter8.ts, 1, 11))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter8.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter8.ts, 0, 0))
+
+    method(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter8.ts, 4, 28))
+>x : Symbol(x, Decl(contextualClassMethodParameter8.ts, 5, 11))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter8.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter8.symbols
@@ -2,7 +2,7 @@
 class Base {
 >Base : Symbol(Base, Decl(contextualClassMethodParameter8.ts, 0, 0))
 
-    method(x: number): true { }
+    method(x: number): true { return true }
 >method : Symbol(Base.method, Decl(contextualClassMethodParameter8.ts, 0, 12))
 >x : Symbol(x, Decl(contextualClassMethodParameter8.ts, 1, 11))
 }

--- a/tests/baselines/reference/contextualClassMethodParameter8.types
+++ b/tests/baselines/reference/contextualClassMethodParameter8.types
@@ -2,9 +2,10 @@
 class Base {
 >Base : Base
 
-    method(x: number): true { }
+    method(x: number): true { return true }
 >method : (x: number) => true
 >x : number
+>true : true
 >true : true
 }
 

--- a/tests/baselines/reference/contextualClassMethodParameter8.types
+++ b/tests/baselines/reference/contextualClassMethodParameter8.types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter8.ts ===
+class Base {
+>Base : Base
+
+    method(x: number): true { }
+>method : (x: number) => true
+>x : number
+>true : true
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method(x) { }
+>method : (x: number) => void
+>x : number
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter9.errors.txt
+++ b/tests/baselines/reference/contextualClassMethodParameter9.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter9.ts(6,15): error TS7006: Parameter 'x' implicitly has an 'any' type.
+
+
+==== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter9.ts (1 errors) ====
+    class Base {
+        method(x: number) { }
+    }
+    
+    class Derived extends Base {
+        method<T>(x) { }
+                  ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+    }
+    

--- a/tests/baselines/reference/contextualClassMethodParameter9.js
+++ b/tests/baselines/reference/contextualClassMethodParameter9.js
@@ -1,0 +1,40 @@
+//// [contextualClassMethodParameter9.ts]
+class Base {
+    method(x: number) { }
+}
+
+class Derived extends Base {
+    method<T>(x) { }
+}
+
+
+//// [contextualClassMethodParameter9.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    Base.prototype.method = function (x) { };
+    return Base;
+}());
+var Derived = /** @class */ (function (_super) {
+    __extends(Derived, _super);
+    function Derived() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Derived.prototype.method = function (x) { };
+    return Derived;
+}(Base));

--- a/tests/baselines/reference/contextualClassMethodParameter9.symbols
+++ b/tests/baselines/reference/contextualClassMethodParameter9.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter9.ts ===
+class Base {
+>Base : Symbol(Base, Decl(contextualClassMethodParameter9.ts, 0, 0))
+
+    method(x: number) { }
+>method : Symbol(Base.method, Decl(contextualClassMethodParameter9.ts, 0, 12))
+>x : Symbol(x, Decl(contextualClassMethodParameter9.ts, 1, 11))
+}
+
+class Derived extends Base {
+>Derived : Symbol(Derived, Decl(contextualClassMethodParameter9.ts, 2, 1))
+>Base : Symbol(Base, Decl(contextualClassMethodParameter9.ts, 0, 0))
+
+    method<T>(x) { }
+>method : Symbol(Derived.method, Decl(contextualClassMethodParameter9.ts, 4, 28))
+>T : Symbol(T, Decl(contextualClassMethodParameter9.ts, 5, 11))
+>x : Symbol(x, Decl(contextualClassMethodParameter9.ts, 5, 14))
+}
+

--- a/tests/baselines/reference/contextualClassMethodParameter9.types
+++ b/tests/baselines/reference/contextualClassMethodParameter9.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter9.ts ===
+class Base {
+>Base : Base
+
+    method(x: number) { }
+>method : (x: number) => void
+>x : number
+}
+
+class Derived extends Base {
+>Derived : Derived
+>Base : Base
+
+    method<T>(x) { }
+>method : <T>(x: any) => void
+>x : any
+}
+

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter1.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter1.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base {
+    method(x: number) { }
+}
+
+class Derived extends Base {
+    method(x) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter10.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter10.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base {
+    method(x: number) { }
+}
+
+class Derived<T> extends Base {
+    method(x) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter11.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter11.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base<T> {
+    method(x: T) { }
+}
+
+class Derived extends Base<string> {
+    method(x) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter12.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter12.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base<T> {
+    method(x: T) { }
+}
+
+class Derived<T> extends Base<T> {
+    method(x) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter13.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter13.ts
@@ -1,0 +1,7 @@
+// @noImplicitAny: true
+
+declare const Base: any
+
+class Derived extends Base {
+    method(x) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter14.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter14.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+declare const Base: {
+    method(x: string): void
+}
+
+class Derived extends Base {
+    method(x) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter15.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter15.ts
@@ -1,0 +1,14 @@
+// @noImplicitAny: true
+
+type BaseProtytype = {
+    new(): BaseProtytype
+    method(x: string): void
+}
+
+declare const Base: {
+    new(): BaseProtytype
+}
+
+class Derived extends Base {
+    method(x) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter16.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter16.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base {
+    method (x: number) { }
+}
+
+class Derived extends Base {
+    method = (x) => { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter17.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter17.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base {
+    method(x: number, y: string) { }
+}
+
+class Derived extends Base {
+    method(x) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter18.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base {
+    method(x: number, y: string) { }
+}
+
+class Derived extends Base {
+    method(x, y, z) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter19.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter19.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: false
+
+class Base {
+    method(x: number) { }
+}
+
+class Derived extends Base {
+    method(x) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter2.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter2.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base {
+    method(x: number, y: string) { }
+}
+
+class Derived extends Base {
+    method(x, y) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter20.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter20.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base {
+    method = (x: number) => { }
+}
+
+class Derived extends Base {
+    method = (x) => { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter21.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter21.ts
@@ -1,9 +1,9 @@
 // @noImplicitAny: true
 
 class Base {
-    method(x: "a" | "b") { }
+    method<T>(x: T) { }
 }
 
 class Derived extends Base {
-    method(y = "c") { }
+    method(x) { }
 }

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter22.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter22.ts
@@ -1,0 +1,11 @@
+// @noImplicitAny: true
+
+class Base {
+    method(x: number) { }
+}
+
+class Derived extends Base {
+    method(x): x is number {
+        return true
+    }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter23.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter23.ts
@@ -1,7 +1,9 @@
 // @noImplicitAny: true
 
 class Base {
-    method(x: number): true { return true }
+    method(x: number): x is number {
+        return true
+    }
 }
 
 class Derived extends Base {

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter24.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter24.ts
@@ -1,9 +1,11 @@
 // @noImplicitAny: true
 
 class Base {
-    method(x: "a" | "b") { }
+    method(x: number) { }
 }
 
 class Derived extends Base {
-    method(y = "c") { }
+    method(x): true {
+        return true
+    }
 }

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter25.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter25.ts
@@ -1,9 +1,9 @@
 // @noImplicitAny: true
 
 class Base {
-    method(x: "a" | "b") { }
+    method(x: number, ...v: any[]) { }
 }
 
 class Derived extends Base {
-    method(y = "c") { }
+    method(x) { }
 }

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter26.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter26.ts
@@ -1,9 +1,13 @@
 // @noImplicitAny: true
 
 class Base {
-    method(x: number): true { return true }
+    method(x: number) { }
 }
 
 class Derived extends Base {
     method(x) { }
+}
+
+class DD extends Derived {
+    method (x) { }
 }

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter27.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter27.ts
@@ -1,0 +1,13 @@
+// @noImplicitAny: true
+
+class Base {
+    method(x: number) { }
+}
+
+class Derived extends Base {
+    method(x: 42 | 12) { }
+}
+
+class DD extends Derived {
+    method (x) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter28.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter28.ts
@@ -1,7 +1,8 @@
 // @noImplicitAny: true
 
 class Base {
-    method(x: number): true { return true }
+    method(x: number): void
+    method(x: number | string): void { }
 }
 
 class Derived extends Base {

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter29.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter29.ts
@@ -1,9 +1,11 @@
 // @noImplicitAny: true
 
 class Base {
-    method(x: number): true { return true }
+    method(x: number): void
+    method(x: number | string): void { }
 }
 
 class Derived extends Base {
+    method(): void
     method(x) { }
 }

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter3.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter3.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base {
+    method(x: number, y: string, z: boolean) { }
+}
+
+class Derived extends Base {
+    method(x, ...y) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter4.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter4.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base {
+    method(x: number, y: string, z: boolean) { }
+}
+
+class Derived extends Base {
+    method(x: number, y, z: boolean) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter5.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter5.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base {
+    method = (x: number) => { }
+}
+
+class Derived extends Base {
+    method(x) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter6.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter6.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base {
+    method(x: "a" | "b") { }
+}
+
+class Derived extends Base {
+    method(x = "a") { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter6.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter6.ts
@@ -5,5 +5,6 @@ class Base {
 }
 
 class Derived extends Base {
-    method(x = "a") { }
+    method(y = "a") { }
 }
+

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter7.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter7.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base {
+    method(x: "a" | "b") { }
+}
+
+class Derived extends Base {
+    method(x = "c") { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter8.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter8.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base {
+    method(x: number): true { }
+}
+
+class Derived extends Base {
+    method(x) { }
+}

--- a/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter9.ts
+++ b/tests/cases/conformance/classes/contextualClassMethodParameter/contextualClassMethodParameter9.ts
@@ -1,0 +1,9 @@
+// @noImplicitAny: true
+
+class Base {
+    method(x: number) { }
+}
+
+class Derived extends Base {
+    method<T>(x) { }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Close #41303
Fixes #23911

Added some test cases.

Infer from interface does not support yet.