### PR TITLE
Tracing: dump more information about types

### DIFF
--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -237,6 +237,16 @@ namespace ts { // eslint-disable-line one-namespace-per-file
                     };
                 }
 
+                let reverseMappedProperties: object = {};
+                if (objectFlags & ObjectFlags.ReverseMapped) {
+                    const reverseMappedType = type as ReverseMappedType;
+                    reverseMappedProperties = {
+                        reverseMappedSourceType: reverseMappedType.source?.id,
+                        reverseMappedMappedType: reverseMappedType.mappedType?.id,
+                        reverseMappedConstraintType: reverseMappedType.constraintType?.id,
+                    };
+                }
+
                 // We can't print out an arbitrary object, so just assign each one a unique number.
                 // Don't call it an "id" so people don't treat it as a type id.
                 let recursionToken: number | undefined;
@@ -262,6 +272,7 @@ namespace ts { // eslint-disable-line one-namespace-per-file
                     ...referenceProperties,
                     ...conditionalProperties,
                     ...substitutionProperties,
+                    ...reverseMappedProperties,
                     firstDeclaration: firstDeclaration && {
                         path: firstFile.path,
                         start: indexFromOne(getLineAndCharacterOfPosition(firstFile, firstDeclaration.pos)),

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -275,6 +275,7 @@ namespace ts { // eslint-disable-line one-namespace-per-file
                     intrinsicName: (type as any).intrinsicName,
                     symbolName: symbol?.escapedName && unescapeLeadingUnderscores(symbol.escapedName),
                     recursionId: recursionToken,
+                    isTuple: objectFlags & ObjectFlags.Tuple ? true :  undefined,
                     unionTypes: (type.flags & TypeFlags.Union) ? (type as UnionType).types?.map(t => t.id) : undefined,
                     intersectionTypes: (type.flags & TypeFlags.Intersection) ? (type as IntersectionType).types.map(t => t.id) : undefined,
                     aliasTypeArguments: type.aliasTypeArguments?.map(t => t.id),

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -187,6 +187,8 @@ namespace ts { // eslint-disable-line one-namespace-per-file
                 const symbol = type.aliasSymbol ?? type.symbol;
                 const firstDeclaration = symbol?.declarations?.[0];
                 const firstFile = firstDeclaration && getSourceFileOfNode(firstDeclaration);
+                const destructuringPattern = type.pattern;
+                const destructuringPatternFile = destructuringPattern && getSourceFileOfNode(destructuringPattern);
 
                 // It's slow to compute the display text, so skip it unless it's really valuable (or cheap)
                 let display: string | undefined;
@@ -273,10 +275,15 @@ namespace ts { // eslint-disable-line one-namespace-per-file
                     ...conditionalProperties,
                     ...substitutionProperties,
                     ...reverseMappedProperties,
-                    firstDeclaration: firstDeclaration && {
+                    destructuringPattern: destructuringPatternFile && {
+                        path: destructuringPatternFile.path,
+                        start: indexFromOne(getLineAndCharacterOfPosition(destructuringPatternFile, destructuringPattern!.pos)),
+                        end: indexFromOne(getLineAndCharacterOfPosition(destructuringPatternFile, destructuringPattern!.end)),
+                    },
+                    firstDeclaration: firstFile && {
                         path: firstFile.path,
                         start: indexFromOne(getLineAndCharacterOfPosition(firstFile, firstDeclaration.pos)),
-                        end: indexFromOne(getLineAndCharacterOfPosition(getSourceFileOfNode(firstDeclaration), firstDeclaration.end)),
+                        end: indexFromOne(getLineAndCharacterOfPosition(firstFile, firstDeclaration.end)),
                     },
                     flags: Debug.formatTypeFlags(type.flags).split("|"),
                     display,

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -217,6 +217,15 @@ namespace ts { // eslint-disable-line one-namespace-per-file
                         instantiatedType: referenceType.target?.id,
                         typeArguments: referenceType.resolvedTypeArguments?.map(t => t.id),
                     };
+                    const referenceNode = referenceType.node;
+                    if (referenceNode) {
+                        const sourceFile = getSourceFileOfNode(referenceNode);
+                        (referenceProperties as any).referenceLocation = {
+                            path: sourceFile.path,
+                            start: indexFromOne(getLineAndCharacterOfPosition(sourceFile, referenceNode.pos)),
+                            end: indexFromOne(getLineAndCharacterOfPosition(sourceFile, referenceNode.end)),
+                        }
+                    }
                 }
 
                 let conditionalProperties: object = {};

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -228,6 +228,15 @@ namespace ts { // eslint-disable-line one-namespace-per-file
                     };
                 }
 
+                let substitutionProperties: object = {};
+                if (type.flags & TypeFlags.Substitution) {
+                    const substitutionType = type as SubstitutionType;
+                    substitutionProperties = {
+                        substitutionBaseType: substitutionType.baseType?.id,
+                        substituteType: substitutionType.substitute?.id,
+                    };
+                }
+
                 // We can't print out an arbitrary object, so just assign each one a unique number.
                 // Don't call it an "id" so people don't treat it as a type id.
                 let recursionToken: number | undefined;
@@ -252,6 +261,7 @@ namespace ts { // eslint-disable-line one-namespace-per-file
                     ...indexedAccessProperties,
                     ...referenceProperties,
                     ...conditionalProperties,
+                    ...substitutionProperties,
                     firstDeclaration: firstDeclaration && {
                         path: firstFile.path,
                         start: indexFromOne(getLineAndCharacterOfPosition(firstFile, firstDeclaration.pos)),

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -224,7 +224,7 @@ namespace ts { // eslint-disable-line one-namespace-per-file
                             path: sourceFile.path,
                             start: indexFromOne(getLineAndCharacterOfPosition(sourceFile, referenceNode.pos)),
                             end: indexFromOne(getLineAndCharacterOfPosition(sourceFile, referenceNode.end)),
-                        }
+                        };
                     }
                 }
 
@@ -284,7 +284,7 @@ namespace ts { // eslint-disable-line one-namespace-per-file
                     intrinsicName: (type as any).intrinsicName,
                     symbolName: symbol?.escapedName && unescapeLeadingUnderscores(symbol.escapedName),
                     recursionId: recursionToken,
-                    isTuple: objectFlags & ObjectFlags.Tuple ? true :  undefined,
+                    isTuple: objectFlags & ObjectFlags.Tuple ? true : undefined,
                     unionTypes: (type.flags & TypeFlags.Union) ? (type as UnionType).types?.map(t => t.id) : undefined,
                     intersectionTypes: (type.flags & TypeFlags.Intersection) ? (type as IntersectionType).types.map(t => t.id) : undefined,
                     aliasTypeArguments: type.aliasTypeArguments?.map(t => t.id),

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -249,6 +249,15 @@ namespace ts { // eslint-disable-line one-namespace-per-file
                     };
                 }
 
+                let evolvingArrayProperties: object = {};
+                if (objectFlags & ObjectFlags.EvolvingArray) {
+                    const evolvingArrayType = type as EvolvingArrayType;
+                    evolvingArrayProperties = {
+                        evolvingArrayElementType: evolvingArrayType.elementType.id,
+                        evolvingArrayFinalType: evolvingArrayType.finalArrayType?.id,
+                    };
+                }
+
                 // We can't print out an arbitrary object, so just assign each one a unique number.
                 // Don't call it an "id" so people don't treat it as a type id.
                 let recursionToken: number | undefined;
@@ -275,6 +284,7 @@ namespace ts { // eslint-disable-line one-namespace-per-file
                     ...conditionalProperties,
                     ...substitutionProperties,
                     ...reverseMappedProperties,
+                    ...evolvingArrayProperties,
                     destructuringPattern: destructuringPatternFile && {
                         path: destructuringPatternFile.path,
                         start: indexFromOne(getLineAndCharacterOfPosition(destructuringPatternFile, destructuringPattern!.pos)),


### PR DESCRIPTION
I was reviewing some traces and discovered that there were type records with basically no properties.