### PR TITLE
Do a shallow clone for Docker tests.

### DIFF
--- a/tests/cases/docker/azure-sdk/Dockerfile
+++ b/tests/cases/docker/azure-sdk/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:current
 RUN npm install -g @microsoft/rush
-RUN git clone https://github.com/Azure/azure-sdk-for-js.git /azure-sdk
+RUN git clone --depth 1 https://github.com/Azure/azure-sdk-for-js.git /azure-sdk
 WORKDIR /azure-sdk
 RUN git pull
 RUN rush update

--- a/tests/cases/docker/azure-sdk/Dockerfile
+++ b/tests/cases/docker/azure-sdk/Dockerfile
@@ -2,7 +2,6 @@ FROM node:current
 RUN npm install -g @microsoft/rush
 RUN git clone --depth 1 https://github.com/Azure/azure-sdk-for-js.git /azure-sdk
 WORKDIR /azure-sdk
-RUN git pull
 RUN rush update
 WORKDIR /azure-sdk/sdk/core/core-http
 # Sync up all TS versions used internally so they're all linked from a known location

--- a/tests/cases/docker/chrome-devtools-frontend-next/Dockerfile
+++ b/tests/cases/docker/chrome-devtools-frontend-next/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:current
-RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools
+RUN git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools
 ENV PATH=/depot_tools:$PATH
 WORKDIR /
 RUN mkdir devtools

--- a/tests/cases/docker/office-ui-fabric/Dockerfile
+++ b/tests/cases/docker/office-ui-fabric/Dockerfile
@@ -4,7 +4,7 @@ ENV CI=true
 ENV TF_BUILD=true
 # Download repo version, sets up better layer caching for the following clone
 ADD https://api.github.com/repos/OfficeDev/office-ui-fabric-react/git/ref/heads/master version.json
-RUN git clone https://github.com/OfficeDev/office-ui-fabric-react.git /office-ui-fabric-react
+RUN git clone --depth 1 https://github.com/OfficeDev/office-ui-fabric-react.git /office-ui-fabric-react
 WORKDIR /office-ui-fabric-react
 RUN git pull
 WORKDIR /

--- a/tests/cases/docker/office-ui-fabric/Dockerfile
+++ b/tests/cases/docker/office-ui-fabric/Dockerfile
@@ -6,7 +6,6 @@ ENV TF_BUILD=true
 ADD https://api.github.com/repos/OfficeDev/office-ui-fabric-react/git/ref/heads/master version.json
 RUN git clone --depth 1 https://github.com/OfficeDev/office-ui-fabric-react.git /office-ui-fabric-react
 WORKDIR /office-ui-fabric-react
-RUN git pull
 WORKDIR /
 COPY --from=typescript/typescript /typescript/typescript-*.tgz typescript.tgz
 WORKDIR /office-ui-fabric-react

--- a/tests/cases/docker/prettier/Dockerfile
+++ b/tests/cases/docker/prettier/Dockerfile
@@ -2,7 +2,6 @@ FROM node:current
 RUN npm i -g yarn --force
 RUN git clone --depth 1 https://github.com/prettier/prettier.git /prettier
 WORKDIR /prettier
-RUN git pull
 COPY --from=typescript/typescript /typescript/typescript-*.tgz /typescript.tgz
 RUN mkdir /typescript
 RUN tar -xzvf /typescript.tgz -C /typescript

--- a/tests/cases/docker/prettier/Dockerfile
+++ b/tests/cases/docker/prettier/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:current
 RUN npm i -g yarn --force
-RUN git clone https://github.com/prettier/prettier.git /prettier
+RUN git clone --depth 1 https://github.com/prettier/prettier.git /prettier
 WORKDIR /prettier
 RUN git pull
 COPY --from=typescript/typescript /typescript/typescript-*.tgz /typescript.tgz

--- a/tests/cases/docker/pyright/Dockerfile
+++ b/tests/cases/docker/pyright/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:current
-RUN git clone https://github.com/microsoft/pyright.git /pyright
+RUN git clone --depth 1 https://github.com/microsoft/pyright.git /pyright
 WORKDIR /pyright
 RUN git pull
 RUN npm i

--- a/tests/cases/docker/pyright/Dockerfile
+++ b/tests/cases/docker/pyright/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:current
 RUN git clone --depth 1 https://github.com/microsoft/pyright.git /pyright
 WORKDIR /pyright
-RUN git pull
 RUN npm i
 COPY --from=typescript/typescript /typescript/typescript-*.tgz /typescript.tgz
 RUN npm install /typescript.tgz --exact --ignore-scripts --save-dev

--- a/tests/cases/docker/rxjs/Dockerfile
+++ b/tests/cases/docker/rxjs/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:10
 RUN git clone --depth 1 https://github.com/ReactiveX/rxjs /rxjs
 WORKDIR /rxjs
-RUN git pull
 COPY --from=typescript/typescript /typescript/typescript-*.tgz /typescript.tgz
 RUN mkdir /typescript
 RUN tar -xzvf /typescript.tgz -C /typescript

--- a/tests/cases/docker/rxjs/Dockerfile
+++ b/tests/cases/docker/rxjs/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:10
-RUN git clone https://github.com/ReactiveX/rxjs /rxjs
+RUN git clone --depth 1 https://github.com/ReactiveX/rxjs /rxjs
 WORKDIR /rxjs
 RUN git pull
 COPY --from=typescript/typescript /typescript/typescript-*.tgz /typescript.tgz

--- a/tests/cases/docker/vscode/Dockerfile
+++ b/tests/cases/docker/vscode/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get install libsecret-1-dev libx11-dev libxkbfile-dev -y
 RUN npm i -g yarn --force
 RUN git clone --depth 1 https://github.com/microsoft/vscode.git /vscode
 WORKDIR /vscode
-RUN git pull
 COPY --from=typescript/typescript /typescript/typescript-*.tgz /typescript.tgz
 WORKDIR /vscode/build
 RUN yarn add typescript@/typescript.tgz

--- a/tests/cases/docker/vscode/Dockerfile
+++ b/tests/cases/docker/vscode/Dockerfile
@@ -3,7 +3,7 @@ FROM node:10
 RUN apt-get update
 RUN apt-get install libsecret-1-dev libx11-dev libxkbfile-dev -y
 RUN npm i -g yarn --force
-RUN git clone https://github.com/microsoft/vscode.git /vscode
+RUN git clone --depth 1 https://github.com/microsoft/vscode.git /vscode
 WORKDIR /vscode
 RUN git pull
 COPY --from=typescript/typescript /typescript/typescript-*.tgz /typescript.tgz

--- a/tests/cases/docker/vue-next/Dockerfile
+++ b/tests/cases/docker/vue-next/Dockerfile
@@ -2,7 +2,6 @@ FROM node:current
 RUN npm install -g yarn lerna --force
 RUN git clone --depth 1 https://github.com/vuejs/vue-next.git /vue-next
 WORKDIR /vue-next
-RUN git pull
 COPY --from=typescript/typescript /typescript/typescript-*.tgz typescript.tgz
 # Sync up all TS versions used internally to the new one
 RUN yarn add typescript@./typescript.tgz --exact --dev --ignore-scripts -W

--- a/tests/cases/docker/vue-next/Dockerfile
+++ b/tests/cases/docker/vue-next/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:current
 RUN npm install -g yarn lerna --force
-RUN git clone https://github.com/vuejs/vue-next.git /vue-next
+RUN git clone --depth 1 https://github.com/vuejs/vue-next.git /vue-next
 WORKDIR /vue-next
 RUN git pull
 COPY --from=typescript/typescript /typescript/typescript-*.tgz typescript.tgz

--- a/tests/cases/docker/xterm.js/Dockerfile
+++ b/tests/cases/docker/xterm.js/Dockerfile
@@ -1,6 +1,6 @@
 # node-pty doesn't build on node 12 right now, so we lock to 10
 FROM node:10
-RUN git clone https://github.com/xtermjs/xterm.js.git /xtermjs
+RUN git clone --depth 1 https://github.com/xtermjs/xterm.js.git /xtermjs
 WORKDIR /xtermjs
 RUN git pull
 COPY --from=typescript/typescript /typescript/typescript-*.tgz /typescript.tgz

--- a/tests/cases/docker/xterm.js/Dockerfile
+++ b/tests/cases/docker/xterm.js/Dockerfile
@@ -2,7 +2,6 @@
 FROM node:10
 RUN git clone --depth 1 https://github.com/xtermjs/xterm.js.git /xtermjs
 WORKDIR /xtermjs
-RUN git pull
 COPY --from=typescript/typescript /typescript/typescript-*.tgz /typescript.tgz
 RUN mkdir /typescript
 RUN tar -xzvf /typescript.tgz -C /typescript


### PR DESCRIPTION
Just saves a bit of time and work since we don't need the full history.