### PR TITLE
Fix: checkAliasSymbol crash when checking for @deprecated

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37124,7 +37124,7 @@ namespace ts {
                     error(node, Diagnostics.Re_exporting_a_type_when_the_isolatedModules_flag_is_provided_requires_using_export_type);
                 }
 
-                if (isImportSpecifier(node) && every(target.declarations, d => !!(getCombinedNodeFlags(d) & NodeFlags.Deprecated))) {
+                if (isImportSpecifier(node) && target.declarations?.every(d => !!(getCombinedNodeFlags(d) & NodeFlags.Deprecated))) {
                     addDeprecatedSuggestion(node.name, target.declarations, symbol.escapedName as string);
                 }
             }

--- a/tests/baselines/reference/importPropertyFromMappedType.js
+++ b/tests/baselines/reference/importPropertyFromMappedType.js
@@ -1,6 +1,8 @@
 //// [tests/cases/compiler/importPropertyFromMappedType.ts] ////
 
 //// [errors.d.ts]
+// #42957
+
 export = createHttpError;
 declare const createHttpError: createHttpError.NamedConstructors;
 declare namespace createHttpError {

--- a/tests/baselines/reference/importPropertyFromMappedType.js
+++ b/tests/baselines/reference/importPropertyFromMappedType.js
@@ -1,0 +1,16 @@
+//// [tests/cases/compiler/importPropertyFromMappedType.ts] ////
+
+//// [errors.d.ts]
+export = createHttpError;
+declare const createHttpError: createHttpError.NamedConstructors;
+declare namespace createHttpError {
+    type NamedConstructors =  { [P in 'NotFound']: unknown;}
+}
+
+//// [main.ts]
+import { NotFound } from './errors'
+
+
+//// [main.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/importPropertyFromMappedType.symbols
+++ b/tests/baselines/reference/importPropertyFromMappedType.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/errors.d.ts ===
+export = createHttpError;
+>createHttpError : Symbol(createHttpError, Decl(errors.d.ts, 1, 13), Decl(errors.d.ts, 1, 65))
+
+declare const createHttpError: createHttpError.NamedConstructors;
+>createHttpError : Symbol(createHttpError, Decl(errors.d.ts, 1, 13), Decl(errors.d.ts, 1, 65))
+>createHttpError : Symbol(createHttpError, Decl(errors.d.ts, 1, 13), Decl(errors.d.ts, 1, 65))
+>NamedConstructors : Symbol(createHttpError.NamedConstructors, Decl(errors.d.ts, 2, 35))
+
+declare namespace createHttpError {
+>createHttpError : Symbol(createHttpError, Decl(errors.d.ts, 1, 13), Decl(errors.d.ts, 1, 65))
+
+    type NamedConstructors =  { [P in 'NotFound']: unknown;}
+>NamedConstructors : Symbol(NamedConstructors, Decl(errors.d.ts, 2, 35))
+>P : Symbol(P, Decl(errors.d.ts, 3, 33))
+}
+
+=== tests/cases/compiler/main.ts ===
+import { NotFound } from './errors'
+>NotFound : Symbol(NotFound, Decl(main.ts, 0, 8))
+

--- a/tests/baselines/reference/importPropertyFromMappedType.symbols
+++ b/tests/baselines/reference/importPropertyFromMappedType.symbols
@@ -1,18 +1,20 @@
 === tests/cases/compiler/errors.d.ts ===
+// #42957
+
 export = createHttpError;
->createHttpError : Symbol(createHttpError, Decl(errors.d.ts, 1, 13), Decl(errors.d.ts, 1, 65))
+>createHttpError : Symbol(createHttpError, Decl(errors.d.ts, 3, 13), Decl(errors.d.ts, 3, 65))
 
 declare const createHttpError: createHttpError.NamedConstructors;
->createHttpError : Symbol(createHttpError, Decl(errors.d.ts, 1, 13), Decl(errors.d.ts, 1, 65))
->createHttpError : Symbol(createHttpError, Decl(errors.d.ts, 1, 13), Decl(errors.d.ts, 1, 65))
->NamedConstructors : Symbol(createHttpError.NamedConstructors, Decl(errors.d.ts, 2, 35))
+>createHttpError : Symbol(createHttpError, Decl(errors.d.ts, 3, 13), Decl(errors.d.ts, 3, 65))
+>createHttpError : Symbol(createHttpError, Decl(errors.d.ts, 3, 13), Decl(errors.d.ts, 3, 65))
+>NamedConstructors : Symbol(createHttpError.NamedConstructors, Decl(errors.d.ts, 4, 35))
 
 declare namespace createHttpError {
->createHttpError : Symbol(createHttpError, Decl(errors.d.ts, 1, 13), Decl(errors.d.ts, 1, 65))
+>createHttpError : Symbol(createHttpError, Decl(errors.d.ts, 3, 13), Decl(errors.d.ts, 3, 65))
 
     type NamedConstructors =  { [P in 'NotFound']: unknown;}
->NamedConstructors : Symbol(NamedConstructors, Decl(errors.d.ts, 2, 35))
->P : Symbol(P, Decl(errors.d.ts, 3, 33))
+>NamedConstructors : Symbol(NamedConstructors, Decl(errors.d.ts, 4, 35))
+>P : Symbol(P, Decl(errors.d.ts, 5, 33))
 }
 
 === tests/cases/compiler/main.ts ===

--- a/tests/baselines/reference/importPropertyFromMappedType.types
+++ b/tests/baselines/reference/importPropertyFromMappedType.types
@@ -1,4 +1,6 @@
 === tests/cases/compiler/errors.d.ts ===
+// #42957
+
 export = createHttpError;
 >createHttpError : createHttpError.NamedConstructors
 

--- a/tests/baselines/reference/importPropertyFromMappedType.types
+++ b/tests/baselines/reference/importPropertyFromMappedType.types
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/errors.d.ts ===
+export = createHttpError;
+>createHttpError : createHttpError.NamedConstructors
+
+declare const createHttpError: createHttpError.NamedConstructors;
+>createHttpError : createHttpError.NamedConstructors
+>createHttpError : any
+
+declare namespace createHttpError {
+    type NamedConstructors =  { [P in 'NotFound']: unknown;}
+>NamedConstructors : NamedConstructors
+}
+
+=== tests/cases/compiler/main.ts ===
+import { NotFound } from './errors'
+>NotFound : unknown
+

--- a/tests/cases/compiler/importPropertyFromMappedType.ts
+++ b/tests/cases/compiler/importPropertyFromMappedType.ts
@@ -1,0 +1,11 @@
+// #
+
+// @filename: errors.d.ts
+export = createHttpError;
+declare const createHttpError: createHttpError.NamedConstructors;
+declare namespace createHttpError {
+    type NamedConstructors =  { [P in 'NotFound']: unknown;}
+}
+
+// @filename: main.ts
+import { NotFound } from './errors'

--- a/tests/cases/compiler/importPropertyFromMappedType.ts
+++ b/tests/cases/compiler/importPropertyFromMappedType.ts
@@ -1,4 +1,4 @@
-// #
+// #42957
 
 // @filename: errors.d.ts
 export = createHttpError;


### PR DESCRIPTION
It's possible that we shouldn't be creating symbol with no declarations from non-homomorphic mapped types, but for 4.2, the right fix is to make the @deprecated-check in checkAliasSymbol ensure that target.declarations is defined.

Fixes #42957, test case based on `@types/http-errors`
