### PR TITLE
Add skipLibCheck to scripts/tsconfig.json

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "strictNullChecks": true,
+        "skipLibCheck": true,
         "removeComments": false,
         "declaration": false,
         "sourceMap": true,


### PR DESCRIPTION
Right now, there's an error in `node_modules\@octokit\plugin-rest-endpoint-methods\dist-types\generated\parameters-and-response-types.d.ts` and it wasn't obvious to me why we were building that.