### PR TITLE
Only filter ignored paths from module specifier generation if there exists a better option

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -282,10 +282,12 @@ namespace ts.moduleSpecifiers {
         const redirects = host.redirectTargetsMap.get(importedPath) || emptyArray;
         const importedFileNames = [...(referenceRedirect ? [referenceRedirect] : emptyArray), importedFileName, ...redirects];
         const targets = importedFileNames.map(f => getNormalizedAbsolutePath(f, cwd));
+        let filterIgnoredPaths = some(targets, not(containsIgnoredPath));
+
         if (!preferSymlinks) {
             // Symlinks inside ignored paths are already filtered out of the symlink cache,
             // so we only need to remove them from the realpath filenames.
-            const result = forEach(targets, p => !containsIgnoredPath(p) && cb(p, referenceRedirect === p));
+            const result = forEach(targets, p => !(filterIgnoredPaths && containsIgnoredPath(p)) && cb(p, referenceRedirect === p));
             if (result) return result;
         }
         const links = host.getSymlinkCache
@@ -312,12 +314,13 @@ namespace ts.moduleSpecifiers {
                 for (const symlinkDirectory of symlinkDirectories) {
                     const option = resolvePath(symlinkDirectory, relative);
                     const result = cb(option, target === referenceRedirect);
+                    filterIgnoredPaths = true; // We found a non-ignored path in symlinks, so we can reject ignored-path realpaths
                     if (result) return result;
                 }
             });
         });
         return result || (preferSymlinks
-            ? forEach(targets, p => containsIgnoredPath(p) ? undefined : cb(p, p === referenceRedirect))
+            ? forEach(targets, p => filterIgnoredPaths && containsIgnoredPath(p) ? undefined : cb(p, p === referenceRedirect))
             : undefined);
     }
 

--- a/tests/baselines/reference/nodeModuleReexportFromDottedPath.js
+++ b/tests/baselines/reference/nodeModuleReexportFromDottedPath.js
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/nodeModuleReexportFromDottedPath.ts] ////
+
+//// [index.d.ts]
+export interface PrismaClientOptions {
+  rejectOnNotFound?: any;
+}
+
+export class PrismaClient<T extends PrismaClientOptions = PrismaClientOptions> {
+  private fetcher;
+}
+
+//// [index.d.ts]
+export * from ".prisma/client";
+
+//// [index.ts]
+import { PrismaClient } from "@prisma/client";
+declare const enhancePrisma: <TPrismaClientCtor>(client: TPrismaClientCtor) => TPrismaClientCtor & { enhanced: unknown };
+const EnhancedPrisma = enhancePrisma(PrismaClient);
+export default new EnhancedPrisma();
+
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+var client_1 = require("@prisma/client");
+var EnhancedPrisma = enhancePrisma(client_1.PrismaClient);
+exports["default"] = new EnhancedPrisma();
+
+
+//// [index.d.ts]
+import { PrismaClient } from "@prisma/client";
+declare const _default: PrismaClient<import(".prisma/client").PrismaClientOptions>;
+export default _default;

--- a/tests/baselines/reference/nodeModuleReexportFromDottedPath.symbols
+++ b/tests/baselines/reference/nodeModuleReexportFromDottedPath.symbols
@@ -1,0 +1,41 @@
+=== /node_modules/.prisma/client/index.d.ts ===
+export interface PrismaClientOptions {
+>PrismaClientOptions : Symbol(PrismaClientOptions, Decl(index.d.ts, 0, 0))
+
+  rejectOnNotFound?: any;
+>rejectOnNotFound : Symbol(PrismaClientOptions.rejectOnNotFound, Decl(index.d.ts, 0, 38))
+}
+
+export class PrismaClient<T extends PrismaClientOptions = PrismaClientOptions> {
+>PrismaClient : Symbol(PrismaClient, Decl(index.d.ts, 2, 1))
+>T : Symbol(T, Decl(index.d.ts, 4, 26))
+>PrismaClientOptions : Symbol(PrismaClientOptions, Decl(index.d.ts, 0, 0))
+>PrismaClientOptions : Symbol(PrismaClientOptions, Decl(index.d.ts, 0, 0))
+
+  private fetcher;
+>fetcher : Symbol(PrismaClient.fetcher, Decl(index.d.ts, 4, 80))
+}
+
+=== /node_modules/@prisma/client/index.d.ts ===
+export * from ".prisma/client";
+No type information for this code.
+No type information for this code.=== /index.ts ===
+import { PrismaClient } from "@prisma/client";
+>PrismaClient : Symbol(PrismaClient, Decl(index.ts, 0, 8))
+
+declare const enhancePrisma: <TPrismaClientCtor>(client: TPrismaClientCtor) => TPrismaClientCtor & { enhanced: unknown };
+>enhancePrisma : Symbol(enhancePrisma, Decl(index.ts, 1, 13))
+>TPrismaClientCtor : Symbol(TPrismaClientCtor, Decl(index.ts, 1, 30))
+>client : Symbol(client, Decl(index.ts, 1, 49))
+>TPrismaClientCtor : Symbol(TPrismaClientCtor, Decl(index.ts, 1, 30))
+>TPrismaClientCtor : Symbol(TPrismaClientCtor, Decl(index.ts, 1, 30))
+>enhanced : Symbol(enhanced, Decl(index.ts, 1, 100))
+
+const EnhancedPrisma = enhancePrisma(PrismaClient);
+>EnhancedPrisma : Symbol(EnhancedPrisma, Decl(index.ts, 2, 5))
+>enhancePrisma : Symbol(enhancePrisma, Decl(index.ts, 1, 13))
+>PrismaClient : Symbol(PrismaClient, Decl(index.ts, 0, 8))
+
+export default new EnhancedPrisma();
+>EnhancedPrisma : Symbol(EnhancedPrisma, Decl(index.ts, 2, 5))
+

--- a/tests/baselines/reference/nodeModuleReexportFromDottedPath.types
+++ b/tests/baselines/reference/nodeModuleReexportFromDottedPath.types
@@ -1,0 +1,35 @@
+=== /node_modules/.prisma/client/index.d.ts ===
+export interface PrismaClientOptions {
+  rejectOnNotFound?: any;
+>rejectOnNotFound : any
+}
+
+export class PrismaClient<T extends PrismaClientOptions = PrismaClientOptions> {
+>PrismaClient : PrismaClient<T>
+
+  private fetcher;
+>fetcher : any
+}
+
+=== /node_modules/@prisma/client/index.d.ts ===
+export * from ".prisma/client";
+No type information for this code.
+No type information for this code.=== /index.ts ===
+import { PrismaClient } from "@prisma/client";
+>PrismaClient : typeof PrismaClient
+
+declare const enhancePrisma: <TPrismaClientCtor>(client: TPrismaClientCtor) => TPrismaClientCtor & { enhanced: unknown };
+>enhancePrisma : <TPrismaClientCtor>(client: TPrismaClientCtor) => TPrismaClientCtor & { enhanced: unknown; }
+>client : TPrismaClientCtor
+>enhanced : unknown
+
+const EnhancedPrisma = enhancePrisma(PrismaClient);
+>EnhancedPrisma : typeof PrismaClient & { enhanced: unknown; }
+>enhancePrisma(PrismaClient) : typeof PrismaClient & { enhanced: unknown; }
+>enhancePrisma : <TPrismaClientCtor>(client: TPrismaClientCtor) => TPrismaClientCtor & { enhanced: unknown; }
+>PrismaClient : typeof PrismaClient
+
+export default new EnhancedPrisma();
+>new EnhancedPrisma() : PrismaClient<import("/node_modules/.prisma/client/index").PrismaClientOptions>
+>EnhancedPrisma : typeof PrismaClient & { enhanced: unknown; }
+

--- a/tests/cases/compiler/nodeModuleReexportFromDottedPath.ts
+++ b/tests/cases/compiler/nodeModuleReexportFromDottedPath.ts
@@ -1,0 +1,19 @@
+// @declaration: true
+
+// @Filename: /node_modules/.prisma/client/index.d.ts
+export interface PrismaClientOptions {
+  rejectOnNotFound?: any;
+}
+
+export class PrismaClient<T extends PrismaClientOptions = PrismaClientOptions> {
+  private fetcher;
+}
+
+// @Filename: /node_modules/@prisma/client/index.d.ts
+export * from ".prisma/client";
+
+// @Filename: /index.ts
+import { PrismaClient } from "@prisma/client";
+declare const enhancePrisma: <TPrismaClientCtor>(client: TPrismaClientCtor) => TPrismaClientCtor & { enhanced: unknown };
+const EnhancedPrisma = enhancePrisma(PrismaClient);
+export default new EnhancedPrisma();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #42785 
Fixes #43011

Sometimes the resolver can’t come up with a module specifier that doesn’t have an “ignored path” (like `.pnpm` or `.prisma`) in it. In those cases, we need to use the undesirable ignored path. In @dlannoye’s repro, the `.pnpm` path never actually manifests in a declaration file—the resolver separately finds an accessible re-export and uses that, but there was nevertheless an assertion that we could come up with _something_ for the declaring module itself. The test case included is based off of @flybayer’s repro. This case _does_ result in a type serialization that references `node_modules/.prisma` directly, which isn’t great, but that would have happened in 4.1 and earlier as well. (The real example from @flybayer has `noEmit` enabled, so in fact neither real-world case actually exhibits bad behavior with this PR. And I think for the Prisma case, it’s not strictly harmful if declaration files reference `".prisma"` anyway, since that folder will have to get created during build/install for `"@prisma/client"` to work.)
