### PR TITLE
deduplicate references lists in tsbuildinfo

### DIFF
--- a/tests/baselines/reference/tsbuild/configFileErrors/incremental-declaration-changes/builds-after-fixing-config-file-errors.js
+++ b/tests/baselines/reference/tsbuild/configFileErrors/incremental-declaration-changes/builds-after-fixing-config-file-errors.js
@@ -60,6 +60,8 @@ exports.bar = bar;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./a.ts",

--- a/tests/baselines/reference/tsbuild/configFileExtends/initial-build/when-building-project-uses-reference-and-both-extend-config-with-include.js
+++ b/tests/baselines/reference/tsbuild/configFileExtends/initial-build/when-building-project-uses-reference-and-both-extend-config-with-include.js
@@ -100,6 +100,8 @@ exports.a = 1;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "../../shared/index.ts",
@@ -149,6 +151,8 @@ exports.b = 1;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "../../shared/typings-base/globals.d.ts",

--- a/tests/baselines/reference/tsbuild/configFileExtends/initial-build/when-building-solution-with-projects-extends-config-with-include.js
+++ b/tests/baselines/reference/tsbuild/configFileExtends/initial-build/when-building-solution-with-projects-extends-config-with-include.js
@@ -101,6 +101,8 @@ exports.a = 1;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "../../shared/index.ts",
@@ -150,6 +152,8 @@ exports.b = 1;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "../../shared/typings-base/globals.d.ts",

--- a/tests/baselines/reference/tsbuild/containerOnlyReferenced/initial-build/verify-that-subsequent-builds-after-initial-build-doesnt-build-anything.js
+++ b/tests/baselines/reference/tsbuild/containerOnlyReferenced/initial-build/verify-that-subsequent-builds-after-initial-build-doesnt-build-anything.js
@@ -132,6 +132,8 @@ exports.x = 10;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "./index.ts"
@@ -172,6 +174,8 @@ exports.x = 10;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "./index.ts"
@@ -212,6 +216,8 @@ exports.x = 10;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./index.ts"

--- a/tests/baselines/reference/tsbuild/declarationEmit/initial-build/when-declaration-file-is-referenced-through-triple-slash-but-uses-no-references.js
+++ b/tests/baselines/reference/tsbuild/declarationEmit/initial-build/when-declaration-file-is-referenced-through-triple-slash-but-uses-no-references.js
@@ -148,24 +148,31 @@ exports.getVar = getVar;
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/common/nominal.ts": [
-        "../src/common/types.d.ts"
-      ],
-      "../src/subproject/index.ts": [
-        "../src/common/nominal.ts"
-      ],
-      "../src/subproject2/index.ts": [
-        "../src/subproject/index.ts"
-      ]
+      "0": 1,
+      "2": 0,
+      "3": 2
     },
     "exportedModulesMap": {
-      "../src/subproject/index.ts": [
-        "../src/common/nominal.ts"
-      ],
-      "../src/subproject2/index.ts": [
-        "../src/subproject/index.ts"
-      ]
+      "2": 0,
+      "3": 2
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../src/common/nominal.ts",
+      "../src/common/types.d.ts",
+      "../src/subproject/index.ts",
+      "../src/subproject2/index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "../src/common/nominal.ts",

--- a/tests/baselines/reference/tsbuild/declarationEmit/initial-build/when-declaration-file-is-referenced-through-triple-slash.js
+++ b/tests/baselines/reference/tsbuild/declarationEmit/initial-build/when-declaration-file-is-referenced-through-triple-slash.js
@@ -118,11 +118,18 @@ exports.__esModule = true;
       "configFilePath": "../../../src/common/tsconfig.json"
     },
     "referencedMap": {
-      "../../../src/common/nominal.ts": [
-        "../../../src/common/types.d.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../../../src/common/nominal.ts",
+      "../../../src/common/types.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../lib/lib.d.ts",
       "../../../src/common/nominal.ts",
@@ -174,21 +181,26 @@ exports.__esModule = true;
       "configFilePath": "../../../src/subProject/tsconfig.json"
     },
     "referencedMap": {
-      "../common/nominal.d.ts": [
-        "../../../src/common/types.d.ts"
-      ],
-      "../../../src/subproject/index.ts": [
-        "../common/nominal.d.ts"
-      ]
+      "1": 1,
+      "2": 0
     },
     "exportedModulesMap": {
-      "../common/nominal.d.ts": [
-        "../../../src/common/types.d.ts"
-      ],
-      "../../../src/subproject/index.ts": [
-        "../common/nominal.d.ts"
-      ]
+      "1": 1,
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../../../src/common/types.d.ts",
+      "../../../src/subproject/index.ts",
+      "../common/nominal.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../lib/lib.d.ts",
       "../common/nominal.d.ts",
@@ -258,27 +270,32 @@ exports.getVar = getVar;
       "configFilePath": "../../../src/subProject2/tsconfig.json"
     },
     "referencedMap": {
-      "../common/nominal.d.ts": [
-        "../../../src/common/types.d.ts"
-      ],
-      "../subproject/index.d.ts": [
-        "../common/nominal.d.ts"
-      ],
-      "../../../src/subproject2/index.ts": [
-        "../subproject/index.d.ts"
-      ]
+      "1": 2,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../common/nominal.d.ts": [
-        "../../../src/common/types.d.ts"
-      ],
-      "../subproject/index.d.ts": [
-        "../common/nominal.d.ts"
-      ],
-      "../../../src/subproject2/index.ts": [
-        "../subproject/index.d.ts"
-      ]
+      "1": 2,
+      "2": 0,
+      "3": 1
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ],
+      [
+        3
+      ]
+    ],
+    "mapFiles": [
+      "../../../src/common/types.d.ts",
+      "../../../src/subproject2/index.ts",
+      "../common/nominal.d.ts",
+      "../subproject/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../lib/lib.d.ts",
       "../common/nominal.d.ts",

--- a/tests/baselines/reference/tsbuild/declarationEmit/initial-build/when-declaration-file-used-inferred-type-from-referenced-project.js
+++ b/tests/baselines/reference/tsbuild/declarationEmit/initial-build/when-declaration-file-used-inferred-type-from-referenced-project.js
@@ -100,6 +100,8 @@ exports.__esModule = true;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../lib/lib.d.ts",
       "../src/index.ts"
@@ -156,15 +158,20 @@ exports.fn4 = fn4;
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/index.ts": [
-        "../../pkg1/lib/src/index.d.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {
-      "../src/index.ts": [
-        "../../pkg1/lib/src/index.d.ts"
-      ]
+      "1": 0
     },
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../../pkg1/lib/src/index.d.ts",
+      "../src/index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../lib/lib.d.ts",
       "../../pkg1/lib/src/index.d.ts",

--- a/tests/baselines/reference/tsbuild/demo/initial-build/in-bad-ref-branch-reports-the-error-about-files-not-in-rootDir-at-the-import-location.js
+++ b/tests/baselines/reference/tsbuild/demo/initial-build/in-bad-ref-branch-reports-the-error-about-files-not-in-rootDir-at-the-import-location.js
@@ -258,27 +258,33 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
       "configFilePath": "../../core/tsconfig.json"
     },
     "referencedMap": {
-      "../../animals/dog.ts": [
-        "../../animals/index.ts",
-        "../../core/utilities.ts"
-      ],
-      "../../animals/index.ts": [
-        "../../animals/animal.ts",
-        "../../animals/dog.ts"
-      ],
-      "../../core/utilities.ts": [
-        "../../animals/index.ts"
-      ]
+      "1": 2,
+      "2": 1,
+      "3": 0
     },
     "exportedModulesMap": {
-      "../../animals/dog.ts": [
-        "../../animals/index.ts"
-      ],
-      "../../animals/index.ts": [
-        "../../animals/animal.ts",
-        "../../animals/dog.ts"
-      ]
+      "1": 0,
+      "2": 1
     },
+    "mapLists": [
+      [
+        2
+      ],
+      [
+        0,
+        1
+      ],
+      [
+        2,
+        3
+      ]
+    ],
+    "mapFiles": [
+      "../../animals/animal.ts",
+      "../../animals/dog.ts",
+      "../../animals/index.ts",
+      "../../core/utilities.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "../../animals/animal.ts",

--- a/tests/baselines/reference/tsbuild/demo/initial-build/in-master-branch-with-everything-setup-correctly-and-reports-no-error.js
+++ b/tests/baselines/reference/tsbuild/demo/initial-build/in-master-branch-with-everything-setup-correctly-and-reports-no-error.js
@@ -264,24 +264,32 @@ Object.defineProperty(exports, "createDog", { enumerable: true, get: function ()
       "configFilePath": "../../animals/tsconfig.json"
     },
     "referencedMap": {
-      "../../animals/dog.ts": [
-        "../../animals/index.ts",
-        "../core/utilities.d.ts"
-      ],
-      "../../animals/index.ts": [
-        "../../animals/animal.ts",
-        "../../animals/dog.ts"
-      ]
+      "1": 2,
+      "2": 1
     },
     "exportedModulesMap": {
-      "../../animals/dog.ts": [
-        "../../animals/index.ts"
-      ],
-      "../../animals/index.ts": [
-        "../../animals/animal.ts",
-        "../../animals/dog.ts"
-      ]
+      "1": 0,
+      "2": 1
     },
+    "mapLists": [
+      [
+        2
+      ],
+      [
+        0,
+        1
+      ],
+      [
+        2,
+        3
+      ]
+    ],
+    "mapFiles": [
+      "../../animals/animal.ts",
+      "../../animals/dog.ts",
+      "../../animals/index.ts",
+      "../core/utilities.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "../../animals/animal.ts",
@@ -324,6 +332,8 @@ Object.defineProperty(exports, "createDog", { enumerable: true, get: function ()
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "../../core/utilities.ts"
@@ -398,29 +408,30 @@ exports.lastElementOf = lastElementOf;
       "configFilePath": "../../zoo/tsconfig.json"
     },
     "referencedMap": {
-      "../animals/dog.d.ts": [
-        "../animals/index.d.ts"
-      ],
-      "../animals/index.d.ts": [
-        "../animals/animal.d.ts",
-        "../animals/dog.d.ts"
-      ],
-      "../../zoo/zoo.ts": [
-        "../animals/index.d.ts"
-      ]
+      "0": 0,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../animals/dog.d.ts": [
-        "../animals/index.d.ts"
-      ],
-      "../animals/index.d.ts": [
-        "../animals/animal.d.ts",
-        "../animals/dog.d.ts"
-      ],
-      "../../zoo/zoo.ts": [
-        "../animals/index.d.ts"
-      ]
+      "0": 0,
+      "2": 0,
+      "3": 1
     },
+    "mapLists": [
+      [
+        3
+      ],
+      [
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../../zoo/zoo.ts",
+      "../animals/animal.d.ts",
+      "../animals/dog.d.ts",
+      "../animals/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "../animals/animal.d.ts",

--- a/tests/baselines/reference/tsbuild/emitDeclarationOnly/initial-build/only-dts-output-in-circular-import-project-with-emitDeclarationOnly-and-declarationMap.js
+++ b/tests/baselines/reference/tsbuild/emitDeclarationOnly/initial-build/only-dts-output-in-circular-import-project-with-emitDeclarationOnly-and-declarationMap.js
@@ -166,37 +166,39 @@ export { C } from "./c";
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/a.ts": [
-        "./src/b.ts"
-      ],
-      "./src/b.ts": [
-        "./src/c.ts"
-      ],
-      "./src/c.ts": [
-        "./src/a.ts"
-      ],
-      "./src/index.ts": [
-        "./src/a.ts",
-        "./src/b.ts",
-        "./src/c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
     "exportedModulesMap": {
-      "./src/a.ts": [
-        "./src/b.ts"
-      ],
-      "./src/b.ts": [
-        "./src/c.ts"
-      ],
-      "./src/c.ts": [
-        "./src/a.ts"
-      ],
-      "./src/index.ts": [
-        "./src/a.ts",
-        "./src/b.ts",
-        "./src/c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1
+      ],
+      [
+        2
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/a.ts",
+      "./src/b.ts",
+      "./src/c.ts",
+      "./src/index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./src/a.ts",
@@ -298,37 +300,39 @@ export interface A {
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/a.ts": [
-        "./src/b.ts"
-      ],
-      "./src/b.ts": [
-        "./src/c.ts"
-      ],
-      "./src/c.ts": [
-        "./src/a.ts"
-      ],
-      "./src/index.ts": [
-        "./src/a.ts",
-        "./src/b.ts",
-        "./src/c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
     "exportedModulesMap": {
-      "./src/a.ts": [
-        "./src/b.ts"
-      ],
-      "./src/b.ts": [
-        "./src/c.ts"
-      ],
-      "./src/c.ts": [
-        "./src/a.ts"
-      ],
-      "./src/index.ts": [
-        "./src/a.ts",
-        "./src/b.ts",
-        "./src/c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1
+      ],
+      [
+        2
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/a.ts",
+      "./src/b.ts",
+      "./src/c.ts",
+      "./src/index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./src/a.ts",

--- a/tests/baselines/reference/tsbuild/emitDeclarationOnly/initial-build/only-dts-output-in-circular-import-project-with-emitDeclarationOnly.js
+++ b/tests/baselines/reference/tsbuild/emitDeclarationOnly/initial-build/only-dts-output-in-circular-import-project-with-emitDeclarationOnly.js
@@ -153,37 +153,39 @@ export { C } from "./c";
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/a.ts": [
-        "./src/b.ts"
-      ],
-      "./src/b.ts": [
-        "./src/c.ts"
-      ],
-      "./src/c.ts": [
-        "./src/a.ts"
-      ],
-      "./src/index.ts": [
-        "./src/a.ts",
-        "./src/b.ts",
-        "./src/c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
     "exportedModulesMap": {
-      "./src/a.ts": [
-        "./src/b.ts"
-      ],
-      "./src/b.ts": [
-        "./src/c.ts"
-      ],
-      "./src/c.ts": [
-        "./src/a.ts"
-      ],
-      "./src/index.ts": [
-        "./src/a.ts",
-        "./src/b.ts",
-        "./src/c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1
+      ],
+      [
+        2
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/a.ts",
+      "./src/b.ts",
+      "./src/c.ts",
+      "./src/index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./src/a.ts",
@@ -278,37 +280,39 @@ export interface A {
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/a.ts": [
-        "./src/b.ts"
-      ],
-      "./src/b.ts": [
-        "./src/c.ts"
-      ],
-      "./src/c.ts": [
-        "./src/a.ts"
-      ],
-      "./src/index.ts": [
-        "./src/a.ts",
-        "./src/b.ts",
-        "./src/c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
     "exportedModulesMap": {
-      "./src/a.ts": [
-        "./src/b.ts"
-      ],
-      "./src/b.ts": [
-        "./src/c.ts"
-      ],
-      "./src/c.ts": [
-        "./src/a.ts"
-      ],
-      "./src/index.ts": [
-        "./src/a.ts",
-        "./src/b.ts",
-        "./src/c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1
+      ],
+      [
+        2
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/a.ts",
+      "./src/b.ts",
+      "./src/c.ts",
+      "./src/index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./src/a.ts",

--- a/tests/baselines/reference/tsbuild/emitDeclarationOnly/initial-build/only-dts-output-in-non-circular-imports-project-with-emitDeclarationOnly.js
+++ b/tests/baselines/reference/tsbuild/emitDeclarationOnly/initial-build/only-dts-output-in-non-circular-imports-project-with-emitDeclarationOnly.js
@@ -148,21 +148,26 @@ export interface C {
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/b.ts": [
-        "./src/c.ts"
-      ],
-      "./src/c.ts": [
-        "./src/a.ts"
-      ]
+      "1": 1,
+      "2": 0
     },
     "exportedModulesMap": {
-      "./src/b.ts": [
-        "./src/c.ts"
-      ],
-      "./src/c.ts": [
-        "./src/a.ts"
-      ]
+      "1": 1,
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/a.ts",
+      "./src/b.ts",
+      "./src/c.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./src/a.ts",
@@ -248,21 +253,26 @@ exitCode:: ExitStatus.Success
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/b.ts": [
-        "./src/c.ts"
-      ],
-      "./src/c.ts": [
-        "./src/a.ts"
-      ]
+      "1": 1,
+      "2": 0
     },
     "exportedModulesMap": {
-      "./src/b.ts": [
-        "./src/c.ts"
-      ],
-      "./src/c.ts": [
-        "./src/a.ts"
-      ]
+      "1": 1,
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/a.ts",
+      "./src/b.ts",
+      "./src/c.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./src/a.ts",
@@ -359,21 +369,26 @@ export interface A {
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/b.ts": [
-        "./src/c.ts"
-      ],
-      "./src/c.ts": [
-        "./src/a.ts"
-      ]
+      "1": 1,
+      "2": 0
     },
     "exportedModulesMap": {
-      "./src/b.ts": [
-        "./src/c.ts"
-      ],
-      "./src/c.ts": [
-        "./src/a.ts"
-      ]
+      "1": 1,
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/a.ts",
+      "./src/b.ts",
+      "./src/c.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./src/a.ts",

--- a/tests/baselines/reference/tsbuild/emptyFiles/initial-build/does-not-have-empty-files-diagnostic-when-files-is-empty-and-references-are-provided.js
+++ b/tests/baselines/reference/tsbuild/emptyFiles/initial-build/does-not-have-empty-files-diagnostic-when-files-is-empty-and-references-are-provided.js
@@ -93,6 +93,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./index.ts"

--- a/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-build/inferred-type-from-transitive-module-with-isolatedModules.js
+++ b/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-build/inferred-type-from-transitive-module-with-isolatedModules.js
@@ -195,23 +195,28 @@ Object.defineProperty(exports, "bar", { enumerable: true, get: function () { ret
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../index.ts": [
-        "../bundling.ts",
-        "../lazyindex.ts"
-      ],
-      "../lazyindex.ts": [
-        "../bar.ts"
-      ]
+      "2": 1,
+      "3": 0
     },
     "exportedModulesMap": {
-      "../index.ts": [
-        "../bundling.ts",
-        "../lazyindex.ts"
-      ],
-      "../lazyindex.ts": [
-        "../bar.ts"
-      ]
+      "2": 1,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1,
+        3
+      ]
+    ],
+    "mapFiles": [
+      "../bar.ts",
+      "../bundling.ts",
+      "../index.ts",
+      "../lazyindex.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../bar.ts",
@@ -317,23 +322,28 @@ export declare const lazyBar: LazyAction<() => void, typeof import("./lazyIndex"
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../index.ts": [
-        "../bundling.ts",
-        "../lazyindex.ts"
-      ],
-      "../lazyindex.ts": [
-        "../bar.ts"
-      ]
+      "2": 1,
+      "3": 0
     },
     "exportedModulesMap": {
-      "../index.ts": [
-        "../bundling.ts",
-        "../lazyindex.ts"
-      ],
-      "../lazyindex.ts": [
-        "../bar.ts"
-      ]
+      "2": 1,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1,
+        3
+      ]
+    ],
+    "mapFiles": [
+      "../bar.ts",
+      "../bundling.ts",
+      "../index.ts",
+      "../lazyindex.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../bar.ts",

--- a/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-build/inferred-type-from-transitive-module.js
+++ b/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-build/inferred-type-from-transitive-module.js
@@ -194,23 +194,28 @@ Object.defineProperty(exports, "bar", { enumerable: true, get: function () { ret
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../index.ts": [
-        "../bundling.ts",
-        "../lazyindex.ts"
-      ],
-      "../lazyindex.ts": [
-        "../bar.ts"
-      ]
+      "2": 1,
+      "3": 0
     },
     "exportedModulesMap": {
-      "../index.ts": [
-        "../bundling.ts",
-        "../lazyindex.ts"
-      ],
-      "../lazyindex.ts": [
-        "../bar.ts"
-      ]
+      "2": 1,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1,
+        3
+      ]
+    ],
+    "mapFiles": [
+      "../bar.ts",
+      "../bundling.ts",
+      "../index.ts",
+      "../lazyindex.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../bar.ts",
@@ -316,23 +321,28 @@ export declare const lazyBar: LazyAction<() => void, typeof import("./lazyIndex"
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../index.ts": [
-        "../bundling.ts",
-        "../lazyindex.ts"
-      ],
-      "../lazyindex.ts": [
-        "../bar.ts"
-      ]
+      "2": 1,
+      "3": 0
     },
     "exportedModulesMap": {
-      "../index.ts": [
-        "../bundling.ts",
-        "../lazyindex.ts"
-      ],
-      "../lazyindex.ts": [
-        "../bar.ts"
-      ]
+      "2": 1,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1,
+        3
+      ]
+    ],
+    "mapFiles": [
+      "../bar.ts",
+      "../bundling.ts",
+      "../index.ts",
+      "../lazyindex.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../bar.ts",

--- a/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-build/reports-errors-in-files-affected-by-change-in-signature-with-isolatedModules.js
+++ b/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-build/reports-errors-in-files-affected-by-change-in-signature-with-isolatedModules.js
@@ -199,23 +199,28 @@ var bar_2 = require("./bar");
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../index.ts": [
-        "../bundling.ts",
-        "../lazyindex.ts"
-      ],
-      "../lazyindex.ts": [
-        "../bar.ts"
-      ]
+      "2": 1,
+      "3": 0
     },
     "exportedModulesMap": {
-      "../index.ts": [
-        "../bundling.ts",
-        "../lazyindex.ts"
-      ],
-      "../lazyindex.ts": [
-        "../bar.ts"
-      ]
+      "2": 1,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1,
+        3
+      ]
+    ],
+    "mapFiles": [
+      "../bar.ts",
+      "../bundling.ts",
+      "../index.ts",
+      "../lazyindex.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../bar.ts",
@@ -309,23 +314,28 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../index.ts": [
-        "../bundling.ts",
-        "../lazyindex.ts"
-      ],
-      "../lazyindex.ts": [
-        "../bar.ts"
-      ]
+      "2": 1,
+      "3": 0
     },
     "exportedModulesMap": {
-      "../index.ts": [
-        "../bundling.ts",
-        "../lazyindex.ts"
-      ],
-      "../lazyindex.ts": [
-        "../bar.ts"
-      ]
+      "2": 1,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1,
+        3
+      ]
+    ],
+    "mapFiles": [
+      "../bar.ts",
+      "../bundling.ts",
+      "../index.ts",
+      "../lazyindex.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../bar.ts",
@@ -462,23 +472,28 @@ var bar_2 = require("./bar");
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../index.ts": [
-        "../bundling.ts",
-        "../lazyindex.ts"
-      ],
-      "../lazyindex.ts": [
-        "../bar.ts"
-      ]
+      "2": 1,
+      "3": 0
     },
     "exportedModulesMap": {
-      "../index.ts": [
-        "../bundling.ts",
-        "../lazyindex.ts"
-      ],
-      "../lazyindex.ts": [
-        "../bar.ts"
-      ]
+      "2": 1,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1,
+        3
+      ]
+    ],
+    "mapFiles": [
+      "../bar.ts",
+      "../bundling.ts",
+      "../index.ts",
+      "../lazyindex.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../bar.ts",

--- a/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-js-based-projects-and-emits-them-correctly.js
+++ b/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-js-based-projects-and-emits-them-correctly.js
@@ -159,6 +159,8 @@ module.exports = {};
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../lib.d.ts",
       "../../src/common/nominal.js"
@@ -211,11 +213,18 @@ exports.__esModule = true;
       "configFilePath": "../../src/sub-project/tsconfig.json"
     },
     "referencedMap": {
-      "../../src/sub-project/index.js": [
-        "../common/nominal.d.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../../src/sub-project/index.js",
+      "../common/nominal.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../common/nominal.d.ts",
       "../lib.d.ts",
@@ -289,18 +298,25 @@ exports.getVar = getVar;
       "configFilePath": "../../src/sub-project-2/tsconfig.json"
     },
     "referencedMap": {
-      "../sub-project/index.d.ts": [
-        "../common/nominal.d.ts"
-      ],
-      "../../src/sub-project-2/index.js": [
-        "../sub-project/index.d.ts"
-      ]
+      "0": 1,
+      "2": 0
     },
     "exportedModulesMap": {
-      "../sub-project/index.d.ts": [
-        "../common/nominal.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        1
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../../src/sub-project-2/index.js",
+      "../common/nominal.d.ts",
+      "../sub-project/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../common/nominal.d.ts",
       "../lib.d.ts",

--- a/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-js-based-projects-with-non-moved-json-files-and-emits-them-correctly.js
+++ b/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-js-based-projects-with-non-moved-json-files-and-emits-them-correctly.js
@@ -172,18 +172,25 @@ exports.m = common_1["default"];
       "configFilePath": "../../src/sub-project/tsconfig.json"
     },
     "referencedMap": {
-      "../../src/common/index.d.ts": [
-        "../../src/common/obj.json"
-      ],
-      "../../src/sub-project/index.js": [
-        "../../src/common/index.d.ts"
-      ]
+      "0": 1,
+      "2": 0
     },
     "exportedModulesMap": {
-      "../../src/common/index.d.ts": [
-        "../../src/common/obj.json"
-      ]
+      "0": 1
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../../src/common/index.d.ts",
+      "../../src/common/obj.json",
+      "../../src/sub-project/index.js"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../../src/common/index.d.ts",
@@ -249,11 +256,18 @@ exports.getVar = getVar;
       "configFilePath": "../../src/sub-project-2/tsconfig.json"
     },
     "referencedMap": {
-      "../../src/sub-project-2/index.js": [
-        "../sub-project/index.d.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../../src/sub-project-2/index.js",
+      "../sub-project/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../sub-project/index.d.ts",
@@ -307,15 +321,20 @@ module.exports = x;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "./obj.json"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "./obj.json"
-      ]
+      "0": 0
     },
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "./index.ts",
+      "./obj.json"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./index.ts",

--- a/tests/baselines/reference/tsbuild/lateBoundSymbol/initial-build/interface-is-merged-and-contains-late-bound-member.js
+++ b/tests/baselines/reference/tsbuild/lateBoundSymbol/initial-build/interface-is-merged-and-contains-late-bound-member.js
@@ -101,15 +101,20 @@ var x = 10;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/main.ts": [
-        "./src/hkt.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {
-      "./src/main.ts": [
-        "./src/hkt.ts"
-      ]
+      "1": 0
     },
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "./src/hkt.ts",
+      "./src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./src/globals.d.ts",
@@ -190,15 +195,20 @@ var sym = Symbol();
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/main.ts": [
-        "./src/hkt.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {
-      "./src/main.ts": [
-        "./src/hkt.ts"
-      ]
+      "1": 0
     },
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "./src/hkt.ts",
+      "./src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./src/globals.d.ts",

--- a/tests/baselines/reference/tsbuild/moduleResolution/resolves-specifier-in-output-declaration-file-from-referenced-project-correctly-with-preserveSymlinks.js
+++ b/tests/baselines/reference/tsbuild/moduleResolution/resolves-specifier-in-output-declaration-file-from-referenced-project-correctly-with-preserveSymlinks.js
@@ -171,15 +171,20 @@ export type { TheNum } from 'const';
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../index.ts": [
-        "../const.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {
-      "../index.ts": [
-        "../const.ts"
-      ]
+      "1": 0
     },
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../const.ts",
+      "../index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../../../a/lib/lib.d.ts",
       "../const.ts",

--- a/tests/baselines/reference/tsbuild/moduleResolution/resolves-specifier-in-output-declaration-file-from-referenced-project-correctly.js
+++ b/tests/baselines/reference/tsbuild/moduleResolution/resolves-specifier-in-output-declaration-file-from-referenced-project-correctly.js
@@ -171,15 +171,20 @@ export type { TheNum } from 'const';
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../index.ts": [
-        "../const.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {
-      "../index.ts": [
-        "../const.ts"
-      ]
+      "1": 0
     },
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../const.ts",
+      "../index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../../../a/lib/lib.d.ts",
       "../const.ts",

--- a/tests/baselines/reference/tsbuild/moduleSpecifiers/initial-build/synthesized-module-specifiers-resolve-correctly.js
+++ b/tests/baselines/reference/tsbuild/moduleSpecifiers/initial-build/synthesized-module-specifiers-resolve-correctly.js
@@ -173,6 +173,8 @@ exports.__esModule = true;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../lib/lib.d.ts",
       "../../../solution/common/nominal.ts"
@@ -219,15 +221,20 @@ exports.__esModule = true;
       "configFilePath": "../../../solution/sub-project/tsconfig.json"
     },
     "referencedMap": {
-      "../../../solution/sub-project/index.ts": [
-        "../common/nominal.d.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {
-      "../../../solution/sub-project/index.ts": [
-        "../common/nominal.d.ts"
-      ]
+      "0": 0
     },
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../../../solution/sub-project/index.ts",
+      "../common/nominal.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../lib/lib.d.ts",
       "../common/nominal.d.ts",
@@ -292,21 +299,26 @@ exports.getVar = getVar;
       "configFilePath": "../../../solution/sub-project-2/tsconfig.json"
     },
     "referencedMap": {
-      "../sub-project/index.d.ts": [
-        "../common/nominal.d.ts"
-      ],
-      "../../../solution/sub-project-2/index.ts": [
-        "../sub-project/index.d.ts"
-      ]
+      "0": 1,
+      "2": 0
     },
     "exportedModulesMap": {
-      "../sub-project/index.d.ts": [
-        "../common/nominal.d.ts"
-      ],
-      "../../../solution/sub-project-2/index.ts": [
-        "../sub-project/index.d.ts"
-      ]
+      "0": 1,
+      "2": 0
     },
+    "mapLists": [
+      [
+        1
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../../../solution/sub-project-2/index.ts",
+      "../common/nominal.d.ts",
+      "../sub-project/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../lib/lib.d.ts",
       "../common/nominal.d.ts",

--- a/tests/baselines/reference/tsbuild/noEmitOnError/initial-build/semantic-errors-with-incremental.js
+++ b/tests/baselines/reference/tsbuild/noEmitOnError/initial-build/semantic-errors-with-incremental.js
@@ -97,11 +97,18 @@ Semantic diagnostics in builder refreshed for::
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -242,11 +249,18 @@ console.log("hi");
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../shared/types/db.ts",

--- a/tests/baselines/reference/tsbuild/noEmitOnError/initial-build/syntax-errors-with-incremental.js
+++ b/tests/baselines/reference/tsbuild/noEmitOnError/initial-build/syntax-errors-with-incremental.js
@@ -184,11 +184,18 @@ console.log("hi");
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../shared/types/db.ts",

--- a/tests/baselines/reference/tsbuild/outFile/initial-build/non-module-projects-without-prepend.js
+++ b/tests/baselines/reference/tsbuild/outFile/initial-build/non-module-projects-without-prepend.js
@@ -237,6 +237,8 @@ function f() {
       "skipDefaultLibCheck": true,
       "configFilePath": "./tsconfig.json"
     },
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./first_part1.ts",
@@ -325,6 +327,8 @@ var C = (function () {
       "skipDefaultLibCheck": true,
       "configFilePath": "./tsconfig.json"
     },
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./second_part1.ts",
@@ -401,6 +405,8 @@ c.doSomething();
       "skipDefaultLibCheck": true,
       "configFilePath": "./tsconfig.json"
     },
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../first/first_part1.d.ts",

--- a/tests/baselines/reference/tsbuild/outputPaths/initial-build/when-rootDir-is-not-specified-and-is-composite.js
+++ b/tests/baselines/reference/tsbuild/outputPaths/initial-build/when-rootDir-is-not-specified-and-is-composite.js
@@ -67,6 +67,8 @@ exports.x = 10;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../src/index.ts"

--- a/tests/baselines/reference/tsbuild/outputPaths/initial-build/when-rootDir-is-specified-but-not-all-files-belong-to-rootDir-and-is-composite.js
+++ b/tests/baselines/reference/tsbuild/outputPaths/initial-build/when-rootDir-is-specified-but-not-all-files-belong-to-rootDir-and-is-composite.js
@@ -127,6 +127,8 @@ exports.x = 10;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": []
   },
   "version": "FakeTSVersion"

--- a/tests/baselines/reference/tsbuild/projectReferenceWithRootDirInParent/initial-build/builds-correctly.js
+++ b/tests/baselines/reference/tsbuild/projectReferenceWithRootDirInParent/initial-build/builds-correctly.js
@@ -111,11 +111,18 @@ exports.b = 0;
       "configFilePath": "../../src/main/tsconfig.json"
     },
     "referencedMap": {
-      "../../src/main/a.ts": [
-        "../../src/main/b.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../../src/main/a.ts",
+      "../../src/main/b.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "../../src/main/a.ts",
@@ -161,6 +168,8 @@ exports.Other = 0;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "../../src/other/other.ts"

--- a/tests/baselines/reference/tsbuild/projectReferenceWithRootDirInParent/initial-build/reports-error-for-same-tsbuildinfo-file-because-no-rootDir-in-the-base.js
+++ b/tests/baselines/reference/tsbuild/projectReferenceWithRootDirInParent/initial-build/reports-error-for-same-tsbuildinfo-file-because-no-rootDir-in-the-base.js
@@ -115,6 +115,8 @@ exports.Other = 0;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../src/other/other.ts"

--- a/tests/baselines/reference/tsbuild/projectReferenceWithRootDirInParent/initial-build/reports-error-for-same-tsbuildinfo-file.js
+++ b/tests/baselines/reference/tsbuild/projectReferenceWithRootDirInParent/initial-build/reports-error-for-same-tsbuildinfo-file.js
@@ -95,6 +95,8 @@ exports.Other = 0;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../src/other/other.ts"

--- a/tests/baselines/reference/tsbuild/projectReferenceWithRootDirInParent/initial-build/reports-no-error-when-tsbuildinfo-differ.js
+++ b/tests/baselines/reference/tsbuild/projectReferenceWithRootDirInParent/initial-build/reports-no-error-when-tsbuildinfo-differ.js
@@ -113,11 +113,18 @@ exports.Other = 0;
       "configFilePath": "../src/main/tsconfig.main.json"
     },
     "referencedMap": {
-      "../src/main/a.ts": [
-        "../src/main/b.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../src/main/a.ts",
+      "../src/main/b.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../src/main/a.ts",
@@ -149,6 +156,8 @@ exports.Other = 0;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../src/other/other.ts"

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/files-containing-json-file.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/files-containing-json-file.js
@@ -125,11 +125,18 @@ exports["default"] = hello_json_1["default"].hello;
       "configFilePath": "../tsconfig_withFiles.json"
     },
     "referencedMap": {
-      "../src/index.ts": [
-        "../src/hello.json"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../src/hello.json",
+      "../src/index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../src/hello.json",

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/importing-json-module-from-project-reference.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/importing-json-module-from-project-reference.js
@@ -139,11 +139,18 @@ console.log(foo_json_1.foo);
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../strings/foo.json"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../strings/foo.json",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./index.ts",
@@ -181,6 +188,8 @@ console.log(foo_json_1.foo);
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./foo.json"

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/include-and-files.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/include-and-files.js
@@ -128,11 +128,18 @@ exports["default"] = hello_json_1["default"].hello;
       "configFilePath": "../tsconfig_withIncludeAndFiles.json"
     },
     "referencedMap": {
-      "../src/index.ts": [
-        "../src/hello.json"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../src/hello.json",
+      "../src/index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../src/hello.json",

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/include-of-json-along-with-other-include-and-file-name-matches-ts-file.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/include-of-json-along-with-other-include-and-file-name-matches-ts-file.js
@@ -121,11 +121,18 @@ exports["default"] = index_json_1["default"].hello;
       "configFilePath": "../tsconfig_withIncludeOfJson.json"
     },
     "referencedMap": {
-      "../src/index.ts": [
-        "../src/index.json"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../src/index.json",
+      "../src/index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../src/index.json",

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/include-of-json-along-with-other-include.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/include-of-json-along-with-other-include.js
@@ -125,11 +125,18 @@ exports["default"] = hello_json_1["default"].hello;
       "configFilePath": "../tsconfig_withIncludeOfJson.json"
     },
     "referencedMap": {
-      "../src/index.ts": [
-        "../src/hello.json"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../src/hello.json",
+      "../src/index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../src/hello.json",

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/include-only.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/include-only.js
@@ -111,11 +111,18 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsSkipped
       "configFilePath": "../tsconfig_withInclude.json"
     },
     "referencedMap": {
-      "../src/index.ts": [
-        "../src/hello.json"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../src/hello.json",
+      "../src/index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../src/hello.json",

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/sourcemap.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/sourcemap.js
@@ -129,11 +129,18 @@ exports["default"] = hello_json_1["default"].hello;
       "configFilePath": "../tsconfig_withFiles.json"
     },
     "referencedMap": {
-      "../src/index.ts": [
-        "../src/hello.json"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../src/hello.json",
+      "../src/index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../src/hello.json",

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/without-outDir.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/without-outDir.js
@@ -110,11 +110,18 @@ exports["default"] = hello_json_1["default"].hello;
       "configFilePath": "./tsconfig_withFiles.json"
     },
     "referencedMap": {
-      "./src/index.ts": [
-        "./src/hello.json"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "./src/hello.json",
+      "./src/index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./src/hello.json",

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/Detects-type-only-changes-in-upstream-projects.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/Detects-type-only-changes-in-upstream-projects.js
@@ -80,6 +80,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/rebuilds-when-tsconfig-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/rebuilds-when-tsconfig-changes.js
@@ -75,23 +75,29 @@ exitCode:: ExitStatus.Success
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-doesnt-change/Only-builds-the-leaf-node-project.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-doesnt-change/Only-builds-the-leaf-node-project.js
@@ -54,6 +54,8 @@ var m = 10;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./index.ts"

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/always-builds-under-with-force-option.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/always-builds-under-with-force-option.js
@@ -169,6 +169,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -235,16 +237,25 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -310,23 +321,29 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/builds-correctly-when-declarationDir-is-specified.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/builds-correctly-when-declarationDir-is-specified.js
@@ -157,6 +157,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -222,16 +224,25 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -297,23 +308,29 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/out/decls/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/out/decls/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/out/decls/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/out/decls/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/builds-correctly-when-outDir-is-specified.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/builds-correctly-when-outDir-is-specified.js
@@ -157,6 +157,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -222,16 +224,25 @@ exports.m = mod;
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../index.ts": [
-        "../../core/anothermodule.d.ts",
-        "../../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "../index.ts": [
-        "../../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../../core/anothermodule.d.ts",
+      "../../core/index.d.ts",
+      "../index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "../../core/anothermodule.d.ts",
@@ -297,23 +308,29 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/outdir/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/outdir/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/outdir/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/outdir/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/can-detect-when-and-what-to-rebuild.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/can-detect-when-and-what-to-rebuild.js
@@ -73,6 +73,8 @@ Input::
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -144,16 +146,25 @@ Input::
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -226,23 +237,29 @@ Input::
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/does-not-build-downstream-projects-if-upstream-projects-have-errors.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/does-not-build-downstream-projects-if-upstream-projects-have-errors.js
@@ -186,6 +186,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -230,16 +232,25 @@ exports.multiply = multiply;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/explainFiles.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/explainFiles.js
@@ -219,6 +219,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -286,16 +288,25 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -362,23 +373,29 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -522,6 +539,8 @@ exports.someClass = someClass;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -570,16 +589,25 @@ exports.someClass = someClass;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -631,23 +659,29 @@ exports.someClass = someClass;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -764,6 +798,8 @@ var someClass2 = /** @class */ (function () {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/listEmittedFiles.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/listEmittedFiles.js
@@ -184,6 +184,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -251,16 +253,25 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -327,23 +338,29 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -447,6 +464,8 @@ exports.someClass = someClass;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -495,16 +514,25 @@ exports.someClass = someClass;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -556,23 +584,29 @@ exports.someClass = someClass;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -666,6 +700,8 @@ var someClass2 = /** @class */ (function () {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/listFiles.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/listFiles.js
@@ -183,6 +183,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -250,16 +252,25 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -326,23 +337,29 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -448,6 +465,8 @@ exports.someClass = someClass;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -496,16 +515,25 @@ exports.someClass = someClass;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -557,23 +585,29 @@ exports.someClass = someClass;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -667,6 +701,8 @@ var someClass2 = /** @class */ (function () {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/rebuilds-when-extended-config-file-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/rebuilds-when-extended-config-file-changes.js
@@ -189,6 +189,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -255,16 +257,25 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -331,23 +342,29 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -426,23 +443,29 @@ exitCode:: ExitStatus.Success
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/sample.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/sample.js
@@ -351,6 +351,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -542,16 +544,25 @@ sourceFile:index.ts
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -617,23 +628,29 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -895,6 +912,8 @@ exports.someClass = someClass;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -943,16 +962,25 @@ exports.someClass = someClass;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -1003,23 +1031,29 @@ exports.someClass = someClass;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -1139,6 +1173,8 @@ var someClass2 = /** @class */ (function () {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -1248,16 +1284,25 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -1308,23 +1353,29 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/decls/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/decls/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/decls/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/decls/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/when-declaration-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/when-declaration-option-changes.js
@@ -118,6 +118,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -199,6 +201,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/when-esModuleInterop-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/when-esModuleInterop-option-changes.js
@@ -187,6 +187,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -253,16 +255,25 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -329,23 +340,29 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -468,23 +485,29 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/when-logic-specifies-tsBuildInfoFile.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/when-logic-specifies-tsBuildInfoFile.js
@@ -352,6 +352,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -544,16 +546,25 @@ sourceFile:index.ts
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -619,23 +630,29 @@ exports.m = mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/when-module-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/when-module-option-changes.js
@@ -118,6 +118,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",
@@ -208,6 +210,8 @@ define(["require", "exports"], function (require, exports) {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./anothermodule.ts",

--- a/tests/baselines/reference/tsbuild/sample1/initial-build/when-target-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-build/when-target-option-changes.js
@@ -135,6 +135,8 @@ export function multiply(a, b) { return a * b; }
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.esnext.d.ts",
       "../../lib/lib.esnext.full.d.ts",
@@ -239,6 +241,8 @@ exports.multiply = multiply;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../../lib/lib.esnext.d.ts",

--- a/tests/baselines/reference/tsbuild/transitiveReferences/initial-build/builds-correctly-when-the-referenced-project-uses-different-module-resolution.js
+++ b/tests/baselines/reference/tsbuild/transitiveReferences/initial-build/builds-correctly-when-the-referenced-project-uses-different-module-resolution.js
@@ -131,6 +131,8 @@ a_1.X;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./a.ts"
@@ -166,15 +168,20 @@ a_1.X;
       "configFilePath": "./tsconfig.b.json"
     },
     "referencedMap": {
-      "./b.ts": [
-        "./a.d.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {
-      "./b.ts": [
-        "./a.d.ts"
-      ]
+      "1": 0
     },
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "./a.d.ts",
+      "./b.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./a.d.ts",

--- a/tests/baselines/reference/tsbuild/transitiveReferences/initial-build/builds-correctly.js
+++ b/tests/baselines/reference/tsbuild/transitiveReferences/initial-build/builds-correctly.js
@@ -143,6 +143,8 @@ a_1.X;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./a.ts"
@@ -184,15 +186,20 @@ a_1.X;
       "configFilePath": "./tsconfig.b.json"
     },
     "referencedMap": {
-      "./b.ts": [
-        "./a.d.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {
-      "./b.ts": [
-        "./a.d.ts"
-      ]
+      "1": 0
     },
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "./a.d.ts",
+      "./b.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./a.d.ts",

--- a/tests/baselines/reference/tsbuild/transitiveReferences/initial-build/reports-error-about-module-not-found-with-node-resolution-with-external-module-name.js
+++ b/tests/baselines/reference/tsbuild/transitiveReferences/initial-build/reports-error-about-module-not-found-with-node-resolution-with-external-module-name.js
@@ -106,6 +106,8 @@ exports.A = A;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       "./a.ts"
@@ -137,6 +139,8 @@ exports.A = A;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../lib/lib.d.ts",
       [

--- a/tests/baselines/reference/tsbuild/watchMode/configFileErrors/reports-syntax-errors-in-config-file.js
+++ b/tests/baselines/reference/tsbuild/watchMode/configFileErrors/reports-syntax-errors-in-config-file.js
@@ -305,6 +305,8 @@ export declare function bar(): void;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./a.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/demo/updates-with-bad-reference.js
+++ b/tests/baselines/reference/tsbuild/watchMode/demo/updates-with-bad-reference.js
@@ -318,27 +318,33 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../../core/tsconfig.json"
     },
     "referencedMap": {
-      "../../animals/dog.ts": [
-        "../../animals/index.ts",
-        "../../core/utilities.ts"
-      ],
-      "../../animals/index.ts": [
-        "../../animals/animal.ts",
-        "../../animals/dog.ts"
-      ],
-      "../../core/utilities.ts": [
-        "../../animals/index.ts"
-      ]
+      "1": 2,
+      "2": 1,
+      "3": 0
     },
     "exportedModulesMap": {
-      "../../animals/dog.ts": [
-        "../../animals/index.ts"
-      ],
-      "../../animals/index.ts": [
-        "../../animals/animal.ts",
-        "../../animals/dog.ts"
-      ]
+      "1": 0,
+      "2": 1
     },
+    "mapLists": [
+      [
+        2
+      ],
+      [
+        0,
+        1
+      ],
+      [
+        2,
+        3
+      ]
+    ],
+    "mapFiles": [
+      "../../animals/animal.ts",
+      "../../animals/dog.ts",
+      "../../animals/index.ts",
+      "../../core/utilities.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../../a/lib/lib.d.ts",
       "../../animals/animal.ts",
@@ -557,27 +563,33 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../../core/tsconfig.json"
     },
     "referencedMap": {
-      "../../animals/dog.ts": [
-        "../../animals/index.ts",
-        "../../core/utilities.ts"
-      ],
-      "../../animals/index.ts": [
-        "../../animals/animal.ts",
-        "../../animals/dog.ts"
-      ],
-      "../../core/utilities.ts": [
-        "../../animals/index.ts"
-      ]
+      "1": 2,
+      "2": 1,
+      "3": 0
     },
     "exportedModulesMap": {
-      "../../animals/dog.ts": [
-        "../../animals/index.ts"
-      ],
-      "../../animals/index.ts": [
-        "../../animals/animal.ts",
-        "../../animals/dog.ts"
-      ]
+      "1": 0,
+      "2": 1
     },
+    "mapLists": [
+      [
+        2
+      ],
+      [
+        0,
+        1
+      ],
+      [
+        2,
+        3
+      ]
+    ],
+    "mapFiles": [
+      "../../animals/animal.ts",
+      "../../animals/dog.ts",
+      "../../animals/index.ts",
+      "../../core/utilities.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../../a/lib/lib.d.ts",
       "../../animals/animal.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/demo/updates-with-circular-reference.js
+++ b/tests/baselines/reference/tsbuild/watchMode/demo/updates-with-circular-reference.js
@@ -367,6 +367,8 @@ export declare function lastElementOf<T>(arr: T[]): T | undefined;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../../a/lib/lib.d.ts",
       "../../core/utilities.ts"
@@ -474,24 +476,32 @@ export declare function createDog(): Dog;
       "configFilePath": "../../animals/tsconfig.json"
     },
     "referencedMap": {
-      "../../animals/dog.ts": [
-        "../../animals/index.ts",
-        "../core/utilities.d.ts"
-      ],
-      "../../animals/index.ts": [
-        "../../animals/animal.ts",
-        "../../animals/dog.ts"
-      ]
+      "1": 2,
+      "2": 1
     },
     "exportedModulesMap": {
-      "../../animals/dog.ts": [
-        "../../animals/index.ts"
-      ],
-      "../../animals/index.ts": [
-        "../../animals/animal.ts",
-        "../../animals/dog.ts"
-      ]
+      "1": 0,
+      "2": 1
     },
+    "mapLists": [
+      [
+        2
+      ],
+      [
+        0,
+        1
+      ],
+      [
+        2,
+        3
+      ]
+    ],
+    "mapFiles": [
+      "../../animals/animal.ts",
+      "../../animals/dog.ts",
+      "../../animals/index.ts",
+      "../core/utilities.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../../a/lib/lib.d.ts",
       "../../animals/animal.ts",
@@ -567,29 +577,30 @@ export declare function createZoo(): Array<Dog>;
       "configFilePath": "../../zoo/tsconfig.json"
     },
     "referencedMap": {
-      "../animals/dog.d.ts": [
-        "../animals/index.d.ts"
-      ],
-      "../animals/index.d.ts": [
-        "../animals/animal.d.ts",
-        "../animals/dog.d.ts"
-      ],
-      "../../zoo/zoo.ts": [
-        "../animals/index.d.ts"
-      ]
+      "0": 0,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../animals/dog.d.ts": [
-        "../animals/index.d.ts"
-      ],
-      "../animals/index.d.ts": [
-        "../animals/animal.d.ts",
-        "../animals/dog.d.ts"
-      ],
-      "../../zoo/zoo.ts": [
-        "../animals/index.d.ts"
-      ]
+      "0": 0,
+      "2": 0,
+      "3": 1
     },
+    "mapLists": [
+      [
+        3
+      ],
+      [
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../../zoo/zoo.ts",
+      "../animals/animal.d.ts",
+      "../animals/dog.d.ts",
+      "../animals/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../../a/lib/lib.d.ts",
       "../animals/animal.d.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/noEmitOnError/does-not-emit-any-files-on-error-with-incremental.js
+++ b/tests/baselines/reference/tsbuild/watchMode/noEmitOnError/does-not-emit-any-files-on-error-with-incremental.js
@@ -259,11 +259,18 @@ console.log("hi");
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -363,11 +370,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -542,11 +556,18 @@ var a = "hello";
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/creates-solution-in-watch-mode.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/creates-solution-in-watch-mode.js
@@ -246,6 +246,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -312,16 +314,25 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -388,23 +399,29 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/incremental-updates-in-verbose-mode.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/incremental-updates-in-verbose-mode.js
@@ -263,6 +263,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -329,16 +331,25 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -405,23 +416,29 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -555,16 +572,25 @@ function someFn() { }
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -721,16 +747,25 @@ export declare function someFn(): void;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -782,23 +817,29 @@ export declare function someFn(): void;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/declarationEmitErrors/introduceError/when-file-with-no-error-changes.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/declarationEmitErrors/introduceError/when-file-with-no-error-changes.js
@@ -127,6 +127,8 @@ export declare class myClass {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./filewitherror.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/declarationEmitErrors/introduceError/when-fixing-errors-only-changed-file-is-emitted.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/declarationEmitErrors/introduceError/when-fixing-errors-only-changed-file-is-emitted.js
@@ -127,6 +127,8 @@ export declare class myClass {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./filewitherror.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/declarationEmitErrors/when-fixing-error-files-all-files-are-emitted.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/declarationEmitErrors/when-fixing-error-files-all-files-are-emitted.js
@@ -178,6 +178,8 @@ export declare class myClass {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./filewitherror.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/when-preserveWatchOutput-is-not-used.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/when-preserveWatchOutput-is-not-used.js
@@ -246,6 +246,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -312,16 +314,25 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -388,23 +399,29 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -517,16 +534,25 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -652,6 +678,8 @@ exitCode:: ExitStatus.undefined
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/when-preserveWatchOutput-is-passed-on-command-line.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/reportErrors/when-preserveWatchOutput-is-passed-on-command-line.js
@@ -246,6 +246,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -313,16 +315,25 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -390,23 +401,29 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -519,16 +536,25 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -654,6 +680,8 @@ exitCode:: ExitStatus.undefined
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/should-not-trigger-recompilation-because-of-program-emit-with-outDir-specified.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/should-not-trigger-recompilation-because-of-program-emit-with-outDir-specified.js
@@ -127,6 +127,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../../a/lib/lib.d.ts",
       "../anothermodule.ts",
@@ -248,6 +250,8 @@ exitCode:: ExitStatus.undefined
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../../a/lib/lib.d.ts",
       "../anothermodule.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/should-not-trigger-recompilation-because-of-program-emit.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/should-not-trigger-recompilation-because-of-program-emit.js
@@ -142,6 +142,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -267,6 +269,8 @@ exitCode:: ExitStatus.undefined
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/watches-config-files-that-are-not-present.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/watches-config-files-that-are-not-present.js
@@ -178,6 +178,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -311,16 +313,25 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -440,23 +451,29 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/when-referenced-project-change-introduces-error-in-the-down-stream-project-and-then-fixes-it.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/when-referenced-project-change-introduces-error-in-the-down-stream-project-and-then-fixes-it.js
@@ -132,6 +132,8 @@ export {};
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./library.ts"
@@ -268,6 +270,8 @@ export {};
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./library.ts"
@@ -387,6 +391,8 @@ export {};
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./library.ts"

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-circular-project-reference/builds-when-new-file-is-added,-and-its-subsequent-updates.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-circular-project-reference/builds-when-new-file-is-added,-and-its-subsequent-updates.js
@@ -212,6 +212,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -278,16 +280,25 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -354,23 +365,29 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -473,6 +490,8 @@ exitCode:: ExitStatus.undefined
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -689,6 +708,8 @@ exitCode:: ExitStatus.undefined
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-circular-project-reference/change-builds-changes-and-reports-found-errors-message.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-circular-project-reference/change-builds-changes-and-reports-found-errors-message.js
@@ -212,6 +212,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -278,16 +280,25 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -354,23 +365,29 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -492,6 +509,8 @@ export declare class someClass {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -585,16 +604,25 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -696,23 +724,29 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -825,6 +859,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -918,16 +954,25 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -1029,23 +1074,29 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -1176,6 +1227,8 @@ export declare class someClass2 {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -1269,16 +1322,25 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -1380,23 +1442,29 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-circular-project-reference/non-local-change-does-not-start-build-of-referencing-projects.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-circular-project-reference/non-local-change-does-not-start-build-of-referencing-projects.js
@@ -212,6 +212,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -278,16 +280,25 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -354,23 +365,29 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -480,6 +497,8 @@ function foo() { }
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-simple-project-reference-graph/builds-when-new-file-is-added,-and-its-subsequent-updates.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-simple-project-reference-graph/builds-when-new-file-is-added,-and-its-subsequent-updates.js
@@ -246,6 +246,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -312,16 +314,25 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -388,23 +399,29 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -511,6 +528,8 @@ exitCode:: ExitStatus.undefined
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -734,6 +753,8 @@ exitCode:: ExitStatus.undefined
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-simple-project-reference-graph/change-builds-changes-and-reports-found-errors-message.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-simple-project-reference-graph/change-builds-changes-and-reports-found-errors-message.js
@@ -246,6 +246,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -312,16 +314,25 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -388,23 +399,29 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -532,6 +549,8 @@ export declare class someClass {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -625,16 +644,25 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -736,23 +764,29 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -871,6 +905,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -964,16 +1000,25 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -1075,23 +1120,29 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -1228,6 +1279,8 @@ export declare class someClass2 {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -1321,16 +1374,25 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -1432,23 +1494,29 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-simple-project-reference-graph/non-local-change-does-not-start-build-of-referencing-projects.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/with-simple-project-reference-graph/non-local-change-does-not-start-build-of-referencing-projects.js
@@ -246,6 +246,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -312,16 +314,25 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -388,23 +399,29 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -518,6 +535,8 @@ function foo() { }
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/works-correctly-when-project-with-extended-config-is-removed.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/works-correctly-when-project-with-extended-config-is-removed.js
@@ -150,6 +150,8 @@ declare let y: number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "./commonfile1.ts",
       "./commonfile2.ts",
@@ -189,6 +191,8 @@ declare let z: number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "./other.ts",
       "../lib/lib.d.ts"

--- a/tests/baselines/reference/tsbuild/watchMode/programUpdates/works-with-extended-source-files.js
+++ b/tests/baselines/reference/tsbuild/watchMode/programUpdates/works-with-extended-source-files.js
@@ -144,6 +144,8 @@ declare let y: number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "./commonfile1.ts",
       "./commonfile2.ts",
@@ -183,6 +185,8 @@ declare let z: number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "./other.ts",
       "../lib/lib.d.ts"

--- a/tests/baselines/reference/tsbuild/watchMode/reexport/Reports-errors-correctly.js
+++ b/tests/baselines/reference/tsbuild/watchMode/reexport/Reports-errors-correctly.js
@@ -197,15 +197,20 @@ export * from "./session";
       "configFilePath": "../../src/pure/tsconfig.json"
     },
     "referencedMap": {
-      "../../src/pure/index.ts": [
-        "../../src/pure/session.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {
-      "../../src/pure/index.ts": [
-        "../../src/pure/session.ts"
-      ]
+      "0": 0
     },
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../../src/pure/index.ts",
+      "../../src/pure/session.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../../a/lib/lib.d.ts",
       "../../src/pure/index.ts",
@@ -350,15 +355,20 @@ export interface Session {
       "configFilePath": "../../src/pure/tsconfig.json"
     },
     "referencedMap": {
-      "../../src/pure/index.ts": [
-        "../../src/pure/session.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {
-      "../../src/pure/index.ts": [
-        "../../src/pure/session.ts"
-      ]
+      "0": 0
     },
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../../src/pure/index.ts",
+      "../../src/pure/session.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../../a/lib/lib.d.ts",
       "../../src/pure/index.ts",
@@ -485,15 +495,20 @@ export interface Session {
       "configFilePath": "../../src/pure/tsconfig.json"
     },
     "referencedMap": {
-      "../../src/pure/index.ts": [
-        "../../src/pure/session.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {
-      "../../src/pure/index.ts": [
-        "../../src/pure/session.ts"
-      ]
+      "0": 0
     },
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../../src/pure/index.ts",
+      "../../src/pure/session.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../../a/lib/lib.d.ts",
       "../../src/pure/index.ts",

--- a/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-composite.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-composite.js
@@ -193,21 +193,27 @@ function someFunc(arguments) {
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -342,21 +348,27 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -521,21 +533,27 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -735,21 +753,27 @@ exports.classC = classC;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -1029,21 +1053,27 @@ exitCode:: ExitStatus.Success
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -1176,21 +1206,27 @@ exports.classC = classC;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",

--- a/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-incremental-declaration.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-incremental-declaration.js
@@ -194,21 +194,27 @@ function someFunc(arguments) {
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -344,21 +350,27 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -524,21 +536,27 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -739,21 +757,27 @@ exports.classC = classC;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -1034,21 +1058,27 @@ exitCode:: ExitStatus.Success
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -1182,21 +1212,27 @@ exports.classC = classC;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",

--- a/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-incremental.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-incremental.js
@@ -164,21 +164,27 @@ function someFunc(arguments) {
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -313,21 +319,27 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -480,21 +492,27 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -685,21 +703,27 @@ exports.classC = classC;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -979,21 +1003,27 @@ exitCode:: ExitStatus.Success
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -1109,21 +1139,27 @@ exports.classC = classC;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",

--- a/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-with-initial-noEmit-composite.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-with-initial-noEmit-composite.js
@@ -98,21 +98,27 @@ exitCode:: ExitStatus.Success
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -318,21 +324,27 @@ function someFunc(arguments) {
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -472,21 +484,27 @@ exports.classC = classC;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -620,21 +638,27 @@ exitCode:: ExitStatus.Success
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -767,21 +791,27 @@ exports.classC = classC;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",

--- a/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-with-initial-noEmit-incremental-declaration.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-with-initial-noEmit-incremental-declaration.js
@@ -99,21 +99,27 @@ exitCode:: ExitStatus.Success
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -320,21 +326,27 @@ function someFunc(arguments) {
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -475,21 +487,27 @@ exports.classC = classC;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -624,21 +642,27 @@ exitCode:: ExitStatus.Success
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -772,21 +796,27 @@ exports.classC = classC;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",

--- a/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-with-initial-noEmit-incremental.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/noEmit-changes-with-initial-noEmit-incremental.js
@@ -98,21 +98,27 @@ exitCode:: ExitStatus.Success
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -289,21 +295,27 @@ function someFunc(arguments) {
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -434,21 +446,27 @@ exports.classC = classC;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -582,21 +600,27 @@ exitCode:: ExitStatus.Success
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",
@@ -712,21 +736,27 @@ exports.classC = classC;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./src/directuse.ts": [
-        "./src/indirectclass.ts"
-      ],
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ],
-      "./src/indirectuse.ts": [
-        "./src/indirectclass.ts"
-      ]
+      "1": 1,
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "./src/indirectclass.ts": [
-        "./src/class.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./src/class.ts",
+      "./src/directuse.ts",
+      "./src/indirectclass.ts",
+      "./src/indirectuse.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/class.ts",

--- a/tests/baselines/reference/tsc/incremental/initial-build/when-passing-filename-for-buildinfo-on-commandline.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/when-passing-filename-for-buildinfo-on-commandline.js
@@ -65,6 +65,8 @@ exitCode:: ExitStatus.Success
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/main.ts"

--- a/tests/baselines/reference/tsc/incremental/initial-build/when-passing-rootDir-from-commandline.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/when-passing-rootDir-from-commandline.js
@@ -63,6 +63,8 @@ exports.x = 10;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/main.ts"

--- a/tests/baselines/reference/tsc/incremental/initial-build/when-passing-rootDir-is-in-the-tsconfig.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/when-passing-rootDir-is-in-the-tsconfig.js
@@ -64,6 +64,8 @@ exports.x = 10;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
       "../src/main.ts"

--- a/tests/baselines/reference/tsc/incremental/initial-build/with-noEmitOnError-semantic-errors.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/with-noEmitOnError-semantic-errors.js
@@ -98,11 +98,18 @@ Semantic diagnostics in builder refreshed for::
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -244,11 +251,18 @@ console.log("hi");
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../shared/types/db.ts",

--- a/tests/baselines/reference/tsc/incremental/initial-build/with-noEmitOnError-syntax-errors.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/with-noEmitOnError-syntax-errors.js
@@ -105,11 +105,18 @@ Semantic diagnostics in builder refreshed for::
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -248,11 +255,18 @@ console.log("hi");
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "../shared/types/db.ts",

--- a/tests/baselines/reference/tsc/incremental/initial-build/with-only-dts-files.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/with-only-dts-files.js
@@ -57,6 +57,8 @@ exitCode:: ExitStatus.Success
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/another.d.ts",
@@ -118,6 +120,8 @@ exitCode:: ExitStatus.Success
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./src/another.d.ts",

--- a/tests/baselines/reference/tsc/react-jsx-emit-mode/initial-build/with-no-backing-types-found-doesn't-crash-under---strict.js
+++ b/tests/baselines/reference/tsc/react-jsx-emit-mode/initial-build/with-no-backing-types-found-doesn't-crash-under---strict.js
@@ -92,6 +92,8 @@ exports.App = App;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./node_modules/@types/react/index.d.ts",

--- a/tests/baselines/reference/tsc/react-jsx-emit-mode/initial-build/with-no-backing-types-found-doesn't-crash.js
+++ b/tests/baselines/reference/tsc/react-jsx-emit-mode/initial-build/with-no-backing-types-found-doesn't-crash.js
@@ -83,6 +83,8 @@ exports.App = App;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
       "./node_modules/@types/react/index.d.ts",

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/with-noEmitOnError-with-incremental.js
@@ -123,11 +123,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -296,11 +303,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -420,11 +434,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -590,11 +611,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/with-noEmitOnError-with-incremental.js
@@ -124,11 +124,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -298,11 +305,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -437,11 +451,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -608,11 +629,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/with-noEmitOnError-with-incremental.js
@@ -128,11 +128,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -300,11 +307,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -423,11 +437,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -592,11 +613,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/with-noEmitOnError-with-incremental.js
@@ -123,11 +123,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -296,11 +303,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -434,11 +448,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -604,11 +625,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/with-noEmitOnError-with-incremental.js
@@ -123,11 +123,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -296,11 +303,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -420,11 +434,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -590,11 +611,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/with-noEmitOnError-with-incremental.js
@@ -124,11 +124,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -298,11 +305,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -437,11 +451,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",
@@ -608,11 +629,18 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "../tsconfig.json"
     },
     "referencedMap": {
-      "../src/main.ts": [
-        "../shared/types/db.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../shared/types/db.ts",
+      "../src/main.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../shared/types/db.ts",

--- a/tests/baselines/reference/tscWatch/incremental/importHelpers-backing-types-removed-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/importHelpers-backing-types-removed-incremental.js
@@ -86,11 +86,18 @@ exports.x = (0, tslib_1.__assign)({});
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.tsx": [
-        "./node_modules/tslib/index.d.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {},
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "./index.tsx",
+      "./node_modules/tslib/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./index.tsx",
@@ -159,6 +166,8 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       [

--- a/tests/baselines/reference/tscWatch/incremental/incremental-with-circular-references-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/incremental-with-circular-references-incremental.js
@@ -138,37 +138,39 @@ export { C } from "./c";
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./a.ts": [
-        "./b.ts"
-      ],
-      "./b.ts": [
-        "./c.ts"
-      ],
-      "./c.ts": [
-        "./a.ts"
-      ],
-      "./index.ts": [
-        "./a.ts",
-        "./b.ts",
-        "./c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
     "exportedModulesMap": {
-      "./a.ts": [
-        "./b.ts"
-      ],
-      "./b.ts": [
-        "./c.ts"
-      ],
-      "./c.ts": [
-        "./a.ts"
-      ],
-      "./index.ts": [
-        "./a.ts",
-        "./b.ts",
-        "./c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1
+      ],
+      [
+        2
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./a.ts",
+      "./b.ts",
+      "./c.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./a.ts",
@@ -270,37 +272,39 @@ export interface A {
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./a.ts": [
-        "./b.ts"
-      ],
-      "./b.ts": [
-        "./c.ts"
-      ],
-      "./c.ts": [
-        "./a.ts"
-      ],
-      "./index.ts": [
-        "./a.ts",
-        "./b.ts",
-        "./c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
     "exportedModulesMap": {
-      "./a.ts": [
-        "./b.ts"
-      ],
-      "./b.ts": [
-        "./c.ts"
-      ],
-      "./c.ts": [
-        "./a.ts"
-      ],
-      "./index.ts": [
-        "./a.ts",
-        "./b.ts",
-        "./c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1
+      ],
+      [
+        2
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./a.ts",
+      "./b.ts",
+      "./c.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./a.ts",

--- a/tests/baselines/reference/tscWatch/incremental/incremental-with-circular-references-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/incremental-with-circular-references-watch.js
@@ -160,37 +160,39 @@ export { C } from "./c";
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./a.ts": [
-        "./b.ts"
-      ],
-      "./b.ts": [
-        "./c.ts"
-      ],
-      "./c.ts": [
-        "./a.ts"
-      ],
-      "./index.ts": [
-        "./a.ts",
-        "./b.ts",
-        "./c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
     "exportedModulesMap": {
-      "./a.ts": [
-        "./b.ts"
-      ],
-      "./b.ts": [
-        "./c.ts"
-      ],
-      "./c.ts": [
-        "./a.ts"
-      ],
-      "./index.ts": [
-        "./a.ts",
-        "./b.ts",
-        "./c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1
+      ],
+      [
+        2
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./a.ts",
+      "./b.ts",
+      "./c.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./a.ts",
@@ -314,37 +316,39 @@ export interface A {
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./a.ts": [
-        "./b.ts"
-      ],
-      "./b.ts": [
-        "./c.ts"
-      ],
-      "./c.ts": [
-        "./a.ts"
-      ],
-      "./index.ts": [
-        "./a.ts",
-        "./b.ts",
-        "./c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
     "exportedModulesMap": {
-      "./a.ts": [
-        "./b.ts"
-      ],
-      "./b.ts": [
-        "./c.ts"
-      ],
-      "./c.ts": [
-        "./a.ts"
-      ],
-      "./index.ts": [
-        "./a.ts",
-        "./b.ts",
-        "./c.ts"
-      ]
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 3
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        1
+      ],
+      [
+        2
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "./a.ts",
+      "./b.ts",
+      "./c.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./a.ts",

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-added-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-added-incremental.js
@@ -85,6 +85,8 @@ exports.App = App;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       [
@@ -179,15 +181,20 @@ exitCode:: ExitStatus.Success
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.tsx": [
-        "./node_modules/react/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {
-      "./index.tsx": [
-        "./node_modules/react/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "./index.tsx",
+      "./node_modules/react/jsx-runtime/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./index.tsx",

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-added-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-added-watch.js
@@ -100,6 +100,8 @@ exports.App = App;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       [
@@ -214,15 +216,20 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.tsx": [
-        "./node_modules/react/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {
-      "./index.tsx": [
-        "./node_modules/react/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "./index.tsx",
+      "./node_modules/react/jsx-runtime/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./index.tsx",

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-removed-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-removed-incremental.js
@@ -100,15 +100,20 @@ exports.App = App;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.tsx": [
-        "./node_modules/react/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {
-      "./index.tsx": [
-        "./node_modules/react/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "./index.tsx",
+      "./node_modules/react/jsx-runtime/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./index.tsx",
@@ -179,6 +184,8 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       [

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-removed-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-backing-types-removed-watch.js
@@ -120,15 +120,20 @@ exports.App = App;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.tsx": [
-        "./node_modules/react/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {
-      "./index.tsx": [
-        "./node_modules/react/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "./index.tsx",
+      "./node_modules/react/jsx-runtime/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./index.tsx",
@@ -214,6 +219,8 @@ exitCode:: ExitStatus.undefined
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       [

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-incremental.js
@@ -124,15 +124,20 @@ exports.App = App;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.tsx": [
-        "./node_modules/react/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {
-      "./index.tsx": [
-        "./node_modules/react/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "./index.tsx",
+      "./node_modules/react/jsx-runtime/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./index.tsx",
@@ -227,15 +232,20 @@ exports.App = App;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.tsx": [
-        "./node_modules/preact/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {
-      "./index.tsx": [
-        "./node_modules/preact/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "./index.tsx",
+      "./node_modules/preact/jsx-runtime/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       [

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-watch.js
@@ -144,15 +144,20 @@ exports.App = App;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.tsx": [
-        "./node_modules/react/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {
-      "./index.tsx": [
-        "./node_modules/react/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "./index.tsx",
+      "./node_modules/react/jsx-runtime/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./index.tsx",
@@ -264,15 +269,20 @@ exports.App = App;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.tsx": [
-        "./node_modules/preact/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
     "exportedModulesMap": {
-      "./index.tsx": [
-        "./node_modules/preact/jsx-runtime/index.d.ts"
-      ]
+      "0": 0
     },
+    "mapLists": [
+      [
+        1
+      ]
+    ],
+    "mapFiles": [
+      "./index.tsx",
+      "./node_modules/preact/jsx-runtime/index.d.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       [

--- a/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-with-errors-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-with-errors-incremental.js
@@ -100,6 +100,8 @@ define(["require", "exports"], function (require, exports) {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",
@@ -195,6 +197,8 @@ define(["require", "exports"], function (require, exports) {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",

--- a/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-with-errors-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-with-errors-watch.js
@@ -115,6 +115,8 @@ define(["require", "exports"], function (require, exports) {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",
@@ -225,6 +227,8 @@ define(["require", "exports"], function (require, exports) {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",

--- a/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-without-errors-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-without-errors-incremental.js
@@ -92,6 +92,8 @@ define(["require", "exports"], function (require, exports) {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",
@@ -167,6 +169,8 @@ define(["require", "exports"], function (require, exports) {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",

--- a/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-without-errors-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/module-compilation/own-file-emit-without-errors-watch.js
@@ -110,6 +110,8 @@ define(["require", "exports"], function (require, exports) {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",
@@ -203,6 +205,8 @@ define(["require", "exports"], function (require, exports) {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",

--- a/tests/baselines/reference/tscWatch/incremental/own-file-emit-with-errors-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/own-file-emit-with-errors-incremental.js
@@ -89,6 +89,8 @@ var y = 20;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",
@@ -181,6 +183,8 @@ var z = 10;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",

--- a/tests/baselines/reference/tscWatch/incremental/own-file-emit-with-errors-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/own-file-emit-with-errors-watch.js
@@ -104,6 +104,8 @@ var y = 20;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",
@@ -211,6 +213,8 @@ var z = 10;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",

--- a/tests/baselines/reference/tscWatch/incremental/own-file-emit-without-errors/with-commandline-parameters-that-are-not-relative-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/own-file-emit-without-errors/with-commandline-parameters-that-are-not-relative-incremental.js
@@ -82,6 +82,8 @@ var y = 20;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",
@@ -155,6 +157,8 @@ var z = 10;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",

--- a/tests/baselines/reference/tscWatch/incremental/own-file-emit-without-errors/with-commandline-parameters-that-are-not-relative-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/own-file-emit-without-errors/with-commandline-parameters-that-are-not-relative-watch.js
@@ -100,6 +100,8 @@ var y = 20;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",
@@ -191,6 +193,8 @@ var z = 10;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",

--- a/tests/baselines/reference/tscWatch/incremental/own-file-emit-without-errors/without-commandline-options-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/own-file-emit-without-errors/without-commandline-options-incremental.js
@@ -81,6 +81,8 @@ var y = 20;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",
@@ -153,6 +155,8 @@ var z = 10;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",

--- a/tests/baselines/reference/tscWatch/incremental/own-file-emit-without-errors/without-commandline-options-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/own-file-emit-without-errors/without-commandline-options-watch.js
@@ -99,6 +99,8 @@ var y = 20;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",
@@ -189,6 +191,8 @@ var z = 10;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./file1.ts",

--- a/tests/baselines/reference/tscWatch/incremental/when-file-with-ambient-global-declaration-file-is-deleted-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/when-file-with-ambient-global-declaration-file-is-deleted-incremental.js
@@ -79,6 +79,8 @@ console.log(Config.value);
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./globals.d.ts",
@@ -145,6 +147,8 @@ exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       [

--- a/tests/baselines/reference/tscWatch/incremental/when-file-with-ambient-global-declaration-file-is-deleted-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/when-file-with-ambient-global-declaration-file-is-deleted-watch.js
@@ -97,6 +97,8 @@ console.log(Config.value);
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./globals.d.ts",
@@ -176,6 +178,8 @@ exitCode:: ExitStatus.undefined
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       [

--- a/tests/baselines/reference/tscWatch/projectsWithReferences/on-sample-project.js
+++ b/tests/baselines/reference/tscWatch/projectsWithReferences/on-sample-project.js
@@ -154,6 +154,8 @@ export declare function multiply(a: number, b: number): number;
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./anothermodule.ts",
@@ -220,16 +222,25 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -295,23 +306,29 @@ export declare const m: typeof mod;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -458,16 +475,25 @@ function foo() { }
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -620,16 +646,25 @@ export declare function gfoo(): void;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -753,23 +788,29 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -836,16 +877,25 @@ exports.gfoo = gfoo;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts"
-      ]
+      "2": 1
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",
@@ -976,23 +1026,29 @@ exitCode:: ExitStatus.undefined
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "../logic/decls/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts",
-        "../core/index.d.ts",
-        "../logic/decls/index.d.ts"
-      ]
+      "2": 0,
+      "3": 1
     },
     "exportedModulesMap": {
-      "../logic/decls/index.d.ts": [
-        "../core/anothermodule.d.ts"
-      ],
-      "./index.ts": [
-        "../core/anothermodule.d.ts"
-      ]
+      "2": 0,
+      "3": 0
     },
+    "mapLists": [
+      [
+        0
+      ],
+      [
+        0,
+        1,
+        2
+      ]
+    ],
+    "mapFiles": [
+      "../core/anothermodule.d.ts",
+      "../core/index.d.ts",
+      "../logic/decls/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../core/anothermodule.d.ts",

--- a/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-in-different-folders.js
+++ b/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references-in-different-folders.js
@@ -77,6 +77,8 @@ export declare class A {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "./index.ts"
@@ -130,15 +132,20 @@ export declare const b: A;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../a/index.d.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../a/index.d.ts"
-      ]
+      "1": 0
     },
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../a/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../a/index.d.ts",
@@ -297,15 +304,20 @@ export declare function gfoo(): void;
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./index.ts": [
-        "../a/index.d.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {
-      "./index.ts": [
-        "../a/index.d.ts"
-      ]
+      "1": 0
     },
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "../a/index.d.ts",
+      "./index.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../../a/lib/lib.d.ts",
       "../a/index.d.ts",

--- a/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references.js
+++ b/tests/baselines/reference/tscWatch/projectsWithReferences/on-transitive-references.js
@@ -101,6 +101,8 @@ export declare class A {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./a.ts"
@@ -154,15 +156,20 @@ export declare const b: A;
       "configFilePath": "./tsconfig.b.json"
     },
     "referencedMap": {
-      "./b.ts": [
-        "./a.d.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {
-      "./b.ts": [
-        "./a.d.ts"
-      ]
+      "1": 0
     },
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "./a.d.ts",
+      "./b.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./a.d.ts",
@@ -314,15 +321,20 @@ export declare function gfoo(): void;
       "configFilePath": "./tsconfig.b.json"
     },
     "referencedMap": {
-      "./b.ts": [
-        "./a.d.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {
-      "./b.ts": [
-        "./a.d.ts"
-      ]
+      "1": 0
     },
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "./a.d.ts",
+      "./b.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./a.d.ts",

--- a/tests/baselines/reference/tscWatch/projectsWithReferences/when-referenced-project-uses-different-module-resolution.js
+++ b/tests/baselines/reference/tscWatch/projectsWithReferences/when-referenced-project-uses-different-module-resolution.js
@@ -88,6 +88,8 @@ export declare class A {
     },
     "referencedMap": {},
     "exportedModulesMap": {},
+    "mapLists": [],
+    "mapFiles": [],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./a.ts"
@@ -135,15 +137,20 @@ export declare const b: A;
       "configFilePath": "./tsconfig.b.json"
     },
     "referencedMap": {
-      "./b.ts": [
-        "./a.d.ts"
-      ]
+      "1": 0
     },
     "exportedModulesMap": {
-      "./b.ts": [
-        "./a.d.ts"
-      ]
+      "1": 0
     },
+    "mapLists": [
+      [
+        0
+      ]
+    ],
+    "mapFiles": [
+      "./a.d.ts",
+      "./b.ts"
+    ],
     "semanticDiagnosticsPerFile": [
       "../../../../a/lib/lib.d.ts",
       "./a.d.ts",


### PR DESCRIPTION
When `referencedMap` or `exportedModulesMap` contain duplicates, they are replaced with an index of the deduplicated value in `referencedMapLists` resp. `exportedModulesMapLists`.

This is actually quite common as .d.ts and .ts file often share references.

This saves a bit storage, makes restoring faster and due to using references to a shared list (since immutable) this also saves a bit of memory.

Finding duplicates during storing can be expensive, so we make use of the equal identity when this was restored from tsbuildinfo. Otherwise we create a Map by list length to avoid checking too many lists.

* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change
