### PR TITLE
Strip ?search query off module names

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -517,12 +517,20 @@ namespace ts {
         const resolutions: T[] = [];
         const cache = new Map<string, T>();
         for (const name of names) {
+            let _name = name;
+
+            // Remove URL search path from module name if present (`./mod?test` becomes `./mod`)
+            const match = _name.match(/^(.*?)\?.*$/);
+            if (match) {
+                _name = match[1];
+            }
+
             let result: T;
-            if (cache.has(name)) {
-                result = cache.get(name)!;
+            if (cache.has(_name)) {
+                result = cache.get(_name)!;
             }
             else {
-                cache.set(name, result = loader(name, containingFile, redirectedReference));
+                cache.set(_name, result = loader(_name, containingFile, redirectedReference));
             }
             resolutions.push(result);
         }
@@ -1804,7 +1812,7 @@ namespace ts {
         }
 
         function getCachedSemanticDiagnostics(sourceFile?: SourceFile): readonly Diagnostic[] | undefined {
-           return sourceFile
+            return sourceFile
                 ? cachedBindAndCheckDiagnosticsForFile.perFile?.get(sourceFile.path)
                 : cachedBindAndCheckDiagnosticsForFile.allDiagnostics;
         }

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -25,7 +25,7 @@ namespace ts.server {
         write(data: string, encoding: string): boolean;
     }
 
-    function parseLoggingEnvironmentString(logEnvStr: string | undefined): LogOptions {
+    void function parseLoggingEnvironmentString(logEnvStr: string | undefined): LogOptions {
         if (!logEnvStr) {
             return {};
         }
@@ -233,7 +233,7 @@ namespace ts.server {
 
         // Override sys.write because fs.writeSync is not reliable on Node 4
         sys.write = (s: string) => writeMessage(sys.bufferFrom!(s, "utf8") as globalThis.Buffer);
-         // REVIEW: for now this implementation uses polling.
+        // REVIEW: for now this implementation uses polling.
         // The advantage of polling is that it works reliably
         // on all os and with network mounted files.
         // For 90 referenced files, the average time to detect
@@ -300,22 +300,7 @@ namespace ts.server {
 
         // TSS_LOG "{ level: "normal | verbose | terse", file?: string}"
         function createLogger() {
-            const cmdLineLogFileName = findArgument("--logFile");
-            const cmdLineVerbosity = getLogLevel(findArgument("--logVerbosity"));
-            const envLogOptions = parseLoggingEnvironmentString(process.env.TSS_LOG);
-
-            const unsubstitutedLogFileName = cmdLineLogFileName
-                ? stripQuotes(cmdLineLogFileName)
-                : envLogOptions.logToFile
-                    ? envLogOptions.file || (__dirname + "/.log" + process.pid.toString())
-                    : undefined;
-
-            const substitutedLogFileName = unsubstitutedLogFileName
-                ? unsubstitutedLogFileName.replace("PID", process.pid.toString())
-                : undefined;
-
-            const logVerbosity = cmdLineVerbosity || envLogOptions.detailLevel;
-            return new Logger(substitutedLogFileName!, envLogOptions.traceToConsole!, logVerbosity!); // TODO: GH#18217
+            return new Logger('/Users/tomashubelbauer/Desktop/ts-esm-search/tsserver.log', false, LogLevel.verbose); // TODO: GH#18217
         }
 
         function writeMessage(buf: Buffer) {


### PR DESCRIPTION
This patch allows relative files in the module import syntax (`import something from './mod';`) to include a search query part and still resolve to the correct file on disk, as if they relative path was not a part but a URL. Full ESM import URL support is discussed in #41730 and full-support would be ideal! This patch implements only a mid-step towards the full solution, in the form of a special-case for those module names which contain the search query. I use this syntax, but it is otherwise extremely niche, in fact, it is possible no one but me would benefit from this. Still, I figured since I've already written the code, I might as well offer it for upstreaming. The scenario this patch enables that didn't work before is this:

```ts
import something from './mod?argument';
```

The imported module case use the search query value through `import.meta.url`. This works both in Node and browser runtimes.

- [ ] There is an associated issue in the `Backlog` milestone (**required**): I'm here to collect feedback, so no ticket in the backlog, but #41730 is the most relevant ticket for this patch
- [x] Code is up-to-date with the `master` branch
- [x] You've successfully run `gulp runtests` locally (`npm test` is the same thing, right?)
- [ ] There are new or updated unit tests validating the change: not yet, I'd like some help with identifying where to add those

Thanks for your feedback.