### PR TITLE
fix CommonJs modules no longer affecting the global scope

### DIFF
--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -479,7 +479,7 @@ namespace ts {
          */
         function isFileAffectingGlobalScope(sourceFile: SourceFile) {
             return containsGlobalScopeAugmentation(sourceFile) ||
-                !isExternalModule(sourceFile) && !containsOnlyAmbientModules(sourceFile);
+                !isExternalOrCommonJsModule(sourceFile) && !containsOnlyAmbientModules(sourceFile);
         }
 
         /**

--- a/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-js-based-projects-and-emits-them-correctly.js
+++ b/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-js-based-projects-and-emits-them-correctly.js
@@ -144,7 +144,7 @@ module.exports = {};
       "../../src/common/nominal.js": {
         "version": "-9003723607-/**\n * @template T, Name\n * @typedef {T & {[Symbol.species]: Name}} Nominal\n */\nmodule.exports = {};\n",
         "signature": "-15964609857-export type Nominal<T, Name> = T & {\r\n    [Symbol.species]: Name;\r\n};\r\n",
-        "affectsGlobalScope": true
+        "affectsGlobalScope": false
       }
     },
     "options": {


### PR DESCRIPTION
I think this was an oversight as CommonJS modules should be treated equal to ESM in this regard.