### PR TITLE
make "es2017 lib" error message casing consistent

### DIFF
--- a/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2016Plus.errors.txt
+++ b/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2016Plus.errors.txt
@@ -1,12 +1,12 @@
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(2,32): error TS2550: Property 'includes' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2016' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(5,31): error TS2550: Property 'padStart' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(6,29): error TS2550: Property 'padEnd' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(7,44): error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(8,45): error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(9,63): error TS2550: Property 'getOwnPropertyDescriptors' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(10,64): error TS2550: Property 'formatToParts' does not exist on type 'DateTimeFormat'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(11,21): error TS2583: Cannot find name 'Atomics'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(12,35): error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(5,31): error TS2550: Property 'padStart' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(6,29): error TS2550: Property 'padEnd' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(7,44): error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(8,45): error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(9,63): error TS2550: Property 'getOwnPropertyDescriptors' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(10,64): error TS2550: Property 'formatToParts' does not exist on type 'DateTimeFormat'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(11,21): error TS2583: Cannot find name 'Atomics'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(12,35): error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(15,50): error TS2550: Property 'finally' does not exist on type 'Promise<unknown>'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(16,113): error TS2550: Property 'groups' does not exist on type 'RegExpMatchArray'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
 tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(17,111): error TS2550: Property 'groups' does not exist on type 'RegExpExecArray'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
@@ -42,28 +42,28 @@ tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(44,70): err
     // es2017
     const testStringPadStart = "".padStart(2);
                                   ~~~~~~~~
-!!! error TS2550: Property 'padStart' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'padStart' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
     const testStringPadEnd = "".padEnd(2);
                                 ~~~~~~
-!!! error TS2550: Property 'padEnd' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'padEnd' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
     const testObjectConstructorValues = Object.values({});
                                                ~~~~~~
-!!! error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
     const testObjectConstructorEntries = Object.entries({});
                                                 ~~~~~~~
-!!! error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
     const testObjectConstructorGetOwnPropertyDescriptors = Object.getOwnPropertyDescriptors({});
                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2550: Property 'getOwnPropertyDescriptors' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'getOwnPropertyDescriptors' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
     const testIntlFormatToParts = new Intl.DateTimeFormat("en-US").formatToParts();
                                                                    ~~~~~~~~~~~~~
-!!! error TS2550: Property 'formatToParts' does not exist on type 'DateTimeFormat'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'formatToParts' does not exist on type 'DateTimeFormat'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
     const testAtomics = Atomics.add(new Uint8Array(0), 0, 0);
                         ~~~~~~~
-!!! error TS2583: Cannot find name 'Atomics'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2583: Cannot find name 'Atomics'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
     const testSharedArrayBuffer = new SharedArrayBuffer(5);
                                       ~~~~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
     
     // es2018
     const testPromiseFinally = new Promise(() => {}).finally();

--- a/tests/baselines/reference/useObjectValuesAndEntries2.errors.txt
+++ b/tests/baselines/reference/useObjectValuesAndEntries2.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts(3,22): error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts(7,22): error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts(3,22): error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
+tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts(7,22): error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
 
 
 ==== tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts (2 errors) ====
@@ -7,10 +7,10 @@ tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts(7,22): error TS2550
     
     for (var x of Object.values(o)) {
                          ~~~~~~
-!!! error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
         let y = x;
     }
     
     var entries = Object.entries(o);
                          ~~~~~~~
-!!! error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.

--- a/tests/baselines/reference/useObjectValuesAndEntries3.errors.txt
+++ b/tests/baselines/reference/useObjectValuesAndEntries3.errors.txt
@@ -1,16 +1,16 @@
-tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts(3,22): error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts(7,22): error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+tests/cases/conformance/ES2017/useObjectValuesAndEntries3.ts(3,22): error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
+tests/cases/conformance/ES2017/useObjectValuesAndEntries3.ts(7,22): error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
 
 
-==== tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts (2 errors) ====
+==== tests/cases/conformance/ES2017/useObjectValuesAndEntries3.ts (2 errors) ====
     var o = { a: 1, b: 2 };
     
     for (var x of Object.values(o)) {
                          ~~~~~~
-!!! error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
         let y = x;
     }
     
     var entries = Object.entries(o);
                          ~~~~~~~
-!!! error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.

--- a/tests/baselines/reference/useSharedArrayBuffer2.errors.txt
+++ b/tests/baselines/reference/useSharedArrayBuffer2.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/es2017/useSharedArrayBuffer2.ts(1,16): error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+tests/cases/conformance/es2017/useSharedArrayBuffer2.ts(1,16): error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
 
 
 ==== tests/cases/conformance/es2017/useSharedArrayBuffer2.ts (1 errors) ====
     var foge = new SharedArrayBuffer(1024);
                    ~~~~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
     var bar = foge.slice(1, 10);
     var len = foge.byteLength;

--- a/tests/baselines/reference/useSharedArrayBuffer3.errors.txt
+++ b/tests/baselines/reference/useSharedArrayBuffer3.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/es2017/useSharedArrayBuffer3.ts(1,16): error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+tests/cases/conformance/es2017/useSharedArrayBuffer3.ts(1,16): error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
 
 
 ==== tests/cases/conformance/es2017/useSharedArrayBuffer3.ts (1 errors) ====
     var foge = new SharedArrayBuffer(1024);
                    ~~~~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'ES2017' or later.
     var bar = foge.slice(1, 10);
     var len = foge.byteLength;


### PR DESCRIPTION
The "Try changing the `lib` compiler option to 'es2017' or later." error message was inconsistent with the capital "ES2017" tsconfig.json option.

* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
<details>
<summary>When I ran "gulp runtests", 74914 tests were passing, in 25 minutes, and 5 were failing.</summary>
<br>

```
[11:02:40] Using gulpfile ~/repositories/TypeScript/gulpfile.js
[11:02:40] Starting 'runtests'...
[11:02:40] Starting 'generateLibs'...
[11:02:40] Starting 'buildScripts'...
[11:02:40] Finished 'generateLibs' after 669 ms
[11:02:41] Finished 'buildScripts' after 721 ms
[11:02:41] Starting 'generateDiagnostics'...
[11:02:41] Finished 'generateDiagnostics' after 1.27 ms
[11:02:41] Starting 'buildShims'...
[11:02:41] Starting 'buildDebugTools'...
[11:02:41] Finished 'buildShims' after 365 ms
[11:02:41] Finished 'buildDebugTools' after 365 ms
[11:02:41] Starting 'buildTsc'...
[11:02:41] Starting 'buildTests'...
[11:02:41] Starting 'buildTypescriptServicesOut'...
[11:02:41] Starting 'buildServerLibraryOut'...
[11:02:41] Finished 'buildTsc' after 483 ms
[11:02:41] Finished 'buildTests' after 483 ms
[11:02:41] Finished 'buildTypescriptServicesOut' after 483 ms
[11:02:41] Starting 'createTypescriptServicesJs'...
[11:02:41] Finished 'buildServerLibraryOut' after 483 ms
[11:02:41] Starting 'createServerLibraryJs'...
[11:02:41] Finished 'createTypescriptServicesJs' after 46 ms
[11:02:41] Starting 'createTypescriptServicesDts'...
[11:02:41] Finished 'createServerLibraryJs' after 53 ms
[11:02:41] Starting 'createServerLibraryDts'...
[11:02:41] Finished 'createTypescriptServicesDts' after 14 ms
[11:02:41] Starting 'createTypescriptJs'...
[11:02:41] Finished 'createServerLibraryDts' after 13 ms
[11:02:41] Finished 'createTypescriptJs' after 50 ms
[11:02:41] Starting 'createTypescriptDts'...
[11:02:41] Finished 'createTypescriptDts' after 5.72 ms
[11:02:41] Starting 'createTypescriptStandaloneDts'...
[11:02:42] Finished 'createTypescriptStandaloneDts' after 5.04 ms
[11:02:42] Starting 'runTests'...
[11:02:42] Running tests with config: {"light":true,"noColor":false,"timeout":40000,"keepFailed":false}
[11:02:42] > node /Users/hamirmahal/repositories/TypeScript/node_modules/mocha/bin/_mocha -R scripts/failed-tests -O "reporter=mocha-fivemat-progress-reporter" --colors -t 40000 built/local/run.js
  [․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․]
    conformance tests
  [▬▬▬▬▬▬▬▬․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․]
Test failure:
Correct errors for tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts

Test failure:
Correct errors for tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts

Test failure:
Correct errors for tests/cases/conformance/es2017/useSharedArrayBuffer2.ts

Test failure:
Correct errors for tests/cases/conformance/es2017/useSharedArrayBuffer3.ts
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 30750 tests
passed: 30746
failed: 4


    compiler tests
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․]
Test failure:
Correct errors for tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 33180 tests
passed: 33179
failed: 1


    projects tests
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2528 tests
passed: 2528
failed: 0


    fourslash tests
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 4534 tests
passed: 4534
failed: 0


    fourslash-shims tests
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 23 tests
passed: 23
failed: 0


    fourslash-shims-pp tests
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 23 tests
passed: 23
failed: 0


    fourslash-server tests
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬․․․․․․․․․․․․․․․․․․․]
```
followed by
```
passed: 16
failed: 0


    unittests:: tsbuild:: outFile::
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 133 tests
passed: 133
failed: 0


    unittests:: tsbuild - output file paths
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 20 tests
passed: 20
failed: 0


    unittests:: tsbuild:: with rootDir of project reference in parentDirectory
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 4 tests
passed: 4
failed: 0


    unittests:: tsbuild:: with resolveJsonModule option on project resolveJsonModuleAndComposite
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 9 tests
passed: 9
failed: 0


    unittests:: tsbuild:: with resolveJsonModule option on project importJsonFromProjectReference
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsbuild:: on 'sample1' project
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 54 tests
passed: 54
failed: 0


    unittests:: tsbuild:: when project reference is referenced transitively
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 3 tests
passed: 3
failed: 0


    unittests:: tsbuild:: watchEnvironment:: tsbuild:: watchMode:: with different watch environments
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsbuild:: watchMode:: program updates
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 23 tests
passed: 23
failed: 0


    unittests:: tsbuild:: watchMode:: with demo project
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsbuild:: watchMode:: with noEmitOnError
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsbuild:: watchMode:: with reexport when referenced project reexports definitions from another file
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsbuild:: watchMode:: configFileErrors:: reports syntax errors in config file
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsc:: composite::
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 4 tests
passed: 4
failed: 0


    unittests:: tsc:: declarationEmit::
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 6 tests
passed: 6
failed: 0


    unittests:: tsc:: incremental::
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 91 tests
passed: 91
failed: 0


    unittests:: tsc:: listFilesOnly::
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsc:: projectReferences::
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsc:: runWithoutArgs::
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsc-watch:: console clearing
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 6 tests
passed: 6
failed: 0


    unittests:: tsc-watch:: emit with outFile or out setting
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 5 tests
passed: 5
failed: 0


    unittests:: tsc-watch:: emit for configured projects
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 12 tests
passed: 12
failed: 0


    unittests:: tsc-watch:: emit file content
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 5 tests
passed: 5
failed: 0


    unittests:: tsc-watch:: emit with when module emit is specified as node
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsc-watch:: Emit times and Error updates in builder after program changes
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 42 tests
passed: 42
failed: 0


    unittests:: tsc-watch:: forceConsistentCasingInFileNames
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 16 tests
passed: 16
failed: 0


    unittests:: tsc-watch:: emit file --incremental
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 27 tests
passed: 27
failed: 0


    unittests:: tsc-watch:: program updates
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 67 tests
passed: 67
failed: 0


    unittests:: tsc-watch:: projects with references: invoking when references are already built
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 4 tests
passed: 4
failed: 0


    unittests:: tsc-watch:: resolutionCache:: tsc-watch module resolution caching
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 11 tests
passed: 11
failed: 0


    unittests:: tsc-watch:: watchAPI:: with sourceOfProjectReferenceRedirect
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 18 tests
passed: 18
failed: 0


    unittests:: tsc-watch:: watchAPI:: tsc-watch with custom module resolution
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsc-watch:: watchAPI:: tsc-watch expose error count to watch status reporter
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsc-watch:: watchAPI:: when watchHost does not implement setTimeout or clearTimeout
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsc-watch:: watchAPI:: when watchHost can add extraFileExtensions to process
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsc-watch:: watchAPI:: when watchHost uses createSemanticDiagnosticsBuilderProgram
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 3 tests
passed: 3
failed: 0


    unittests:: tsc-watch:: watchEnvironment:: tsc-watch with different polling/non polling options
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 20 tests
passed: 20
failed: 0


    unittests:: tsserver:: applyChangesToOpenFiles
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: autoImportProvider
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 12 tests
passed: 12
failed: 0


    unittests:: tsserver:: autoImportProvider - monorepo
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: CachingFileSystemInformation:: tsserverProjectSystem CachingFileSystemInformation
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 11 tests
passed: 11
failed: 0


    unittests:: tsserver:: cancellationToken
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 3 tests
passed: 3
failed: 0


    unittests:: tsserver:: compileOnSave:: affected list
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 25 tests
passed: 25
failed: 0


    unittests:: tsserver:: compileOnSave:: EmitFile test
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 11 tests
passed: 11
failed: 0


    unittests:: tsserver:: compileOnSave:: CompileOnSaveAffectedFileListRequest with and without projectFileName in request
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: completions
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: searching for config file
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 7 tests
passed: 7
failed: 0


    unittests:: tsserver:: ConfiguredProjects
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 34 tests
passed: 34
failed: 0


    unittests:: tsserver:: ConfiguredProjects:: non-existing directories listed in config file input array
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 5 tests
passed: 5
failed: 0


    unittests:: tsserver:: ConfiguredProjects:: when reading tsconfig file fails
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: with declaration file maps:: project references
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 21 tests
passed: 21
failed: 0


    unittests:: tsserver:: document registry in project service
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: duplicate packages
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: dynamicFiles:: Untitled files
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 3 tests
passed: 3
failed: 0


    unittests:: tsserver:: dynamicFiles:: 
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 6 tests
passed: 6
failed: 0


    unittests:: tsserver:: events:: LargeFileReferencedEvent with large file
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 4 tests
passed: 4
failed: 0


    unittests:: tsserver:: events:: ProjectLanguageServiceStateEvent
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: events:: ProjectLoadingStart and ProjectLoadingFinish events
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 16 tests
passed: 16
failed: 0


    unittests:: tsserver:: events:: ProjectsUpdatedInBackground
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 54 tests
passed: 54
failed: 0


    unittests:: tsserver:: ExternalProjects
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 24 tests
passed: 24
failed: 0


    unittests:: tsserver:: forceConsistentCasingInFileNames
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 3 tests
passed: 3
failed: 0


    unittests:: tsserver:: format settings
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: getApplicableRefactors
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: getEditsForFileRename
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 3 tests
passed: 3
failed: 0


    unittests:: tsserver:: getExportReferences
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 5 tests
passed: 5
failed: 0


    unittests:: tsserver:: getFileReferences
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: import helpers
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: importSuggestionsCache
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 4 tests
passed: 4
failed: 0


    unittests:: tsserver:: Inferred projects
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 11 tests
passed: 11
failed: 0


    unittests:: tsserver:: Language service
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: maxNodeModuleJsDepth for inferred projects
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: with metadata in response
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 3 tests
passed: 3
failed: 0


    unittests:: tsserver:: navigate-to for javascript project
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 4 tests
passed: 4
failed: 0


    unittests:: tsserver:: occurrence highlight on string
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: Open-file
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 6 tests
passed: 6
failed: 0


    unittests:: tsserver:: packageJsonInfo
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 5 tests
passed: 5
failed: 0


    unittests:: tsserver:: Semantic operations on partialSemanticServer
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 7 tests
passed: 7
failed: 0


    unittests:: tsserver:: plugins loading
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: Project Errors
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 4 tests
passed: 4
failed: 0


    unittests:: tsserver:: Project Errors are reported as appropriate
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 11 tests
passed: 11
failed: 0


    unittests:: tsserver:: Project Errors for Configure file diagnostics events
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 7 tests
passed: 7
failed: 0


    unittests:: tsserver:: Project Errors dont include overwrite emit error
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: Project Errors reports Options Diagnostic locations correctly with changes in configFile contents
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: Project Errors with config file change
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: Project Errors with resolveJsonModule
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: Project Errors with npm install when
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: with project references and compile on save
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 45 tests
passed: 45
failed: 0


    unittests:: tsserver:: with project references and compile on save with external projects
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: with project references and error reporting
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 16 tests
passed: 16
failed: 0


    unittests:: tsserver:: with project references and tsbuild
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 38 tests
passed: 38
failed: 0


    unittests:: tsserver:: with project references and tsbuild source map
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 126 tests
passed: 126
failed: 0


    unittests:: tsserver:: Projects
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 42 tests
passed: 42
failed: 0


    unittests:: tsserver:: projects with references: invoking when references are already built
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 6 tests
passed: 6
failed: 0


    unittests:: tsserver:: refactors
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 3 tests
passed: 3
failed: 0


    unittests:: tsserver:: reload
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: reloadProjects
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 4 tests
passed: 4
failed: 0


    unittests:: tsserver:: rename
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 3 tests
passed: 3
failed: 0


    unittests:: tsserver:: resolutionCache:: tsserverProjectSystem extra resolution pass in server host
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: resolutionCache:: tsserverProjectSystem watching @types
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: resolutionCache:: tsserverProjectSystem add the missing module file for inferred project
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 5 tests
passed: 5
failed: 0


    unittests:: tsserver:: resolutionCache:: tsserverProjectSystem rename a module file and rename back
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 4 tests
passed: 4
failed: 0


    unittests:: tsserver:: resolutionCache:: tsserverProjectSystem module resolution caching
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 10 tests
passed: 10
failed: 0


    unittests:: tsserver:: Session:: General functionality
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 12 tests
passed: 12
failed: 0


    unittests:: tsserver:: Session:: exceptions
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: Session:: how Session is extendable via subclassing
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 3 tests
passed: 3
failed: 0


    unittests:: tsserver:: Session:: an example of using the Session API to create an in-process server
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: Session:: helpers
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: with skipLibCheck
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 7 tests
passed: 7
failed: 0


    unittests:: tsserver:: smartSelection
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: symLinks
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 7 tests
passed: 7
failed: 0


    unittests:: tsserver:: Semantic operations on Syntax server
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 4 tests
passed: 4
failed: 0


    unittests:: tsserver:: syntax operations
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: Text storage
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 7 tests
passed: 7
failed: 0


    unittests:: tsserver:: project telemetry
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 12 tests
passed: 12
failed: 0


    unittests:: tsserver:: autoDiscovery
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: prefer typings to js
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: typeOnlyImportChains
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 8 tests
passed: 8
failed: 0


    unittests:: tsserver:: typeReferenceDirectives
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: typingsInstaller:: local module
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: typingsInstaller:: General functionality
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 24 tests
passed: 24
failed: 0


    unittests:: tsserver:: typingsInstaller:: Validate package name:
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 11 tests
passed: 11
failed: 0


    unittests:: tsserver:: typingsInstaller:: Invalid package names
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: typingsInstaller:: discover typings
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 8 tests
passed: 8
failed: 0


    unittests:: tsserver:: typingsInstaller:: telemetry events
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: typingsInstaller:: progress notifications
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: typingsInstaller:: npm installation command
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: tsserver:: typingsInstaller:: recomputing resolutions of unresolved imports
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 3 tests
passed: 3
failed: 0


    unittests:: tsserver:: typingsInstaller:: tsserver:: with inferred Project
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 1 tests
passed: 1
failed: 0


    unittests:: tsserver:: VersionCache TS code
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 7 tests
passed: 7
failed: 0


    unittests:: tsserver:: VersionCache simple text
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 18 tests
passed: 18
failed: 0


    unittests:: tsserver:: VersionCache stress test
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 7 tests
passed: 7
failed: 0


    unittests:: tsserver:: watchEnvironment:: tsserverProjectSystem watchDirectories implementation
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 3 tests
passed: 3
failed: 0


    unittests:: tsserver:: watchEnvironment:: tsserverProjectSystem Watched recursive directories with windows style file system
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 4 tests
passed: 4
failed: 0


    unittests:: tsserver:: watchEnvironment:: tsserverProjectSystem watching files with network style paths
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 5 tests
passed: 5
failed: 0


    unittests:: tsserver:: watchEnvironment:: handles watch compiler options
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 14 tests
passed: 14
failed: 0


    unittests:: tsserver:: watchEnvironment:: file names on case insensitive file system
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 3 tests
passed: 3
failed: 0


    unittests:: tsserver:: webServer
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]
completed: 2 tests
passed: 2
failed: 0


    unittests:: debugDeprecation
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  74914 passing (25m)
  5 failing

  1) conformance tests
       conformance tests for tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts
         Correct errors for tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts:
     Error: The baseline file useObjectValuesAndEntries2.errors.txt has changed.
      at writeComparison (src/harness/harnessIO.ts:1390:27)
      at Object.runBaseline (src/harness/harnessIO.ts:1401:13)
      at Object.doErrorBaseline (src/harness/harnessIO.ts:692:22)
      at CompilerTest.verifyDiagnostics (src/testRunner/compilerRunner.ts:253:22)
      at Context.<anonymous> (src/testRunner/compilerRunner.ts:88:71)
      at processImmediate (internal/timers.js:456:21)

  2) conformance tests
       conformance tests for tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts
         Correct errors for tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts:
     Error: The baseline file useObjectValuesAndEntries3.errors.txt has changed.
      at writeComparison (src/harness/harnessIO.ts:1390:27)
      at Object.runBaseline (src/harness/harnessIO.ts:1401:13)
      at Object.doErrorBaseline (src/harness/harnessIO.ts:692:22)
      at CompilerTest.verifyDiagnostics (src/testRunner/compilerRunner.ts:253:22)
      at Context.<anonymous> (src/testRunner/compilerRunner.ts:88:71)
      at processImmediate (internal/timers.js:456:21)

  3) conformance tests
       conformance tests for tests/cases/conformance/es2017/useSharedArrayBuffer2.ts
         Correct errors for tests/cases/conformance/es2017/useSharedArrayBuffer2.ts:
     Error: The baseline file useSharedArrayBuffer2.errors.txt has changed.
      at writeComparison (src/harness/harnessIO.ts:1390:27)
      at Object.runBaseline (src/harness/harnessIO.ts:1401:13)
      at Object.doErrorBaseline (src/harness/harnessIO.ts:692:22)
      at CompilerTest.verifyDiagnostics (src/testRunner/compilerRunner.ts:253:22)
      at Context.<anonymous> (src/testRunner/compilerRunner.ts:88:71)
      at processImmediate (internal/timers.js:456:21)

  4) conformance tests
       conformance tests for tests/cases/conformance/es2017/useSharedArrayBuffer3.ts
         Correct errors for tests/cases/conformance/es2017/useSharedArrayBuffer3.ts:
     Error: The baseline file useSharedArrayBuffer3.errors.txt has changed.
      at writeComparison (src/harness/harnessIO.ts:1390:27)
      at Object.runBaseline (src/harness/harnessIO.ts:1401:13)
      at Object.doErrorBaseline (src/harness/harnessIO.ts:692:22)
      at CompilerTest.verifyDiagnostics (src/testRunner/compilerRunner.ts:253:22)
      at Context.<anonymous> (src/testRunner/compilerRunner.ts:88:71)
      at processImmediate (internal/timers.js:456:21)

  5) compiler tests
       compiler tests for tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts
         Correct errors for tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts:
     Error: The baseline file doYouNeedToChangeYourTargetLibraryES2016Plus.errors.txt has changed.
      at writeComparison (src/harness/harnessIO.ts:1390:27)
      at Object.runBaseline (src/harness/harnessIO.ts:1401:13)
      at Object.doErrorBaseline (src/harness/harnessIO.ts:692:22)
      at CompilerTest.verifyDiagnostics (src/testRunner/compilerRunner.ts:253:22)
      at Context.<anonymous> (src/testRunner/compilerRunner.ts:88:71)
      at processImmediate (internal/timers.js:456:21)



[11:27:40] 'runTests' errored after 25 min
[11:27:40] Error: Process exited with code: 5
    at ChildProcess.<anonymous> (/Users/hamirmahal/repositories/TypeScript/scripts/build/utils.js:54:28)
    at ChildProcess.emit (events.js:315:20)
    at ChildProcess.EventEmitter.emit (domain.js:506:15)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)
    at Process.callbackTrampoline (internal/async_hooks.js:120:14)
[11:27:40] 'runtests' errored after 25 min       
```
</details>

* [ ] There are new or updated unit tests validating the change

I'm not sure where to place tests that test changing capitalization from "es2017" to "ES2017", or if any are recommended for this change.

Fixes #43000 

Hope this helps!