### PR TITLE
Allow await in class static field context

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6440,7 +6440,9 @@ namespace ts {
         ): PropertyDeclaration {
             const exclamationToken = !questionToken && !scanner.hasPrecedingLineBreak() ? parseOptionalToken(SyntaxKind.ExclamationToken) : undefined;
             const type = parseTypeAnnotation();
-            const initializer = doOutsideOfContext(NodeFlags.YieldContext | NodeFlags.AwaitContext | NodeFlags.DisallowInContext, parseInitializer);
+            const isStatic = some(modifiers, isStaticModifier);
+            const staticContextAwaitFlags = isStatic ? NodeFlags.None : NodeFlags.AwaitContext;
+            const initializer = doOutsideOfContext(staticContextAwaitFlags | NodeFlags.YieldContext | NodeFlags.DisallowInContext, parseInitializer);
             parseSemicolon();
             const node = factory.createPropertyDeclaration(decorators, modifiers, name, questionToken || exclamationToken, type, initializer);
             return withJSDoc(finishNode(node, pos), hasJSDoc);

--- a/tests/baselines/reference/awaitAndYieldInProperty.errors.txt
+++ b/tests/baselines/reference/awaitAndYieldInProperty.errors.txt
@@ -1,7 +1,6 @@
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(3,9): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(3,21): error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(4,16): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/conformance/classes/awaitAndYieldInProperty.ts(4,28): error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(6,9): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(6,21): error TS1163: A 'yield' expression is only allowed in a generator body.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(7,16): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
@@ -9,14 +8,13 @@ tests/cases/conformance/classes/awaitAndYieldInProperty.ts(7,28): error TS1163: 
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(11,9): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(11,21): error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(12,16): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/conformance/classes/awaitAndYieldInProperty.ts(12,28): error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(14,9): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(14,21): error TS1163: A 'yield' expression is only allowed in a generator body.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(15,16): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 tests/cases/conformance/classes/awaitAndYieldInProperty.ts(15,28): error TS1163: A 'yield' expression is only allowed in a generator body.
 
 
-==== tests/cases/conformance/classes/awaitAndYieldInProperty.ts (16 errors) ====
+==== tests/cases/conformance/classes/awaitAndYieldInProperty.ts (14 errors) ====
     async function* test(x: Promise<string>) {
         class C {
             [await x] = await x;
@@ -27,8 +25,6 @@ tests/cases/conformance/classes/awaitAndYieldInProperty.ts(15,28): error TS1163:
             static [await x] = await x;
                    ~~~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-                               ~~~~~
-!!! error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
     
             [yield 1] = yield 2;
             ~~~~~~~~~
@@ -51,8 +47,6 @@ tests/cases/conformance/classes/awaitAndYieldInProperty.ts(15,28): error TS1163:
             static [await x] = await x;
                    ~~~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-                               ~~~~~
-!!! error TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.
     
             [yield 1] = yield 2;
             ~~~~~~~~~

--- a/tests/baselines/reference/awaitContextAndStaticMembers1(target=es5).js
+++ b/tests/baselines/reference/awaitContextAndStaticMembers1(target=es5).js
@@ -1,0 +1,63 @@
+//// [awaitContextAndStaticMembers1.ts]
+async function wrapper (v: Promise<number>) {
+    return class {
+        static staticField = await (v);
+    }
+}
+
+
+//// [awaitContextAndStaticMembers1.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+function wrapper(v) {
+    var _a;
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    _a = /** @class */ (function () {
+                            function class_1() {
+                            }
+                            return class_1;
+                        }());
+                    return [4 /*yield*/, (v)];
+                case 1: return [2 /*return*/, (_a.staticField = _b.sent(),
+                        _a)];
+            }
+        });
+    });
+}

--- a/tests/baselines/reference/awaitContextAndStaticMembers1(target=es5).symbols
+++ b/tests/baselines/reference/awaitContextAndStaticMembers1(target=es5).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers1.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : Symbol(wrapper, Decl(awaitContextAndStaticMembers1.ts, 0, 0))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers1.ts, 0, 24))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+
+    return class {
+        static staticField = await (v);
+>staticField : Symbol((Anonymous class).staticField, Decl(awaitContextAndStaticMembers1.ts, 1, 18))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers1.ts, 0, 24))
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers1(target=es5).types
+++ b/tests/baselines/reference/awaitContextAndStaticMembers1(target=es5).types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers1.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : (v: Promise<number>) => Promise<typeof (Anonymous class)>
+>v : Promise<number>
+
+    return class {
+>class {        static staticField = await (v);    } : typeof (Anonymous class)
+
+        static staticField = await (v);
+>staticField : number
+>await (v) : number
+>(v) : Promise<number>
+>v : Promise<number>
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers1(target=es6).js
+++ b/tests/baselines/reference/awaitContextAndStaticMembers1(target=es6).js
@@ -1,0 +1,27 @@
+//// [awaitContextAndStaticMembers1.ts]
+async function wrapper (v: Promise<number>) {
+    return class {
+        static staticField = await (v);
+    }
+}
+
+
+//// [awaitContextAndStaticMembers1.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+function wrapper(v) {
+    var _a;
+    return __awaiter(this, void 0, void 0, function* () {
+        return _a = class {
+            },
+            _a.staticField = yield (v),
+            _a;
+    });
+}

--- a/tests/baselines/reference/awaitContextAndStaticMembers1(target=es6).symbols
+++ b/tests/baselines/reference/awaitContextAndStaticMembers1(target=es6).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers1.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : Symbol(wrapper, Decl(awaitContextAndStaticMembers1.ts, 0, 0))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers1.ts, 0, 24))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    return class {
+        static staticField = await (v);
+>staticField : Symbol((Anonymous class).staticField, Decl(awaitContextAndStaticMembers1.ts, 1, 18))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers1.ts, 0, 24))
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers1(target=es6).types
+++ b/tests/baselines/reference/awaitContextAndStaticMembers1(target=es6).types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers1.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : (v: Promise<number>) => Promise<typeof (Anonymous class)>
+>v : Promise<number>
+
+    return class {
+>class {        static staticField = await (v);    } : typeof (Anonymous class)
+
+        static staticField = await (v);
+>staticField : number
+>await (v) : number
+>(v) : Promise<number>
+>v : Promise<number>
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers1(target=esnext).js
+++ b/tests/baselines/reference/awaitContextAndStaticMembers1(target=esnext).js
@@ -1,0 +1,16 @@
+//// [awaitContextAndStaticMembers1.ts]
+async function wrapper (v: Promise<number>) {
+    return class {
+        static staticField = await (v);
+    }
+}
+
+
+//// [awaitContextAndStaticMembers1.js]
+async function wrapper(v) {
+    var _a;
+    return _a = class {
+        },
+        _a.staticField = await (v),
+        _a;
+}

--- a/tests/baselines/reference/awaitContextAndStaticMembers1(target=esnext).symbols
+++ b/tests/baselines/reference/awaitContextAndStaticMembers1(target=esnext).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers1.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : Symbol(wrapper, Decl(awaitContextAndStaticMembers1.ts, 0, 0))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers1.ts, 0, 24))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+    return class {
+        static staticField = await (v);
+>staticField : Symbol((Anonymous class).staticField, Decl(awaitContextAndStaticMembers1.ts, 1, 18))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers1.ts, 0, 24))
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers1(target=esnext).types
+++ b/tests/baselines/reference/awaitContextAndStaticMembers1(target=esnext).types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers1.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : (v: Promise<number>) => Promise<typeof (Anonymous class)>
+>v : Promise<number>
+
+    return class {
+>class {        static staticField = await (v);    } : typeof (Anonymous class)
+
+        static staticField = await (v);
+>staticField : number
+>await (v) : number
+>(v) : Promise<number>
+>v : Promise<number>
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers2(target=es5).errors.txt
+++ b/tests/baselines/reference/awaitContextAndStaticMembers2(target=es5).errors.txt
@@ -1,0 +1,12 @@
+tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers2.ts(3,17): error TS2304: Cannot find name 'await'.
+
+
+==== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers2.ts (1 errors) ====
+    async function wrapper (v: Promise<number>) {
+        return class {
+            field = await (v);
+                    ~~~~~
+!!! error TS2304: Cannot find name 'await'.
+        }
+    }
+    

--- a/tests/baselines/reference/awaitContextAndStaticMembers2(target=es5).js
+++ b/tests/baselines/reference/awaitContextAndStaticMembers2(target=es5).js
@@ -1,0 +1,57 @@
+//// [awaitContextAndStaticMembers2.ts]
+async function wrapper (v: Promise<number>) {
+    return class {
+        field = await (v);
+    }
+}
+
+
+//// [awaitContextAndStaticMembers2.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+function wrapper(v) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            return [2 /*return*/, /** @class */ (function () {
+                    function class_1() {
+                        this.field = await(v);
+                    }
+                    return class_1;
+                }())];
+        });
+    });
+}

--- a/tests/baselines/reference/awaitContextAndStaticMembers2(target=es5).symbols
+++ b/tests/baselines/reference/awaitContextAndStaticMembers2(target=es5).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers2.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : Symbol(wrapper, Decl(awaitContextAndStaticMembers2.ts, 0, 0))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers2.ts, 0, 24))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+
+    return class {
+        field = await (v);
+>field : Symbol((Anonymous class).field, Decl(awaitContextAndStaticMembers2.ts, 1, 18))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers2.ts, 0, 24))
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers2(target=es5).types
+++ b/tests/baselines/reference/awaitContextAndStaticMembers2(target=es5).types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers2.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : (v: Promise<number>) => Promise<typeof (Anonymous class)>
+>v : Promise<number>
+
+    return class {
+>class {        field = await (v);    } : typeof (Anonymous class)
+
+        field = await (v);
+>field : any
+>await (v) : any
+>await : any
+>v : Promise<number>
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers2(target=es6).errors.txt
+++ b/tests/baselines/reference/awaitContextAndStaticMembers2(target=es6).errors.txt
@@ -1,0 +1,12 @@
+tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers2.ts(3,17): error TS2304: Cannot find name 'await'.
+
+
+==== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers2.ts (1 errors) ====
+    async function wrapper (v: Promise<number>) {
+        return class {
+            field = await (v);
+                    ~~~~~
+!!! error TS2304: Cannot find name 'await'.
+        }
+    }
+    

--- a/tests/baselines/reference/awaitContextAndStaticMembers2(target=es6).js
+++ b/tests/baselines/reference/awaitContextAndStaticMembers2(target=es6).js
@@ -1,0 +1,27 @@
+//// [awaitContextAndStaticMembers2.ts]
+async function wrapper (v: Promise<number>) {
+    return class {
+        field = await (v);
+    }
+}
+
+
+//// [awaitContextAndStaticMembers2.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+function wrapper(v) {
+    return __awaiter(this, void 0, void 0, function* () {
+        return class {
+            constructor() {
+                this.field = await(v);
+            }
+        };
+    });
+}

--- a/tests/baselines/reference/awaitContextAndStaticMembers2(target=es6).symbols
+++ b/tests/baselines/reference/awaitContextAndStaticMembers2(target=es6).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers2.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : Symbol(wrapper, Decl(awaitContextAndStaticMembers2.ts, 0, 0))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers2.ts, 0, 24))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    return class {
+        field = await (v);
+>field : Symbol((Anonymous class).field, Decl(awaitContextAndStaticMembers2.ts, 1, 18))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers2.ts, 0, 24))
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers2(target=es6).types
+++ b/tests/baselines/reference/awaitContextAndStaticMembers2(target=es6).types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers2.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : (v: Promise<number>) => Promise<typeof (Anonymous class)>
+>v : Promise<number>
+
+    return class {
+>class {        field = await (v);    } : typeof (Anonymous class)
+
+        field = await (v);
+>field : any
+>await (v) : any
+>await : any
+>v : Promise<number>
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers2(target=esnext).errors.txt
+++ b/tests/baselines/reference/awaitContextAndStaticMembers2(target=esnext).errors.txt
@@ -1,0 +1,12 @@
+tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers2.ts(3,17): error TS2304: Cannot find name 'await'.
+
+
+==== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers2.ts (1 errors) ====
+    async function wrapper (v: Promise<number>) {
+        return class {
+            field = await (v);
+                    ~~~~~
+!!! error TS2304: Cannot find name 'await'.
+        }
+    }
+    

--- a/tests/baselines/reference/awaitContextAndStaticMembers2(target=esnext).js
+++ b/tests/baselines/reference/awaitContextAndStaticMembers2(target=esnext).js
@@ -1,0 +1,16 @@
+//// [awaitContextAndStaticMembers2.ts]
+async function wrapper (v: Promise<number>) {
+    return class {
+        field = await (v);
+    }
+}
+
+
+//// [awaitContextAndStaticMembers2.js]
+async function wrapper(v) {
+    return class {
+        constructor() {
+            this.field = await(v);
+        }
+    };
+}

--- a/tests/baselines/reference/awaitContextAndStaticMembers2(target=esnext).symbols
+++ b/tests/baselines/reference/awaitContextAndStaticMembers2(target=esnext).symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers2.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : Symbol(wrapper, Decl(awaitContextAndStaticMembers2.ts, 0, 0))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers2.ts, 0, 24))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+    return class {
+        field = await (v);
+>field : Symbol((Anonymous class).field, Decl(awaitContextAndStaticMembers2.ts, 1, 18))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers2.ts, 0, 24))
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers2(target=esnext).types
+++ b/tests/baselines/reference/awaitContextAndStaticMembers2(target=esnext).types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers2.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : (v: Promise<number>) => Promise<typeof (Anonymous class)>
+>v : Promise<number>
+
+    return class {
+>class {        field = await (v);    } : typeof (Anonymous class)
+
+        field = await (v);
+>field : any
+>await (v) : any
+>await : any
+>v : Promise<number>
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers3(target=es5).js
+++ b/tests/baselines/reference/awaitContextAndStaticMembers3(target=es5).js
@@ -1,0 +1,67 @@
+//// [awaitContextAndStaticMembers3.ts]
+async function wrapper (v: Promise<number>) {
+    return class C {
+        static staticField1 = await (v);
+        static staticField2 = await (v) + C.staticField1;
+    }
+}
+
+
+//// [awaitContextAndStaticMembers3.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+function wrapper(v) {
+    var _a;
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    _a = /** @class */ (function () {
+                            function C() {
+                            }
+                            return C;
+                        }());
+                    return [4 /*yield*/, (v)];
+                case 1:
+                    _a.staticField1 = _b.sent();
+                    return [4 /*yield*/, (v)];
+                case 2: return [2 /*return*/, (_a.staticField2 = (_b.sent()) + _a.staticField1,
+                        _a)];
+            }
+        });
+    });
+}

--- a/tests/baselines/reference/awaitContextAndStaticMembers3(target=es5).symbols
+++ b/tests/baselines/reference/awaitContextAndStaticMembers3(target=es5).symbols
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers3.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : Symbol(wrapper, Decl(awaitContextAndStaticMembers3.ts, 0, 0))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers3.ts, 0, 24))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+
+    return class C {
+>C : Symbol(C, Decl(awaitContextAndStaticMembers3.ts, 1, 10))
+
+        static staticField1 = await (v);
+>staticField1 : Symbol(C.staticField1, Decl(awaitContextAndStaticMembers3.ts, 1, 20))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers3.ts, 0, 24))
+
+        static staticField2 = await (v) + C.staticField1;
+>staticField2 : Symbol(C.staticField2, Decl(awaitContextAndStaticMembers3.ts, 2, 40))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers3.ts, 0, 24))
+>C.staticField1 : Symbol(C.staticField1, Decl(awaitContextAndStaticMembers3.ts, 1, 20))
+>C : Symbol(C, Decl(awaitContextAndStaticMembers3.ts, 1, 10))
+>staticField1 : Symbol(C.staticField1, Decl(awaitContextAndStaticMembers3.ts, 1, 20))
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers3(target=es5).types
+++ b/tests/baselines/reference/awaitContextAndStaticMembers3(target=es5).types
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers3.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : (v: Promise<number>) => Promise<typeof C>
+>v : Promise<number>
+
+    return class C {
+>class C {        static staticField1 = await (v);        static staticField2 = await (v) + C.staticField1;    } : typeof C
+>C : typeof C
+
+        static staticField1 = await (v);
+>staticField1 : number
+>await (v) : number
+>(v) : Promise<number>
+>v : Promise<number>
+
+        static staticField2 = await (v) + C.staticField1;
+>staticField2 : number
+>await (v) + C.staticField1 : number
+>await (v) : number
+>(v) : Promise<number>
+>v : Promise<number>
+>C.staticField1 : number
+>C : typeof C
+>staticField1 : number
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers3(target=es6).js
+++ b/tests/baselines/reference/awaitContextAndStaticMembers3(target=es6).js
@@ -1,0 +1,29 @@
+//// [awaitContextAndStaticMembers3.ts]
+async function wrapper (v: Promise<number>) {
+    return class C {
+        static staticField1 = await (v);
+        static staticField2 = await (v) + C.staticField1;
+    }
+}
+
+
+//// [awaitContextAndStaticMembers3.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+function wrapper(v) {
+    var _a;
+    return __awaiter(this, void 0, void 0, function* () {
+        return _a = class C {
+            },
+            _a.staticField1 = yield (v),
+            _a.staticField2 = (yield (v)) + _a.staticField1,
+            _a;
+    });
+}

--- a/tests/baselines/reference/awaitContextAndStaticMembers3(target=es6).symbols
+++ b/tests/baselines/reference/awaitContextAndStaticMembers3(target=es6).symbols
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers3.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : Symbol(wrapper, Decl(awaitContextAndStaticMembers3.ts, 0, 0))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers3.ts, 0, 24))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    return class C {
+>C : Symbol(C, Decl(awaitContextAndStaticMembers3.ts, 1, 10))
+
+        static staticField1 = await (v);
+>staticField1 : Symbol(C.staticField1, Decl(awaitContextAndStaticMembers3.ts, 1, 20))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers3.ts, 0, 24))
+
+        static staticField2 = await (v) + C.staticField1;
+>staticField2 : Symbol(C.staticField2, Decl(awaitContextAndStaticMembers3.ts, 2, 40))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers3.ts, 0, 24))
+>C.staticField1 : Symbol(C.staticField1, Decl(awaitContextAndStaticMembers3.ts, 1, 20))
+>C : Symbol(C, Decl(awaitContextAndStaticMembers3.ts, 1, 10))
+>staticField1 : Symbol(C.staticField1, Decl(awaitContextAndStaticMembers3.ts, 1, 20))
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers3(target=es6).types
+++ b/tests/baselines/reference/awaitContextAndStaticMembers3(target=es6).types
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers3.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : (v: Promise<number>) => Promise<typeof C>
+>v : Promise<number>
+
+    return class C {
+>class C {        static staticField1 = await (v);        static staticField2 = await (v) + C.staticField1;    } : typeof C
+>C : typeof C
+
+        static staticField1 = await (v);
+>staticField1 : number
+>await (v) : number
+>(v) : Promise<number>
+>v : Promise<number>
+
+        static staticField2 = await (v) + C.staticField1;
+>staticField2 : number
+>await (v) + C.staticField1 : number
+>await (v) : number
+>(v) : Promise<number>
+>v : Promise<number>
+>C.staticField1 : number
+>C : typeof C
+>staticField1 : number
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers3(target=esnext).js
+++ b/tests/baselines/reference/awaitContextAndStaticMembers3(target=esnext).js
@@ -1,0 +1,18 @@
+//// [awaitContextAndStaticMembers3.ts]
+async function wrapper (v: Promise<number>) {
+    return class C {
+        static staticField1 = await (v);
+        static staticField2 = await (v) + C.staticField1;
+    }
+}
+
+
+//// [awaitContextAndStaticMembers3.js]
+async function wrapper(v) {
+    var _a;
+    return _a = class C {
+        },
+        _a.staticField1 = await (v),
+        _a.staticField2 = await (v) + _a.staticField1,
+        _a;
+}

--- a/tests/baselines/reference/awaitContextAndStaticMembers3(target=esnext).symbols
+++ b/tests/baselines/reference/awaitContextAndStaticMembers3(target=esnext).symbols
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers3.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : Symbol(wrapper, Decl(awaitContextAndStaticMembers3.ts, 0, 0))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers3.ts, 0, 24))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+    return class C {
+>C : Symbol(C, Decl(awaitContextAndStaticMembers3.ts, 1, 10))
+
+        static staticField1 = await (v);
+>staticField1 : Symbol(C.staticField1, Decl(awaitContextAndStaticMembers3.ts, 1, 20))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers3.ts, 0, 24))
+
+        static staticField2 = await (v) + C.staticField1;
+>staticField2 : Symbol(C.staticField2, Decl(awaitContextAndStaticMembers3.ts, 2, 40))
+>v : Symbol(v, Decl(awaitContextAndStaticMembers3.ts, 0, 24))
+>C.staticField1 : Symbol(C.staticField1, Decl(awaitContextAndStaticMembers3.ts, 1, 20))
+>C : Symbol(C, Decl(awaitContextAndStaticMembers3.ts, 1, 10))
+>staticField1 : Symbol(C.staticField1, Decl(awaitContextAndStaticMembers3.ts, 1, 20))
+    }
+}
+

--- a/tests/baselines/reference/awaitContextAndStaticMembers3(target=esnext).types
+++ b/tests/baselines/reference/awaitContextAndStaticMembers3(target=esnext).types
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers3.ts ===
+async function wrapper (v: Promise<number>) {
+>wrapper : (v: Promise<number>) => Promise<typeof C>
+>v : Promise<number>
+
+    return class C {
+>class C {        static staticField1 = await (v);        static staticField2 = await (v) + C.staticField1;    } : typeof C
+>C : typeof C
+
+        static staticField1 = await (v);
+>staticField1 : number
+>await (v) : number
+>(v) : Promise<number>
+>v : Promise<number>
+
+        static staticField2 = await (v) + C.staticField1;
+>staticField2 : number
+>await (v) + C.staticField1 : number
+>await (v) : number
+>(v) : Promise<number>
+>v : Promise<number>
+>C.staticField1 : number
+>C : typeof C
+>staticField1 : number
+    }
+}
+

--- a/tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers1.ts
+++ b/tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers1.ts
@@ -1,0 +1,6 @@
+// @target: esnext, es6, es5
+async function wrapper (v: Promise<number>) {
+    return class {
+        static staticField = await (v);
+    }
+}

--- a/tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers2.ts
+++ b/tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers2.ts
@@ -1,0 +1,6 @@
+// @target: esnext, es6, es5
+async function wrapper (v: Promise<number>) {
+    return class {
+        field = await (v);
+    }
+}

--- a/tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers3.ts
+++ b/tests/cases/conformance/classes/members/awaitAndYieldContextAndStaticMembers/awaitContextAndStaticMembers3.ts
@@ -1,0 +1,7 @@
+// @target: esnext, es6, es5
+async function wrapper (v: Promise<number>) {
+    return class C {
+        static staticField1 = await (v);
+        static staticField2 = await (v) + C.staticField1;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #43099 

This PR allows await inside static class field context.

And seems `yield` could cross the class boundary but the function. 

It's not match with out downgrade emit. So I haven't support yield.