### PR TITLE
Made TS6059 rootDir validation consistent for programmatic usage

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3195,9 +3195,10 @@ namespace ts {
                 }
             }
 
-            // there has to be common source directory if user specified --outdir || --sourceRoot
+            // there has to be common source directory if user specified --outdir || --rootDir || --sourceRoot
             // if user specified --mapRoot, there needs to be common source directory if there would be multiple files being emitted
             if (options.outDir || // there is --outDir specified
+                options.rootDir || // there is --rootDir specified
                 options.sourceRoot || // there is --sourceRoot specified
                 options.mapRoot) { // there is --mapRoot specified
 

--- a/src/testRunner/unittests/services/transpile.ts
+++ b/src/testRunner/unittests/services/transpile.ts
@@ -372,7 +372,7 @@ var x = 0;`, {
         });
 
         transpilesCorrectly("Supports setting 'rootDir'", "x;", {
-            options: { compilerOptions: { rootDir: "./rootDir" }, fileName: "input.js", reportDiagnostics: true }
+            options: { compilerOptions: { rootDir: "./rootDir" }, fileName: "./rootDir/input.js", reportDiagnostics: true }
         });
 
         transpilesCorrectly("Supports setting 'rootDirs'", "x;", {

--- a/tests/baselines/reference/project/rootDirectoryWithoutOutDir/amd/rootDirectoryWithoutOutDir.errors.txt
+++ b/tests/baselines/reference/project/rootDirectoryWithoutOutDir/amd/rootDirectoryWithoutOutDir.errors.txt
@@ -1,0 +1,18 @@
+error TS6059: File 'FolderA/FolderB/fileB.ts' is not under 'rootDir' 'FolderA/FolderB/FolderC'. 'rootDir' is expected to contain all source files.
+  The file is in the program because:
+    Root file specified for compilation
+
+
+!!! error TS6059: File 'FolderA/FolderB/fileB.ts' is not under 'rootDir' 'FolderA/FolderB/FolderC'. 'rootDir' is expected to contain all source files.
+!!! error TS6059:   The file is in the program because:
+!!! error TS6059:     Root file specified for compilation
+==== FolderA/FolderB/FolderC/fileC.ts (0 errors) ====
+    class C {
+    }
+    
+==== FolderA/FolderB/fileB.ts (0 errors) ====
+    /// <reference path='FolderC/fileC.ts'/>
+    class B {
+        public c: C;
+    }
+    

--- a/tests/baselines/reference/project/rootDirectoryWithoutOutDir/amd/rootDirectoryWithoutOutDir.json
+++ b/tests/baselines/reference/project/rootDirectoryWithoutOutDir/amd/rootDirectoryWithoutOutDir.json
@@ -1,0 +1,17 @@
+{
+    "scenario": "rootDirectory: Files outside the rootDirectory without outDir",
+    "projectRoot": "tests/cases/projects/rootDirectory",
+    "inputFiles": [
+        "FolderA/FolderB/fileB.ts"
+    ],
+    "rootDir": "FolderA/FolderB/FolderC",
+    "resolvedInputFiles": [
+        "lib.es5.d.ts",
+        "FolderA/FolderB/FolderC/fileC.ts",
+        "FolderA/FolderB/fileB.ts"
+    ],
+    "emittedFiles": [
+        "FolderA/FolderB/FolderC/fileC.js",
+        "FolderA/FolderB/fileB.js"
+    ]
+}

--- a/tests/baselines/reference/project/rootDirectoryWithoutOutDir/node/rootDirectoryWithoutOutDir.errors.txt
+++ b/tests/baselines/reference/project/rootDirectoryWithoutOutDir/node/rootDirectoryWithoutOutDir.errors.txt
@@ -1,0 +1,18 @@
+error TS6059: File 'FolderA/FolderB/fileB.ts' is not under 'rootDir' 'FolderA/FolderB/FolderC'. 'rootDir' is expected to contain all source files.
+  The file is in the program because:
+    Root file specified for compilation
+
+
+!!! error TS6059: File 'FolderA/FolderB/fileB.ts' is not under 'rootDir' 'FolderA/FolderB/FolderC'. 'rootDir' is expected to contain all source files.
+!!! error TS6059:   The file is in the program because:
+!!! error TS6059:     Root file specified for compilation
+==== FolderA/FolderB/FolderC/fileC.ts (0 errors) ====
+    class C {
+    }
+    
+==== FolderA/FolderB/fileB.ts (0 errors) ====
+    /// <reference path='FolderC/fileC.ts'/>
+    class B {
+        public c: C;
+    }
+    

--- a/tests/baselines/reference/project/rootDirectoryWithoutOutDir/node/rootDirectoryWithoutOutDir.json
+++ b/tests/baselines/reference/project/rootDirectoryWithoutOutDir/node/rootDirectoryWithoutOutDir.json
@@ -1,0 +1,17 @@
+{
+    "scenario": "rootDirectory: Files outside the rootDirectory without outDir",
+    "projectRoot": "tests/cases/projects/rootDirectory",
+    "inputFiles": [
+        "FolderA/FolderB/fileB.ts"
+    ],
+    "rootDir": "FolderA/FolderB/FolderC",
+    "resolvedInputFiles": [
+        "lib.es5.d.ts",
+        "FolderA/FolderB/FolderC/fileC.ts",
+        "FolderA/FolderB/fileB.ts"
+    ],
+    "emittedFiles": [
+        "FolderA/FolderB/FolderC/fileC.js",
+        "FolderA/FolderB/fileB.js"
+    ]
+}

--- a/tests/cases/project/rootDirectoryWithoutOutDir.json
+++ b/tests/cases/project/rootDirectoryWithoutOutDir.json
@@ -1,0 +1,8 @@
+{
+    "scenario": "rootDirectory: Files outside the rootDirectory without outDir",
+    "projectRoot": "tests/cases/projects/rootDirectory",
+    "inputFiles": [
+        "FolderA/FolderB/fileB.ts"
+    ],
+    "rootDir": "FolderA/FolderB/FolderC"
+}


### PR DESCRIPTION
When `outDir`, `sourceRoot`, and/or `mapRoot` are specified, the program preemptively called `getCommonSourceDirectory`, which reports the missing diagnostic if needed. This should still happen if `rootDir` is enabled without any of the other flags.

Fixes #41020.
