### PR TITLE
Added a sys.resetCurrentDirectory() in front of build cache enabling

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1653,6 +1653,23 @@ namespace ts {
     }
 
     /**
+     * A version of `memoize` that can be cleared on demand.
+     *
+     * @remarks
+     * Don't use in repeated (memory leakable) blocks: the callback reference is preserved.
+     */
+    export function memoizeWithClear<T>(callback: () => T): [() => T, () => void] {
+        let getValue = memoize(callback);
+
+        return [
+            () => getValue(),
+            () => {
+                getValue = memoize(callback);
+            },
+        ];
+    }
+
+    /**
      * High-order function, composes functions. Note that functions are composed inside-out;
      * for example, `compose(a, b)` is the equivalent of `x => b(a(x))`.
      *

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1178,6 +1178,7 @@ namespace ts {
         createDirectory(path: string): void;
         getExecutingFilePath(): string;
         getCurrentDirectory(): string;
+        /*@internal*/resetCurrentDirectory(): void;
         getDirectories(path: string): string[];
         readDirectory(path: string, extensions?: readonly string[], exclude?: readonly string[], include?: readonly string[], depth?: number): string[];
         getModifiedTime?(path: string): Date | undefined;
@@ -1278,7 +1279,7 @@ namespace ts {
             const platform: string = _os.platform();
             const useCaseSensitiveFileNames = isFileSystemCaseSensitive();
             const fsSupportsRecursiveFsWatch = isNode4OrLater && (process.platform === "win32" || process.platform === "darwin");
-            const getCurrentDirectory = memoize(() => process.cwd());
+            const [getCurrentDirectory, resetCurrentDirectory] = memoizeWithClear(() => process.cwd());
             const { watchFile, watchDirectory } = createSystemWatchFunctions({
                 pollingWatchFile: createSingleFileWatcherPerName(fsWatchFileWorker, useCaseSensitiveFileNames),
                 getModifiedTime,
@@ -1335,6 +1336,7 @@ namespace ts {
                     return __filename;
                 },
                 getCurrentDirectory,
+                resetCurrentDirectory,
                 getDirectories,
                 getEnvironmentVariable(name: string) {
                     return process.env[name] || "";

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -512,6 +512,10 @@ namespace ts {
             disableCache(state);
         }
 
+        // Public implementers may process.chdir between builds
+        // https://github.com/microsoft/TypeScript/issues/43120
+        sys.resetCurrentDirectory();
+
         const { compilerHost, host } = state;
 
         const originalReadFileWithCache = state.readFileWithCache;

--- a/src/harness/fakesHosts.ts
+++ b/src/harness/fakesHosts.ts
@@ -78,6 +78,8 @@ namespace fakes {
             return this.vfs.cwd();
         }
 
+        public resetCurrentDirectory() { /*noop*/ }
+
         public getDirectories(path: string) {
             const result: string[] = [];
             try {

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -248,6 +248,7 @@ namespace Harness.LanguageService {
         }
 
         getCurrentDirectory(): string { return virtualFileSystemRoot; }
+        resetCurrentDirectory() { /*noop*/ }
 
         getDefaultLibFileName(): string { return Compiler.defaultLibFileName; }
 
@@ -369,6 +370,7 @@ namespace Harness.LanguageService {
         getCompilationSettings(): string { return JSON.stringify(this.nativeHost.getCompilationSettings()); }
         getCancellationToken(): ts.HostCancellationToken { return this.nativeHost.getCancellationToken(); }
         getCurrentDirectory(): string { return this.nativeHost.getCurrentDirectory(); }
+        resetCurrentDirectory() { this.nativeHost.resetCurrentDirectory(); }
         getDirectories(path: string): string { return JSON.stringify(this.nativeHost.getDirectories(path)); }
         getDefaultLibFileName(): string { return this.nativeHost.getDefaultLibFileName(); }
         getScriptFileNames(): string { return JSON.stringify(this.nativeHost.getScriptFileNames()); }
@@ -772,6 +774,10 @@ namespace Harness.LanguageService {
         }
 
         getCurrentDirectory(): string {
+            return this.host.getCurrentDirectory();
+        }
+
+        resetCurrentDirectory(): string {
             return this.host.getCurrentDirectory();
         }
 

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -1112,6 +1112,7 @@ interface Array<T> { length: number; [n: number]: T; }`
         readonly resolvePath = (s: string) => s;
         readonly getExecutingFilePath = () => this.executingFilePath;
         readonly getCurrentDirectory = () => this.currentDirectory;
+        readonly resetCurrentDirectory = noop;
         exit(exitCode?: number) {
             this.exitCode = exitCode;
             throw new Error(this.exitMessage);

--- a/src/testRunner/unittests/tsserver/session.ts
+++ b/src/testRunner/unittests/tsserver/session.ts
@@ -17,6 +17,7 @@ namespace ts.server {
         createDirectory: noop,
         getExecutingFilePath(): string { return ""; },
         getCurrentDirectory(): string { return ""; },
+        resetCurrentDirectory: noop,
         getEnvironmentVariable(): string { return ""; },
         readDirectory() { return []; },
         exit: noop,

--- a/src/webServer/webServer.ts
+++ b/src/webServer/webServer.ts
@@ -129,6 +129,7 @@ namespace ts.server {
 
             getExecutingFilePath: () => directorySeparator,
             getCurrentDirectory: returnEmptyString, // For inferred project root if projectRoot path is not set, normalizing the paths
+            resetCurrentDirectory: noop,
 
             /* eslint-disable no-restricted-globals */
             setTimeout,


### PR DESCRIPTION
Fixes #43120

I'm suspicious of this change: it feels odd to add a specific "reset" function to the global system that is only used by the Node version... but `ts.sys` is a global namespace "constant" that isn't reset between builds.

I was also confused by the existing unit test locations and couldn't figure out which area was the precedent to follow. Could someone give me a hint please? (sorry!)