### PR TITLE
Fix37991

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -34665,8 +34665,8 @@ namespace ts {
                 }
             }
 
-            if (node.kind === SyntaxKind.BindingElement) {
-                if (node.parent.kind === SyntaxKind.ObjectBindingPattern && languageVersion < ScriptTarget.ESNext) {
+            if (isBindingElement(node)) {
+                if (isObjectBindingPattern(node.parent) && node.dotDotDotToken && languageVersion < ScriptTarget.ES2018) {
                     checkExternalEmitHelpers(node, ExternalEmitHelpers.Rest);
                 }
                 // check computed properties inside property names of binding elements

--- a/tests/baselines/reference/tslibInJs.errors.txt
+++ b/tests/baselines/reference/tslibInJs.errors.txt
@@ -1,11 +1,8 @@
-tests/cases/compiler/main.js(2,9): error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.
 tests/cases/compiler/main.js(2,25): error TS2307: Cannot find module 'bar' or its corresponding type declarations.
 
 
-==== tests/cases/compiler/main.js (2 errors) ====
+==== tests/cases/compiler/main.js (1 errors) ====
     "use strict";
     const { foo } = require("bar");
-            ~~~
-!!! error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.
                             ~~~~~
 !!! error TS2307: Cannot find module 'bar' or its corresponding type declarations.

--- a/tests/baselines/reference/tslibInJs.errors.txt
+++ b/tests/baselines/reference/tslibInJs.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/main.js(2,9): error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.
+tests/cases/compiler/main.js(2,25): error TS2307: Cannot find module 'bar' or its corresponding type declarations.
+
+
+==== tests/cases/compiler/main.js (2 errors) ====
+    "use strict";
+    const { foo } = require("bar");
+            ~~~
+!!! error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.
+                            ~~~~~
+!!! error TS2307: Cannot find module 'bar' or its corresponding type declarations.

--- a/tests/baselines/reference/tslibInJs.symbols
+++ b/tests/baselines/reference/tslibInJs.symbols
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/main.js ===
+"use strict";
+const { foo } = require("bar");
+>foo : Symbol(foo, Decl(main.js, 1, 7))
+>require : Symbol(require)
+

--- a/tests/baselines/reference/tslibInJs.types
+++ b/tests/baselines/reference/tslibInJs.types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/main.js ===
+"use strict";
+>"use strict" : "use strict"
+
+const { foo } = require("bar");
+>foo : any
+>require("bar") : any
+>require : any
+>"bar" : "bar"
+

--- a/tests/cases/compiler/tslibInJs.ts
+++ b/tests/cases/compiler/tslibInJs.ts
@@ -1,0 +1,13 @@
+// @checkJs: true
+// @allowJs: true
+// @moduleResolution: node
+// @target: es2018
+// @module: commonjs
+// @importHelpers: true
+// @lib: es2018
+// @outDir: out
+// @noEmit: true
+
+// @fileName: main.js
+"use strict";
+const { foo } = require("bar");


### PR DESCRIPTION
Our check for when we need the `__rest` helper was too broad.

If you go by commit, you can see the error as it exists today in the first commit, with the fix applied in the second commit.

Fixes #37991
