### PR TITLE
Allowed tsconfig 'extends' to match node_modules/ .jsonc file

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1060,19 +1060,12 @@ namespace ts {
      * in cases when we know upfront that all load attempts will fail (because containing folder does not exists) however we still need to record all failed lookup locations.
      */
     function loadModuleFromFile(extensions: Extensions, candidate: string, onlyRecordFailures: boolean, state: ModuleResolutionState): PathAndExtension | undefined {
-        // JSON files may be imported as a module only if there is an explicit .json extension
-        if (extensions === Extensions.Json) {
+        if (extensions === Extensions.Json || extensions === Extensions.TSConfig) {
             const extensionLess = tryRemoveExtension(candidate, Extension.Json);
-            return extensionLess === undefined ? undefined : tryAddingExtensions(extensionLess || candidate, extensions, onlyRecordFailures, state);
+            return (extensionLess === undefined && extensions === Extensions.Json) ? undefined : tryAddingExtensions(extensionLess || candidate, extensions, onlyRecordFailures, state);
         }
 
-        // TSConfig files may exist as extensionless, '.json', or '.jsonc'
-        if (extensions === Extensions.TSConfig) {
-            const extensionLess = tryRemoveExtension(candidate, Extension.Json) || tryRemoveExtension(candidate, Extension.Jsonc);
-            return tryAddingExtensions(extensionLess || candidate, extensions, onlyRecordFailures, state);
-        }
-
-        // For all other file imports, first try adding an extension. An import of "foo" could be matched by a file "foo.ts", or "foo.js" by "foo.js.ts"
+        // First, try adding an extension. An import of "foo" could be matched by a file "foo.ts", or "foo.js" by "foo.js.ts"
         const resolvedByAddingExtension = tryAddingExtensions(candidate, extensions, onlyRecordFailures, state);
         if (resolvedByAddingExtension) {
             return resolvedByAddingExtension;
@@ -1108,7 +1101,7 @@ namespace ts {
             case Extensions.JavaScript:
                 return tryExtension(Extension.Js) || tryExtension(Extension.Jsx);
             case Extensions.TSConfig:
-                return tryExtension(Extension.Json) || tryExtension(Extension.Jsonc);
+                return tryExtension(Extension.Json) || tryExtension(Extension.Extensionless);
             case Extensions.Json:
                 return tryExtension(Extension.Json);
         }

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1060,12 +1060,19 @@ namespace ts {
      * in cases when we know upfront that all load attempts will fail (because containing folder does not exists) however we still need to record all failed lookup locations.
      */
     function loadModuleFromFile(extensions: Extensions, candidate: string, onlyRecordFailures: boolean, state: ModuleResolutionState): PathAndExtension | undefined {
-        if (extensions === Extensions.Json || extensions === Extensions.TSConfig) {
+        // JSON files may be imported as a module only if there is an explicit .json extension
+        if (extensions === Extensions.Json) {
             const extensionLess = tryRemoveExtension(candidate, Extension.Json);
-            return (extensionLess === undefined && extensions === Extensions.Json) ? undefined : tryAddingExtensions(extensionLess || candidate, extensions, onlyRecordFailures, state);
+            return extensionLess === undefined ? undefined : tryAddingExtensions(extensionLess || candidate, extensions, onlyRecordFailures, state);
         }
 
-        // First, try adding an extension. An import of "foo" could be matched by a file "foo.ts", or "foo.js" by "foo.js.ts"
+        // TSConfig files may exist as extensionless, '.json', or '.jsonc'
+        if (extensions === Extensions.TSConfig) {
+            const extensionLess = tryRemoveExtension(candidate, Extension.Json) || tryRemoveExtension(candidate, Extension.Jsonc);
+            return tryAddingExtensions(extensionLess || candidate, extensions, onlyRecordFailures, state);
+        }
+
+        // For all other file imports, first try adding an extension. An import of "foo" could be matched by a file "foo.ts", or "foo.js" by "foo.js.ts"
         const resolvedByAddingExtension = tryAddingExtensions(candidate, extensions, onlyRecordFailures, state);
         if (resolvedByAddingExtension) {
             return resolvedByAddingExtension;
@@ -1101,6 +1108,7 @@ namespace ts {
             case Extensions.JavaScript:
                 return tryExtension(Extension.Js) || tryExtension(Extension.Jsx);
             case Extensions.TSConfig:
+                return tryExtension(Extension.Json) || tryExtension(Extension.Jsonc);
             case Extensions.Json:
                 return tryExtension(Extension.Json);
         }

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -678,8 +678,9 @@ namespace ts.moduleSpecifiers {
             case Extension.Jsx:
             case Extension.Json:
                 return ext;
+            case Extension.Jsonc:
             case Extension.TsBuildInfo:
-                return Debug.fail(`Extension ${Extension.TsBuildInfo} is unsupported:: FileName:: ${fileName}`);
+                return Debug.fail(`Extension ${ext} is unsupported:: FileName:: ${fileName}`);
             default:
                 return Debug.assertNever(ext);
         }

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -678,7 +678,7 @@ namespace ts.moduleSpecifiers {
             case Extension.Jsx:
             case Extension.Json:
                 return ext;
-            case Extension.Jsonc:
+            case Extension.Extensionless:
             case Extension.TsBuildInfo:
                 return Debug.fail(`Extension ${ext} is unsupported:: FileName:: ${fileName}`);
             default:

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6351,13 +6351,13 @@ namespace ts {
     }
 
     export const enum Extension {
+        Extensionless = "",
         Ts = ".ts",
         Tsx = ".tsx",
         Dts = ".d.ts",
         Js = ".js",
         Jsx = ".jsx",
         Json = ".json",
-        Jsonc = ".jsonc",
         TsBuildInfo = ".tsbuildinfo"
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6357,6 +6357,7 @@ namespace ts {
         Js = ".js",
         Jsx = ".jsx",
         Json = ".json",
+        Jsonc = ".jsonc",
         TsBuildInfo = ".tsbuildinfo"
     }
 

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -90,7 +90,9 @@ namespace ts.Completions.StringCompletions {
             case Extension.Jsx: return ScriptElementKindModifier.jsxModifier;
             case Extension.Ts: return ScriptElementKindModifier.tsModifier;
             case Extension.Tsx: return ScriptElementKindModifier.tsxModifier;
-            case Extension.TsBuildInfo: return Debug.fail(`Extension ${Extension.TsBuildInfo} is unsupported.`);
+            case Extension.Jsonc:
+            case Extension.TsBuildInfo:
+                return Debug.fail(`Extension ${extension} is unsupported.`);
             case undefined: return ScriptElementKindModifier.none;
             default:
                 return Debug.assertNever(extension);

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -90,7 +90,7 @@ namespace ts.Completions.StringCompletions {
             case Extension.Jsx: return ScriptElementKindModifier.jsxModifier;
             case Extension.Ts: return ScriptElementKindModifier.tsModifier;
             case Extension.Tsx: return ScriptElementKindModifier.tsxModifier;
-            case Extension.Jsonc:
+            case Extension.Extensionless:
             case Extension.TsBuildInfo:
                 return Debug.fail(`Extension ${extension} is unsupported.`);
             case undefined: return ScriptElementKindModifier.none;

--- a/src/testRunner/unittests/config/configurationExtension.ts
+++ b/src/testRunner/unittests/config/configurationExtension.ts
@@ -19,6 +19,11 @@ namespace ts {
                             strict: false,
                         }
                     }),
+                    "dev/node_modules/config-box/with-comments.jsonc": JSON.stringify({
+                        compilerOptions: {
+                            strict: true,
+                        }
+                    }) + "// ...",
                     "dev/tsconfig.extendsBox.json": JSON.stringify({
                         extends: "config-box",
                         files: [
@@ -39,6 +44,12 @@ namespace ts {
                     }),
                     "dev/tsconfig.extendsStrictExtension.json": JSON.stringify({
                         extends: "config-box/strict.json",
+                        files: [
+                            "main.ts",
+                        ]
+                    }),
+                    "dev/tsconfig.extendsCommentExtension.json": JSON.stringify({
+                        extends: "config-box/with-comments.jsonc",
                         files: [
                             "main.ts",
                         ]
@@ -329,6 +340,7 @@ namespace ts {
                     testSuccess("can lookup via package-relative path", "tsconfig.extendsStrict.json", { strict: true }, [combinePaths(basePath, "main.ts")]);
                     testSuccess("can lookup via non-redirected-to package-relative path", "tsconfig.extendsUnStrict.json", { strict: false }, [combinePaths(basePath, "main.ts")]);
                     testSuccess("can lookup via package-relative path with extension", "tsconfig.extendsStrictExtension.json", { strict: true }, [combinePaths(basePath, "main.ts")]);
+                    testSuccess("can lookup via package-relative path with extension that has comments", "tsconfig.extendsCommentExtension.json", { strict: true }, [combinePaths(basePath, "main.ts")]);
                     testSuccess("can lookup via an implicit tsconfig", "tsconfig.extendsBoxImplied.json", { strict: true }, [combinePaths(basePath, "main.ts")]);
                     testSuccess("can lookup via an implicit tsconfig in a package-relative directory", "tsconfig.extendsBoxImpliedUnstrict.json", { strict: false }, [combinePaths(basePath, "main.ts")]);
                     testSuccess("can lookup via an implicit tsconfig in a package-relative directory with name", "tsconfig.extendsBoxImpliedUnstrictExtension.json", { strict: false }, [combinePaths(basePath, "main.ts")]);

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3052,13 +3052,13 @@ declare namespace ts {
         version: string;
     }
     export enum Extension {
+        Extensionless = "",
         Ts = ".ts",
         Tsx = ".tsx",
         Dts = ".d.ts",
         Js = ".js",
         Jsx = ".jsx",
         Json = ".json",
-        Jsonc = ".jsonc",
         TsBuildInfo = ".tsbuildinfo"
     }
     export interface ResolvedModuleWithFailedLookupLocations {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3058,6 +3058,7 @@ declare namespace ts {
         Js = ".js",
         Jsx = ".jsx",
         Json = ".json",
+        Jsonc = ".jsonc",
         TsBuildInfo = ".tsbuildinfo"
     }
     export interface ResolvedModuleWithFailedLookupLocations {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3052,13 +3052,13 @@ declare namespace ts {
         version: string;
     }
     export enum Extension {
+        Extensionless = "",
         Ts = ".ts",
         Tsx = ".tsx",
         Dts = ".d.ts",
         Js = ".js",
         Jsx = ".jsx",
         Json = ".json",
-        Jsonc = ".jsonc",
         TsBuildInfo = ".tsbuildinfo"
     }
     export interface ResolvedModuleWithFailedLookupLocations {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3058,6 +3058,7 @@ declare namespace ts {
         Js = ".js",
         Jsx = ".jsx",
         Json = ".json",
+        Jsonc = ".jsonc",
         TsBuildInfo = ".tsbuildinfo"
     }
     export interface ResolvedModuleWithFailedLookupLocations {


### PR DESCRIPTION
Fixes #43121

Adds `Extension.Jsonc` as an option for module resolution specifically in tsconfig extension lookups.

A little unfortunate to add more `Debug.fail`s. Perhaps this is an accidental step towards more first-class support for `.jsonc` files...?