### PR TITLE
Corrected parsing for decorators on 'this' parameters

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33729,10 +33729,6 @@ namespace ts {
                 case SyntaxKind.Parameter:
                     expectedReturnType = voidType;
 
-                    if (isThisIdentifier(node.parent.name)) {
-                        error(node, Diagnostics.Decorators_may_not_be_applied_to_this_parameters);
-                    }
-
                     errorInfo = chainDiagnosticMessages(
                         /*details*/ undefined,
                         Diagnostics.The_return_type_of_a_parameter_decorator_function_must_be_either_void_or_any);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33728,6 +33728,11 @@ namespace ts {
 
                 case SyntaxKind.Parameter:
                     expectedReturnType = voidType;
+
+                    if (isThisIdentifier(node.parent.name)) {
+                        error(node, Diagnostics.Decorators_may_not_be_applied_to_this_parameters);
+                    }
+
                     errorInfo = chainDiagnosticMessages(
                         /*details*/ undefined,
                         Diagnostics.The_return_type_of_a_parameter_decorator_function_must_be_either_void_or_any);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33728,7 +33728,6 @@ namespace ts {
 
                 case SyntaxKind.Parameter:
                     expectedReturnType = voidType;
-
                     errorInfo = chainDiagnosticMessages(
                         /*details*/ undefined,
                         Diagnostics.The_return_type_of_a_parameter_decorator_function_must_be_either_void_or_any);

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1360,6 +1360,10 @@
         "category": "Error",
         "code": 1432
     },
+    "Decorators may not be applied to 'this' parameters.": {
+        "category": "Error",
+        "code": 1433
+    },
 
     "The types of '{0}' are incompatible between these types.": {
         "category": "Error",

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2976,6 +2976,11 @@ namespace ts {
                     parseTypeAnnotation(),
                     /*initializer*/ undefined
                 );
+
+                if (decorators) {
+                    parseErrorAtRange(decorators[0], Diagnostics.Decorators_may_not_be_applied_to_this_parameters);
+                }
+
                 return withJSDoc(finishNode(node, pos), hasJSDoc);
             }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2959,9 +2959,16 @@ namespace ts {
         function parseParameterWorker(inOuterAwaitContext: boolean): ParameterDeclaration {
             const pos = getNodePos();
             const hasJSDoc = hasPrecedingJSDocComment();
+
+            // FormalParameter [Yield,Await]:
+            //      BindingElement[?Yield,?Await]
+
+            // Decorators are parsed in the outer [Await] context, the rest of the parameter is parsed in the function's [Await] context.
+            const decorators = inOuterAwaitContext ? doInAwaitContext(parseDecorators) : parseDecorators();
+
             if (token() === SyntaxKind.ThisKeyword) {
                 const node = factory.createParameterDeclaration(
-                    /*decorators*/ undefined,
+                    decorators,
                     /*modifiers*/ undefined,
                     /*dotDotDotToken*/ undefined,
                     createIdentifier(/*isIdentifier*/ true),
@@ -2972,11 +2979,6 @@ namespace ts {
                 return withJSDoc(finishNode(node, pos), hasJSDoc);
             }
 
-            // FormalParameter [Yield,Await]:
-            //      BindingElement[?Yield,?Await]
-
-            // Decorators are parsed in the outer [Await] context, the rest of the parameter is parsed in the function's [Await] context.
-            const decorators = inOuterAwaitContext ? doInAwaitContext(parseDecorators) : parseDecorators();
             const savedTopLevel = topLevel;
             topLevel = false;
             const modifiers = parseModifiers();

--- a/tests/baselines/reference/decoratorOnClassMethodThisParameter.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassMethodThisParameter.errors.txt
@@ -1,12 +1,12 @@
 tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts(4,12): error TS1433: Decorators may not be applied to 'this' parameters.
-tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts(8,30): error TS1433: Decorators may not be applied to 'this' parameters.
+tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts(8,29): error TS1433: Decorators may not be applied to 'this' parameters.
 tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts(8,30): error TS2680: A 'this' parameter must be the first parameter.
 
 
 ==== tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts (3 errors) ====
     declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
     
-    class C { 
+    class C {
         method(@dec this: C) {}
                ~~~~
 !!! error TS1433: Decorators may not be applied to 'this' parameters.
@@ -14,7 +14,7 @@ tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethod
     
     class C2 {
         method(@dec allowed: C2, @dec this: C2) {}
-                                 ~~~~
+                                ~~~~~
 !!! error TS1433: Decorators may not be applied to 'this' parameters.
                                  ~~~~~~~~~~~~~
 !!! error TS2680: A 'this' parameter must be the first parameter.

--- a/tests/baselines/reference/decoratorOnClassMethodThisParameter.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassMethodThisParameter.errors.txt
@@ -1,14 +1,21 @@
-tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts(4,17): error TS1359: Identifier expected. 'this' is a reserved word that cannot be used here.
-tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts(4,17): error TS2680: A 'this' parameter must be the first parameter.
+tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts(4,12): error TS1433: Decorators may not be applied to 'this' parameters.
+tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts(8,30): error TS1433: Decorators may not be applied to 'this' parameters.
+tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts(8,30): error TS2680: A 'this' parameter must be the first parameter.
 
 
-==== tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts (2 errors) ====
+==== tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts (3 errors) ====
     declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
     
-    class C {
+    class C { 
         method(@dec this: C) {}
-                    ~~~~
-!!! error TS1359: Identifier expected. 'this' is a reserved word that cannot be used here.
-                    ~~~~~~~
+               ~~~~
+!!! error TS1433: Decorators may not be applied to 'this' parameters.
+    }
+    
+    class C2 {
+        method(@dec allowed: C2, @dec this: C2) {}
+                                 ~~~~
+!!! error TS1433: Decorators may not be applied to 'this' parameters.
+                                 ~~~~~~~~~~~~~
 !!! error TS2680: A 'this' parameter must be the first parameter.
     }

--- a/tests/baselines/reference/decoratorOnClassMethodThisParameter.js
+++ b/tests/baselines/reference/decoratorOnClassMethodThisParameter.js
@@ -1,8 +1,12 @@
 //// [decoratorOnClassMethodThisParameter.ts]
 declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
 
-class C {
+class C { 
     method(@dec this: C) {}
+}
+
+class C2 {
+    method(@dec allowed: C2, @dec this: C2) {}
 }
 
 //// [decoratorOnClassMethodThisParameter.js]
@@ -19,8 +23,14 @@ var C = /** @class */ (function () {
     function C() {
     }
     C.prototype.method = function () { };
-    __decorate([
-        __param(0, dec)
-    ], C.prototype, "method", null);
     return C;
+}());
+var C2 = /** @class */ (function () {
+    function C2() {
+    }
+    C2.prototype.method = function (allowed) { };
+    __decorate([
+        __param(0, dec), __param(1, dec)
+    ], C2.prototype, "method", null);
+    return C2;
 }());

--- a/tests/baselines/reference/decoratorOnClassMethodThisParameter.js
+++ b/tests/baselines/reference/decoratorOnClassMethodThisParameter.js
@@ -1,7 +1,7 @@
 //// [decoratorOnClassMethodThisParameter.ts]
 declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
 
-class C { 
+class C {
     method(@dec this: C) {}
 }
 

--- a/tests/baselines/reference/decoratorOnClassMethodThisParameter.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethodThisParameter.symbols
@@ -6,7 +6,7 @@ declare function dec(target: Object, propertyKey: string | symbol, parameterInde
 >propertyKey : Symbol(propertyKey, Decl(decoratorOnClassMethodThisParameter.ts, 0, 36))
 >parameterIndex : Symbol(parameterIndex, Decl(decoratorOnClassMethodThisParameter.ts, 0, 66))
 
-class C { 
+class C {
 >C : Symbol(C, Decl(decoratorOnClassMethodThisParameter.ts, 0, 97))
 
     method(@dec this: C) {}

--- a/tests/baselines/reference/decoratorOnClassMethodThisParameter.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethodThisParameter.symbols
@@ -6,13 +6,25 @@ declare function dec(target: Object, propertyKey: string | symbol, parameterInde
 >propertyKey : Symbol(propertyKey, Decl(decoratorOnClassMethodThisParameter.ts, 0, 36))
 >parameterIndex : Symbol(parameterIndex, Decl(decoratorOnClassMethodThisParameter.ts, 0, 66))
 
-class C {
+class C { 
 >C : Symbol(C, Decl(decoratorOnClassMethodThisParameter.ts, 0, 97))
 
     method(@dec this: C) {}
 >method : Symbol(C.method, Decl(decoratorOnClassMethodThisParameter.ts, 2, 9))
 >dec : Symbol(dec, Decl(decoratorOnClassMethodThisParameter.ts, 0, 0))
-> : Symbol((Missing), Decl(decoratorOnClassMethodThisParameter.ts, 3, 11))
->this : Symbol(this, Decl(decoratorOnClassMethodThisParameter.ts, 3, 15))
+>this : Symbol(this, Decl(decoratorOnClassMethodThisParameter.ts, 3, 11))
 >C : Symbol(C, Decl(decoratorOnClassMethodThisParameter.ts, 0, 97))
+}
+
+class C2 {
+>C2 : Symbol(C2, Decl(decoratorOnClassMethodThisParameter.ts, 4, 1))
+
+    method(@dec allowed: C2, @dec this: C2) {}
+>method : Symbol(C2.method, Decl(decoratorOnClassMethodThisParameter.ts, 6, 10))
+>dec : Symbol(dec, Decl(decoratorOnClassMethodThisParameter.ts, 0, 0))
+>allowed : Symbol(allowed, Decl(decoratorOnClassMethodThisParameter.ts, 7, 11))
+>C2 : Symbol(C2, Decl(decoratorOnClassMethodThisParameter.ts, 4, 1))
+>dec : Symbol(dec, Decl(decoratorOnClassMethodThisParameter.ts, 0, 0))
+>this : Symbol(this, Decl(decoratorOnClassMethodThisParameter.ts, 7, 28))
+>C2 : Symbol(C2, Decl(decoratorOnClassMethodThisParameter.ts, 4, 1))
 }

--- a/tests/baselines/reference/decoratorOnClassMethodThisParameter.types
+++ b/tests/baselines/reference/decoratorOnClassMethodThisParameter.types
@@ -5,12 +5,22 @@ declare function dec(target: Object, propertyKey: string | symbol, parameterInde
 >propertyKey : string | symbol
 >parameterIndex : number
 
-class C {
+class C { 
 >C : C
 
     method(@dec this: C) {}
->method : (: any, this: C) => void
+>method : (this: C) => void
 >dec : (target: Object, propertyKey: string | symbol, parameterIndex: number) => void
-> : any
 >this : C
+}
+
+class C2 {
+>C2 : C2
+
+    method(@dec allowed: C2, @dec this: C2) {}
+>method : (allowed: C2, this: C2) => void
+>dec : (target: Object, propertyKey: string | symbol, parameterIndex: number) => void
+>allowed : C2
+>dec : (target: Object, propertyKey: string | symbol, parameterIndex: number) => void
+>this : C2
 }

--- a/tests/baselines/reference/decoratorOnClassMethodThisParameter.types
+++ b/tests/baselines/reference/decoratorOnClassMethodThisParameter.types
@@ -5,7 +5,7 @@ declare function dec(target: Object, propertyKey: string | symbol, parameterInde
 >propertyKey : string | symbol
 >parameterIndex : number
 
-class C { 
+class C {
 >C : C
 
     method(@dec this: C) {}

--- a/tests/baselines/reference/decoratorOnFunctionParameter.errors.txt
+++ b/tests/baselines/reference/decoratorOnFunctionParameter.errors.txt
@@ -1,0 +1,15 @@
+tests/cases/conformance/decorators/invalid/decoratorOnFunctionParameter.ts(5,17): error TS1433: Decorators may not be applied to 'this' parameters.
+tests/cases/conformance/decorators/invalid/decoratorOnFunctionParameter.ts(6,17): error TS1433: Decorators may not be applied to 'this' parameters.
+
+
+==== tests/cases/conformance/decorators/invalid/decoratorOnFunctionParameter.ts (2 errors) ====
+    declare const dec: any;
+    
+    class C { n = true; }
+    
+    function direct(@dec this: C) { return this.n; }
+                    ~~~~
+!!! error TS1433: Decorators may not be applied to 'this' parameters.
+    function called(@dec() this: C) { return this.n; }
+                    ~~~~~~
+!!! error TS1433: Decorators may not be applied to 'this' parameters.

--- a/tests/baselines/reference/decoratorOnFunctionParameter.js
+++ b/tests/baselines/reference/decoratorOnFunctionParameter.js
@@ -1,0 +1,17 @@
+//// [decoratorOnFunctionParameter.ts]
+declare const dec: any;
+
+class C { n = true; }
+
+function direct(@dec this: C) { return this.n; }
+function called(@dec() this: C) { return this.n; }
+
+//// [decoratorOnFunctionParameter.js]
+var C = /** @class */ (function () {
+    function C() {
+        this.n = true;
+    }
+    return C;
+}());
+function direct() { return this.n; }
+function called() { return this.n; }

--- a/tests/baselines/reference/decoratorOnFunctionParameter.symbols
+++ b/tests/baselines/reference/decoratorOnFunctionParameter.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/decorators/invalid/decoratorOnFunctionParameter.ts ===
+declare const dec: any;
+>dec : Symbol(dec, Decl(decoratorOnFunctionParameter.ts, 0, 13))
+
+class C { n = true; }
+>C : Symbol(C, Decl(decoratorOnFunctionParameter.ts, 0, 23))
+>n : Symbol(C.n, Decl(decoratorOnFunctionParameter.ts, 2, 9))
+
+function direct(@dec this: C) { return this.n; }
+>direct : Symbol(direct, Decl(decoratorOnFunctionParameter.ts, 2, 21))
+>dec : Symbol(dec, Decl(decoratorOnFunctionParameter.ts, 0, 13))
+>this : Symbol(this, Decl(decoratorOnFunctionParameter.ts, 4, 16))
+>C : Symbol(C, Decl(decoratorOnFunctionParameter.ts, 0, 23))
+>this.n : Symbol(C.n, Decl(decoratorOnFunctionParameter.ts, 2, 9))
+>this : Symbol(this, Decl(decoratorOnFunctionParameter.ts, 4, 16))
+>n : Symbol(C.n, Decl(decoratorOnFunctionParameter.ts, 2, 9))
+
+function called(@dec() this: C) { return this.n; }
+>called : Symbol(called, Decl(decoratorOnFunctionParameter.ts, 4, 48))
+>dec : Symbol(dec, Decl(decoratorOnFunctionParameter.ts, 0, 13))
+>this : Symbol(this, Decl(decoratorOnFunctionParameter.ts, 5, 16))
+>C : Symbol(C, Decl(decoratorOnFunctionParameter.ts, 0, 23))
+>this.n : Symbol(C.n, Decl(decoratorOnFunctionParameter.ts, 2, 9))
+>this : Symbol(this, Decl(decoratorOnFunctionParameter.ts, 5, 16))
+>n : Symbol(C.n, Decl(decoratorOnFunctionParameter.ts, 2, 9))
+

--- a/tests/baselines/reference/decoratorOnFunctionParameter.types
+++ b/tests/baselines/reference/decoratorOnFunctionParameter.types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/decorators/invalid/decoratorOnFunctionParameter.ts ===
+declare const dec: any;
+>dec : any
+
+class C { n = true; }
+>C : C
+>n : boolean
+>true : true
+
+function direct(@dec this: C) { return this.n; }
+>direct : (this: C) => boolean
+>dec : any
+>this : C
+>this.n : boolean
+>this : C
+>n : boolean
+
+function called(@dec() this: C) { return this.n; }
+>called : (this: C) => boolean
+>dec() : any
+>dec : any
+>this : C
+>this.n : boolean
+>this : C
+>n : boolean
+

--- a/tests/baselines/reference/thisTypeInFunctionsNegative.errors.txt
+++ b/tests/baselines/reference/thisTypeInFunctionsNegative.errors.txt
@@ -79,6 +79,7 @@ tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(168,26): e
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(169,23): error TS1359: Identifier expected. 'this' is a reserved word that cannot be used here.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(169,23): error TS2680: A 'this' parameter must be the first parameter.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(170,23): error TS1005: ',' expected.
+tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(171,20): error TS1433: Decorators may not be applied to 'this' parameters.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(172,30): error TS1005: ',' expected.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(172,32): error TS1359: Identifier expected. 'new' is a reserved word that cannot be used here.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(172,37): error TS1005: ',' expected.
@@ -93,7 +94,7 @@ tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(177,19): e
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(178,22): error TS2730: An arrow function cannot have a 'this' parameter.
 
 
-==== tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts (63 errors) ====
+==== tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts (64 errors) ====
     class C {
         n: number;
         explicitThis(this: this, m: number): number {
@@ -405,6 +406,8 @@ tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(178,22): e
                           ~
 !!! error TS1005: ',' expected.
     function decorated(@deco() this: C): number { return this.n; }
+                       ~~~~~~~
+!!! error TS1433: Decorators may not be applied to 'this' parameters.
     function initializer(this: C = new C()): number { return this.n; }
                                  ~
 !!! error TS1005: ',' expected.

--- a/tests/baselines/reference/thisTypeInFunctionsNegative.errors.txt
+++ b/tests/baselines/reference/thisTypeInFunctionsNegative.errors.txt
@@ -79,8 +79,6 @@ tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(168,26): e
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(169,23): error TS1359: Identifier expected. 'this' is a reserved word that cannot be used here.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(169,23): error TS2680: A 'this' parameter must be the first parameter.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(170,23): error TS1005: ',' expected.
-tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(171,28): error TS1359: Identifier expected. 'this' is a reserved word that cannot be used here.
-tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(171,28): error TS2680: A 'this' parameter must be the first parameter.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(172,30): error TS1005: ',' expected.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(172,32): error TS1359: Identifier expected. 'new' is a reserved word that cannot be used here.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(172,37): error TS1005: ',' expected.
@@ -95,7 +93,7 @@ tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(177,19): e
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(178,22): error TS2730: An arrow function cannot have a 'this' parameter.
 
 
-==== tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts (65 errors) ====
+==== tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts (63 errors) ====
     class C {
         n: number;
         explicitThis(this: this, m: number): number {
@@ -407,10 +405,6 @@ tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(178,22): e
                           ~
 !!! error TS1005: ',' expected.
     function decorated(@deco() this: C): number { return this.n; }
-                               ~~~~
-!!! error TS1359: Identifier expected. 'this' is a reserved word that cannot be used here.
-                               ~~~~~~~
-!!! error TS2680: A 'this' parameter must be the first parameter.
     function initializer(this: C = new C()): number { return this.n; }
                                  ~
 !!! error TS1005: ',' expected.

--- a/tests/baselines/reference/thisTypeInFunctionsNegative.symbols
+++ b/tests/baselines/reference/thisTypeInFunctionsNegative.symbols
@@ -646,9 +646,11 @@ function optional(this?: C): number { return this.n; }
 
 function decorated(@deco() this: C): number { return this.n; }
 >decorated : Symbol(decorated, Decl(thisTypeInFunctionsNegative.ts, 169, 54))
-> : Symbol((Missing), Decl(thisTypeInFunctionsNegative.ts, 170, 19))
->this : Symbol(this, Decl(thisTypeInFunctionsNegative.ts, 170, 26))
+>this : Symbol(this, Decl(thisTypeInFunctionsNegative.ts, 170, 19))
 >C : Symbol(C, Decl(thisTypeInFunctionsNegative.ts, 0, 0))
+>this.n : Symbol(C.n, Decl(thisTypeInFunctionsNegative.ts, 0, 9))
+>this : Symbol(this, Decl(thisTypeInFunctionsNegative.ts, 170, 19))
+>n : Symbol(C.n, Decl(thisTypeInFunctionsNegative.ts, 0, 9))
 
 function initializer(this: C = new C()): number { return this.n; }
 >initializer : Symbol(initializer, Decl(thisTypeInFunctionsNegative.ts, 170, 62))

--- a/tests/baselines/reference/thisTypeInFunctionsNegative.types
+++ b/tests/baselines/reference/thisTypeInFunctionsNegative.types
@@ -733,14 +733,13 @@ function optional(this?: C): number { return this.n; }
 >n : any
 
 function decorated(@deco() this: C): number { return this.n; }
->decorated : (: any, this: C) => number
+>decorated : (this: C) => number
 >deco() : any
 >deco : any
-> : any
 >this : C
->this.n : any
->this : any
->n : any
+>this.n : number
+>this : C
+>n : number
 
 function initializer(this: C = new C()): number { return this.n; }
 >initializer : (this: C, : any, C: any) => any

--- a/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts
+++ b/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts
@@ -2,6 +2,10 @@
 // @experimentaldecorators: true
 declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
 
-class C {
+class C { 
     method(@dec this: C) {}
+}
+
+class C2 {
+    method(@dec allowed: C2, @dec this: C2) {}
 }

--- a/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts
+++ b/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts
@@ -2,7 +2,7 @@
 // @experimentaldecorators: true
 declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
 
-class C { 
+class C {
     method(@dec this: C) {}
 }
 

--- a/tests/cases/conformance/decorators/invalid/decoratorOnFunctionParameter.ts
+++ b/tests/cases/conformance/decorators/invalid/decoratorOnFunctionParameter.ts
@@ -1,0 +1,6 @@
+declare const dec: any;
+
+class C { n = true; }
+
+function direct(@dec this: C) { return this.n; }
+function called(@dec() this: C) { return this.n; }


### PR DESCRIPTION
Fixes #43106

Improves the generated AST in the case of `@decorator this: ...`:

* The parser will now attach decorators to a `this` parameter
* The checker will now give a special cased error 