### PR TITLE
Don't inherit jsdoc tags from overloaded signatures (#43165)

### DIFF
--- a/tests/baselines/reference/deprecatedInheritedJSDocOverload.baseline
+++ b/tests/baselines/reference/deprecatedInheritedJSDocOverload.baseline
@@ -1,0 +1,140 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/deprecatedInheritedJSDocOverload.ts",
+      "position": 1183,
+      "name": ""
+    },
+    "quickInfo": {
+      "kind": "method",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1174,
+        "length": 9
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "ThingWithDeprecations",
+          "kind": "interfaceName"
+        },
+        {
+          "text": "<",
+          "kind": "punctuation"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        },
+        {
+          "text": ">",
+          "kind": "punctuation"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "subscribe",
+          "kind": "methodName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "observer",
+          "kind": "parameterName"
+        },
+        {
+          "text": "?",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "PartialObserver",
+          "kind": "interfaceName"
+        },
+        {
+          "text": "<",
+          "kind": "punctuation"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        },
+        {
+          "text": ">",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Subscription",
+          "kind": "interfaceName"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "+",
+          "kind": "operator"
+        },
+        {
+          "text": "2",
+          "kind": "numericLiteral"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "overloads",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        }
+      ],
+      "documentation": []
+    }
+  }
+]

--- a/tests/baselines/reference/deprecatedInheritedJSDocOverload.baseline
+++ b/tests/baselines/reference/deprecatedInheritedJSDocOverload.baseline
@@ -2,8 +2,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/deprecatedInheritedJSDocOverload.ts",
-      "position": 1183,
-      "name": ""
+      "position": 1183
     },
     "quickInfo": {
       "kind": "method",

--- a/tests/cases/fourslash/deprecatedInheritedJSDocOverload.ts
+++ b/tests/cases/fourslash/deprecatedInheritedJSDocOverload.ts
@@ -1,0 +1,30 @@
+
+//// interface PartialObserver<T> {}
+//// interface Subscription {}
+//// interface Unsubscribable {}
+//// 
+//// export interface Subscribable<T> {
+////   subscribe(observer?: PartialObserver<T>): Unsubscribable;
+////   /** @deprecated Base deprecation 1 */
+////   subscribe(next: null | undefined, error: null | undefined, complete: () => void): Unsubscribable;
+////   /** @deprecated Base deprecation 2 */
+////   subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Unsubscribable;
+////   /** @deprecated Base deprecation 3 */
+////   subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Unsubscribable;
+////   subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Unsubscribable;
+//// }
+
+//// interface ThingWithDeprecations<T> extends Subscribable<T> {
+////    subscribe(observer?: PartialObserver<T>): Subscription;
+////    /** @deprecated 'real' deprecation */
+////    subscribe(next: null | undefined, error: null | undefined, complete: () => void): Subscription;
+////    /** @deprecated 'real' deprecation */
+////    subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Subscription;
+//// }
+
+//// declare const a: ThingWithDeprecations<void>
+//// a.subscribe/**/(() => {
+////   console.log('something happened');
+//// });
+
+verify.baselineQuickInfo();


### PR DESCRIPTION
Replicates #43165 for the 4.2 branch