### PR TITLE
Specified diagnostic for CLI flags mismatched with/out --build

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1220,23 +1220,15 @@ namespace ts {
         return optionsNameMapCache ||= createOptionNameMap(optionDeclarations);
     }
 
-    let compilerOptionsAlternateModeCache: AlternateModeDiagnostics;
+    const compilerOptionsAlternateMode: AlternateModeDiagnostics = {
+        diagnostic: Diagnostics.Compiler_option_0_may_only_be_used_with_build,
+        options: new Set(commandOptionsOnlyBuild.map(option => option.name))
+    };
 
-    function getCompilerOptionsAlternateMode(): AlternateModeDiagnostics {
-        return compilerOptionsAlternateModeCache ||= {
-            diagnostic: Diagnostics.Compiler_option_0_may_only_be_used_with_build,
-            options: new Set(commandOptionsOnlyBuild.map(option => option.name))
-        };
-    }
-
-    let buildModeAlternateModeCache: AlternateModeDiagnostics;
-
-    function getBuildOptionsAlternateMode(): AlternateModeDiagnostics {
-        return buildModeAlternateModeCache ||= {
-            diagnostic: Diagnostics.Compiler_option_0_may_not_be_used_with_build,
-            options: new Set(commandOptionsWithoutBuild.map(option => option.name))
-        };
-    }
+    const buildOptionsAlternateMode: AlternateModeDiagnostics = {
+        diagnostic: Diagnostics.Compiler_option_0_may_not_be_used_with_build,
+        options: new Set(commandOptionsWithoutBuild.map(option => option.name))
+    };
 
     /* @internal */
     export const defaultInitCompilerOptions: CompilerOptions = {
@@ -1317,9 +1309,8 @@ namespace ts {
         createDiagnostics: (message: DiagnosticMessage, arg0: string, arg1?: string) => Diagnostic,
         unknownOptionErrorText?: string
     ) {
-        const alternateMode = diagnostics.getAlternateMode?.();
-        if (alternateMode?.options.has(unknownOption)) {
-            return createDiagnostics(alternateMode.diagnostic, unknownOption);
+        if (diagnostics.alternateMode?.options.has(unknownOption)) {
+            return createDiagnostics(diagnostics.alternateMode.diagnostic, unknownOption);
         }
 
         const possibleOption = getSpellingSuggestion(unknownOption, diagnostics.optionDeclarations, getOptionName);
@@ -1487,7 +1478,7 @@ namespace ts {
 
     /*@internal*/
     export const compilerOptionsDidYouMeanDiagnostics: ParseCommandLineWorkerDiagnostics = {
-        getAlternateMode: getCompilerOptionsAlternateMode,
+        alternateMode: compilerOptionsAlternateMode,
         getOptionsNameMap,
         optionDeclarations,
         unknownOptionDiagnostic: Diagnostics.Unknown_compiler_option_0,
@@ -1530,7 +1521,7 @@ namespace ts {
     }
 
     const buildOptionsDidYouMeanDiagnostics: ParseCommandLineWorkerDiagnostics = {
-        getAlternateMode: getBuildOptionsAlternateMode,
+        alternateMode: buildOptionsAlternateMode,
         getOptionsNameMap: getBuildOptionsNameMap,
         optionDeclarations: buildOpts,
         unknownOptionDiagnostic: Diagnostics.Unknown_build_option_0,

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1122,9 +1122,7 @@ namespace ts {
     export const transpileOptionValueCompilerOptions: readonly CommandLineOption[] = optionDeclarations.filter(option =>
         hasProperty(option, "transpileOptionValue"));
 
-    /* @internal */
-    export const buildOpts: CommandLineOption[] = [
-        ...commonOptionsWithBuild,
+    const commandOptionsOnlyBuild: CommandLineOption[]  = [
         {
             name: "verbose",
             shortName: "v",
@@ -1152,6 +1150,12 @@ namespace ts {
             description: Diagnostics.Delete_the_outputs_of_all_projects,
             type: "boolean"
         }
+    ];
+
+    /* @internal */
+    export const buildOpts: CommandLineOption[] = [
+        ...commonOptionsWithBuild,
+        ...commandOptionsOnlyBuild,
     ];
 
     /* @internal */
@@ -1466,7 +1470,7 @@ namespace ts {
     export const compilerOptionsDidYouMeanDiagnostics: ParseCommandLineWorkerDiagnostics = {
         alternateMode: {
             diagnostic: Diagnostics.Compiler_option_0_may_only_be_used_with_build,
-            options: new Set(["clean", "dry", "force", "verbose"])
+            options: new Set(commandOptionsOnlyBuild.map(option => option.name))
         },
         getOptionsNameMap,
         optionDeclarations,
@@ -1512,7 +1516,7 @@ namespace ts {
     const buildOptionsDidYouMeanDiagnostics: ParseCommandLineWorkerDiagnostics = {
         alternateMode: {
             diagnostic: Diagnostics.Compiler_option_0_may_not_be_used_with_build,
-            options: new Set(commandOptionsWithoutBuild.map(option => option.name)),
+            options: new Set(commandOptionsWithoutBuild.map(option => option.name))
         },
         getOptionsNameMap: getBuildOptionsNameMap,
         optionDeclarations: buildOpts,

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -306,10 +306,8 @@ namespace ts {
         description: Diagnostics.Specify_ECMAScript_target_version_Colon_ES3_default_ES5_ES2015_ES2016_ES2017_ES2018_ES2019_ES2020_ES2021_or_ESNEXT,
     };
 
-    /* @internal */
-    export const optionDeclarations: CommandLineOption[] = [
+    const commandOptionsWithoutBuild: CommandLineOption[] = [
         // CommandLine only options
-        ...commonOptionsWithBuild,
         {
             name: "all",
             type: "boolean",
@@ -1099,6 +1097,12 @@ namespace ts {
     ];
 
     /* @internal */
+    export const optionDeclarations: CommandLineOption[] = [
+        ...commonOptionsWithBuild,
+        ...commandOptionsWithoutBuild,
+    ];
+
+    /* @internal */
     export const semanticDiagnosticsOptionDeclarations: readonly CommandLineOption[] =
         optionDeclarations.filter(option => !!option.affectsSemanticDiagnostics);
 
@@ -1506,6 +1510,10 @@ namespace ts {
     }
 
     const buildOptionsDidYouMeanDiagnostics: ParseCommandLineWorkerDiagnostics = {
+        alternateMode: {
+            diagnostic: Diagnostics.Compiler_option_0_may_not_be_used_with_build,
+            options: new Set(commandOptionsWithoutBuild.map(option => option.name)),
+        },
         getOptionsNameMap: getBuildOptionsNameMap,
         optionDeclarations: buildOpts,
         unknownOptionDiagnostic: Diagnostics.Unknown_build_option_0,

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1222,12 +1222,7 @@ namespace ts {
 
     const compilerOptionsAlternateMode: AlternateModeDiagnostics = {
         diagnostic: Diagnostics.Compiler_option_0_may_only_be_used_with_build,
-        options: new Set(commandOptionsOnlyBuild.map(option => option.name))
-    };
-
-    const buildOptionsAlternateMode: AlternateModeDiagnostics = {
-        diagnostic: Diagnostics.Compiler_option_0_may_not_be_used_with_build,
-        options: new Set(commandOptionsWithoutBuild.map(option => option.name))
+        getOptionsNameMap: getBuildOptionsNameMap
     };
 
     /* @internal */
@@ -1309,7 +1304,7 @@ namespace ts {
         createDiagnostics: (message: DiagnosticMessage, arg0: string, arg1?: string) => Diagnostic,
         unknownOptionErrorText?: string
     ) {
-        if (diagnostics.alternateMode?.options.has(unknownOption)) {
+        if (diagnostics.alternateMode?.getOptionsNameMap().optionsNameMap.has(unknownOption.toLowerCase())) {
             return createDiagnostics(diagnostics.alternateMode.diagnostic, unknownOption);
         }
 
@@ -1519,6 +1514,11 @@ namespace ts {
     function getBuildOptionsNameMap(): OptionsNameMap {
         return buildOptionsNameMapCache || (buildOptionsNameMapCache = createOptionNameMap(buildOpts));
     }
+
+    const buildOptionsAlternateMode: AlternateModeDiagnostics = {
+        diagnostic: Diagnostics.Compiler_option_0_may_not_be_used_with_build,
+        getOptionsNameMap
+    };
 
     const buildOptionsDidYouMeanDiagnostics: ParseCommandLineWorkerDiagnostics = {
         alternateMode: buildOptionsAlternateMode,

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1185,6 +1185,13 @@ namespace ts {
         },
     ];
 
+    const specificStandaloneDiagnosticMessages = new Map([
+        ["clean", Diagnostics.Compiler_option_0_may_only_be_used_with_build],
+        ["dry", Diagnostics.Compiler_option_0_may_only_be_used_with_build],
+        ["force", Diagnostics.Compiler_option_0_may_only_be_used_with_build],
+        ["verbose", Diagnostics.Compiler_option_0_may_only_be_used_with_build],
+    ]);
+
     /* @internal */
     export interface OptionsNameMap {
         optionsNameMap: ESMap<string, CommandLineOption>;
@@ -1291,6 +1298,11 @@ namespace ts {
         createDiagnostics: (message: DiagnosticMessage, arg0: string, arg1?: string) => Diagnostic,
         unknownOptionErrorText?: string
     ) {
+        const knownMessage = diagnostics.specificDiagnosticMessages?.get(unknownOption);
+        if (knownMessage) {
+            return createDiagnostics(knownMessage, unknownOption);
+        }
+
         const possibleOption = getSpellingSuggestion(unknownOption, diagnostics.optionDeclarations, getOptionName);
         return possibleOption ?
             createDiagnostics(diagnostics.unknownDidYouMeanDiagnostic, unknownOptionErrorText || unknownOption, possibleOption.name) :
@@ -1458,6 +1470,7 @@ namespace ts {
     export const compilerOptionsDidYouMeanDiagnostics: ParseCommandLineWorkerDiagnostics = {
         getOptionsNameMap,
         optionDeclarations,
+        specificDiagnosticMessages: specificStandaloneDiagnosticMessages,
         unknownOptionDiagnostic: Diagnostics.Unknown_compiler_option_0,
         unknownDidYouMeanDiagnostic: Diagnostics.Unknown_compiler_option_0_Did_you_mean_1,
         optionTypeMismatchDiagnostic: Diagnostics.Compiler_option_0_expects_an_argument

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1185,13 +1185,6 @@ namespace ts {
         },
     ];
 
-    const specificStandaloneDiagnosticMessages = new Map([
-        ["clean", Diagnostics.Compiler_option_0_may_only_be_used_with_build],
-        ["dry", Diagnostics.Compiler_option_0_may_only_be_used_with_build],
-        ["force", Diagnostics.Compiler_option_0_may_only_be_used_with_build],
-        ["verbose", Diagnostics.Compiler_option_0_may_only_be_used_with_build],
-    ]);
-
     /* @internal */
     export interface OptionsNameMap {
         optionsNameMap: ESMap<string, CommandLineOption>;
@@ -1298,9 +1291,8 @@ namespace ts {
         createDiagnostics: (message: DiagnosticMessage, arg0: string, arg1?: string) => Diagnostic,
         unknownOptionErrorText?: string
     ) {
-        const knownMessage = diagnostics.specificDiagnosticMessages?.get(unknownOption);
-        if (knownMessage) {
-            return createDiagnostics(knownMessage, unknownOption);
+        if (diagnostics.alternateMode?.options.has(unknownOption)) {
+            return createDiagnostics(diagnostics.alternateMode.diagnostic, unknownOption);
         }
 
         const possibleOption = getSpellingSuggestion(unknownOption, diagnostics.optionDeclarations, getOptionName);
@@ -1468,9 +1460,12 @@ namespace ts {
 
     /*@internal*/
     export const compilerOptionsDidYouMeanDiagnostics: ParseCommandLineWorkerDiagnostics = {
+        alternateMode: {
+            diagnostic: Diagnostics.Compiler_option_0_may_only_be_used_with_build,
+            options: new Set(["clean", "dry", "force", "verbose"])
+        },
         getOptionsNameMap,
         optionDeclarations,
-        specificDiagnosticMessages: specificStandaloneDiagnosticMessages,
         unknownOptionDiagnostic: Diagnostics.Unknown_compiler_option_0,
         unknownDidYouMeanDiagnostic: Diagnostics.Unknown_compiler_option_0_Did_you_mean_1,
         optionTypeMismatchDiagnostic: Diagnostics.Compiler_option_0_expects_an_argument

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3858,6 +3858,10 @@
         "category": "Error",
         "code": 5093
     },
+    "Compiler option '--{0}' may not be used with '--build'.": {
+        "category": "Error",
+        "code": 5094
+    },
 
     "Generates a sourcemap for each corresponding '.d.ts' file.": {
         "category": "Message",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3854,6 +3854,10 @@
         "category": "Error",
         "code": 5092
     },
+    "Compiler option '--{0}' may only be used with '--build'.": {
+        "category": "Error",
+        "code": 5093
+    },
 
     "Generates a sourcemap for each corresponding '.d.ts' file.": {
         "category": "Message",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6125,6 +6125,7 @@ namespace ts {
 
     /* @internal */
     export interface DidYouMeanOptionsDiagnostics {
+        specificDiagnosticMessages?: ReadonlyESMap<string, DiagnosticMessage>;
         optionDeclarations: CommandLineOption[];
         unknownOptionDiagnostic: DiagnosticMessage,
         unknownDidYouMeanDiagnostic: DiagnosticMessage,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6131,7 +6131,7 @@ namespace ts {
 
     /* @internal */
     export interface DidYouMeanOptionsDiagnostics {
-        getAlternateMode?: () => AlternateModeDiagnostics;
+        alternateMode?: AlternateModeDiagnostics;
         optionDeclarations: CommandLineOption[];
         unknownOptionDiagnostic: DiagnosticMessage,
         unknownDidYouMeanDiagnostic: DiagnosticMessage,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6126,7 +6126,7 @@ namespace ts {
     /* @internal */
     export interface AlternateModeDiagnostics {
         diagnostic: DiagnosticMessage;
-        options: ReadonlySet<string>;
+        getOptionsNameMap: () => OptionsNameMap;
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6131,7 +6131,7 @@ namespace ts {
 
     /* @internal */
     export interface DidYouMeanOptionsDiagnostics {
-        alternateMode?: AlternateModeDiagnostics;
+        getAlternateMode?: () => AlternateModeDiagnostics;
         optionDeclarations: CommandLineOption[];
         unknownOptionDiagnostic: DiagnosticMessage,
         unknownDidYouMeanDiagnostic: DiagnosticMessage,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6124,8 +6124,14 @@ namespace ts {
     }
 
     /* @internal */
+    export interface AlternateModeDiagnostics {
+        diagnostic: DiagnosticMessage;
+        options: ReadonlySet<string>;
+    }
+
+    /* @internal */
     export interface DidYouMeanOptionsDiagnostics {
-        specificDiagnosticMessages?: ReadonlyESMap<string, DiagnosticMessage>;
+        alternateMode?: AlternateModeDiagnostics;
         optionDeclarations: CommandLineOption[];
         unknownOptionDiagnostic: DiagnosticMessage,
         unknownDidYouMeanDiagnostic: DiagnosticMessage,

--- a/src/testRunner/unittests/config/commandLineParsing.ts
+++ b/src/testRunner/unittests/config/commandLineParsing.ts
@@ -46,6 +46,23 @@ namespace ts {
                 });
         });
 
+        it("Handles 'may only be used with --build' flags", () => {
+            const buildFlags = ["--clean", "--dry", "--force", "--verbose"];
+
+            assertParseResult(buildFlags, {
+                errors: buildFlags.map(buildFlag => ({
+                    messageText: `Compiler option '${buildFlag}' may only be used with '--build'.`,
+                    category: Diagnostics.Compiler_option_0_may_only_be_used_with_build.category,
+                    code: Diagnostics.Compiler_option_0_may_only_be_used_with_build.code,
+                    file: undefined,
+                    start: undefined,
+                    length: undefined
+                })),
+                fileNames: [],
+                options: {}
+            });
+        });
+
         it("Handles 'did you mean?' for misspelt flags", () => {
             // --declarations --allowTS
             assertParseResult(["--declarations", "--allowTS"], {

--- a/src/testRunner/unittests/config/commandLineParsing.ts
+++ b/src/testRunner/unittests/config/commandLineParsing.ts
@@ -807,9 +807,9 @@ namespace ts {
             assertParseResult(["--listFilesOnly"],
                 {
                     errors: [{
-                        messageText: "Unknown build option '--listFilesOnly'.",
-                        category: Diagnostics.Unknown_build_option_0.category,
-                        code: Diagnostics.Unknown_build_option_0.code,
+                        messageText: "Compiler option '--listFilesOnly' may not be used with '--build'.",
+                        category: Diagnostics.Compiler_option_0_may_not_be_used_with_build.category,
+                        code: Diagnostics.Compiler_option_0_may_not_be_used_with_build.code,
                         file: undefined,
                         start: undefined,
                         length: undefined,
@@ -880,9 +880,9 @@ namespace ts {
             assertParseResult(["--tsBuildInfoFile", "build.tsbuildinfo", "tests"],
                 {
                     errors: [{
-                        messageText: "Unknown build option '--tsBuildInfoFile'.",
-                        category: Diagnostics.Unknown_build_option_0.category,
-                        code: Diagnostics.Unknown_build_option_0.code,
+                        messageText: "Compiler option '--tsBuildInfoFile' may not be used with '--build'.",
+                        category: Diagnostics.Compiler_option_0_may_not_be_used_with_build.category,
+                        code: Diagnostics.Compiler_option_0_may_not_be_used_with_build.code,
                         file: undefined,
                         start: undefined,
                         length: undefined
@@ -891,6 +891,24 @@ namespace ts {
                     buildOptions: {},
                     watchOptions: undefined,
                 });
+        });
+
+        it("reports other common 'may not be used with --build' flags", () => {
+            const buildFlags = ["--declaration", "--strict"];
+
+            assertParseResult(buildFlags, {
+                errors: buildFlags.map(buildFlag => ({
+                    messageText: `Compiler option '${buildFlag}' may not be used with '--build'.`,
+                    category: Diagnostics.Compiler_option_0_may_not_be_used_with_build.category,
+                    code: Diagnostics.Compiler_option_0_may_not_be_used_with_build.code,
+                    file: undefined,
+                    start: undefined,
+                    length: undefined
+                })),
+                buildOptions: {},
+                projects: ["."],
+                watchOptions: undefined,
+            });
         });
 
         describe("Combining options that make no sense together", () => {


### PR DESCRIPTION
Fixes #43196

Goes off the list of flags in https://www.typescriptlang.org/docs/handbook/project-references.html#tsc--b-commandline that require `--build`. That may change soon if #43193 is resolved.