### PR TITLE
fix(43215): Reserved type primitive names should not be allowed as interface names

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -36282,6 +36282,7 @@ namespace ts {
             switch (name.escapedText) {
                 case "any":
                 case "unknown":
+                case "never":
                 case "number":
                 case "bigint":
                 case "boolean":

--- a/tests/baselines/reference/interfacesWithPredefinedTypesAsNames.errors.txt
+++ b/tests/baselines/reference/interfacesWithPredefinedTypesAsNames.errors.txt
@@ -4,9 +4,11 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfacesWithPredefine
 tests/cases/conformance/interfaces/interfaceDeclarations/interfacesWithPredefinedTypesAsNames.ts(4,11): error TS2427: Interface name cannot be 'boolean'.
 tests/cases/conformance/interfaces/interfaceDeclarations/interfacesWithPredefinedTypesAsNames.ts(5,1): error TS2304: Cannot find name 'interface'.
 tests/cases/conformance/interfaces/interfaceDeclarations/interfacesWithPredefinedTypesAsNames.ts(5,11): error TS1005: ';' expected.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfacesWithPredefinedTypesAsNames.ts(6,11): error TS2427: Interface name cannot be 'unknown'.
+tests/cases/conformance/interfaces/interfaceDeclarations/interfacesWithPredefinedTypesAsNames.ts(7,11): error TS2427: Interface name cannot be 'never'.
 
 
-==== tests/cases/conformance/interfaces/interfaceDeclarations/interfacesWithPredefinedTypesAsNames.ts (6 errors) ====
+==== tests/cases/conformance/interfaces/interfaceDeclarations/interfacesWithPredefinedTypesAsNames.ts (8 errors) ====
     interface any { }
               ~~~
 !!! error TS2427: Interface name cannot be 'any'.
@@ -24,3 +26,9 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfacesWithPredefine
 !!! error TS2304: Cannot find name 'interface'.
               ~~~~
 !!! error TS1005: ';' expected.
+    interface unknown {}
+              ~~~~~~~
+!!! error TS2427: Interface name cannot be 'unknown'.
+    interface never {}
+              ~~~~~
+!!! error TS2427: Interface name cannot be 'never'.

--- a/tests/baselines/reference/interfacesWithPredefinedTypesAsNames.js
+++ b/tests/baselines/reference/interfacesWithPredefinedTypesAsNames.js
@@ -4,6 +4,8 @@ interface number { }
 interface string { }
 interface boolean { }
 interface void {}
+interface unknown {}
+interface never {}
 
 //// [interfacesWithPredefinedTypesAsNames.js]
 interface;

--- a/tests/baselines/reference/interfacesWithPredefinedTypesAsNames.symbols
+++ b/tests/baselines/reference/interfacesWithPredefinedTypesAsNames.symbols
@@ -12,3 +12,9 @@ interface boolean { }
 >boolean : Symbol(boolean, Decl(interfacesWithPredefinedTypesAsNames.ts, 2, 20))
 
 interface void {}
+interface unknown {}
+>unknown : Symbol(unknown, Decl(interfacesWithPredefinedTypesAsNames.ts, 4, 17))
+
+interface never {}
+>never : Symbol(never, Decl(interfacesWithPredefinedTypesAsNames.ts, 5, 20))
+

--- a/tests/baselines/reference/interfacesWithPredefinedTypesAsNames.types
+++ b/tests/baselines/reference/interfacesWithPredefinedTypesAsNames.types
@@ -8,3 +8,5 @@ interface void {}
 >void {} : undefined
 >{} : {}
 
+interface unknown {}
+interface never {}

--- a/tests/cases/conformance/interfaces/interfaceDeclarations/interfacesWithPredefinedTypesAsNames.ts
+++ b/tests/cases/conformance/interfaces/interfaceDeclarations/interfacesWithPredefinedTypesAsNames.ts
@@ -3,3 +3,5 @@ interface number { }
 interface string { }
 interface boolean { }
 interface void {}
+interface unknown {}
+interface never {}


### PR DESCRIPTION
Fixes #43215