### PR TITLE
Fix organize imports overlap

### DIFF
--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -63,9 +63,12 @@ namespace ts.OrganizeImports {
                     ? coalesce(importGroup)
                     : importGroup);
 
-            // Delete or replace the first import.
+            // Delete all nodes if there are no imports.
             if (newImportDecls.length === 0) {
-                changeTracker.delete(sourceFile, oldImportDecls[0]);
+                changeTracker.deleteNodes(sourceFile, oldImportDecls, {
+                    leadingTriviaOption: textChanges.LeadingTriviaOption.Exclude,
+                    trailingTriviaOption: textChanges.TrailingTriviaOption.Include,
+                });
             }
             else {
                 // Note: Delete the surrounding trivia because it will have been retained in newImportDecls.
@@ -74,11 +77,11 @@ namespace ts.OrganizeImports {
                     trailingTriviaOption: textChanges.TrailingTriviaOption.Include,
                     suffix: getNewLineOrDefaultFromHost(host, formatContext.options),
                 });
-            }
 
-            // Delete any subsequent imports.
-            for (let i = 1; i < oldImportDecls.length; i++) {
-                changeTracker.deleteNode(sourceFile, oldImportDecls[i]);
+                // Delete any subsequent imports.
+                changeTracker.deleteNodes(sourceFile, oldImportDecls.slice(1), {
+                    trailingTriviaOption: textChanges.TrailingTriviaOption.Include,
+                });
             }
         }
     }

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -65,7 +65,7 @@ namespace ts.OrganizeImports {
 
             // Delete all nodes if there are no imports.
             if (newImportDecls.length === 0) {
-                // Consider the first node to have trailingTrivia as we want to exclude the 
+                // Consider the first node to have trailingTrivia as we want to exclude the
                 // "header" comment.
                 changeTracker.deleteNodes(sourceFile, oldImportDecls, {
                     trailingTriviaOption: textChanges.TrailingTriviaOption.Include,

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -73,13 +73,16 @@ namespace ts.OrganizeImports {
             }
             else {
                 // Note: Delete the surrounding trivia because it will have been retained in newImportDecls.
-                changeTracker.replaceAndDeleteNodeWithNodes(sourceFile, oldImportDecls[0], newImportDecls, oldImportDecls.slice(1), {
+                const replaceOptions = {
                     leadingTriviaOption: textChanges.LeadingTriviaOption.Exclude, // Leave header comment in place
                     trailingTriviaOption: textChanges.TrailingTriviaOption.Include,
                     suffix: getNewLineOrDefaultFromHost(host, formatContext.options),
-                }, {
+                };
+                changeTracker.replaceNodeWithNodes(sourceFile, oldImportDecls[0], newImportDecls, replaceOptions);
+                const hasTrailingComment = changeTracker.nodeHasTrailingComment(sourceFile, oldImportDecls[0], replaceOptions);
+                changeTracker.deleteNodes(sourceFile, oldImportDecls.slice(1), {
                     trailingTriviaOption: textChanges.TrailingTriviaOption.Include,
-                });
+                }, hasTrailingComment);
             }
         }
     }

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -65,21 +65,19 @@ namespace ts.OrganizeImports {
 
             // Delete all nodes if there are no imports.
             if (newImportDecls.length === 0) {
+                // Consider the first node to have trailingTrivia as we want to exclude the 
+                // "header" comment.
                 changeTracker.deleteNodes(sourceFile, oldImportDecls, {
-                    leadingTriviaOption: textChanges.LeadingTriviaOption.Exclude,
                     trailingTriviaOption: textChanges.TrailingTriviaOption.Include,
-                });
+                }, /*hasTrailingComment*/ true);
             }
             else {
                 // Note: Delete the surrounding trivia because it will have been retained in newImportDecls.
-                changeTracker.replaceNodeWithNodes(sourceFile, oldImportDecls[0], newImportDecls, {
+                changeTracker.replaceAndDeleteNodeWithNodes(sourceFile, oldImportDecls[0], newImportDecls, oldImportDecls.slice(1), {
                     leadingTriviaOption: textChanges.LeadingTriviaOption.Exclude, // Leave header comment in place
                     trailingTriviaOption: textChanges.TrailingTriviaOption.Include,
                     suffix: getNewLineOrDefaultFromHost(host, formatContext.options),
-                });
-
-                // Delete any subsequent imports.
-                changeTracker.deleteNodes(sourceFile, oldImportDecls.slice(1), {
+                }, {
                     trailingTriviaOption: textChanges.TrailingTriviaOption.Include,
                 });
             }

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -405,11 +405,8 @@ namespace ts.textChanges {
             this.replaceRangeWithNodes(sourceFile, getAdjustedRange(sourceFile, startNode, endNode, options), newNodes, options);
         }
 
-        public replaceAndDeleteNodeWithNodes(sourceFile: SourceFile, oldNode: Node, newNodes: readonly Node[], deleteNodes: Node[], replaceOptions: ChangeNodeOptions = useNonAdjustedPositions, deleteOptions: ConfigurableStartEnd = { leadingTriviaOption: LeadingTriviaOption.IncludeAll }): void {
-            this.replaceRangeWithNodes(sourceFile, getAdjustedRange(sourceFile, oldNode, oldNode, replaceOptions), newNodes, replaceOptions);
-
-            const hasTrailingComment = !!getEndPositionOfMultilineTrailingComment(sourceFile, oldNode, replaceOptions);
-            this.deleteNodes(sourceFile, deleteNodes, deleteOptions, hasTrailingComment);
+        public nodeHasTrailingComment(sourceFile: SourceFile, oldNode: Node, configurableEnd: ConfigurableEnd = useNonAdjustedPositions): boolean {
+            return !!getEndPositionOfMultilineTrailingComment(sourceFile, oldNode, configurableEnd);
         }
 
         private nextCommaToken(sourceFile: SourceFile, node: Node): Node | undefined {

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -165,11 +165,9 @@ namespace ts.textChanges {
     }
 
     function getAdjustedRange(sourceFile: SourceFile, startNode: Node, endNode: Node, options: ConfigurableStartEnd): TextRange {
-        return { pos: getAdjustedStartPosition(sourceFile, startNode, options), end: getAdjustedEndPosition(sourceFile, endNode, options).end };
+        return { pos: getAdjustedStartPosition(sourceFile, startNode, options), end: getAdjustedEndPosition(sourceFile, endNode, options) };
     }
 
-    // TODO: Need to fix the pattern for trailing comment. This variable shouldn't be placed here.
-    // let isTrailingComment = false;
     function getAdjustedStartPosition(sourceFile: SourceFile, node: Node, options: ConfigurableStartEnd, hasTrailingComment = false) {
         const { leadingTriviaOption } = options;
         if (leadingTriviaOption === LeadingTriviaOption.Exclude) {
@@ -220,21 +218,10 @@ namespace ts.textChanges {
         return getStartPositionOfLine(getLineOfLocalPosition(sourceFile, adjustedStartPosition), sourceFile);
     }
 
-    function getAdjustedEndPosition(sourceFile: SourceFile, node: Node, options: ConfigurableEnd): { end: number, hasTrailingComment: boolean } {
+    /** Return the end position of a multiline comment of it is on another line; otherwise returns `undefined`; */
+    function getPositionIfEndingOnDifferentLine(sourceFile: SourceFile, node: Node, options: ConfigurableEnd): number | undefined {
         const { end } = node;
         const { trailingTriviaOption } = options;
-        if (trailingTriviaOption === TrailingTriviaOption.Exclude) {
-            return { end, hasTrailingComment: false };
-        }
-        if (trailingTriviaOption === TrailingTriviaOption.ExcludeWhitespace) {
-            const comments = concatenate(getTrailingCommentRanges(sourceFile.text, end), getLeadingCommentRanges(sourceFile.text, end));
-            const realEnd = comments?.[comments.length - 1]?.end;
-            if (realEnd) {
-                return { end: realEnd, hasTrailingComment: false };
-            }
-            return { end, hasTrailingComment: false };
-        }
-
         if (trailingTriviaOption === TrailingTriviaOption.Include) {
             // If the trailing comment is a multiline comment that extends to the next lines,
             // return the end of the comment and track it for the next nodes to adjust.
@@ -249,25 +236,44 @@ namespace ts.textChanges {
                     }
 
                     // Get the end line of the comment and compare against the end line of the node.
-                    // If the comment end line position, the multiline comment expans to multiple lines
-                    // and is safe to return the end position.
+                    // If the comment end line position and the multiline comment extends to multiple lines,
+                    // then is safe to return the end position.
                     const commentEndLine = getLineOfLocalPosition(sourceFile, comment.end);
                     if (commentEndLine > nodeEndLine) {
-                        const newEnd = skipTrivia(sourceFile.text, comment.end, /*stopAfterLineBreak*/ true, /*stopAtComments*/ true);
-                        return { end: newEnd, hasTrailingComment: true };
+                        return skipTrivia(sourceFile.text, comment.end, /*stopAfterLineBreak*/ true, /*stopAtComments*/ true);
                     }
                 }
             }
         }
 
+        return undefined;
+    }
+
+    function getAdjustedEndPosition(sourceFile: SourceFile, node: Node, options: ConfigurableEnd): number {
+        const { end } = node;
+        const { trailingTriviaOption } = options;
+        if (trailingTriviaOption === TrailingTriviaOption.Exclude) {
+            return end;
+        }
+        if (trailingTriviaOption === TrailingTriviaOption.ExcludeWhitespace) {
+            const comments = concatenate(getTrailingCommentRanges(sourceFile.text, end), getLeadingCommentRanges(sourceFile.text, end));
+            const realEnd = comments?.[comments.length - 1]?.end;
+            if (realEnd) {
+                return realEnd;
+            }
+            return end;
+        }
+
+        const multilineEndPosition = getPositionIfEndingOnDifferentLine(sourceFile, node, options);
+        if (multilineEndPosition) {
+            return multilineEndPosition;
+        }
+
         const newEnd = skipTrivia(sourceFile.text, end, /*stopAfterLineBreak*/ true);
 
-        return {
-            end: newEnd !== end && (trailingTriviaOption === TrailingTriviaOption.Include || isLineBreak(sourceFile.text.charCodeAt(newEnd - 1)))
-                ? newEnd
-                : end,
-            hasTrailingComment: false
-        };
+        return newEnd !== end && (trailingTriviaOption === TrailingTriviaOption.Include || isLineBreak(sourceFile.text.charCodeAt(newEnd - 1)))
+            ? newEnd
+            : end;
     }
 
     /**
@@ -348,11 +354,11 @@ namespace ts.textChanges {
 
             for (const node of nodes) {
                 const pos = getAdjustedStartPosition(sourceFile, node, options, hasTrailingComment);
-                const adjustedEnd = getAdjustedEndPosition(sourceFile, node, options);
+                const end = getAdjustedEndPosition(sourceFile, node, options);
 
-                hasTrailingComment = adjustedEnd.hasTrailingComment;
+                this.deleteRange(sourceFile, { pos, end });
 
-                this.deleteRange(sourceFile, { pos, end: adjustedEnd.end });
+                hasTrailingComment = !!getPositionIfEndingOnDifferentLine(sourceFile, node, options);
             }
         }
 
@@ -362,7 +368,7 @@ namespace ts.textChanges {
 
         public deleteNodeRange(sourceFile: SourceFile, startNode: Node, endNode: Node, options: ConfigurableStartEnd = { leadingTriviaOption: LeadingTriviaOption.IncludeAll }): void {
             const startPosition = getAdjustedStartPosition(sourceFile, startNode, options);
-            const endPosition = getAdjustedEndPosition(sourceFile, endNode, options).end;
+            const endPosition = getAdjustedEndPosition(sourceFile, endNode, options);
             this.deleteRange(sourceFile, { pos: startPosition, end: endPosition });
         }
 
@@ -482,7 +488,7 @@ namespace ts.textChanges {
                 for (const jsdoc of node.jsDoc) {
                     this.deleteRange(sourceFile, {
                         pos: getLineStartPositionForPosition(jsdoc.getStart(sourceFile), sourceFile),
-                        end: getAdjustedEndPosition(sourceFile, jsdoc, /*options*/ {}).end
+                        end: getAdjustedEndPosition(sourceFile, jsdoc, /*options*/ {})
                     });
                 }
             }
@@ -677,7 +683,7 @@ namespace ts.textChanges {
                     this.replaceRange(sourceFile, createRange(after.end), factory.createToken(SyntaxKind.SemicolonToken));
                 }
             }
-            const endPosition = getAdjustedEndPosition(sourceFile, after, {}).end;
+            const endPosition = getAdjustedEndPosition(sourceFile, after, {});
             return endPosition;
         }
 
@@ -1507,7 +1513,7 @@ namespace ts.textChanges {
     // Exported for tests only! (TODO: improve tests to not need this)
     export function deleteNode(changes: ChangeTracker, sourceFile: SourceFile, node: Node, options: ConfigurableStartEnd = { leadingTriviaOption: LeadingTriviaOption.IncludeAll }): void {
         const startPosition = getAdjustedStartPosition(sourceFile, node, options);
-        const endPosition = getAdjustedEndPosition(sourceFile, node, options).end;
+        const endPosition = getAdjustedEndPosition(sourceFile, node, options);
         changes.deleteRange(sourceFile, { pos: startPosition, end: endPosition });
     }
 
@@ -1526,7 +1532,7 @@ namespace ts.textChanges {
         deletedNodesInLists.add(node);
         changes.deleteRange(sourceFile, {
             pos: startPositionToDeleteNodeInList(sourceFile, node),
-            end: index === containingList.length - 1 ? getAdjustedEndPosition(sourceFile, node, {}).end : startPositionToDeleteNodeInList(sourceFile, containingList[index + 1]),
+            end: index === containingList.length - 1 ? getAdjustedEndPosition(sourceFile, node, {}) : startPositionToDeleteNodeInList(sourceFile, containingList[index + 1]),
         });
     }
 }

--- a/tests/cases/fourslash/organizeImports4.ts
+++ b/tests/cases/fourslash/organizeImports4.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// Regression test for GH#43107
+
+//// import * as something from "path";/** 
+////  * some comment here
+////  * and there
+////  */
+//// import * as somethingElse from "anotherpath";
+//// import * as AnotherThing from "somepath";/** 
+////  * some comment here
+////  * and there
+////  */
+//// import * as AnotherThingElse from "someotherpath";
+
+
+verify.organizeImports(''); 

--- a/tests/cases/fourslash/organizeImports4.ts
+++ b/tests/cases/fourslash/organizeImports4.ts
@@ -13,5 +13,4 @@
 ////  */
 //// import * as AnotherThingElse from "someotherpath";
 
-
 verify.organizeImports(''); 

--- a/tests/cases/fourslash/organizeImports5.ts
+++ b/tests/cases/fourslash/organizeImports5.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts" />
+
+// Regression test for GH#43107
+
+//// import * as something from "path";/** 
+////  * some comment here
+////  * and there
+////  */
+//// import * as somethingElse from "anotherpath";
+//// import * as AnotherThing from "somepath";/** 
+////  * some comment here
+////  * and there
+////  */
+//// import * as AnotherThingElse from "someotherpath";
+
+verify.organizeImports(''); 

--- a/tests/cases/fourslash/organizeImports6.ts
+++ b/tests/cases/fourslash/organizeImports6.ts
@@ -8,9 +8,4 @@
 //// */
 //// import * as somethingElse from "anotherpath";
 
-verify.organizeImports(
-`/* some comment here
-* and there
-*/
-`
-); 
+verify.organizeImports('');

--- a/tests/cases/fourslash/organizeImports6.ts
+++ b/tests/cases/fourslash/organizeImports6.ts
@@ -7,5 +7,15 @@
 //// * and there
 //// */
 //// import * as somethingElse from "anotherpath";
+//// import * as anotherThing from "someopath"; /* small comment */ // single line one.
+//// /* some comment here
+//// * and there
+//// */
+//// import * as anotherThingElse from "someotherpath";
+//// 
+//// anotherThing;
 
-verify.organizeImports('');
+verify.organizeImports(
+`import * as anotherThing from "someopath"; /* small comment */ // single line one.
+
+anotherThing;`);

--- a/tests/cases/fourslash/organizeImports6.ts
+++ b/tests/cases/fourslash/organizeImports6.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts" />
+
+// Regression test for GH#43107
+
+//// import * as something from "path"; /* small comment */ // single line one.
+//// /* some comment here
+//// * and there
+//// */
+//// import * as somethingElse from "anotherpath";
+
+verify.organizeImports(
+`/* some comment here
+* and there
+*/
+`
+); 

--- a/tests/cases/fourslash/organizeImports7.ts
+++ b/tests/cases/fourslash/organizeImports7.ts
@@ -1,0 +1,23 @@
+/// <reference path="fourslash.ts" />
+
+// Regression test for GH#43107
+
+//// import * as something from "path"; /**
+////  * some comment here
+////  * and there
+////  */
+//// import * as somethingElse from "anotherpath";
+//// 
+//// something;
+//// somethingElse;
+
+verify.organizeImports(
+`import * as somethingElse from "anotherpath";
+import * as something from "path"; /**
+ * some comment here
+ * and there
+ */
+
+something;
+somethingElse;`
+);


### PR DESCRIPTION
Fixes #43107

Text changes will now include multiline comments if they are considered trailing comments from the previous node.
