### PR TITLE
fix(43154): Syntax error in emitted output from `tsc` when exporting value of symbol key

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4798,7 +4798,8 @@ namespace ts {
                     }
                     function shouldWriteTypeOfFunctionSymbol() {
                         const isStaticMethodSymbol = !!(symbol.flags & SymbolFlags.Method) &&  // typeof static method
-                            some(symbol.declarations, declaration => hasSyntacticModifier(declaration, ModifierFlags.Static));
+                            some(symbol.declarations, declaration =>
+                                hasSyntacticModifier(declaration, ModifierFlags.Static) && isMethodDeclaration(declaration) && !isComputedPropertyName(declaration.name));
                         const isNonLocalFunctionSymbol = !!(symbol.flags & SymbolFlags.Function) &&
                             (symbol.parent || // is exported function symbol
                                 forEach(symbol.declarations, declaration =>

--- a/tests/baselines/reference/declarationEmitClassMemberWithComputedPropertyName.js
+++ b/tests/baselines/reference/declarationEmitClassMemberWithComputedPropertyName.js
@@ -1,0 +1,131 @@
+//// [declarationEmitClassMemberWithComputedPropertyName.ts]
+const k1 = Symbol();
+const k2 = 'foo' as const;
+
+const k3 = Symbol();
+const k4 = 'prop' as const;
+
+class Foo {
+    static [k1](): number {
+        return 1;
+    }
+    [k1](): string {
+        return "";
+    }
+
+    static [k2]() {
+        return 1;
+    }
+    [k2]() {
+        return "";
+    }
+
+    static m1() {}
+    m1() {}
+
+    static [k3] = 1;
+    [k3] = 1;
+
+    static [k4] = 1;
+    [k4] = 2;
+
+    static p1 = 3;
+    p1 = 4;
+}
+
+export const t1 = Foo[k1];
+export const t2 = new Foo()[k1];
+
+export const t3 = Foo[k2];
+export const t4 = new Foo()[k2];
+
+export const t5 = Foo.m1;
+export const t6 = new Foo().m1;
+
+export const t7 = Foo[k3];
+export const t8 = new Foo()[k3];
+
+export const t9 = Foo[k4];
+export const t10 = new Foo()[k4];
+
+export const t11 = Foo.p1;
+export const t12 = new Foo().p1;
+
+
+//// [declarationEmitClassMemberWithComputedPropertyName.js]
+var _a, _b, _c, _d;
+const k1 = Symbol();
+const k2 = 'foo';
+const k3 = Symbol();
+const k4 = 'prop';
+class Foo {
+    constructor() {
+        this[_b] = 1;
+        this[_d] = 2;
+        this.p1 = 4;
+    }
+    static [k1]() {
+        return 1;
+    }
+    [k1]() {
+        return "";
+    }
+    static [k2]() {
+        return 1;
+    }
+    [k2]() {
+        return "";
+    }
+    static m1() { }
+    m1() { }
+}
+_a = k3, _b = k3, _c = k4, _d = k4;
+Foo[_a] = 1;
+Foo[_c] = 1;
+Foo.p1 = 3;
+export const t1 = Foo[k1];
+export const t2 = new Foo()[k1];
+export const t3 = Foo[k2];
+export const t4 = new Foo()[k2];
+export const t5 = Foo.m1;
+export const t6 = new Foo().m1;
+export const t7 = Foo[k3];
+export const t8 = new Foo()[k3];
+export const t9 = Foo[k4];
+export const t10 = new Foo()[k4];
+export const t11 = Foo.p1;
+export const t12 = new Foo().p1;
+
+
+//// [declarationEmitClassMemberWithComputedPropertyName.d.ts]
+declare const k1: unique symbol;
+declare const k2: "foo";
+declare const k3: unique symbol;
+declare const k4: "prop";
+declare class Foo {
+    static [k1](): number;
+    [k1](): string;
+    static [k2](): number;
+    [k2](): string;
+    static m1(): void;
+    m1(): void;
+    static [k3]: number;
+    [k3]: number;
+    static [k4]: number;
+    [k4]: number;
+    static p1: number;
+    p1: number;
+}
+export declare const t1: () => number;
+export declare const t2: () => string;
+export declare const t3: () => number;
+export declare const t4: () => string;
+export declare const t5: typeof Foo.m1;
+export declare const t6: () => void;
+export declare const t7: number;
+export declare const t8: number;
+export declare const t9: number;
+export declare const t10: number;
+export declare const t11: number;
+export declare const t12: number;
+export {};

--- a/tests/baselines/reference/declarationEmitClassMemberWithComputedPropertyName.symbols
+++ b/tests/baselines/reference/declarationEmitClassMemberWithComputedPropertyName.symbols
@@ -1,0 +1,137 @@
+=== tests/cases/compiler/declarationEmitClassMemberWithComputedPropertyName.ts ===
+const k1 = Symbol();
+>k1 : Symbol(k1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 0, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+
+const k2 = 'foo' as const;
+>k2 : Symbol(k2, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 1, 5))
+
+const k3 = Symbol();
+>k3 : Symbol(k3, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 3, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+
+const k4 = 'prop' as const;
+>k4 : Symbol(k4, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 5))
+
+class Foo {
+>Foo : Symbol(Foo, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 27))
+
+    static [k1](): number {
+>[k1] : Symbol(Foo[k1], Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 6, 11))
+>k1 : Symbol(k1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 0, 5))
+
+        return 1;
+    }
+    [k1](): string {
+>[k1] : Symbol(Foo[k1], Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 9, 5))
+>k1 : Symbol(k1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 0, 5))
+
+        return "";
+    }
+
+    static [k2]() {
+>[k2] : Symbol(Foo[k2], Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 12, 5))
+>k2 : Symbol(k2, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 1, 5))
+
+        return 1;
+    }
+    [k2]() {
+>[k2] : Symbol(Foo[k2], Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 16, 5))
+>k2 : Symbol(k2, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 1, 5))
+
+        return "";
+    }
+
+    static m1() {}
+>m1 : Symbol(Foo.m1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 19, 5))
+
+    m1() {}
+>m1 : Symbol(Foo.m1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 21, 18))
+
+    static [k3] = 1;
+>[k3] : Symbol(Foo[k3], Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 22, 11))
+>k3 : Symbol(k3, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 3, 5))
+
+    [k3] = 1;
+>[k3] : Symbol(Foo[k3], Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 24, 20))
+>k3 : Symbol(k3, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 3, 5))
+
+    static [k4] = 1;
+>[k4] : Symbol(Foo[k4], Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 25, 13))
+>k4 : Symbol(k4, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 5))
+
+    [k4] = 2;
+>[k4] : Symbol(Foo[k4], Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 27, 20))
+>k4 : Symbol(k4, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 5))
+
+    static p1 = 3;
+>p1 : Symbol(Foo.p1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 28, 13))
+
+    p1 = 4;
+>p1 : Symbol(Foo.p1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 30, 18))
+}
+
+export const t1 = Foo[k1];
+>t1 : Symbol(t1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 34, 12))
+>Foo : Symbol(Foo, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 27))
+>k1 : Symbol(k1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 0, 5))
+
+export const t2 = new Foo()[k1];
+>t2 : Symbol(t2, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 35, 12))
+>Foo : Symbol(Foo, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 27))
+>k1 : Symbol(k1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 0, 5))
+
+export const t3 = Foo[k2];
+>t3 : Symbol(t3, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 37, 12))
+>Foo : Symbol(Foo, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 27))
+>k2 : Symbol(k2, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 1, 5))
+
+export const t4 = new Foo()[k2];
+>t4 : Symbol(t4, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 38, 12))
+>Foo : Symbol(Foo, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 27))
+>k2 : Symbol(k2, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 1, 5))
+
+export const t5 = Foo.m1;
+>t5 : Symbol(t5, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 40, 12))
+>Foo.m1 : Symbol(Foo.m1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 19, 5))
+>Foo : Symbol(Foo, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 27))
+>m1 : Symbol(Foo.m1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 19, 5))
+
+export const t6 = new Foo().m1;
+>t6 : Symbol(t6, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 41, 12))
+>new Foo().m1 : Symbol(Foo.m1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 21, 18))
+>Foo : Symbol(Foo, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 27))
+>m1 : Symbol(Foo.m1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 21, 18))
+
+export const t7 = Foo[k3];
+>t7 : Symbol(t7, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 43, 12))
+>Foo : Symbol(Foo, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 27))
+>k3 : Symbol(k3, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 3, 5))
+
+export const t8 = new Foo()[k3];
+>t8 : Symbol(t8, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 44, 12))
+>Foo : Symbol(Foo, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 27))
+>k3 : Symbol(k3, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 3, 5))
+
+export const t9 = Foo[k4];
+>t9 : Symbol(t9, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 46, 12))
+>Foo : Symbol(Foo, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 27))
+>k4 : Symbol(k4, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 5))
+
+export const t10 = new Foo()[k4];
+>t10 : Symbol(t10, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 47, 12))
+>Foo : Symbol(Foo, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 27))
+>k4 : Symbol(k4, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 5))
+
+export const t11 = Foo.p1;
+>t11 : Symbol(t11, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 49, 12))
+>Foo.p1 : Symbol(Foo.p1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 28, 13))
+>Foo : Symbol(Foo, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 27))
+>p1 : Symbol(Foo.p1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 28, 13))
+
+export const t12 = new Foo().p1;
+>t12 : Symbol(t12, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 50, 12))
+>new Foo().p1 : Symbol(Foo.p1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 30, 18))
+>Foo : Symbol(Foo, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 4, 27))
+>p1 : Symbol(Foo.p1, Decl(declarationEmitClassMemberWithComputedPropertyName.ts, 30, 18))
+

--- a/tests/baselines/reference/declarationEmitClassMemberWithComputedPropertyName.types
+++ b/tests/baselines/reference/declarationEmitClassMemberWithComputedPropertyName.types
@@ -1,0 +1,167 @@
+=== tests/cases/compiler/declarationEmitClassMemberWithComputedPropertyName.ts ===
+const k1 = Symbol();
+>k1 : unique symbol
+>Symbol() : unique symbol
+>Symbol : SymbolConstructor
+
+const k2 = 'foo' as const;
+>k2 : "foo"
+>'foo' as const : "foo"
+>'foo' : "foo"
+
+const k3 = Symbol();
+>k3 : unique symbol
+>Symbol() : unique symbol
+>Symbol : SymbolConstructor
+
+const k4 = 'prop' as const;
+>k4 : "prop"
+>'prop' as const : "prop"
+>'prop' : "prop"
+
+class Foo {
+>Foo : Foo
+
+    static [k1](): number {
+>[k1] : () => number
+>k1 : unique symbol
+
+        return 1;
+>1 : 1
+    }
+    [k1](): string {
+>[k1] : () => string
+>k1 : unique symbol
+
+        return "";
+>"" : ""
+    }
+
+    static [k2]() {
+>[k2] : () => number
+>k2 : "foo"
+
+        return 1;
+>1 : 1
+    }
+    [k2]() {
+>[k2] : () => string
+>k2 : "foo"
+
+        return "";
+>"" : ""
+    }
+
+    static m1() {}
+>m1 : () => void
+
+    m1() {}
+>m1 : () => void
+
+    static [k3] = 1;
+>[k3] : number
+>k3 : unique symbol
+>1 : 1
+
+    [k3] = 1;
+>[k3] : number
+>k3 : unique symbol
+>1 : 1
+
+    static [k4] = 1;
+>[k4] : number
+>k4 : "prop"
+>1 : 1
+
+    [k4] = 2;
+>[k4] : number
+>k4 : "prop"
+>2 : 2
+
+    static p1 = 3;
+>p1 : number
+>3 : 3
+
+    p1 = 4;
+>p1 : number
+>4 : 4
+}
+
+export const t1 = Foo[k1];
+>t1 : () => number
+>Foo[k1] : () => number
+>Foo : typeof Foo
+>k1 : unique symbol
+
+export const t2 = new Foo()[k1];
+>t2 : () => string
+>new Foo()[k1] : () => string
+>new Foo() : Foo
+>Foo : typeof Foo
+>k1 : unique symbol
+
+export const t3 = Foo[k2];
+>t3 : () => number
+>Foo[k2] : () => number
+>Foo : typeof Foo
+>k2 : "foo"
+
+export const t4 = new Foo()[k2];
+>t4 : () => string
+>new Foo()[k2] : () => string
+>new Foo() : Foo
+>Foo : typeof Foo
+>k2 : "foo"
+
+export const t5 = Foo.m1;
+>t5 : () => void
+>Foo.m1 : () => void
+>Foo : typeof Foo
+>m1 : () => void
+
+export const t6 = new Foo().m1;
+>t6 : () => void
+>new Foo().m1 : () => void
+>new Foo() : Foo
+>Foo : typeof Foo
+>m1 : () => void
+
+export const t7 = Foo[k3];
+>t7 : number
+>Foo[k3] : number
+>Foo : typeof Foo
+>k3 : unique symbol
+
+export const t8 = new Foo()[k3];
+>t8 : number
+>new Foo()[k3] : number
+>new Foo() : Foo
+>Foo : typeof Foo
+>k3 : unique symbol
+
+export const t9 = Foo[k4];
+>t9 : number
+>Foo[k4] : number
+>Foo : typeof Foo
+>k4 : "prop"
+
+export const t10 = new Foo()[k4];
+>t10 : number
+>new Foo()[k4] : number
+>new Foo() : Foo
+>Foo : typeof Foo
+>k4 : "prop"
+
+export const t11 = Foo.p1;
+>t11 : number
+>Foo.p1 : number
+>Foo : typeof Foo
+>p1 : number
+
+export const t12 = new Foo().p1;
+>t12 : number
+>new Foo().p1 : number
+>new Foo() : Foo
+>Foo : typeof Foo
+>p1 : number
+

--- a/tests/cases/compiler/declarationEmitClassMemberWithComputedPropertyName.ts
+++ b/tests/cases/compiler/declarationEmitClassMemberWithComputedPropertyName.ts
@@ -1,0 +1,54 @@
+// @target: esnext
+// @declaration: true
+
+const k1 = Symbol();
+const k2 = 'foo' as const;
+
+const k3 = Symbol();
+const k4 = 'prop' as const;
+
+class Foo {
+    static [k1](): number {
+        return 1;
+    }
+    [k1](): string {
+        return "";
+    }
+
+    static [k2]() {
+        return 1;
+    }
+    [k2]() {
+        return "";
+    }
+
+    static m1() {}
+    m1() {}
+
+    static [k3] = 1;
+    [k3] = 1;
+
+    static [k4] = 1;
+    [k4] = 2;
+
+    static p1 = 3;
+    p1 = 4;
+}
+
+export const t1 = Foo[k1];
+export const t2 = new Foo()[k1];
+
+export const t3 = Foo[k2];
+export const t4 = new Foo()[k2];
+
+export const t5 = Foo.m1;
+export const t6 = new Foo().m1;
+
+export const t7 = Foo[k3];
+export const t8 = new Foo()[k3];
+
+export const t9 = Foo[k4];
+export const t10 = new Foo()[k4];
+
+export const t11 = Foo.p1;
+export const t12 = new Foo().p1;


### PR DESCRIPTION
Fixes #43154