### PR TITLE
[GH-43213] Fix duplicate comments printed in quick info section

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -585,8 +585,8 @@ namespace ts {
             forEachUnique(declarations, declaration => {
                 const inheritedDocs = findBaseOfDeclaration(checker, declaration, symbol => {
                     if (!seenSymbols.has(symbol)) {
-                        seenSymbols.add(symbol)
-                        return symbol.getDocumentationComment(checker)
+                        seenSymbols.add(symbol);
+                        return symbol.getDocumentationComment(checker);
                     }
                 });
                 // TODO: GH#16312 Return a ReadonlyArray, avoid copying inheritedDocs

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -582,7 +582,7 @@ namespace ts {
         let doc = JsDoc.getJsDocCommentsFromDeclarations(declarations);
         if (checker && (doc.length === 0 || declarations.some(hasJSDocInheritDocTag))) {
             const seenSymbols = new Set<Symbol>();
-            forEachUnique(declarations, declaration => {
+            for (const declaration of declarations) {
                 const inheritedDocs = findBaseOfDeclaration(checker, declaration, symbol => {
                     if (!seenSymbols.has(symbol)) {
                         seenSymbols.add(symbol);
@@ -591,7 +591,7 @@ namespace ts {
                 });
                 // TODO: GH#16312 Return a ReadonlyArray, avoid copying inheritedDocs
                 if (inheritedDocs) doc = doc.length === 0 ? inheritedDocs.slice() : inheritedDocs.concat(lineBreakPart(), doc);
-            });
+            }
         }
         return doc;
     }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -591,8 +591,8 @@ namespace ts {
             });
         }
         let doc: SymbolDisplayPart[] = [];
-        docsSet.forEach(value => doc.push({kind: "text", text: value}))
-        doc = [...doc].map((e, i) => i < doc.length - 1 ? [e, lineBreakPart()] : [e]).reduce((a, b) => a.concat(b))
+        docsSet.forEach(value => doc.push({text: value, kind: "text"}))
+        if (doc.length > 1) doc = doc.map((e, i) => i < doc.length - 1 && e.text !== "" ? [e, lineBreakPart()] : [e]).reduce((a, b) => a.concat(b))
         return doc;
     }
 

--- a/tests/cases/fourslash/server/quickinfoWrongComment.ts
+++ b/tests/cases/fourslash/server/quickinfoWrongComment.ts
@@ -1,0 +1,18 @@
+/// <reference path="../fourslash.ts"/>
+
+//// interface I {
+////     /** The colour */
+////     readonly colour: string
+//// }
+//// interface A extends I {
+////     readonly colour: "red" | "green";
+//// }
+//// interface B extends I {
+////     readonly colour: "yellow" | "green";
+//// }
+//// type F = A | B
+//// const f: F = { colour: "green" }
+//// f.colour/*1*/
+
+goTo.marker("1")
+verify.quickInfoIs("(property) colour: \"red\" | \"green\" | \"yellow\"", "The colour")


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #43213

Only push values to the comments array if it's unique (similar to how we do it for declartation comments in         let doc = JsDoc.getJsDocCommentsFromDeclarations)