### PR TITLE
Fix dump of tracing legend

### DIFF
--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -331,4 +331,5 @@ namespace ts { // eslint-disable-line one-namespace-per-file
 
     // define after tracingEnabled is initialized
     export const startTracing = tracingEnabled.startTracing;
+    export const dumpTracingLegend = tracingEnabled.dumpLegend;
 }

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -501,7 +501,7 @@ namespace ts {
         updateSolutionBuilderHost(sys, cb, buildHost);
         const builder = createSolutionBuilder(buildHost, projects, buildOptions);
         const exitStatus = buildOptions.clean ? builder.clean() : builder.build();
-        tracing?.dumpLegend();
+        dumpTracingLegend(); // Will no-op if there hasn't been any tracing
         return sys.exit(exitStatus);
     }
 


### PR DESCRIPTION
This broke when we moved to the fancier form of skipping work when tracing isn't enabled.