### PR TITLE
fix(43254): Named tuple properties get typed as "any" on hover

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1619,6 +1619,9 @@ namespace ts {
             if (isNewExpression(node.parent) && node.pos === node.parent.pos) {
                 return node.parent.expression;
             }
+            if (isNamedTupleMember(node.parent) && node.pos === node.parent.pos) {
+                return node.parent;
+            }
             return node;
         }
 
@@ -1633,6 +1636,7 @@ namespace ts {
                 case SyntaxKind.ThisKeyword:
                 case SyntaxKind.ThisType:
                 case SyntaxKind.SuperKeyword:
+                case SyntaxKind.NamedTupleMember:
                     return true;
                 default:
                     return false;

--- a/tests/cases/fourslash/quickInfoForNamedTupleMember.ts
+++ b/tests/cases/fourslash/quickInfoForNamedTupleMember.ts
@@ -1,0 +1,5 @@
+/// <reference path="fourslash.ts" />
+
+////type foo = [/**/x: string];
+
+verify.quickInfoAt("", "string");


### PR DESCRIPTION
Fixes #43254