### PR TITLE
Only catalog types when tracing

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3816,7 +3816,9 @@ namespace ts {
             const result = new Type(checker, flags);
             typeCount++;
             result.id = typeCount;
-            typeCatalog.push(result);
+            if (tracing) {
+                typeCatalog.push(result);
+            }
             return result;
         }
 


### PR DESCRIPTION
I suspect it's currently unconditional because we thought checking would be slower, but it might just be an oversight.  Might as well measure.