### PR TITLE
@link support, second try

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5187,7 +5187,7 @@ namespace ts {
                 function preserveCommentsOn<T extends Node>(node: T) {
                     if (some(propertySymbol.declarations, d => d.kind === SyntaxKind.JSDocPropertyTag)) {
                         const d = propertySymbol.declarations?.find(d => d.kind === SyntaxKind.JSDocPropertyTag)! as JSDocPropertyTag;
-                        const commentText = d.comment;
+                        const commentText = getTextOfJSDocComment(d.comment);
                         if (commentText) {
                             setSyntheticLeadingComments(node, [{ kind: SyntaxKind.MultiLineCommentTrivia, text: "*\n * " + commentText.replace(/\n/g, "\n * ") + "\n ", pos: -1, end: -1, hasTrailingNewLine: true }]);
                         }
@@ -6702,7 +6702,7 @@ namespace ts {
                     const typeParams = getSymbolLinks(symbol).typeParameters;
                     const typeParamDecls = map(typeParams, p => typeParameterToDeclaration(p, context));
                     const jsdocAliasDecl = symbol.declarations?.find(isJSDocTypeAlias);
-                    const commentText = jsdocAliasDecl ? jsdocAliasDecl.comment || jsdocAliasDecl.parent.comment : undefined;
+                    const commentText = getTextOfJSDocComment(jsdocAliasDecl ? jsdocAliasDecl.comment || jsdocAliasDecl.parent.comment : undefined);
                     const oldFlags = context.flags;
                     context.flags |= NodeBuilderFlags.InTypeAlias;
                     const oldEnclosingDecl = context.enclosingDeclaration;
@@ -38592,6 +38592,10 @@ namespace ts {
             else if (isJSDocEntryNameReference(name)) {
                 const meaning = SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Value;
                 return resolveEntityName(<EntityName>name, meaning, /*ignoreErrors*/ false, /*dontResolveAlias*/ true, getHostSignatureFromJSDoc(name));
+            }
+            else if (isJSDocLink(name.parent)) {
+                const meaning = SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Value;
+                return resolveEntityName(<EntityName>name, meaning, /*ignoreErrors*/ true);
             }
 
             if (name.parent.kind === SyntaxKind.TypePredicate) {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -3565,13 +3565,16 @@ namespace ts {
         function emitJSDoc(node: JSDoc) {
             write("/**");
             if (node.comment) {
-                const lines = node.comment.split(/\r\n?|\n/g);
-                for (const line of lines) {
-                    writeLine();
-                    writeSpace();
-                    writePunctuation("*");
-                    writeSpace();
-                    write(line);
+                const text = getTextOfJSDocComment(node.comment);
+                if (text) {
+                    const lines = text.split(/\r\n?|\n/g);
+                    for (const line of lines) {
+                        writeLine();
+                        writeSpace();
+                        writePunctuation("*");
+                        writeSpace();
+                        write(line);
+                    }
                 }
             }
             if (node.tags) {
@@ -3704,10 +3707,11 @@ namespace ts {
             emit(tagName);
         }
 
-        function emitJSDocComment(comment: string | undefined) {
-            if (comment) {
+        function emitJSDocComment(comment: NodeArray<JSDocText | JSDocLink> | undefined) {
+            const text = getTextOfJSDocComment(comment);
+            if (text) {
                 writeSpace();
-                write(comment);
+                write(text);
             }
         }
 

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -3707,7 +3707,7 @@ namespace ts {
             emit(tagName);
         }
 
-        function emitJSDocComment(comment: NodeArray<JSDocText | JSDocLink> | undefined) {
+        function emitJSDocComment(comment: string | NodeArray<JSDocText | JSDocLink> | undefined) {
             const text = getTextOfJSDocComment(comment);
             if (text) {
                 writeSpace();

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -34,10 +34,10 @@ namespace ts {
         const getJSDocPrimaryTypeCreateFunction = memoizeOne(<T extends JSDocType>(kind: T["kind"]) => () => createJSDocPrimaryTypeWorker(kind));
         const getJSDocUnaryTypeCreateFunction = memoizeOne(<T extends JSDocType & { readonly type: TypeNode | undefined; }>(kind: T["kind"]) => (type: T["type"]) => createJSDocUnaryTypeWorker<T>(kind, type));
         const getJSDocUnaryTypeUpdateFunction = memoizeOne(<T extends JSDocType & { readonly type: TypeNode | undefined; }>(kind: T["kind"]) => (node: T, type: T["type"]) => updateJSDocUnaryTypeWorker<T>(kind, node, type));
-        const getJSDocSimpleTagCreateFunction = memoizeOne(<T extends JSDocTag>(kind: T["kind"]) => (tagName: Identifier | undefined, comment?: string) => createJSDocSimpleTagWorker(kind, tagName, comment));
-        const getJSDocSimpleTagUpdateFunction = memoizeOne(<T extends JSDocTag>(kind: T["kind"]) => (node: T, tagName: Identifier | undefined, comment?: string) => updateJSDocSimpleTagWorker(kind, node, tagName, comment));
-        const getJSDocTypeLikeTagCreateFunction = memoizeOne(<T extends JSDocTag & { typeExpression?: JSDocTypeExpression }>(kind: T["kind"]) => (tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression, comment?: string) => createJSDocTypeLikeTagWorker(kind, tagName, typeExpression, comment));
-        const getJSDocTypeLikeTagUpdateFunction = memoizeOne(<T extends JSDocTag & { typeExpression?: JSDocTypeExpression }>(kind: T["kind"]) => (node: T, tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression, comment?: string) => updateJSDocTypeLikeTagWorker(kind, node, tagName, typeExpression, comment));
+        const getJSDocSimpleTagCreateFunction = memoizeOne(<T extends JSDocTag>(kind: T["kind"]) => (tagName: Identifier | undefined, comment?: NodeArray<JSDocText | JSDocLink>) => createJSDocSimpleTagWorker(kind, tagName, comment));
+        const getJSDocSimpleTagUpdateFunction = memoizeOne(<T extends JSDocTag>(kind: T["kind"]) => (node: T, tagName: Identifier | undefined, comment?: NodeArray<JSDocText | JSDocLink>) => updateJSDocSimpleTagWorker(kind, node, tagName, comment));
+        const getJSDocTypeLikeTagCreateFunction = memoizeOne(<T extends JSDocTag & { typeExpression?: JSDocTypeExpression }>(kind: T["kind"]) => (tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression, comment?: NodeArray<JSDocText | JSDocLink>) => createJSDocTypeLikeTagWorker(kind, tagName, typeExpression, comment));
+        const getJSDocTypeLikeTagUpdateFunction = memoizeOne(<T extends JSDocTag & { typeExpression?: JSDocTypeExpression }>(kind: T["kind"]) => (node: T, tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression, comment?: NodeArray<JSDocText | JSDocLink>) => updateJSDocTypeLikeTagWorker(kind, node, tagName, typeExpression, comment));
 
         const factory: NodeFactory = {
             get parenthesizer() { return parenthesizerRules(); },
@@ -345,6 +345,8 @@ namespace ts {
             updateJSDocSeeTag,
             createJSDocNameReference,
             updateJSDocNameReference,
+            createJSDocLink,
+            updateJSDocLink,
             // lazily load factory members for JSDoc tags with similar structure
             get createJSDocTypeTag() { return getJSDocTypeLikeTagCreateFunction<JSDocTypeTag>(SyntaxKind.JSDocTypeTag); },
             get updateJSDocTypeTag() { return getJSDocTypeLikeTagUpdateFunction<JSDocTypeTag>(SyntaxKind.JSDocTypeTag); },
@@ -370,6 +372,8 @@ namespace ts {
             get updateJSDocDeprecatedTag() { return getJSDocSimpleTagUpdateFunction<JSDocDeprecatedTag>(SyntaxKind.JSDocDeprecatedTag); },
             createJSDocUnknownTag,
             updateJSDocUnknownTag,
+            createJSDocText,
+            updateJSDocText,
             createJSDocComment,
             updateJSDocComment,
             createJsxElement,
@@ -4236,15 +4240,15 @@ namespace ts {
         }
 
         // @api
-        function createBaseJSDocTag<T extends JSDocTag>(kind: T["kind"], tagName: Identifier, comment: string | undefined) {
+        function createBaseJSDocTag<T extends JSDocTag>(kind: T["kind"], tagName: Identifier, comment: string | NodeArray<JSDocText | JSDocLink> | undefined) {
             const node = createBaseNode<T>(kind);
             node.tagName = tagName;
-            node.comment = comment;
+            node.comment = typeof comment === "string" ? createNodeArray([createJSDocText(comment)]) : comment;
             return node;
         }
 
         // @api
-        function createJSDocTemplateTag(tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment?: string): JSDocTemplateTag {
+        function createJSDocTemplateTag(tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocTemplateTag {
             const node = createBaseJSDocTag<JSDocTemplateTag>(SyntaxKind.JSDocTemplateTag, tagName ?? createIdentifier("template"), comment);
             node.constraint = constraint;
             node.typeParameters = createNodeArray(typeParameters);
@@ -4252,7 +4256,7 @@ namespace ts {
         }
 
         // @api
-        function updateJSDocTemplateTag(node: JSDocTemplateTag, tagName: Identifier = getDefaultTagName(node), constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment: string | undefined): JSDocTemplateTag {
+        function updateJSDocTemplateTag(node: JSDocTemplateTag, tagName: Identifier = getDefaultTagName(node), constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocTemplateTag {
             return node.tagName !== tagName
                 || node.constraint !== constraint
                 || node.typeParameters !== typeParameters
@@ -4262,7 +4266,7 @@ namespace ts {
         }
 
         // @api
-        function createJSDocTypedefTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string): JSDocTypedefTag {
+        function createJSDocTypedefTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocTypedefTag {
             const node = createBaseJSDocTag<JSDocTypedefTag>(SyntaxKind.JSDocTypedefTag, tagName ?? createIdentifier("typedef"), comment);
             node.typeExpression = typeExpression;
             node.fullName = fullName;
@@ -4271,7 +4275,7 @@ namespace ts {
         }
 
         // @api
-        function updateJSDocTypedefTag(node: JSDocTypedefTag, tagName: Identifier = getDefaultTagName(node), typeExpression: JSDocTypeExpression | undefined, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | undefined): JSDocTypedefTag {
+        function updateJSDocTypedefTag(node: JSDocTypedefTag, tagName: Identifier = getDefaultTagName(node), typeExpression: JSDocTypeExpression | undefined, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocTypedefTag {
             return node.tagName !== tagName
                 || node.typeExpression !== typeExpression
                 || node.fullName !== fullName
@@ -4281,7 +4285,7 @@ namespace ts {
         }
 
         // @api
-        function createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocParameterTag {
+        function createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocParameterTag {
             const node = createBaseJSDocTag<JSDocParameterTag>(SyntaxKind.JSDocParameterTag, tagName ?? createIdentifier("param"), comment);
             node.typeExpression = typeExpression;
             node.name = name;
@@ -4291,7 +4295,7 @@ namespace ts {
         }
 
         // @api
-        function updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier = getDefaultTagName(node), name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocParameterTag {
+        function updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier = getDefaultTagName(node), name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocParameterTag {
             return node.tagName !== tagName
                 || node.name !== name
                 || node.isBracketed !== isBracketed
@@ -4303,7 +4307,7 @@ namespace ts {
         }
 
         // @api
-        function createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocPropertyTag {
+        function createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocPropertyTag {
             const node = createBaseJSDocTag<JSDocPropertyTag>(SyntaxKind.JSDocPropertyTag, tagName ?? createIdentifier("prop"), comment);
             node.typeExpression = typeExpression;
             node.name = name;
@@ -4313,7 +4317,7 @@ namespace ts {
         }
 
         // @api
-        function updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier = getDefaultTagName(node), name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocPropertyTag {
+        function updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier = getDefaultTagName(node), name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocPropertyTag {
             return node.tagName !== tagName
                 || node.name !== name
                 || node.isBracketed !== isBracketed
@@ -4325,7 +4329,7 @@ namespace ts {
         }
 
         // @api
-        function createJSDocCallbackTag(tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string): JSDocCallbackTag {
+        function createJSDocCallbackTag(tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocCallbackTag {
             const node = createBaseJSDocTag<JSDocCallbackTag>(SyntaxKind.JSDocCallbackTag, tagName ?? createIdentifier("callback"), comment);
             node.typeExpression = typeExpression;
             node.fullName = fullName;
@@ -4334,7 +4338,7 @@ namespace ts {
         }
 
         // @api
-        function updateJSDocCallbackTag(node: JSDocCallbackTag, tagName: Identifier = getDefaultTagName(node), typeExpression: JSDocSignature, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | undefined): JSDocCallbackTag {
+        function updateJSDocCallbackTag(node: JSDocCallbackTag, tagName: Identifier = getDefaultTagName(node), typeExpression: JSDocSignature, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocCallbackTag {
             return node.tagName !== tagName
                 || node.typeExpression !== typeExpression
                 || node.fullName !== fullName
@@ -4344,14 +4348,14 @@ namespace ts {
         }
 
         // @api
-        function createJSDocAugmentsTag(tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment?: string): JSDocAugmentsTag {
+        function createJSDocAugmentsTag(tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocAugmentsTag {
             const node = createBaseJSDocTag<JSDocAugmentsTag>(SyntaxKind.JSDocAugmentsTag, tagName ?? createIdentifier("augments"), comment);
             node.class = className;
             return node;
         }
 
         // @api
-        function updateJSDocAugmentsTag(node: JSDocAugmentsTag, tagName: Identifier = getDefaultTagName(node), className: JSDocAugmentsTag["class"], comment: string | undefined): JSDocAugmentsTag {
+        function updateJSDocAugmentsTag(node: JSDocAugmentsTag, tagName: Identifier = getDefaultTagName(node), className: JSDocAugmentsTag["class"], comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocAugmentsTag {
             return node.tagName !== tagName
                 || node.class !== className
                 || node.comment !== comment
@@ -4360,21 +4364,21 @@ namespace ts {
         }
 
         // @api
-        function createJSDocImplementsTag(tagName: Identifier | undefined, className: JSDocImplementsTag["class"], comment?: string): JSDocImplementsTag {
+        function createJSDocImplementsTag(tagName: Identifier | undefined, className: JSDocImplementsTag["class"], comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocImplementsTag {
             const node = createBaseJSDocTag<JSDocImplementsTag>(SyntaxKind.JSDocImplementsTag, tagName ?? createIdentifier("implements"), comment);
             node.class = className;
             return node;
         }
 
         // @api
-        function createJSDocSeeTag(tagName: Identifier | undefined, name: JSDocNameReference | undefined, comment?: string): JSDocSeeTag {
+        function createJSDocSeeTag(tagName: Identifier | undefined, name: JSDocNameReference | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocSeeTag {
             const node = createBaseJSDocTag<JSDocSeeTag>(SyntaxKind.JSDocSeeTag, tagName ?? createIdentifier("see"), comment);
             node.name = name;
             return node;
         }
 
         // @api
-        function updateJSDocSeeTag(node: JSDocSeeTag, tagName: Identifier | undefined, name: JSDocNameReference | undefined, comment?: string): JSDocSeeTag {
+        function updateJSDocSeeTag(node: JSDocSeeTag, tagName: Identifier | undefined, name: JSDocNameReference | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocSeeTag {
             return node.tagName !== tagName
                 || node.name !== name
                 || node.comment !== comment
@@ -4397,7 +4401,22 @@ namespace ts {
         }
 
         // @api
-        function updateJSDocImplementsTag(node: JSDocImplementsTag, tagName: Identifier = getDefaultTagName(node), className: JSDocImplementsTag["class"], comment: string | undefined): JSDocImplementsTag {
+        function createJSDocLink(name: EntityName | undefined, text: string): JSDocLink {
+            const node = createBaseNode<JSDocLink>(SyntaxKind.JSDocLink);
+            node.name = name;
+            node.text = text;
+            return node;
+        }
+
+        // @api
+        function updateJSDocLink(node: JSDocLink, name: EntityName | undefined, text: string): JSDocLink {
+            return node.name !== name
+                ? update(createJSDocLink(name, text), node)
+                : node;
+        }
+
+        // @api
+        function updateJSDocImplementsTag(node: JSDocImplementsTag, tagName: Identifier = getDefaultTagName(node), className: JSDocImplementsTag["class"], comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocImplementsTag {
             return node.tagName !== tagName
                 || node.class !== className
                 || node.comment !== comment
@@ -4413,7 +4432,7 @@ namespace ts {
         // createJSDocProtectedTag
         // createJSDocReadonlyTag
         // createJSDocDeprecatedTag
-        function createJSDocSimpleTagWorker<T extends JSDocTag>(kind: T["kind"], tagName: Identifier | undefined, comment?: string) {
+        function createJSDocSimpleTagWorker<T extends JSDocTag>(kind: T["kind"], tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>) {
             const node = createBaseJSDocTag<T>(kind, tagName ?? createIdentifier(getDefaultTagNameForKind(kind)), comment);
             return node;
         }
@@ -4426,7 +4445,7 @@ namespace ts {
         // updateJSDocProtectedTag
         // updateJSDocReadonlyTag
         // updateJSDocDeprecatedTag
-        function updateJSDocSimpleTagWorker<T extends JSDocTag>(kind: T["kind"], node: T, tagName: Identifier = getDefaultTagName(node), comment: string | undefined) {
+        function updateJSDocSimpleTagWorker<T extends JSDocTag>(kind: T["kind"], node: T, tagName: Identifier = getDefaultTagName(node), comment: string | NodeArray<JSDocText | JSDocLink> | undefined) {
             return node.tagName !== tagName
                 || node.comment !== comment
                 ? update(createJSDocSimpleTagWorker(kind, tagName, comment), node) :
@@ -4438,7 +4457,7 @@ namespace ts {
         // createJSDocReturnTag
         // createJSDocThisTag
         // createJSDocEnumTag
-        function createJSDocTypeLikeTagWorker<T extends JSDocTag & { typeExpression?: JSDocTypeExpression }>(kind: T["kind"], tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression, comment?: string) {
+        function createJSDocTypeLikeTagWorker<T extends JSDocTag & { typeExpression?: JSDocTypeExpression }>(kind: T["kind"], tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink>) {
             const node = createBaseJSDocTag<T>(kind, tagName ?? createIdentifier(getDefaultTagNameForKind(kind)), comment);
             node.typeExpression = typeExpression;
             return node;
@@ -4449,7 +4468,7 @@ namespace ts {
         // updateJSDocReturnTag
         // updateJSDocThisTag
         // updateJSDocEnumTag
-        function updateJSDocTypeLikeTagWorker<T extends JSDocTag & { typeExpression?: JSDocTypeExpression }>(kind: T["kind"], node: T, tagName: Identifier = getDefaultTagName(node), typeExpression: JSDocTypeExpression | undefined, comment: string | undefined) {
+        function updateJSDocTypeLikeTagWorker<T extends JSDocTag & { typeExpression?: JSDocTypeExpression }>(kind: T["kind"], node: T, tagName: Identifier = getDefaultTagName(node), typeExpression: JSDocTypeExpression | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined) {
             return node.tagName !== tagName
                 || node.typeExpression !== typeExpression
                 || node.comment !== comment
@@ -4458,13 +4477,13 @@ namespace ts {
         }
 
         // @api
-        function createJSDocUnknownTag(tagName: Identifier, comment?: string): JSDocUnknownTag {
+        function createJSDocUnknownTag(tagName: Identifier, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocUnknownTag {
             const node = createBaseJSDocTag<JSDocUnknownTag>(SyntaxKind.JSDocTag, tagName, comment);
             return node;
         }
 
         // @api
-        function updateJSDocUnknownTag(node: JSDocUnknownTag, tagName: Identifier, comment: string | undefined): JSDocUnknownTag {
+        function updateJSDocUnknownTag(node: JSDocUnknownTag, tagName: Identifier, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocUnknownTag {
             return node.tagName !== tagName
                 || node.comment !== comment
                 ? update(createJSDocUnknownTag(tagName, comment), node)
@@ -4472,15 +4491,29 @@ namespace ts {
         }
 
         // @api
-        function createJSDocComment(comment?: string | undefined, tags?: readonly JSDocTag[] | undefined) {
+        function createJSDocText(text: string): JSDocText {
+            const node = createBaseNode<JSDocText>(SyntaxKind.JSDocText);
+            node.text = text;
+            return node;
+        }
+
+        // @api
+        function updateJSDocText(node: JSDocText, text: string): JSDocText {
+            return node.text !== text
+                ? update(createJSDocText(text), node)
+                : node;
+        }
+
+        // @api
+        function createJSDocComment(comment?: string | NodeArray<JSDocText | JSDocLink> | undefined, tags?: readonly JSDocTag[] | undefined) {
             const node = createBaseNode<JSDoc>(SyntaxKind.JSDocComment);
-            node.comment = comment;
+            node.comment = typeof comment === "string" ? createNodeArray([createJSDocText(comment)]) : comment;
             node.tags = asNodeArray(tags);
             return node;
         }
 
         // @api
-        function updateJSDocComment(node: JSDoc, comment: string | undefined, tags: readonly JSDocTag[] | undefined) {
+        function updateJSDocComment(node: JSDoc, comment: string | NodeArray<JSDocText | JSDocLink> | undefined, tags: readonly JSDocTag[] | undefined) {
             return node.comment !== comment
                 || node.tags !== tags
                 ? update(createJSDocComment(comment, tags), node)

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -4243,7 +4243,7 @@ namespace ts {
         function createBaseJSDocTag<T extends JSDocTag>(kind: T["kind"], tagName: Identifier, comment: string | NodeArray<JSDocText | JSDocLink> | undefined) {
             const node = createBaseNode<T>(kind);
             node.tagName = tagName;
-            node.comment = typeof comment === "string" ? createNodeArray([createJSDocText(comment)]) : comment;
+            node.comment = comment;
             return node;
         }
 
@@ -4507,7 +4507,7 @@ namespace ts {
         // @api
         function createJSDocComment(comment?: string | NodeArray<JSDocText | JSDocLink> | undefined, tags?: readonly JSDocTag[] | undefined) {
             const node = createBaseNode<JSDoc>(SyntaxKind.JSDocComment);
-            node.comment = typeof comment === "string" ? createNodeArray([createJSDocText(comment)]) : comment;
+            node.comment = comment;
             node.tags = asNodeArray(tags);
             return node;
         }

--- a/src/compiler/factory/nodeTests.ts
+++ b/src/compiler/factory/nodeTests.ts
@@ -770,6 +770,10 @@ namespace ts {
         return node.kind === SyntaxKind.JSDocNameReference;
     }
 
+    export function isJSDocLink(node: Node): node is JSDocLink {
+        return node.kind === SyntaxKind.JSDocLink;
+    }
+
     export function isJSDocAllType(node: Node): node is JSDocAllType {
         return node.kind === SyntaxKind.JSDocAllType;
     }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -481,10 +481,12 @@ namespace ts {
                 return visitNodes(cbNode, cbNodes, (<JSDocFunctionType>node).parameters) ||
                     visitNode(cbNode, (<JSDocFunctionType>node).type);
             case SyntaxKind.JSDocComment:
-                return visitNodes(cbNode, cbNodes, (<JSDoc>node).tags);
+                return visitNodes(cbNode, cbNodes, (node as JSDoc).comment)
+                    || visitNodes(cbNode, cbNodes, (node as JSDoc).tags);
             case SyntaxKind.JSDocSeeTag:
                 return visitNode(cbNode, (node as JSDocSeeTag).tagName) ||
-                    visitNode(cbNode, (node as JSDocSeeTag).name);
+                    visitNode(cbNode, (node as JSDocSeeTag).name) ||
+                    visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
             case SyntaxKind.JSDocNameReference:
                 return visitNode(cbNode, (node as JSDocNameReference).name);
             case SyntaxKind.JSDocParameterTag:
@@ -492,43 +494,54 @@ namespace ts {
                 return visitNode(cbNode, (node as JSDocTag).tagName) ||
                     ((node as JSDocPropertyLikeTag).isNameFirst
                         ? visitNode(cbNode, (<JSDocPropertyLikeTag>node).name) ||
-                            visitNode(cbNode, (<JSDocPropertyLikeTag>node).typeExpression)
+                            visitNode(cbNode, (<JSDocPropertyLikeTag>node).typeExpression) ||
+                            visitNodes(cbNode, cbNodes, (node as JSDocTag).comment)
                         : visitNode(cbNode, (<JSDocPropertyLikeTag>node).typeExpression) ||
-                            visitNode(cbNode, (<JSDocPropertyLikeTag>node).name));
+                            visitNode(cbNode, (<JSDocPropertyLikeTag>node).name)) ||
+                            visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
             case SyntaxKind.JSDocAuthorTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName);
             case SyntaxKind.JSDocImplementsTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName) ||
-                    visitNode(cbNode, (<JSDocImplementsTag>node).class);
+                    visitNode(cbNode, (<JSDocImplementsTag>node).class) ||
+                    visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
             case SyntaxKind.JSDocAugmentsTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName) ||
-                    visitNode(cbNode, (<JSDocAugmentsTag>node).class);
+                    visitNode(cbNode, (<JSDocAugmentsTag>node).class) ||
+                    visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
             case SyntaxKind.JSDocTemplateTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName) ||
                     visitNode(cbNode, (<JSDocTemplateTag>node).constraint) ||
-                    visitNodes(cbNode, cbNodes, (<JSDocTemplateTag>node).typeParameters);
+                    visitNodes(cbNode, cbNodes, (<JSDocTemplateTag>node).typeParameters) ||
+                    visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
             case SyntaxKind.JSDocTypedefTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName) ||
                     ((node as JSDocTypedefTag).typeExpression &&
                         (node as JSDocTypedefTag).typeExpression!.kind === SyntaxKind.JSDocTypeExpression
                         ? visitNode(cbNode, (<JSDocTypedefTag>node).typeExpression) ||
-                            visitNode(cbNode, (<JSDocTypedefTag>node).fullName)
+                            visitNode(cbNode, (<JSDocTypedefTag>node).fullName) ||
+                            visitNodes(cbNode, cbNodes, (node as JSDocTag).comment)
                         : visitNode(cbNode, (<JSDocTypedefTag>node).fullName) ||
-                            visitNode(cbNode, (<JSDocTypedefTag>node).typeExpression));
+                            visitNode(cbNode, (<JSDocTypedefTag>node).typeExpression)) ||
+                            visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
             case SyntaxKind.JSDocCallbackTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName) ||
                     visitNode(cbNode, (node as JSDocCallbackTag).fullName) ||
-                    visitNode(cbNode, (node as JSDocCallbackTag).typeExpression);
+                    visitNode(cbNode, (node as JSDocCallbackTag).typeExpression) ||
+                    visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
             case SyntaxKind.JSDocReturnTag:
             case SyntaxKind.JSDocTypeTag:
             case SyntaxKind.JSDocThisTag:
             case SyntaxKind.JSDocEnumTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName) ||
-                    visitNode(cbNode, (node as JSDocReturnTag | JSDocTypeTag | JSDocThisTag | JSDocEnumTag).typeExpression);
+                    visitNode(cbNode, (node as JSDocReturnTag | JSDocTypeTag | JSDocThisTag | JSDocEnumTag).typeExpression) ||
+                    visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
             case SyntaxKind.JSDocSignature:
                 return forEach((<JSDocSignature>node).typeParameters, cbNode) ||
                     forEach((<JSDocSignature>node).parameters, cbNode) ||
                     visitNode(cbNode, (<JSDocSignature>node).type);
+            case SyntaxKind.JSDocLink:
+                return visitNode(cbNode, (node as JSDocLink).name);
             case SyntaxKind.JSDocTypeLiteral:
                 return forEach((node as JSDocTypeLiteral).jsDocPropertyTags, cbNode);
             case SyntaxKind.JSDocTag:
@@ -537,7 +550,8 @@ namespace ts {
             case SyntaxKind.JSDocPrivateTag:
             case SyntaxKind.JSDocProtectedTag:
             case SyntaxKind.JSDocReadonlyTag:
-                return visitNode(cbNode, (node as JSDocTag).tagName);
+                return visitNode(cbNode, (node as JSDocTag).tagName)
+                 || visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
             case SyntaxKind.PartiallyEmittedExpression:
                 return visitNode(cbNode, (<PartiallyEmittedExpression>node).expression);
         }
@@ -7318,7 +7332,10 @@ namespace ts {
                 let tags: JSDocTag[];
                 let tagsPos: number;
                 let tagsEnd: number;
-                const comments: string[] = [];
+                let linkEnd: number;
+                let commentsPos: number | undefined;
+                let comments: string[] = [];
+                const parts: (JSDocLink | JSDocText)[] = [];
 
                 // + 3 for leading /**, - 5 in total for /** */
                 return scanner.scanRange(start + 3, length - 5, () => {
@@ -7348,6 +7365,7 @@ namespace ts {
                             case SyntaxKind.AtToken:
                                 if (state === JSDocState.BeginningOfLine || state === JSDocState.SawAsterisk) {
                                     removeTrailingWhitespace(comments);
+                                    if (!commentsPos) commentsPos = getNodePos();
                                     addTag(parseTag(indent));
                                     // NOTE: According to usejsdoc.org, a tag goes to end of line, except the last tag.
                                     // Real-world comments may break this rule, so "BeginningOfLine" will not be a real line beginning
@@ -7390,6 +7408,22 @@ namespace ts {
                                 break;
                             case SyntaxKind.EndOfFileToken:
                                 break loop;
+                            case SyntaxKind.OpenBraceToken:
+                                state = JSDocState.SavingComments;
+                                const commentEnd = scanner.getStartPos();
+                                const linkStart = scanner.getTextPos() - 1;
+                                const link = parseJSDocLink(linkStart);
+                                if (link) {
+                                    if (!linkEnd) {
+                                        removeLeadingNewlines(comments);
+                                    }
+                                    parts.push(finishNode(factory.createJSDocText(comments.join("")), linkEnd ?? start, commentEnd));
+                                    parts.push(link);
+                                    comments = [];
+                                    linkEnd = scanner.getTextPos();
+                                    break;
+                                }
+                                // fallthrough if it's not a {@link sequence
                             default:
                                 // Anything else is doc comment text. We just save it. Because it
                                 // wasn't a tag, we can no longer parse a tag on this line until we hit the next
@@ -7400,9 +7434,13 @@ namespace ts {
                         }
                         nextTokenJSDoc();
                     }
-                    removeLeadingNewlines(comments);
                     removeTrailingWhitespace(comments);
-                    return createJSDocComment();
+                    if (comments.length) {
+                        parts.push(finishNode(factory.createJSDocText(comments.join("")), linkEnd ?? start, commentsPos));
+                    }
+                    if (parts.length && tags) Debug.assertIsDefined(commentsPos, "having parsed tags implies that the end of the comment span should be set");
+                    const tagsArray = tags && createNodeArray(tags, tagsPos, tagsEnd);
+                    return finishNode(factory.createJSDocComment(parts.length ? createNodeArray(parts, start, commentsPos) : undefined, tagsArray), start, end);
                 });
 
                 function removeLeadingNewlines(comments: string[]) {
@@ -7415,12 +7453,6 @@ namespace ts {
                     while (comments.length && comments[comments.length - 1].trim() === "") {
                         comments.pop();
                     }
-                }
-
-                function createJSDocComment(): JSDoc {
-                    const comment = comments.length ? comments.join("") : undefined;
-                    const tagsArray = tags && createNodeArray(tags, tagsPos, tagsEnd);
-                    return finishNode(factory.createJSDocComment(comment, tagsArray), start, end);
                 }
 
                 function isNextNonwhitespaceTokenEndOfFile(): boolean {
@@ -7556,8 +7588,11 @@ namespace ts {
                     return parseTagComments(margin, indentText.slice(margin));
                 }
 
-                function parseTagComments(indent: number, initialMargin?: string): string | undefined {
-                    const comments: string[] = [];
+                function parseTagComments(indent: number, initialMargin?: string): NodeArray<JSDocText | JSDocLink> | undefined {
+                    const commentsPos = getNodePos();
+                    let comments: string[] = [];
+                    const parts: (JSDocLink | JSDocText)[] = [];
+                    let linkEnd;
                     let state = JSDocState.BeginningOfLine;
                     let previousWhitespace = true;
                     let margin: number | undefined;
@@ -7610,13 +7645,18 @@ namespace ts {
                                 break;
                             case SyntaxKind.OpenBraceToken:
                                 state = JSDocState.SavingComments;
-                                if (lookAhead(() => nextTokenJSDoc() === SyntaxKind.AtToken && tokenIsIdentifierOrKeyword(nextTokenJSDoc()) && scanner.getTokenText() === "link")) {
-                                    pushComment(scanner.getTokenText());
-                                    nextTokenJSDoc();
-                                    pushComment(scanner.getTokenText());
-                                    nextTokenJSDoc();
+                                const commentEnd = scanner.getStartPos();
+                                const linkStart = scanner.getTextPos() - 1;
+                                const link = parseJSDocLink(linkStart);
+                                if (link) {
+                                    parts.push(finishNode(factory.createJSDocText(comments.join("")), linkEnd ?? commentsPos, commentEnd));
+                                    parts.push(link);
+                                    comments = [];
+                                    linkEnd = scanner.getTextPos();
                                 }
-                                pushComment(scanner.getTokenText());
+                                else {
+                                    pushComment(scanner.getTokenText());
+                                }
                                 break;
                             case SyntaxKind.BacktickToken:
                                 if (state === JSDocState.SavingBackticks) {
@@ -7649,12 +7689,42 @@ namespace ts {
 
                     removeLeadingNewlines(comments);
                     removeTrailingWhitespace(comments);
-                    return comments.length === 0 ? undefined : comments.join("");
+                    if (comments.length) {
+                        parts.push(finishNode(factory.createJSDocText(comments.join("")), linkEnd ?? commentsPos));
+                    }
+                    if (parts.length) {
+                        return createNodeArray(parts, commentsPos, scanner.getTextPos());
+                    }
+                }
+
+                function parseJSDocLink(start: number) {
+                    if (!tryParse(parseJSDocLinkPrefix)) {
+                        return undefined;
+                    }
+                    nextTokenJSDoc(); // start at token after link, then skip any whitespace
+                    skipWhitespace();
+                    // parseEntityName logs an error for non-identifier, so create a MissingNode ourselves to avoid the error
+                    const name = tokenIsIdentifierOrKeyword(token())
+                        ? parseEntityName(/*allowReservedWords*/ true)
+                        : undefined;
+                    const text = [];
+                    while (token() !== SyntaxKind.CloseBraceToken && token() !== SyntaxKind.NewLineTrivia) {
+                        text.push(scanner.getTokenText());
+                        nextTokenJSDoc();
+                    }
+                    return finishNode(factory.createJSDocLink(name, text.join("")), start, scanner.getTextPos());
+                }
+
+                function parseJSDocLinkPrefix() {
+                    skipWhitespaceOrAsterisk();
+                    return token() === SyntaxKind.OpenBraceToken
+                        && nextTokenJSDoc() === SyntaxKind.AtToken
+                        && tokenIsIdentifierOrKeyword(nextTokenJSDoc())
+                        && scanner.getTokenValue() === "link";
                 }
 
                 function parseUnknownTag(start: number, tagName: Identifier, indent: number, indentText: string) {
-                    const end = getNodePos();
-                    return finishNode(factory.createJSDocUnknownTag(tagName, parseTrailingTagComments(start, end, indent, indentText)), start, end);
+                    return finishNode(factory.createJSDocUnknownTag(tagName, parseTrailingTagComments(start, getNodePos(), indent, indentText)), start);
                 }
 
                 function addTag(tag: JSDocTag | undefined): void {
@@ -7720,7 +7790,7 @@ namespace ts {
                     const { name, isBracketed } = parseBracketNameInPropertyAndParamTag();
                     const indentText = skipWhitespaceOrAsterisk();
 
-                    if (isNameFirst) {
+                    if (isNameFirst && !lookAhead(parseJSDocLinkPrefix)) {
                         typeExpression = tryParseTypeExpression();
                     }
 
@@ -7760,8 +7830,7 @@ namespace ts {
                     }
 
                     const typeExpression = tryParseTypeExpression();
-                    const end = getNodePos();
-                    return finishNode(factory.createJSDocReturnTag(tagName, typeExpression, parseTrailingTagComments(start, end, indent, indentText)), start, end);
+                    return finishNode(factory.createJSDocReturnTag(tagName, typeExpression, parseTrailingTagComments(start, getNodePos(), indent, indentText)), start);
                 }
 
                 function parseTypeTag(start: number, tagName: Identifier, indent?: number, indentText?: string): JSDocTypeTag {
@@ -7770,24 +7839,30 @@ namespace ts {
                     }
 
                     const typeExpression = parseJSDocTypeExpression(/*mayOmitBraces*/ true);
-                    const end = getNodePos();
-                    const comments = indent !== undefined && indentText !== undefined ? parseTrailingTagComments(start, end, indent, indentText) : undefined;
-                    return finishNode(factory.createJSDocTypeTag(tagName, typeExpression, comments), start, end);
+                    const comments = indent !== undefined && indentText !== undefined ? parseTrailingTagComments(start, getNodePos(), indent, indentText) : undefined;
+                    return finishNode(factory.createJSDocTypeTag(tagName, typeExpression, comments), start);
                 }
 
                 function parseSeeTag(start: number, tagName: Identifier, indent?: number, indentText?: string): JSDocSeeTag {
-                    const nameExpression = parseJSDocNameReference();
-                    const end = getNodePos();
-                    const comments = indent !== undefined && indentText !== undefined ? parseTrailingTagComments(start, end, indent, indentText) : undefined;
-                    return finishNode(factory.createJSDocSeeTag(tagName, nameExpression, comments), start, end);
+                    const isLink = lookAhead(() => nextTokenJSDoc() === SyntaxKind.AtToken && tokenIsIdentifierOrKeyword(nextTokenJSDoc()) && scanner.getTokenValue() === "link");
+                    const nameExpression = isLink ? undefined : parseJSDocNameReference();
+                    const comments = indent !== undefined && indentText !== undefined ? parseTrailingTagComments(start, getNodePos(), indent, indentText) : undefined;
+                    return finishNode(factory.createJSDocSeeTag(tagName, nameExpression, comments), start);
                 }
 
                 function parseAuthorTag(start: number, tagName: Identifier, indent: number, indentText: string): JSDocAuthorTag {
-                    const comments = parseAuthorNameAndEmail() + (parseTrailingTagComments(start, end, indent, indentText) || "");
-                    return finishNode(factory.createJSDocAuthorTag(tagName, comments || undefined), start);
+                    const commentStart = getNodePos();
+                    const textOnly = parseAuthorNameAndEmail();
+                    let commentEnd = scanner.getStartPos();
+                    const comments = parseTrailingTagComments(start, commentEnd, indent, indentText);
+                    if (!comments) {
+                        commentEnd = scanner.getStartPos();
+                    }
+                    const allParts = concatenate([finishNode(textOnly, commentStart, commentEnd)], comments) as (JSDocText | JSDocLink)[]; // cast away readonly
+                    return finishNode(factory.createJSDocAuthorTag(tagName, createNodeArray(allParts, commentStart)), start);
                 }
 
-                function parseAuthorNameAndEmail(): string {
+                function parseAuthorNameAndEmail(): JSDocText {
                     const comments: string[] = [];
                     let inEmail = false;
                     let token = scanner.getToken();
@@ -7807,19 +7882,17 @@ namespace ts {
                         token = nextTokenJSDoc();
                     }
 
-                    return comments.join("");
+                    return factory.createJSDocText(comments.join(""));
                 }
 
                 function parseImplementsTag(start: number, tagName: Identifier, margin: number, indentText: string): JSDocImplementsTag {
                     const className = parseExpressionWithTypeArgumentsForAugments();
-                    const end = getNodePos();
-                    return finishNode(factory.createJSDocImplementsTag(tagName, className, parseTrailingTagComments(start, end, margin, indentText)), start, end);
+                    return finishNode(factory.createJSDocImplementsTag(tagName, className, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);
                 }
 
                 function parseAugmentsTag(start: number, tagName: Identifier, margin: number, indentText: string): JSDocAugmentsTag {
                     const className = parseExpressionWithTypeArgumentsForAugments();
-                    const end = getNodePos();
-                    return finishNode(factory.createJSDocAugmentsTag(tagName, className, parseTrailingTagComments(start, end, margin, indentText)), start, end);
+                    return finishNode(factory.createJSDocAugmentsTag(tagName, className, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);
                 }
 
                 function parseExpressionWithTypeArgumentsForAugments(): ExpressionWithTypeArguments & { expression: Identifier | PropertyAccessEntityNameExpression } {
@@ -7845,23 +7918,20 @@ namespace ts {
                     return node;
                 }
 
-                function parseSimpleTag(start: number, createTag: (tagName: Identifier | undefined, comment?: string) => JSDocTag, tagName: Identifier, margin: number, indentText: string): JSDocTag {
-                    const end = getNodePos();
-                    return finishNode(createTag(tagName, parseTrailingTagComments(start, end, margin, indentText)), start, end);
+                function parseSimpleTag(start: number, createTag: (tagName: Identifier | undefined, comment?: NodeArray<JSDocText | JSDocLink>) => JSDocTag, tagName: Identifier, margin: number, indentText: string): JSDocTag {
+                    return finishNode(createTag(tagName, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);
                 }
 
                 function parseThisTag(start: number, tagName: Identifier, margin: number, indentText: string): JSDocThisTag {
                     const typeExpression = parseJSDocTypeExpression(/*mayOmitBraces*/ true);
                     skipWhitespace();
-                    const end = getNodePos();
-                    return finishNode(factory.createJSDocThisTag(tagName, typeExpression, parseTrailingTagComments(start, end, margin, indentText)), start, end);
+                    return finishNode(factory.createJSDocThisTag(tagName, typeExpression, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);
                 }
 
                 function parseEnumTag(start: number, tagName: Identifier, margin: number, indentText: string): JSDocEnumTag {
                     const typeExpression = parseJSDocTypeExpression(/*mayOmitBraces*/ true);
                     skipWhitespace();
-                    const end = getNodePos();
-                    return finishNode(factory.createJSDocEnumTag(tagName, typeExpression, parseTrailingTagComments(start, end, margin, indentText)), start, end);
+                    return finishNode(factory.createJSDocEnumTag(tagName, typeExpression, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);
                 }
 
                 function parseTypedefTag(start: number, tagName: Identifier, indent: number, indentText: string): JSDocTypedefTag {
@@ -7920,7 +7990,7 @@ namespace ts {
                     }
 
                     const typedefTag = factory.createJSDocTypedefTag(tagName, typeExpression, fullName, comment);
-                    return finishNode(typedefTag, start, end);
+                    return finishNode(typedefTag, start);
                 }
 
                 function parseJSDocTypeNameWithNamespace(nested?: boolean) {
@@ -7972,11 +8042,10 @@ namespace ts {
                         }
                     });
                     const typeExpression = finishNode(factory.createJSDocSignature(/*typeParameters*/ undefined, parameters, returnTag), start);
-                    const end = getNodePos();
                     if (!comment) {
-                        comment = parseTrailingTagComments(start, end, indent, indentText);
+                        comment = parseTrailingTagComments(start, getNodePos(), indent, indentText);
                     }
-                    return finishNode(factory.createJSDocCallbackTag(tagName, typeExpression, fullName, comment), start, end);
+                    return finishNode(factory.createJSDocCallbackTag(tagName, typeExpression, fullName, comment), start);
                 }
 
                 function escapedTextsEqual(a: EntityName, b: EntityName): boolean {
@@ -8098,8 +8167,7 @@ namespace ts {
                     // TODO: Consider only parsing a single type parameter if there is a constraint.
                     const constraint = token() === SyntaxKind.OpenBraceToken ? parseJSDocTypeExpression() : undefined;
                     const typeParameters = parseTemplateTagTypeParameters();
-                    const end = getNodePos();
-                    return finishNode(factory.createJSDocTemplateTag(tagName, constraint, typeParameters, parseTrailingTagComments(start, end, indent, indentText)), start, end);
+                    return finishNode(factory.createJSDocTemplateTag(tagName, constraint, typeParameters, parseTrailingTagComments(start, getNodePos(), indent, indentText)), start);
                 }
 
                 function parseOptionalJsdoc(t: JSDocSyntaxKind): boolean {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -481,12 +481,12 @@ namespace ts {
                 return visitNodes(cbNode, cbNodes, (<JSDocFunctionType>node).parameters) ||
                     visitNode(cbNode, (<JSDocFunctionType>node).type);
             case SyntaxKind.JSDocComment:
-                return visitNodes(cbNode, cbNodes, (node as JSDoc).comment)
+                return (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocText | JSDocLink> | undefined))
                     || visitNodes(cbNode, cbNodes, (node as JSDoc).tags);
             case SyntaxKind.JSDocSeeTag:
                 return visitNode(cbNode, (node as JSDocSeeTag).tagName) ||
                     visitNode(cbNode, (node as JSDocSeeTag).name) ||
-                    visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
+                    (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocText | JSDocLink> | undefined));
             case SyntaxKind.JSDocNameReference:
                 return visitNode(cbNode, (node as JSDocNameReference).name);
             case SyntaxKind.JSDocParameterTag:
@@ -495,47 +495,48 @@ namespace ts {
                     ((node as JSDocPropertyLikeTag).isNameFirst
                         ? visitNode(cbNode, (<JSDocPropertyLikeTag>node).name) ||
                             visitNode(cbNode, (<JSDocPropertyLikeTag>node).typeExpression) ||
-                            visitNodes(cbNode, cbNodes, (node as JSDocTag).comment)
+                            (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocText | JSDocLink> | undefined))
                         : visitNode(cbNode, (<JSDocPropertyLikeTag>node).typeExpression) ||
                             visitNode(cbNode, (<JSDocPropertyLikeTag>node).name)) ||
-                            visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
+                            (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocText | JSDocLink> | undefined));
             case SyntaxKind.JSDocAuthorTag:
-                return visitNode(cbNode, (node as JSDocTag).tagName);
+                return visitNode(cbNode, (node as JSDocTag).tagName) ||
+                    (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocText | JSDocLink> | undefined));
             case SyntaxKind.JSDocImplementsTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName) ||
                     visitNode(cbNode, (<JSDocImplementsTag>node).class) ||
-                    visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
+                    (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocText | JSDocLink> | undefined));
             case SyntaxKind.JSDocAugmentsTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName) ||
                     visitNode(cbNode, (<JSDocAugmentsTag>node).class) ||
-                    visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
+                    (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocText | JSDocLink> | undefined));
             case SyntaxKind.JSDocTemplateTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName) ||
                     visitNode(cbNode, (<JSDocTemplateTag>node).constraint) ||
                     visitNodes(cbNode, cbNodes, (<JSDocTemplateTag>node).typeParameters) ||
-                    visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
+                    (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocText | JSDocLink> | undefined));
             case SyntaxKind.JSDocTypedefTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName) ||
                     ((node as JSDocTypedefTag).typeExpression &&
                         (node as JSDocTypedefTag).typeExpression!.kind === SyntaxKind.JSDocTypeExpression
                         ? visitNode(cbNode, (<JSDocTypedefTag>node).typeExpression) ||
                             visitNode(cbNode, (<JSDocTypedefTag>node).fullName) ||
-                            visitNodes(cbNode, cbNodes, (node as JSDocTag).comment)
+                            (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocText | JSDocLink> | undefined))
                         : visitNode(cbNode, (<JSDocTypedefTag>node).fullName) ||
                             visitNode(cbNode, (<JSDocTypedefTag>node).typeExpression)) ||
-                            visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
+                            (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocText | JSDocLink> | undefined));
             case SyntaxKind.JSDocCallbackTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName) ||
                     visitNode(cbNode, (node as JSDocCallbackTag).fullName) ||
                     visitNode(cbNode, (node as JSDocCallbackTag).typeExpression) ||
-                    visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
+                    (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocText | JSDocLink> | undefined));
             case SyntaxKind.JSDocReturnTag:
             case SyntaxKind.JSDocTypeTag:
             case SyntaxKind.JSDocThisTag:
             case SyntaxKind.JSDocEnumTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName) ||
                     visitNode(cbNode, (node as JSDocReturnTag | JSDocTypeTag | JSDocThisTag | JSDocEnumTag).typeExpression) ||
-                    visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
+                    (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocText | JSDocLink> | undefined));
             case SyntaxKind.JSDocSignature:
                 return forEach((<JSDocSignature>node).typeParameters, cbNode) ||
                     forEach((<JSDocSignature>node).parameters, cbNode) ||
@@ -551,7 +552,7 @@ namespace ts {
             case SyntaxKind.JSDocProtectedTag:
             case SyntaxKind.JSDocReadonlyTag:
                 return visitNode(cbNode, (node as JSDocTag).tagName)
-                 || visitNodes(cbNode, cbNodes, (node as JSDocTag).comment);
+                 || (typeof (node as JSDoc).comment === "string" ? undefined : visitNodes(cbNode, cbNodes, (node as JSDoc).comment as NodeArray<JSDocText | JSDocLink> | undefined));
             case SyntaxKind.PartiallyEmittedExpression:
                 return visitNode(cbNode, (<PartiallyEmittedExpression>node).expression);
         }
@@ -7412,6 +7413,7 @@ namespace ts {
                                 state = JSDocState.SavingComments;
                                 const commentEnd = scanner.getStartPos();
                                 const linkStart = scanner.getTextPos() - 1;
+                                // TODO: redo here
                                 const link = parseJSDocLink(linkStart);
                                 if (link) {
                                     if (!linkEnd) {
@@ -7435,12 +7437,12 @@ namespace ts {
                         nextTokenJSDoc();
                     }
                     removeTrailingWhitespace(comments);
-                    if (comments.length) {
+                    if (parts.length && comments.length) {
                         parts.push(finishNode(factory.createJSDocText(comments.join("")), linkEnd ?? start, commentsPos));
                     }
                     if (parts.length && tags) Debug.assertIsDefined(commentsPos, "having parsed tags implies that the end of the comment span should be set");
                     const tagsArray = tags && createNodeArray(tags, tagsPos, tagsEnd);
-                    return finishNode(factory.createJSDocComment(parts.length ? createNodeArray(parts, start, commentsPos) : undefined, tagsArray), start, end);
+                    return finishNode(factory.createJSDocComment(parts.length ? createNodeArray(parts, start, commentsPos) : comments.length ? comments.join("") : undefined, tagsArray), start, end);
                 });
 
                 function removeLeadingNewlines(comments: string[]) {
@@ -7588,7 +7590,7 @@ namespace ts {
                     return parseTagComments(margin, indentText.slice(margin));
                 }
 
-                function parseTagComments(indent: number, initialMargin?: string): NodeArray<JSDocText | JSDocLink> | undefined {
+                function parseTagComments(indent: number, initialMargin?: string): string | NodeArray<JSDocText | JSDocLink> | undefined {
                     const commentsPos = getNodePos();
                     let comments: string[] = [];
                     const parts: (JSDocLink | JSDocText)[] = [];
@@ -7689,11 +7691,14 @@ namespace ts {
 
                     removeLeadingNewlines(comments);
                     removeTrailingWhitespace(comments);
-                    if (comments.length) {
-                        parts.push(finishNode(factory.createJSDocText(comments.join("")), linkEnd ?? commentsPos));
-                    }
                     if (parts.length) {
+                        if (comments.length) {
+                            parts.push(finishNode(factory.createJSDocText(comments.join("")), linkEnd ?? commentsPos));
+                        }
                         return createNodeArray(parts, commentsPos, scanner.getTextPos());
+                    }
+                    else if (comments.length) {
+                        return comments.join("");
                     }
                 }
 
@@ -7858,8 +7863,10 @@ namespace ts {
                     if (!comments) {
                         commentEnd = scanner.getStartPos();
                     }
-                    const allParts = concatenate([finishNode(textOnly, commentStart, commentEnd)], comments) as (JSDocText | JSDocLink)[]; // cast away readonly
-                    return finishNode(factory.createJSDocAuthorTag(tagName, createNodeArray(allParts, commentStart)), start);
+                    const allParts = typeof comments !== "string"
+                        ? createNodeArray(concatenate([finishNode(textOnly, commentStart, commentEnd)], comments) as (JSDocText | JSDocLink)[], commentStart) // cast away readonly
+                        : textOnly.text + comments;
+                    return finishNode(factory.createJSDocAuthorTag(tagName, allParts), start);
                 }
 
                 function parseAuthorNameAndEmail(): JSDocText {
@@ -7918,7 +7925,7 @@ namespace ts {
                     return node;
                 }
 
-                function parseSimpleTag(start: number, createTag: (tagName: Identifier | undefined, comment?: NodeArray<JSDocText | JSDocLink>) => JSDocTag, tagName: Identifier, margin: number, indentText: string): JSDocTag {
+                function parseSimpleTag(start: number, createTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>) => JSDocTag, tagName: Identifier, margin: number, indentText: string): JSDocTag {
                     return finishNode(createTag(tagName, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);
                 }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7708,7 +7708,7 @@ namespace ts {
                         ? parseEntityName(/*allowReservedWords*/ true)
                         : undefined;
                     const text = [];
-                    while (token() !== SyntaxKind.CloseBraceToken && token() !== SyntaxKind.NewLineTrivia) {
+                    while (token() !== SyntaxKind.CloseBraceToken && token() !== SyntaxKind.NewLineTrivia && token() !== SyntaxKind.EndOfFileToken) {
                         text.push(scanner.getTokenText());
                         nextTokenJSDoc();
                     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -370,8 +370,10 @@ namespace ts {
         JSDocVariadicType,
         JSDocNamepathType, // https://jsdoc.app/about-namepaths.html
         JSDocComment,
+        JSDocText,
         JSDocTypeLiteral,
         JSDocSignature,
+        JSDocLink,
         JSDocTag,
         JSDocAugmentsTag,
         JSDocImplementsTag,
@@ -3133,13 +3135,24 @@ namespace ts {
         readonly kind: SyntaxKind.JSDocComment;
         readonly parent: HasJSDoc;
         readonly tags?: NodeArray<JSDocTag>;
-        readonly comment?: string;
+        readonly comment?: NodeArray<JSDocText | JSDocLink>;
     }
 
     export interface JSDocTag extends Node {
         readonly parent: JSDoc | JSDocTypeLiteral;
         readonly tagName: Identifier;
-        readonly comment?: string;
+        readonly comment?: NodeArray<JSDocText | JSDocLink>;
+    }
+
+    export interface JSDocLink extends Node {
+        readonly kind: SyntaxKind.JSDocLink;
+        readonly name?: EntityName;
+        text: string;
+    }
+
+    export interface JSDocText extends Node {
+        readonly kind: SyntaxKind.JSDocText;
+        text: string;
     }
 
     export interface JSDocUnknownTag extends JSDocTag {
@@ -7166,52 +7179,56 @@ namespace ts {
         updateJSDocTypeExpression(node: JSDocTypeExpression, type: TypeNode): JSDocTypeExpression;
         createJSDocNameReference(name: EntityName): JSDocNameReference;
         updateJSDocNameReference(node: JSDocNameReference, name: EntityName): JSDocNameReference;
+        createJSDocLink(name: EntityName | undefined, text: string): JSDocLink;
+        updateJSDocLink(node: JSDocLink, name: EntityName | undefined, text: string): JSDocLink;
         createJSDocTypeLiteral(jsDocPropertyTags?: readonly JSDocPropertyLikeTag[], isArrayType?: boolean): JSDocTypeLiteral;
         updateJSDocTypeLiteral(node: JSDocTypeLiteral, jsDocPropertyTags: readonly JSDocPropertyLikeTag[] | undefined, isArrayType: boolean | undefined): JSDocTypeLiteral;
         createJSDocSignature(typeParameters: readonly JSDocTemplateTag[] | undefined, parameters: readonly JSDocParameterTag[], type?: JSDocReturnTag): JSDocSignature;
         updateJSDocSignature(node: JSDocSignature, typeParameters: readonly JSDocTemplateTag[] | undefined, parameters: readonly JSDocParameterTag[], type: JSDocReturnTag | undefined): JSDocSignature;
-        createJSDocTemplateTag(tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment?: string): JSDocTemplateTag;
-        updateJSDocTemplateTag(node: JSDocTemplateTag, tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment: string | undefined): JSDocTemplateTag;
-        createJSDocTypedefTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression | JSDocTypeLiteral, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string): JSDocTypedefTag;
-        updateJSDocTypedefTag(node: JSDocTypedefTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | JSDocTypeLiteral | undefined, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | undefined): JSDocTypedefTag;
-        createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocParameterTag;
-        updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocParameterTag;
-        createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocPropertyTag;
-        updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocPropertyTag;
-        createJSDocTypeTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string): JSDocTypeTag;
-        updateJSDocTypeTag(node: JSDocTypeTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | undefined): JSDocTypeTag;
-        createJSDocSeeTag(tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string): JSDocSeeTag;
-        updateJSDocSeeTag(node: JSDocSeeTag, tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string): JSDocSeeTag;
-        createJSDocReturnTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression, comment?: string): JSDocReturnTag;
-        updateJSDocReturnTag(node: JSDocReturnTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | undefined, comment: string | undefined): JSDocReturnTag;
-        createJSDocThisTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string): JSDocThisTag;
-        updateJSDocThisTag(node: JSDocThisTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | undefined, comment: string | undefined): JSDocThisTag;
-        createJSDocEnumTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string): JSDocEnumTag;
-        updateJSDocEnumTag(node: JSDocEnumTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | undefined): JSDocEnumTag;
-        createJSDocCallbackTag(tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string): JSDocCallbackTag;
-        updateJSDocCallbackTag(node: JSDocCallbackTag, tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | undefined): JSDocCallbackTag;
-        createJSDocAugmentsTag(tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment?: string): JSDocAugmentsTag;
-        updateJSDocAugmentsTag(node: JSDocAugmentsTag, tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment: string | undefined): JSDocAugmentsTag;
-        createJSDocImplementsTag(tagName: Identifier | undefined, className: JSDocImplementsTag["class"], comment?: string): JSDocImplementsTag;
-        updateJSDocImplementsTag(node: JSDocImplementsTag, tagName: Identifier | undefined, className: JSDocImplementsTag["class"], comment: string | undefined): JSDocImplementsTag;
-        createJSDocAuthorTag(tagName: Identifier | undefined, comment?: string): JSDocAuthorTag;
-        updateJSDocAuthorTag(node: JSDocAuthorTag, tagName: Identifier | undefined, comment: string | undefined): JSDocAuthorTag;
-        createJSDocClassTag(tagName: Identifier | undefined, comment?: string): JSDocClassTag;
-        updateJSDocClassTag(node: JSDocClassTag, tagName: Identifier | undefined, comment: string | undefined): JSDocClassTag;
-        createJSDocPublicTag(tagName: Identifier | undefined, comment?: string): JSDocPublicTag;
-        updateJSDocPublicTag(node: JSDocPublicTag, tagName: Identifier | undefined, comment: string | undefined): JSDocPublicTag;
-        createJSDocPrivateTag(tagName: Identifier | undefined, comment?: string): JSDocPrivateTag;
-        updateJSDocPrivateTag(node: JSDocPrivateTag, tagName: Identifier | undefined, comment: string | undefined): JSDocPrivateTag;
-        createJSDocProtectedTag(tagName: Identifier | undefined, comment?: string): JSDocProtectedTag;
-        updateJSDocProtectedTag(node: JSDocProtectedTag, tagName: Identifier | undefined, comment: string | undefined): JSDocProtectedTag;
-        createJSDocReadonlyTag(tagName: Identifier | undefined, comment?: string): JSDocReadonlyTag;
-        updateJSDocReadonlyTag(node: JSDocReadonlyTag, tagName: Identifier | undefined, comment: string | undefined): JSDocReadonlyTag;
-        createJSDocUnknownTag(tagName: Identifier, comment?: string): JSDocUnknownTag;
-        updateJSDocUnknownTag(node: JSDocUnknownTag, tagName: Identifier, comment: string | undefined): JSDocUnknownTag;
-        createJSDocDeprecatedTag(tagName: Identifier, comment?: string): JSDocDeprecatedTag;
-        updateJSDocDeprecatedTag(node: JSDocDeprecatedTag, tagName: Identifier, comment?: string): JSDocDeprecatedTag;
-        createJSDocComment(comment?: string | undefined, tags?: readonly JSDocTag[] | undefined): JSDoc;
-        updateJSDocComment(node: JSDoc, comment: string | undefined, tags: readonly JSDocTag[] | undefined): JSDoc;
+        createJSDocTemplateTag(tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocTemplateTag;
+        updateJSDocTemplateTag(node: JSDocTemplateTag, tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocTemplateTag;
+        createJSDocTypedefTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression | JSDocTypeLiteral, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocTypedefTag;
+        updateJSDocTypedefTag(node: JSDocTypedefTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | JSDocTypeLiteral | undefined, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocTypedefTag;
+        createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocParameterTag;
+        updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocParameterTag;
+        createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocPropertyTag;
+        updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocPropertyTag;
+        createJSDocTypeTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocTypeTag;
+        updateJSDocTypeTag(node: JSDocTypeTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocTypeTag;
+        createJSDocSeeTag(tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocSeeTag;
+        updateJSDocSeeTag(node: JSDocSeeTag, tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocSeeTag;
+        createJSDocReturnTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocReturnTag;
+        updateJSDocReturnTag(node: JSDocReturnTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocReturnTag;
+        createJSDocThisTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocThisTag;
+        updateJSDocThisTag(node: JSDocThisTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocThisTag;
+        createJSDocEnumTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocEnumTag;
+        updateJSDocEnumTag(node: JSDocEnumTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocEnumTag;
+        createJSDocCallbackTag(tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocCallbackTag;
+        updateJSDocCallbackTag(node: JSDocCallbackTag, tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocCallbackTag;
+        createJSDocAugmentsTag(tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocAugmentsTag;
+        updateJSDocAugmentsTag(node: JSDocAugmentsTag, tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocAugmentsTag;
+        createJSDocImplementsTag(tagName: Identifier | undefined, className: JSDocImplementsTag["class"], comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocImplementsTag;
+        updateJSDocImplementsTag(node: JSDocImplementsTag, tagName: Identifier | undefined, className: JSDocImplementsTag["class"], comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocImplementsTag;
+        createJSDocAuthorTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocAuthorTag;
+        updateJSDocAuthorTag(node: JSDocAuthorTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocAuthorTag;
+        createJSDocClassTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocClassTag;
+        updateJSDocClassTag(node: JSDocClassTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocClassTag;
+        createJSDocPublicTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocPublicTag;
+        updateJSDocPublicTag(node: JSDocPublicTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocPublicTag;
+        createJSDocPrivateTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocPrivateTag;
+        updateJSDocPrivateTag(node: JSDocPrivateTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocPrivateTag;
+        createJSDocProtectedTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocProtectedTag;
+        updateJSDocProtectedTag(node: JSDocProtectedTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocProtectedTag;
+        createJSDocReadonlyTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocReadonlyTag;
+        updateJSDocReadonlyTag(node: JSDocReadonlyTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocReadonlyTag;
+        createJSDocUnknownTag(tagName: Identifier, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocUnknownTag;
+        updateJSDocUnknownTag(node: JSDocUnknownTag, tagName: Identifier, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocUnknownTag;
+        createJSDocDeprecatedTag(tagName: Identifier, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocDeprecatedTag;
+        updateJSDocDeprecatedTag(node: JSDocDeprecatedTag, tagName: Identifier, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocDeprecatedTag;
+        createJSDocText(text: string): JSDocText;
+        updateJSDocText(node: JSDocText, text: string): JSDocText;
+        createJSDocComment(comment?: string | NodeArray<JSDocText | JSDocLink> | undefined, tags?: readonly JSDocTag[] | undefined): JSDoc;
+        updateJSDocComment(node: JSDoc, comment: string | NodeArray<JSDocText | JSDocLink> | undefined, tags: readonly JSDocTag[] | undefined): JSDoc;
 
         //
         // JSX

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3135,13 +3135,13 @@ namespace ts {
         readonly kind: SyntaxKind.JSDocComment;
         readonly parent: HasJSDoc;
         readonly tags?: NodeArray<JSDocTag>;
-        readonly comment?: NodeArray<JSDocText | JSDocLink>;
+        readonly comment?: string | NodeArray<JSDocText | JSDocLink>;
     }
 
     export interface JSDocTag extends Node {
         readonly parent: JSDoc | JSDocTypeLiteral;
         readonly tagName: Identifier;
-        readonly comment?: NodeArray<JSDocText | JSDocLink>;
+        readonly comment?: string | NodeArray<JSDocText | JSDocLink>;
     }
 
     export interface JSDocLink extends Node {

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -896,6 +896,11 @@ namespace ts {
         return getJSDocTags(node).filter(doc => doc.kind === kind);
     }
 
+    /** Gets the text of a jsdoc comment, flattening links to their text. */
+    export function getTextOfJSDocComment(comment?: NodeArray<JSDocText | JSDocLink>) {
+        return comment?.map(c => c.kind === SyntaxKind.JSDocText ? c.text : `{@link ${c.name ? entityNameToString(c.name) + " " : ""}${c.text}}`).join("");
+    }
+
     /**
      * Gets the effective type parameters. If the node was parsed in a
      * JavaScript file, gets the type parameters from the `@template` tag from JSDoc.
@@ -1860,7 +1865,13 @@ namespace ts {
 
     /** True if node is of a kind that may contain comment text. */
     export function isJSDocCommentContainingNode(node: Node): boolean {
-        return node.kind === SyntaxKind.JSDocComment || node.kind === SyntaxKind.JSDocNamepathType || isJSDocTag(node) || isJSDocTypeLiteral(node) || isJSDocSignature(node);
+        return node.kind === SyntaxKind.JSDocComment
+            || node.kind === SyntaxKind.JSDocNamepathType
+            || node.kind === SyntaxKind.JSDocText
+            || node.kind === SyntaxKind.JSDocLink
+            || isJSDocTag(node)
+            || isJSDocTypeLiteral(node)
+            || isJSDocSignature(node);
     }
 
     // TODO: determine what this does before making it public.

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -897,8 +897,10 @@ namespace ts {
     }
 
     /** Gets the text of a jsdoc comment, flattening links to their text. */
-    export function getTextOfJSDocComment(comment?: NodeArray<JSDocText | JSDocLink>) {
-        return comment?.map(c => c.kind === SyntaxKind.JSDocText ? c.text : `{@link ${c.name ? entityNameToString(c.name) + " " : ""}${c.text}}`).join("");
+    export function getTextOfJSDocComment(comment?: string | NodeArray<JSDocText | JSDocLink>) {
+        return typeof comment === "string" ? comment
+            : comment?.map(c =>
+                c.kind === SyntaxKind.JSDocText ? c.text : `{@link ${c.name ? entityNameToString(c.name) + " " : ""}${c.text}}`).join("");
     }
 
     /**

--- a/src/deprecatedCompat/deprecations.ts
+++ b/src/deprecatedCompat/deprecations.ts
@@ -1229,7 +1229,7 @@ namespace ts {
 
     /** @deprecated Use `factory.createJSDocParameterTag` or the factory supplied by your transformation context instead. */
     export const createJSDocParamTag = Debug.deprecate(function createJSDocParamTag(name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, comment?: string): JSDocParameterTag {
-        return factory.createJSDocParameterTag(/*tagName*/ undefined, name, isBracketed, typeExpression, /*isNameFirst*/ false, comment);
+        return factory.createJSDocParameterTag(/*tagName*/ undefined, name, isBracketed, typeExpression, /*isNameFirst*/ false, comment ? factory.createNodeArray([factory.createJSDocText(comment)]) : undefined);
     }, factoryDeprecation);
 
     /** @deprecated Use `factory.createComma` or the factory supplied by your transformation context instead. */

--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -175,8 +175,8 @@ namespace ts.server {
                 kindModifiers: body.kindModifiers,
                 textSpan: this.decodeSpan(body, fileName),
                 displayParts: [{ kind: "text", text: body.displayString }],
-                documentation: [{ kind: "text", text: body.documentation }],
-                tags: body.tags
+                documentation: typeof body.documentation === "string" ? [{ kind: "text", text: body.documentation }] : body.documentation,
+                tags: this.decodeLinkDisplayParts(body.tags)
             };
         }
 
@@ -536,6 +536,13 @@ namespace ts.server {
                 this.lineOffsetToPosition(fileName, span.end, lineMap));
         }
 
+        private decodeLinkDisplayParts(tags: (protocol.JSDocTagInfo | JSDocTagInfo)[]): JSDocTagInfo[] {
+            return tags.map(tag => typeof tag.text === "string" ? {
+                ...tag,
+                text: [textPart(tag.text)]
+            } : (tag as JSDocTagInfo));
+        }
+
         getNameOrDottedNameSpan(_fileName: string, _startPos: number, _endPos: number): TextSpan {
             return notImplemented();
         }
@@ -554,9 +561,10 @@ namespace ts.server {
                 return undefined;
             }
 
-            const { items, applicableSpan: encodedApplicableSpan, selectedItemIndex, argumentIndex, argumentCount } = response.body;
+            const { items: encodedItems, applicableSpan: encodedApplicableSpan, selectedItemIndex, argumentIndex, argumentCount } = response.body;
 
-            const applicableSpan = this.decodeSpan(encodedApplicableSpan, fileName);
+            const applicableSpan = encodedApplicableSpan as unknown as TextSpan;
+            const items = (encodedItems as (SignatureHelpItem | protocol.SignatureHelpItem)[]).map(item => ({ ...item, tags: this.decodeLinkDisplayParts(item.tags) }));
 
             return { items, applicableSpan, selectedItemIndex, argumentIndex, argumentCount };
         }

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -1583,7 +1583,7 @@ namespace FourSlash {
             assert.equal(actualTags.length, (options.tags || ts.emptyArray).length, this.assertionMessageAtLastKnownMarker("signature help tags"));
             ts.zipWith((options.tags || ts.emptyArray), actualTags, (expectedTag, actualTag) => {
                 assert.equal(actualTag.name, expectedTag.name);
-                assert.equal(actualTag.text, expectedTag.text, this.assertionMessageAtLastKnownMarker("signature help tag " + actualTag.name));
+                assert.deepEqual(actualTag.text, expectedTag.text, this.assertionMessageAtLastKnownMarker("signature help tag " + actualTag.name));
             });
 
             const allKeys: readonly (keyof FourSlashInterface.VerifySignatureHelpOptions)[] = [

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -979,6 +979,16 @@ namespace ts.server.protocol {
         file: string;
     }
 
+    export interface JSDocTagInfo {
+        /** Name of the JSDoc tag */
+        name: string;
+        /**
+         * Comment text after the JSDoc tag -- the text after the tag name until the next tag or end of comment
+         * Display parts when UserPreferences.displayPartsForJSDoc is true, flattened to string otherwise.
+         */
+        text?: string | SymbolDisplayPart[];
+    }
+
     export interface TextSpanWithContext extends TextSpan {
         contextStart?: Location;
         contextEnd?: Location;
@@ -1951,6 +1961,7 @@ namespace ts.server.protocol {
      */
     export interface QuickInfoRequest extends FileLocationRequest {
         command: CommandTypes.Quickinfo;
+        arguments: FileLocationRequestArgs;
     }
 
     /**
@@ -1984,8 +1995,9 @@ namespace ts.server.protocol {
 
         /**
          * Documentation associated with symbol.
+         * Display parts when UserPreferences.displayPartsForJSDoc is true, flattened to string otherwise.
          */
-        documentation: string;
+        documentation: string | SymbolDisplayPart[];
 
         /**
          * JSDoc tags associated with symbol.
@@ -2206,6 +2218,12 @@ namespace ts.server.protocol {
          * The symbol's kind (such as 'className' or 'parameterName' or plain 'text').
          */
         kind: string;
+    }
+
+    /** A part of a symbol description that links from a jsdoc @link tag to a declaration */
+    export interface JSDocLinkDisplayPart extends SymbolDisplayPart {
+        /** The location of the declaration that the @link tag links to. */
+        target: FileSpan;
     }
 
     /**
@@ -3301,6 +3319,7 @@ namespace ts.server.protocol {
         readonly allowRenameOfImportPath?: boolean;
         readonly includePackageJsonAutoImports?: "auto" | "on" | "off";
 
+        readonly displayPartsForJSDoc?: boolean;
         readonly generateReturnInDocTemplate?: boolean;
     }
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1274,6 +1274,32 @@ namespace ts.server {
                 result;
         }
 
+        private mapJSDocTagInfo(tags: JSDocTagInfo[] | undefined, project: Project, richResponse: boolean): protocol.JSDocTagInfo[] {
+            return tags ? tags.map(tag => ({
+                ...tag,
+                text: richResponse ? this.mapDisplayParts(tag.text, project) : tag.text?.map(part => part.text).join("")
+            })) : [];
+        }
+
+        private mapDisplayParts(parts: SymbolDisplayPart[] | undefined, project: Project): protocol.SymbolDisplayPart[] {
+            if (!parts) {
+                return [];
+            }
+            return parts.map(part => part.kind !== "linkName" ? part : {
+                ...part,
+                target: this.toFileSpan((part as JSDocLinkDisplayPart).target.fileName, (part as JSDocLinkDisplayPart).target.textSpan, project),
+            });
+        }
+
+        private mapSignatureHelpItems(items: SignatureHelpItem[], project: Project, richResponse: boolean): protocol.SignatureHelpItem[] {
+            return items.map(item => ({
+                ...item,
+                documentation: this.mapDisplayParts(item.documentation, project),
+                parameters: item.parameters.map(p => ({ ...p, documentation: this.mapDisplayParts(p.documentation, project) })),
+                tags: this.mapJSDocTagInfo(item.tags, project, richResponse),
+            }));
+        }
+
         private mapDefinitionInfo(definitions: readonly DefinitionInfo[], project: Project): readonly protocol.FileSpanWithContext[] {
             return definitions.map(def => this.toFileSpanWithContext(def.fileName, def.textSpan, def.contextSpan, project));
         }
@@ -1685,22 +1711,24 @@ namespace ts.server {
                 return undefined;
             }
 
+            const useDisplayParts = !!this.getPreferences(file).displayPartsForJSDoc;
             if (simplifiedResult) {
                 const displayString = displayPartsToString(quickInfo.displayParts);
-                const docString = displayPartsToString(quickInfo.documentation);
-
                 return {
                     kind: quickInfo.kind,
                     kindModifiers: quickInfo.kindModifiers,
                     start: scriptInfo.positionToLineOffset(quickInfo.textSpan.start),
                     end: scriptInfo.positionToLineOffset(textSpanEnd(quickInfo.textSpan)),
                     displayString,
-                    documentation: docString,
-                    tags: quickInfo.tags || []
+                    documentation: useDisplayParts ? this.mapDisplayParts(quickInfo.documentation, project) : displayPartsToString(quickInfo.documentation),
+                    tags: this.mapJSDocTagInfo(quickInfo.tags, project, useDisplayParts),
                 };
             }
             else {
-                return quickInfo;
+                return useDisplayParts ? quickInfo : {
+                    ...quickInfo,
+                    tags: this.mapJSDocTagInfo(quickInfo.tags, project, /*useDisplayParts*/ false) as JSDocTagInfo[]
+                };
             }
         }
 
@@ -1830,19 +1858,25 @@ namespace ts.server {
             return res;
         }
 
-        private getCompletionEntryDetails(args: protocol.CompletionDetailsRequestArgs, simplifiedResult: boolean): readonly protocol.CompletionEntryDetails[] | readonly CompletionEntryDetails[] {
+        private getCompletionEntryDetails(args: protocol.CompletionDetailsRequestArgs, fullResult: boolean): readonly protocol.CompletionEntryDetails[] | readonly CompletionEntryDetails[] {
             const { file, project } = this.getFileAndProject(args);
             const scriptInfo = this.projectService.getScriptInfoForNormalizedPath(file)!;
             const position = this.getPosition(args, scriptInfo);
             const formattingOptions = project.projectService.getFormatCodeOptions(file);
+            const useDisplayParts = !!this.getPreferences(file).displayPartsForJSDoc;
 
             const result = mapDefined(args.entryNames, entryName => {
                 const { name, source, data } = typeof entryName === "string" ? { name: entryName, source: undefined, data: undefined } : entryName;
                 return project.getLanguageService().getCompletionEntryDetails(file, position, name, formattingOptions, source, this.getPreferences(file), data ? cast(data, isCompletionEntryData) : undefined);
             });
-            return simplifiedResult
-                ? result.map(details => ({ ...details, codeActions: map(details.codeActions, action => this.mapCodeAction(action)) }))
-                : result;
+            return fullResult
+                ? (useDisplayParts ? result : result.map(details => ({ ...details, tags: this.mapJSDocTagInfo(details.tags, project, /*richResponse*/ false) as JSDocTagInfo[] })))
+                : result.map(details => ({
+                    ...details,
+                    codeActions: map(details.codeActions, action => this.mapCodeAction(action)),
+                    documentation: this.mapDisplayParts(details.documentation, project),
+                    tags: this.mapJSDocTagInfo(details.tags, project, useDisplayParts),
+                }));
         }
 
         private getCompileOnSaveAffectedFileList(args: protocol.FileRequestArgs): readonly protocol.CompileOnSaveAffectedFileListSingleProject[] {
@@ -1902,25 +1936,26 @@ namespace ts.server {
             const scriptInfo = this.projectService.getScriptInfoForNormalizedPath(file)!;
             const position = this.getPosition(args, scriptInfo);
             const helpItems = project.getLanguageService().getSignatureHelpItems(file, position, args);
-            if (!helpItems) {
-                return undefined;
-            }
-
-            if (simplifiedResult) {
+            const useDisplayParts = !!this.getPreferences(file).displayPartsForJSDoc;
+            if (helpItems && simplifiedResult) {
                 const span = helpItems.applicableSpan;
                 return {
-                    items: helpItems.items,
+                    ...helpItems,
                     applicableSpan: {
                         start: scriptInfo.positionToLineOffset(span.start),
                         end: scriptInfo.positionToLineOffset(span.start + span.length)
                     },
-                    selectedItemIndex: helpItems.selectedItemIndex,
-                    argumentIndex: helpItems.argumentIndex,
-                    argumentCount: helpItems.argumentCount,
+                    items: this.mapSignatureHelpItems(helpItems.items, project, useDisplayParts),
                 };
             }
-            else {
+            else if (useDisplayParts || !helpItems) {
                 return helpItems;
+            }
+            else {
+                return {
+                    ...helpItems,
+                    items: helpItems.items.map(item => ({ ...item, tags: this.mapJSDocTagInfo(item.tags, project, /*richResponse*/ false) as JSDocTagInfo[] }))
+                };
             }
         }
 
@@ -2700,10 +2735,10 @@ namespace ts.server {
                 return this.requiredResponse(this.getCompletions(request.arguments, CommandNames.CompletionsFull));
             },
             [CommandNames.CompletionDetails]: (request: protocol.CompletionDetailsRequest) => {
-                return this.requiredResponse(this.getCompletionEntryDetails(request.arguments, /*simplifiedResult*/ true));
+                return this.requiredResponse(this.getCompletionEntryDetails(request.arguments, /*fullResult*/ false));
             },
             [CommandNames.CompletionDetailsFull]: (request: protocol.CompletionDetailsRequest) => {
-                return this.requiredResponse(this.getCompletionEntryDetails(request.arguments, /*simplifiedResult*/ false));
+                return this.requiredResponse(this.getCompletionEntryDetails(request.arguments, /*fullResult*/ true));
             },
             [CommandNames.CompileOnSaveAffectedFileList]: (request: protocol.CompileOnSaveAffectedFileListRequest) => {
                 return this.requiredResponse(this.getCompileOnSaveAffectedFileList(request.arguments));

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -740,6 +740,9 @@ namespace ts {
                             pos = tag.end;
                             break;
                     }
+                    if (tag.comment) {
+                        pushCommentRange(tag.comment.pos, tag.comment.end - tag.comment.pos);
+                    }
                 }
             }
 

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -722,26 +722,57 @@ namespace ts {
                     pushClassification(tag.tagName.pos, tag.tagName.end - tag.tagName.pos, ClassificationType.docCommentTagName); // e.g. "param"
 
                     pos = tag.tagName.end;
+                    let commentStart = tag.tagName.end;
 
                     switch (tag.kind) {
                         case SyntaxKind.JSDocParameterTag:
-                            processJSDocParameterTag(<JSDocParameterTag>tag);
+                            const param = tag as JSDocParameterTag;
+                            processJSDocParameterTag(param);
+                            commentStart = param.isNameFirst && param.typeExpression?.end || param.name.end;
+                            break;
+                        case SyntaxKind.JSDocPropertyTag:
+                            const prop = tag as JSDocPropertyTag;
+                            commentStart = prop.isNameFirst && prop.typeExpression?.end || prop.name.end;
                             break;
                         case SyntaxKind.JSDocTemplateTag:
                             processJSDocTemplateTag(<JSDocTemplateTag>tag);
                             pos = tag.end;
+                            commentStart = (tag as JSDocTemplateTag).typeParameters.end;
+                            break;
+                        case SyntaxKind.JSDocTypedefTag:
+                            const type = tag as JSDocTypedefTag;
+                            commentStart = type.typeExpression?.kind === SyntaxKind.JSDocTypeExpression && type.fullName?.end || type.typeExpression?.end || commentStart;
+                            break;
+                        case SyntaxKind.JSDocCallbackTag:
+                            commentStart = (tag as JSDocCallbackTag).typeExpression.end;
                             break;
                         case SyntaxKind.JSDocTypeTag:
                             processElement((<JSDocTypeTag>tag).typeExpression);
                             pos = tag.end;
+                            commentStart = (tag as JSDocTypeTag).typeExpression.end;
+                            break;
+                        case SyntaxKind.JSDocThisTag:
+                        case SyntaxKind.JSDocEnumTag:
+                            commentStart = (tag as JSDocThisTag | JSDocEnumTag).typeExpression.end;
                             break;
                         case SyntaxKind.JSDocReturnTag:
                             processElement((<JSDocReturnTag>tag).typeExpression);
                             pos = tag.end;
+                            commentStart = (tag as JSDocReturnTag).typeExpression?.end || commentStart;
+                            break;
+                        case SyntaxKind.JSDocSeeTag:
+                            commentStart = (tag as JSDocSeeTag).name?.end || commentStart;
+                            break;
+                        case SyntaxKind.JSDocAugmentsTag:
+                        case SyntaxKind.JSDocImplementsTag:
+                            commentStart = (tag as JSDocImplementsTag | JSDocAugmentsTag).class.end;
                             break;
                     }
-                    if (tag.comment) {
+                    if (typeof tag.comment === "object") {
                         pushCommentRange(tag.comment.pos, tag.comment.end - tag.comment.pos);
+                    }
+                    else if (typeof tag.comment === "string") {
+                        pushCommentRange(commentStart, tag.end - commentStart);
                     }
                 }
             }

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -128,7 +128,7 @@ namespace ts.codefix {
                     const typeNode = getTypeNodeIfAccessible(type, parent, program, host);
                     if (typeNode) {
                         // Note that the codefix will never fire with an existing `@type` tag, so there is no need to merge tags
-                        const typeTag = factory.createJSDocTypeTag(/*tagName*/ undefined, factory.createJSDocTypeExpression(typeNode), /*comment*/ "");
+                        const typeTag = factory.createJSDocTypeTag(/*tagName*/ undefined, factory.createJSDocTypeExpression(typeNode), /*comment*/ undefined);
                         addJSDocTags(changes, sourceFile, cast(parent.parent.parent, isExpressionStatement), [typeTag]);
                     }
                     importAdder.writeFixes(changes);
@@ -307,7 +307,7 @@ namespace ts.codefix {
                     return;
                 }
                 const typeExpression = factory.createJSDocTypeExpression(typeNode);
-                const typeTag = isGetAccessorDeclaration(declaration) ? factory.createJSDocReturnTag(/*tagName*/ undefined, typeExpression, "") : factory.createJSDocTypeTag(/*tagName*/ undefined, typeExpression, "");
+                const typeTag = isGetAccessorDeclaration(declaration) ? factory.createJSDocReturnTag(/*tagName*/ undefined, typeExpression, /*comment*/ undefined) : factory.createJSDocTypeTag(/*tagName*/ undefined, typeExpression, /*comment*/ undefined);
                 addJSDocTags(changes, sourceFile, parent, [typeTag]);
             }
             else if (!tryReplaceImportTypeNodeWithAutoImport(typeNode, declaration, sourceFile, changes, importAdder, getEmitScriptTarget(program.getCompilerOptions()))) {
@@ -374,20 +374,20 @@ namespace ts.codefix {
         }
         else {
             const paramTags = map(inferences, ({ name, typeNode, isOptional }) =>
-                factory.createJSDocParameterTag(/*tagName*/ undefined, name, /*isBracketed*/ !!isOptional, factory.createJSDocTypeExpression(typeNode), /* isNameFirst */ false, ""));
+                factory.createJSDocParameterTag(/*tagName*/ undefined, name, /*isBracketed*/ !!isOptional, factory.createJSDocTypeExpression(typeNode), /* isNameFirst */ false, /*comment*/ undefined));
             addJSDocTags(changes, sourceFile, signature, paramTags);
         }
     }
 
     export function addJSDocTags(changes: textChanges.ChangeTracker, sourceFile: SourceFile, parent: HasJSDoc, newTags: readonly JSDocTag[]): void {
-        const comments = mapDefined(parent.jsDoc, j => j.comment);
+        const comments = flatMap(parent.jsDoc, j => j.comment) as (JSDocText | JSDocLink)[];
         const oldTags = flatMapToMutable(parent.jsDoc, j => j.tags);
         const unmergedNewTags = newTags.filter(newTag => !oldTags || !oldTags.some((tag, i) => {
             const merged = tryMergeJsdocTags(tag, newTag);
             if (merged) oldTags[i] = merged;
             return !!merged;
         }));
-        const tag = factory.createJSDocComment(comments.join("\n"), factory.createNodeArray([...(oldTags || emptyArray), ...unmergedNewTags]));
+        const tag = factory.createJSDocComment(factory.createNodeArray(intersperse(comments, factory.createJSDocText("\n"))), factory.createNodeArray([...(oldTags || emptyArray), ...unmergedNewTags]));
         const jsDocNode = parent.kind === SyntaxKind.ArrowFunction ? getJsDocNodeForArrowFunction(parent) : parent;
         jsDocNode.jsDoc = parent.jsDoc;
         jsDocNode.jsDocCache = parent.jsDocCache;

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -380,7 +380,7 @@ namespace ts.codefix {
     }
 
     export function addJSDocTags(changes: textChanges.ChangeTracker, sourceFile: SourceFile, parent: HasJSDoc, newTags: readonly JSDocTag[]): void {
-        const comments = flatMap(parent.jsDoc, j => j.comment) as (JSDocText | JSDocLink)[];
+        const comments = flatMap(parent.jsDoc, j => typeof j.comment === 'string' ? factory.createJSDocText(j.comment) : j.comment) as (JSDocText | JSDocLink)[];
         const oldTags = flatMapToMutable(parent.jsDoc, j => j.tags);
         const unmergedNewTags = newTags.filter(newTag => !oldTags || !oldTags.some((tag, i) => {
             const merged = tryMergeJsdocTags(tag, newTag);

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -380,7 +380,7 @@ namespace ts.codefix {
     }
 
     export function addJSDocTags(changes: textChanges.ChangeTracker, sourceFile: SourceFile, parent: HasJSDoc, newTags: readonly JSDocTag[]): void {
-        const comments = flatMap(parent.jsDoc, j => typeof j.comment === 'string' ? factory.createJSDocText(j.comment) : j.comment) as (JSDocText | JSDocLink)[];
+        const comments = flatMap(parent.jsDoc, j => typeof j.comment === "string" ? factory.createJSDocText(j.comment) : j.comment) as (JSDocText | JSDocLink)[];
         const oldTags = flatMapToMutable(parent.jsDoc, j => j.tags);
         const unmergedNewTags = newTags.filter(newTag => !oldTags || !oldTags.some((tag, i) => {
             const merged = tryMergeJsdocTags(tag, newTag);

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -82,21 +82,28 @@ namespace ts.JsDoc {
     let jsDocTagNameCompletionEntries: CompletionEntry[];
     let jsDocTagCompletionEntries: CompletionEntry[];
 
-    export function getJsDocCommentsFromDeclarations(declarations: readonly Declaration[]): SymbolDisplayPart[] {
+    export function getJsDocCommentsFromDeclarations(declarations: readonly Declaration[], checker?: TypeChecker): SymbolDisplayPart[] {
         // Only collect doc comments from duplicate declarations once:
         // In case of a union property there might be same declaration multiple times
         // which only varies in type parameter
         // Eg. const a: Array<string> | Array<number>; a.length
         // The property length will have two declarations of property length coming
         // from Array<T> - Array<string> and Array<number>
-        const documentationComment: string[] = [];
+        const parts: SymbolDisplayPart[][] = [];
         forEachUnique(declarations, declaration => {
             for (const { comment } of getCommentHavingNodes(declaration)) {
                 if (comment === undefined) continue;
-                pushIfUnique(documentationComment, comment);
+                const newparts = getDisplayPartsFromComment(comment, checker);
+                if (!contains(parts, newparts, isIdenticalListOfDisplayParts)) {
+                    parts.push(newparts);
+                }
             }
         });
-        return intersperse(map(documentationComment, textPart), lineBreakPart());
+        return flatten(intersperse(parts, [lineBreakPart()]));
+    }
+
+    function isIdenticalListOfDisplayParts(parts1: SymbolDisplayPart[], parts2: SymbolDisplayPart[]) {
+        return arraysEqual(parts1, parts2, (p1, p2) => p1.kind === p2.kind && p1.text === p2.text);
     }
 
     function getCommentHavingNodes(declaration: Declaration): readonly (JSDoc | JSDocTag)[] {
@@ -112,18 +119,25 @@ namespace ts.JsDoc {
         }
     }
 
-    export function getJsDocTagsFromDeclarations(declarations?: Declaration[]): JSDocTagInfo[] {
+    export function getJsDocTagsFromDeclarations(declarations?: Declaration[], checker?: TypeChecker): JSDocTagInfo[] {
         // Only collect doc comments from duplicate declarations once.
         const tags: JSDocTagInfo[] = [];
         forEachUnique(declarations, declaration => {
             for (const tag of getJSDocTags(declaration)) {
-                tags.push({ name: tag.tagName.text, text: getCommentText(tag) });
+                tags.push({ name: tag.tagName.text, text: getCommentDisplayParts(tag, checker) });
             }
         });
         return tags;
     }
 
-    function getCommentText(tag: JSDocTag): string | undefined {
+    function getDisplayPartsFromComment(comment: readonly (JSDocText | JSDocLink)[], checker: TypeChecker | undefined): SymbolDisplayPart[] {
+        return flatMap(
+            comment,
+            node => node.kind === SyntaxKind.JSDocText ? [textPart(node.text)] : buildLinkParts(node, checker)
+        ) as SymbolDisplayPart[];
+    }
+
+    function getCommentDisplayParts(tag: JSDocTag, checker?: TypeChecker): SymbolDisplayPart[] | undefined {
         const { comment } = tag;
         switch (tag.kind) {
             case SyntaxKind.JSDocImplementsTag:
@@ -131,7 +145,7 @@ namespace ts.JsDoc {
             case SyntaxKind.JSDocAugmentsTag:
                 return withNode((tag as JSDocAugmentsTag).class);
             case SyntaxKind.JSDocTemplateTag:
-                return withList((tag as JSDocTemplateTag).typeParameters);
+                return addComment((tag as JSDocTemplateTag).typeParameters.map(tp => tp.getText()).join(", "));
             case SyntaxKind.JSDocTypeTag:
                 return withNode((tag as JSDocTypeTag).typeExpression);
             case SyntaxKind.JSDocTypedefTag:
@@ -140,21 +154,17 @@ namespace ts.JsDoc {
             case SyntaxKind.JSDocParameterTag:
             case SyntaxKind.JSDocSeeTag:
                 const { name } = tag as JSDocTypedefTag | JSDocPropertyTag | JSDocParameterTag | JSDocSeeTag;
-                return name ? withNode(name) : comment;
+                return name ? withNode(name) : comment && getDisplayPartsFromComment(comment, checker);
             default:
-                return comment;
+                return comment && getDisplayPartsFromComment(comment, checker);
         }
 
         function withNode(node: Node) {
             return addComment(node.getText());
         }
 
-        function withList(list: NodeArray<Node>): string {
-            return addComment(list.map(x => x.getText()).join(", "));
-        }
-
         function addComment(s: string) {
-            return comment === undefined ? s : `${s} ${comment}`;
+            return comment ? [textPart(s), spacePart(), ...getDisplayPartsFromComment(comment, checker)] : [textPart(s)];
         }
     }
 

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -130,7 +130,10 @@ namespace ts.JsDoc {
         return tags;
     }
 
-    function getDisplayPartsFromComment(comment: readonly (JSDocText | JSDocLink)[], checker: TypeChecker | undefined): SymbolDisplayPart[] {
+    function getDisplayPartsFromComment(comment: string | readonly (JSDocText | JSDocLink)[], checker: TypeChecker | undefined): SymbolDisplayPart[] {
+        if (typeof comment === "string") {
+            return [textPart(comment)];
+        }
         return flatMap(
             comment,
             node => node.kind === SyntaxKind.JSDocText ? [textPart(node.text)] : buildLinkParts(node, checker)
@@ -154,9 +157,9 @@ namespace ts.JsDoc {
             case SyntaxKind.JSDocParameterTag:
             case SyntaxKind.JSDocSeeTag:
                 const { name } = tag as JSDocTypedefTag | JSDocPropertyTag | JSDocParameterTag | JSDocSeeTag;
-                return name ? withNode(name) : comment && getDisplayPartsFromComment(comment, checker);
+                return name ? withNode(name) : comment === undefined ? undefined : getDisplayPartsFromComment(comment, checker);
             default:
-                return comment && getDisplayPartsFromComment(comment, checker);
+                return comment === undefined ? undefined : getDisplayPartsFromComment(comment, checker);
         }
 
         function withNode(node: Node) {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -292,13 +292,10 @@ namespace ts {
         // Undefined is used to indicate the value has not been computed. If, after computing, the
         // symbol has no doc comment, then the empty array will be returned.
         documentationComment?: SymbolDisplayPart[];
+        tags?: JSDocTagInfo[]; // same
 
         contextualGetAccessorDocumentationComment?: SymbolDisplayPart[];
         contextualSetAccessorDocumentationComment?: SymbolDisplayPart[];
-
-        // Undefined is used to indicate the value has not been computed. If, after computing, the
-        // symbol has no JSDoc tags, then the empty array will be returned.
-        tags?: JSDocTagInfo[];
 
         constructor(flags: SymbolFlags, name: __String) {
             this.flags = flags;
@@ -359,9 +356,9 @@ namespace ts {
             }
         }
 
-        getJsDocTags(): JSDocTagInfo[] {
+        getJsDocTags(checker?: TypeChecker): JSDocTagInfo[] {
             if (this.tags === undefined) {
-                this.tags = JsDoc.getJsDocTagsFromDeclarations(this.declarations);
+                this.tags = JsDoc.getJsDocTagsFromDeclarations(this.declarations, checker);
             }
 
             return this.tags;
@@ -521,10 +518,7 @@ namespace ts {
         // Undefined is used to indicate the value has not been computed. If, after computing, the
         // symbol has no doc comment, then the empty array will be returned.
         documentationComment?: SymbolDisplayPart[];
-
-        // Undefined is used to indicate the value has not been computed. If, after computing, the
-        // symbol has no doc comment, then the empty array will be returned.
-        jsDocTags?: JSDocTagInfo[];
+        jsDocTags?: JSDocTagInfo[]; // same
 
         constructor(checker: TypeChecker, flags: SignatureFlags) {
             this.checker = checker;
@@ -566,7 +560,7 @@ namespace ts {
     }
 
     function getJsDocTagsOfSignature(declaration: Declaration, checker: TypeChecker): JSDocTagInfo[] {
-        let tags = JsDoc.getJsDocTagsFromDeclarations([declaration]);
+        let tags = JsDoc.getJsDocTagsFromDeclarations([declaration], checker);
         if (tags.length === 0 || hasJSDocInheritDocTag(declaration)) {
             const inheritedTags = findBaseOfDeclaration(checker, declaration, symbol => symbol.declarations?.length === 1 ? symbol.getJsDocTags() : undefined);
             if (inheritedTags) {
@@ -579,7 +573,7 @@ namespace ts {
     function getDocumentationComment(declarations: readonly Declaration[] | undefined, checker: TypeChecker | undefined): SymbolDisplayPart[] {
         if (!declarations) return emptyArray;
 
-        let doc = JsDoc.getJsDocCommentsFromDeclarations(declarations);
+        let doc = JsDoc.getJsDocCommentsFromDeclarations(declarations, checker);
         if (checker && (doc.length === 0 || declarations.some(hasJSDocInheritDocTag))) {
             forEachUnique(declarations, declaration => {
                 const inheritedDocs = findBaseOfDeclaration(checker, declaration, symbol => symbol.getDocumentationComment(checker));
@@ -1598,7 +1592,7 @@ namespace ts {
                     textSpan: createTextSpanFromNode(nodeForQuickInfo, sourceFile),
                     displayParts: typeChecker.runWithCancellationToken(cancellationToken, typeChecker => typeToDisplayParts(typeChecker, type, getContainerNode(nodeForQuickInfo))),
                     documentation: type.symbol ? type.symbol.getDocumentationComment(typeChecker) : undefined,
-                    tags: type.symbol ? type.symbol.getJsDocTags() : undefined
+                    tags: type.symbol ? type.symbol.getJsDocTags(typeChecker) : undefined
                 };
             }
 

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -574,7 +574,7 @@ namespace ts.SignatureHelp {
         const parameters = typeParameters.map(t => createSignatureHelpParameterForTypeParameter(t, checker, enclosingDeclaration, sourceFile, printer));
 
         const documentation = symbol.getDocumentationComment(checker);
-        const tags = symbol.getJsDocTags();
+        const tags = symbol.getJsDocTags(checker);
         const prefixDisplayParts = [...typeSymbolDisplay, punctuationPart(SyntaxKind.LessThanToken)];
         return { isVariadic: false, prefixDisplayParts, suffixDisplayParts: [punctuationPart(SyntaxKind.GreaterThanToken)], separatorDisplayParts, parameters, documentation, tags };
     }

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -441,7 +441,7 @@ namespace ts.SymbolDisplay {
                     }
                     else {
                         documentationFromAlias = resolvedSymbol.getContextualDocumentationComment(resolvedNode, typeChecker);
-                        tagsFromAlias = resolvedSymbol.getJsDocTags();
+                        tagsFromAlias = resolvedSymbol.getJsDocTags(typeChecker);
                     }
                 }
             }
@@ -570,7 +570,7 @@ namespace ts.SymbolDisplay {
                     }
 
                     documentation = rhsSymbol.getDocumentationComment(typeChecker);
-                    tags = rhsSymbol.getJsDocTags();
+                    tags = rhsSymbol.getJsDocTags(typeChecker);
                     if (documentation.length > 0) {
                         break;
                     }
@@ -579,7 +579,7 @@ namespace ts.SymbolDisplay {
         }
 
         if (tags.length === 0 && !hasMultipleSignatures) {
-            tags = symbol.getJsDocTags();
+            tags = symbol.getJsDocTags(typeChecker);
         }
 
         if (documentation.length === 0 && documentationFromAlias) {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -43,7 +43,7 @@ namespace ts {
         getDocumentationComment(typeChecker: TypeChecker | undefined): SymbolDisplayPart[];
         /* @internal */
         getContextualDocumentationComment(context: Node | undefined, checker: TypeChecker | undefined): SymbolDisplayPart[]
-        getJsDocTags(): JSDocTagInfo[];
+        getJsDocTags(checker?: TypeChecker): JSDocTagInfo[];
     }
 
     export interface Type {
@@ -1032,6 +1032,9 @@ namespace ts {
         enumMemberName,
         functionName,
         regularExpressionLiteral,
+        link,
+        linkName,
+        linkText,
     }
 
     export interface SymbolDisplayPart {
@@ -1039,9 +1042,13 @@ namespace ts {
         kind: string;
     }
 
+    export interface JSDocLinkDisplayPart extends SymbolDisplayPart {
+        target: DocumentSpan;
+    }
+
     export interface JSDocTagInfo {
         name: string;
-        text?: string;
+        text?: SymbolDisplayPart[];
     }
 
     export interface QuickInfo {
@@ -1391,6 +1398,15 @@ namespace ts {
 
         /** String literal */
         string = "string",
+
+        /** Jsdoc @link: in `{@link C link text}`, the before and after text "{@link " and "}" */
+        link = "link",
+
+        /** Jsdoc @link: in `{@link C link text}`, the entity name "C" */
+        linkName = "link name",
+
+        /** Jsdoc @link: in `{@link C link text}`, the link text "link text" */
+        linkText = "link text",
     }
 
     export const enum ScriptElementKindModifier {

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -105,7 +105,7 @@ namespace ts {
         else if (isDeclarationName(node)) {
             return getMeaningFromDeclaration(node.parent);
         }
-        else if (isEntityName(node) && isJSDocNameReference(node.parent)) {
+        else if (isEntityName(node) && (isJSDocNameReference(node.parent) || isJSDocLink(node.parent))) {
             return SemanticMeaning.All;
         }
         else if (isTypeReference(node)) {
@@ -2181,6 +2181,44 @@ namespace ts {
 
     export function textPart(text: string) {
         return displayPart(text, SymbolDisplayPartKind.text);
+    }
+
+    export function linkTextPart(text: string) {
+        return displayPart(text, SymbolDisplayPartKind.linkText);
+    }
+
+    export function linkNamePart(name: EntityName, target: Declaration): JSDocLinkDisplayPart {
+        return {
+            text: getTextOfNode(name),
+            kind: SymbolDisplayPartKind[SymbolDisplayPartKind.linkName],
+            target: {
+                fileName: getSourceFileOfNode(target).fileName,
+                textSpan: createTextSpanFromNode(target),
+            },
+        };
+    }
+
+    export function linkPart(text: string) {
+        return displayPart(text, SymbolDisplayPartKind.link);
+    }
+
+    export function buildLinkParts(link: JSDocLink, checker?: TypeChecker): SymbolDisplayPart[] {
+        const parts = [linkPart("{@link ")];
+        if (!link.name) {
+            if (link.text) {parts.push(linkTextPart(link.text));}
+        }
+        else {
+            const symbol = checker?.getSymbolAtLocation(link.name);
+            if (symbol?.valueDeclaration) {
+                parts.push(linkNamePart(link.name, symbol.valueDeclaration));
+                if (link.text) {parts.push(linkTextPart(link.text));}
+            }
+            else {
+                parts.push(linkTextPart(getTextOfNode(link.name) + link.text));
+            }
+        }
+        parts.push(linkPart("}"));
+        return parts;
     }
 
     const carriageReturnLineFeed = "\r\n";

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -179,6 +179,7 @@
         "unittests/tsserver/importHelpers.ts",
         "unittests/tsserver/importSuggestionsCache.ts",
         "unittests/tsserver/inferredProjects.ts",
+        "unittests/tsserver/jsdocTag.ts",
         "unittests/tsserver/languageService.ts",
         "unittests/tsserver/maxNodeModuleJsDepth.ts",
         "unittests/tsserver/metadataInResponse.ts",

--- a/src/testRunner/unittests/jsDocParsing.ts
+++ b/src/testRunner/unittests/jsDocParsing.ts
@@ -312,8 +312,23 @@ namespace ts {
 */`);
                 parsesCorrectly("@link tags",
                     `/**
- * {@link first link}
+ * {@link first }
  * Inside {@link link text} thing
+ * @param foo See also {@link A.Reference}
+ * @param bar Or see {@link http://www.zombocom.com }
+ * {@link Standalone.Complex }
+ * This empty one: {@link} is OK.
+ * This double-space one: {@link  doubled  } is OK too.
+ * This should work, despite being badly formatted: {@link
+oh.no
+}
+ * Forgot to close this one {@link https://typescriptlang.org
+ * But it's still OK.
+ * Although it skips the newline so parses the asterisks in the wrong state.
+ * This shouldn't work: {@link
+ * nope
+ * }, because of the intermediate asterisks.
+ * @author Alfa Romero <a@parsing.com> See my home page: {@link https://example.com}
  */`);
                 parsesCorrectly("authorTag",
                     `/**

--- a/src/testRunner/unittests/publicApi.ts
+++ b/src/testRunner/unittests/publicApi.ts
@@ -67,7 +67,9 @@ function test() {}`;
         const funcDec = testSourceFile.statements.find(ts.isFunctionDeclaration)!;
         const tags = ts.getJSDocTags(funcDec);
         assert.isDefined(tags[0].comment);
-        assert.equal(tags[0].comment, "Some\n text\r\n with newlines.");
+        assert.isDefined(tags[0].comment![0]);
+        assert.equal(tags[0].comment![0].kind, ts.SyntaxKind.JSDocText);
+        assert.equal(tags[0].comment![0].text, "Some\n text\r\n with newlines.");
     });
 });
 

--- a/src/testRunner/unittests/publicApi.ts
+++ b/src/testRunner/unittests/publicApi.ts
@@ -68,8 +68,8 @@ function test() {}`;
         const tags = ts.getJSDocTags(funcDec);
         assert.isDefined(tags[0].comment);
         assert.isDefined(tags[0].comment![0]);
-        assert.equal(tags[0].comment![0].kind, ts.SyntaxKind.JSDocText);
-        assert.equal(tags[0].comment![0].text, "Some\n text\r\n with newlines.");
+        assert.isString(tags[0].comment);
+        assert.equal(tags[0].comment as string, "Some\n text\r\n with newlines.");
     });
 });
 

--- a/src/testRunner/unittests/tsserver/completions.ts
+++ b/src/testRunner/unittests/tsserver/completions.ts
@@ -69,7 +69,6 @@ namespace ts.projectSystem {
                 kindModifiers: ScriptElementKindModifier.exportedModifier,
                 name: "foo",
                 source: [{ text: "./a", kind: "text" }],
-                tags: undefined,
             };
             assert.deepEqual<readonly protocol.CompletionEntryDetails[] | undefined>(detailsResponse, [
                 {
@@ -91,6 +90,7 @@ namespace ts.projectSystem {
                             commands: undefined,
                         },
                     ],
+                    tags: [],
                     ...detailsCommon,
                 },
             ]);
@@ -117,6 +117,7 @@ namespace ts.projectSystem {
                             commands: undefined,
                         }
                     ],
+                    tags: [],
                     ...detailsCommon,
                 }
             ]);

--- a/src/testRunner/unittests/tsserver/jsdocTag.ts
+++ b/src/testRunner/unittests/tsserver/jsdocTag.ts
@@ -1,0 +1,693 @@
+namespace ts.projectSystem {
+    describe("unittests:: tsserver:: jsdoc @link ", () => {
+        const config: File = {
+            path: "/a/tsconfig.json",
+            content: `{
+"compilerOptions": {
+"checkJs": true,
+"noEmit": true
+}
+"files": ["someFile1.js"]
+}
+`
+        };
+        function assertQuickInfoJSDoc(file: File, options: {
+            displayPartsForJSDoc: boolean,
+            command: protocol.CommandTypes,
+            tags: string | unknown[] | undefined,
+            documentation: string | unknown[]
+        }) {
+
+            const { command, displayPartsForJSDoc, tags, documentation } = options;
+            const session = createSession(createServerHost([file, config]));
+            session.getProjectService().setHostConfiguration({ preferences: { displayPartsForJSDoc } });
+            openFilesForSession([file], session);
+            const indexOfX = file.content.indexOf("x");
+            const quickInfo = session.executeCommandSeq<protocol.QuickInfoRequest>({
+                command: command as protocol.CommandTypes.Quickinfo,
+                arguments: {
+                    file: file.path,
+                    position: indexOfX,
+                } as protocol.FileLocationRequestArgs
+            }).response;
+            const summaryAndLocation = command === protocol.CommandTypes.Quickinfo ? {
+                displayString: "var x: number",
+                start: {
+                    line: 3,
+                    offset: 5,
+                },
+                end: {
+                    line: 3,
+                    offset: 6,
+                }
+            } : {
+                displayParts: [{
+                    kind: "keyword",
+                    text: "var",
+                }, {
+                    kind: "space",
+                    text: " ",
+                }, {
+                    kind: "localName",
+                    text: "x",
+                }, {
+                    kind: "punctuation",
+                    text: ":",
+                }, {
+                    kind: "space",
+                    text: " ",
+                }, {
+                    kind: "keyword",
+                    text: "number",
+                }],
+                textSpan: {
+                    length: 1,
+                    start: 38,
+                }
+            };
+            assert.deepEqual(quickInfo, {
+                kind: "var",
+                kindModifiers: "",
+                ...summaryAndLocation,
+                documentation,
+                tags
+            });
+        }
+
+        const linkInTag: File = {
+            path: "/a/someFile1.js",
+            content: `class C { }
+/** @wat {@link C} */
+var x = 1`
+        };
+        const linkInComment: File = {
+            path: "/a/someFile1.js",
+            content: `class C { }
+     /** {@link C} */
+var x = 1
+;`
+        };
+
+        it("for quickinfo, should provide display parts plus a span for a working link in a tag", () => {
+            assertQuickInfoJSDoc(linkInTag, {
+                command: protocol.CommandTypes.Quickinfo,
+                displayPartsForJSDoc: true,
+                documentation: [],
+                tags: [{
+                    name: "wat",
+                    text: [{
+                        kind: "text",
+                        text: "",
+                    }, {
+                        kind: "link",
+                        text: "{@link ",
+                    }, {
+                        kind: "linkName",
+                        target: {
+                            end: {
+                                line: 1,
+                                offset: 12,
+                            },
+                            file: "/a/someFile1.js",
+                            start: {
+                                line: 1,
+                                offset: 1,
+                            },
+                        },
+                        text: "C",
+                    }, {
+                        kind: "link",
+                        text: "}",
+                    }]
+                }],
+            });
+        });
+        it("for quickinfo, should provide a string for a working link in a tag", () => {
+            assertQuickInfoJSDoc(linkInTag, {
+                command: protocol.CommandTypes.Quickinfo,
+                displayPartsForJSDoc: false,
+                documentation: "",
+                tags: [{
+                    name: "wat",
+                    text: "{@link C}"
+                }],
+            });
+        });
+        it("for quickinfo, should provide display parts for a working link in a comment", () => {
+            assertQuickInfoJSDoc(linkInComment, {
+                command: protocol.CommandTypes.Quickinfo,
+                displayPartsForJSDoc: true,
+                documentation: [{
+                    kind: "text",
+                    text: "",
+                }, {
+                    kind: "link",
+                    text: "{@link ",
+                }, {
+                    kind: "linkName",
+                    target: {
+                        end: {
+                            line: 1,
+                            offset: 12,
+                        },
+                        file: "/a/someFile1.js",
+                        start: {
+                            line: 1,
+                            offset: 1,
+                        },
+                    },
+                    text: "C",
+                }, {
+                    kind: "link",
+                    text: "}",
+                }],
+                tags: [],
+            });
+        });
+        it("for quickinfo, should provide a string for a working link in a comment", () => {
+            assertQuickInfoJSDoc(linkInComment, {
+                command: protocol.CommandTypes.Quickinfo,
+                displayPartsForJSDoc: false,
+                documentation: "{@link C}",
+                tags: [],
+            });
+        });
+
+        it("for quickinfo-full, should provide display parts plus a span for a working link in a tag", () => {
+            assertQuickInfoJSDoc(linkInTag, {
+                command: protocol.CommandTypes.QuickinfoFull,
+                displayPartsForJSDoc: true,
+                documentation: [],
+                tags: [{
+                    name: "wat",
+                    text: [{
+                        kind: "text",
+                        text: "",
+                    }, {
+                        kind: "link",
+                        text: "{@link ",
+                    }, {
+                        kind: "linkName",
+                        target: {
+                            fileName: "/a/someFile1.js",
+                            textSpan: {
+                                length: 11,
+                                start: 0
+                            },
+                        },
+                        text: "C",
+                    }, {
+                        kind: "link",
+                        text: "}",
+                    }]
+                }],
+            });
+        });
+        it("for quickinfo-full, should provide a string for a working link in a tag", () => {
+            assertQuickInfoJSDoc(linkInTag, {
+                command: protocol.CommandTypes.QuickinfoFull,
+                displayPartsForJSDoc: false,
+                documentation: [],
+                tags: [{
+                    name: "wat",
+                    text: "{@link C}"
+                }],
+            });
+        });
+        it("for quickinfo-full, should provide display parts plus a span for a working link in a comment", () => {
+            assertQuickInfoJSDoc(linkInComment, {
+                command: protocol.CommandTypes.QuickinfoFull,
+                displayPartsForJSDoc: true,
+                documentation: [{
+                    kind: "text",
+                    text: "",
+                }, {
+                    kind: "link",
+                    text: "{@link ",
+                }, {
+                    kind: "linkName",
+                    target: {
+                        fileName: "/a/someFile1.js",
+                        textSpan: {
+                            length: 11,
+                            start: 0
+                        },
+                    },
+                    text: "C",
+                }, {
+                    kind: "link",
+                    text: "}",
+                }],
+                tags: undefined,
+            });
+        });
+        it("for quickinfo-full, should provide a string for a working link in a comment", () => {
+            assertQuickInfoJSDoc(linkInComment, {
+                command: protocol.CommandTypes.QuickinfoFull,
+                displayPartsForJSDoc: false,
+                documentation: [{
+                        kind: "text",
+                        text: "",
+                    }, {
+                        kind: "link",
+                        text: "{@link ",
+                    }, {
+                        kind: "linkName",
+                        target: {
+                            fileName: "/a/someFile1.js",
+                            textSpan: {
+                                length: 11,
+                                start: 0
+                            },
+                        },
+                        text: "C",
+                    }, {
+                        kind: "link",
+                        text: "}",
+                    }],
+                tags: [],
+            });
+        });
+
+        function assertSignatureHelpJSDoc(options: {
+            displayPartsForJSDoc: boolean,
+            command: protocol.CommandTypes,
+            documentation: string | unknown[],
+            tags: unknown[]
+        }) {
+            const linkInParamTag: File = {
+                path: "/a/someFile1.js",
+                content: `class C { }
+/** @param y - {@link C} */
+function x(y) { }
+x(1)`
+            };
+
+            const { command, displayPartsForJSDoc, documentation, tags } = options;
+            const session = createSession(createServerHost([linkInParamTag, config]));
+            session.getProjectService().setHostConfiguration({ preferences: { displayPartsForJSDoc } });
+            openFilesForSession([linkInParamTag], session);
+            const indexOfX = linkInParamTag.content.lastIndexOf("1");
+            const signatureHelp = session.executeCommandSeq<protocol.SignatureHelpRequest>({
+                command: command as protocol.CommandTypes.SignatureHelp,
+                arguments: {
+                    triggerReason: {
+                        kind: "invoked"
+                    },
+                    file: linkInParamTag.path,
+                    position: indexOfX,
+                } as protocol.SignatureHelpRequestArgs
+            }).response;
+            const applicableSpan = command === protocol.CommandTypes.SignatureHelp ? {
+                end: {
+                    line: 4,
+                    offset: 4
+                },
+                start: {
+                    line: 4,
+                    offset: 3
+                }
+            } : {
+                length: 1,
+                start: 60
+            };
+            assert.deepEqual(signatureHelp, {
+                applicableSpan,
+                argumentCount: 1,
+                argumentIndex: 0,
+                selectedItemIndex: 0,
+                items: [{
+                    documentation: [],
+                    isVariadic: false,
+                    parameters: [{
+                        displayParts: [{
+                            kind: "parameterName",
+                            text: "y"
+                        }, {
+                            kind: "punctuation",
+                            text: ":"
+                        }, {
+                            kind: "space",
+                            text: " "
+                        }, {
+                            kind: "keyword",
+                            text: "any"
+                        }],
+                        documentation,
+                        isOptional: false,
+                        isRest: false,
+                        name: "y"
+                    }],
+                    prefixDisplayParts: [
+                        {
+                            kind: "functionName",
+                            text: "x",
+                        },
+                        {
+                            kind: "punctuation",
+                            text: "(",
+                        },
+                    ],
+                    separatorDisplayParts: [
+                        {
+                            kind: "punctuation",
+                            text: ",",
+                        },
+                        {
+                            kind: "space",
+                            text: " ",
+                        },
+                    ],
+                    suffixDisplayParts: [
+                        {
+                            kind: "punctuation",
+                            text: ")",
+                        },
+                        {
+                            kind: "punctuation",
+                            text: ":",
+                        },
+                        {
+                            kind: "space",
+                            text: " ",
+                        },
+                        {
+                            kind: "keyword",
+                            text: "void",
+                        }
+                    ],
+                    tags,
+                }],
+            });
+        }
+        it("for signature help, should provide a string for a working link in a comment", () => {
+            assertSignatureHelpJSDoc({
+                command: protocol.CommandTypes.SignatureHelp,
+                displayPartsForJSDoc: false,
+                tags: [{
+                    name: "param",
+                    text: "y - {@link C}"
+                }],
+                documentation: [{
+                    kind: "text",
+                    text: "- "
+                }, {
+                    kind: "link",
+                    text: "{@link "
+                }, {
+                    kind: "linkName",
+                    target: {
+                        file: "/a/someFile1.js",
+                        start: {
+                            line: 1,
+                            offset: 1
+                        },
+                        end: {
+                            line: 1,
+                            offset: 12
+                        }
+                    },
+                    text: "C"
+                }, {
+                    kind: "link",
+                    text: "}"
+                }],
+            });
+        });
+        it("for signature help, should provide display parts for a working link in a comment", () => {
+            const tags = [{
+                name: "param",
+                text: [{
+                    kind: "text",
+                    text: "y"
+                }, {
+                    kind: "space",
+                    text: " "
+                }, {
+                    kind: "text",
+                    text: "- "
+                }, {
+                    kind: "link",
+                    text: "{@link "
+                }, {
+                    kind: "linkName",
+                    target: {
+                        file: "/a/someFile1.js",
+                        start: {
+                            line: 1,
+                            offset: 1
+                        },
+                        end: {
+                            line: 1,
+                            offset: 12
+                        }
+                    },
+                    text: "C"
+                }, {
+                    kind: "link",
+                    text: "}"
+                }]
+            }];
+            assertSignatureHelpJSDoc({
+                command: protocol.CommandTypes.SignatureHelp,
+                displayPartsForJSDoc: true,
+                tags,
+                documentation: tags[0].text.slice(2)
+            });
+        });
+        it("for signature help-full, should provide a string for a working link in a comment", () => {
+            assertSignatureHelpJSDoc({
+                command: protocol.CommandTypes.SignatureHelpFull,
+                displayPartsForJSDoc: false,
+                tags: [{
+                    name: "param",
+                    text: "y - {@link C}"
+                }],
+                documentation: [{
+                    kind: "text",
+                    text: "- "
+                }, {
+                    kind: "link",
+                    text: "{@link "
+                }, {
+                    kind: "linkName",
+                    target: {
+                        fileName: "/a/someFile1.js",
+                        textSpan: {
+                            length: 11,
+                            start: 0
+                        }
+                    },
+                    text: "C"
+                }, {
+                    kind: "link",
+                    text: "}"
+                }],
+            });
+        });
+        it("for signature help-full, should provide display parts for a working link in a comment", () => {
+            const tags = [{
+                name: "param",
+                text: [{
+                    kind: "text",
+                    text: "y"
+                }, {
+                    kind: "space",
+                    text: " "
+                }, {
+                    kind: "text",
+                    text: "- "
+                }, {
+                    kind: "link",
+                    text: "{@link "
+                }, {
+                    kind: "linkName",
+                    target: {
+                        fileName: "/a/someFile1.js",
+                        textSpan: {
+                            length: 11,
+                            start: 0
+                        }
+                    },
+                    text: "C"
+                }, {
+                    kind: "link",
+                    text: "}"
+                }]
+            }];
+            assertSignatureHelpJSDoc({
+                command: protocol.CommandTypes.SignatureHelpFull,
+                displayPartsForJSDoc: true,
+                tags,
+                documentation: tags[0].text.slice(2),
+            });
+        });
+
+        function assertCompletionsJSDoc(options: {
+            displayPartsForJSDoc: boolean,
+            command: protocol.CommandTypes,
+            tags: unknown[]
+        }) {
+            const linkInParamJSDoc: File = {
+                path: "/a/someFile1.js",
+                content: `class C { }
+/** @param x - see {@link C} */
+function foo (x) { }
+foo`
+            };
+            const { command, displayPartsForJSDoc, tags } = options;
+            const session = createSession(createServerHost([linkInParamJSDoc, config]));
+            session.getProjectService().setHostConfiguration({ preferences: { displayPartsForJSDoc } });
+            openFilesForSession([linkInParamJSDoc], session);
+            const indexOfFoo = linkInParamJSDoc.content.lastIndexOf("fo");
+            const completions = session.executeCommandSeq<protocol.CompletionDetailsRequest>({
+                command: command as protocol.CommandTypes.CompletionDetails,
+                arguments: {
+                    entryNames: ["foo"],
+                    file: linkInParamJSDoc.path,
+                    position: indexOfFoo,
+                } as protocol.CompletionDetailsRequestArgs
+            }).response;
+            assert.deepEqual(completions, [{
+                codeActions: undefined,
+                displayParts: [{
+                    kind: "keyword",
+                    text: "function",
+                }, {
+                    kind: "space",
+                    text: " ",
+                }, {
+                    kind: "functionName",
+                    text: "foo",
+                }, {
+                    kind: "punctuation",
+                    text: "(",
+                }, {
+                    kind: "parameterName",
+                    text: "x",
+                }, {
+                    kind: "punctuation",
+                    text: ":",
+                }, {
+                    kind: "space",
+                    text: " ",
+                }, {
+                    kind: "keyword",
+                    text: "any",
+                }, {
+                    kind: "punctuation",
+                    text: ")",
+                }, {
+                    kind: "punctuation",
+                    text: ":",
+                }, {
+                    kind: "space",
+                    text: " ",
+                }, {
+                    kind: "keyword",
+                    text: "void",
+                }],
+                documentation: [],
+                kind: "function",
+                kindModifiers: "",
+                name: "foo",
+                source: undefined,
+                tags,
+            }]);
+        }
+        it("for completions, should provide display parts for a working link in a comment", () => {
+            assertCompletionsJSDoc({
+                command: protocol.CommandTypes.CompletionDetails,
+                displayPartsForJSDoc: true,
+                tags: [{
+                    name: "param",
+                    text: [{
+                        kind: "text",
+                        text: "x"
+                    }, {
+                        kind: "space",
+                        text: " "
+                    }, {
+                        kind: "text",
+                        text: "- see "
+                    }, {
+                        kind: "link",
+                        text: "{@link "
+                    }, {
+                        kind: "linkName",
+                        target: {
+                            file: "/a/someFile1.js",
+                            end: {
+                                line: 1,
+                                offset: 12,
+                            },
+                            start: {
+                                line: 1,
+                                offset: 1,
+                            }
+                        },
+                        text: "C"
+                    }, {
+                        kind: "link",
+                        text: "}"
+                    }],
+                }],
+            });
+        });
+        it("for completions, should provide a string for a working link in a comment", () => {
+            assertCompletionsJSDoc({
+                command: protocol.CommandTypes.CompletionDetails,
+                displayPartsForJSDoc: false,
+                tags: [{
+                    name: "param",
+                    text: "x - see {@link C}",
+                }],
+            });
+        });
+        it("for completions-full, should provide display parts for a working link in a comment", () => {
+            assertCompletionsJSDoc({
+                command: protocol.CommandTypes.CompletionDetailsFull,
+                displayPartsForJSDoc: true,
+                tags: [{
+                    name: "param",
+                    text: [{
+                        kind: "text",
+                        text: "x"
+                    }, {
+                        kind: "space",
+                        text: " "
+                    }, {
+                        kind: "text",
+                        text: "- see "
+                    }, {
+                        kind: "link",
+                        text: "{@link "
+                    }, {
+                        kind: "linkName",
+                        target: {
+                            fileName: "/a/someFile1.js",
+                            textSpan: {
+                                length: 11,
+                                start: 0
+                            }
+                        },
+                        text: "C"
+                    }, {
+                        kind: "link",
+                        text: "}"
+                    }],
+                }],
+            });
+        });
+        it("for completions-full, should provide a string for a working link in a comment", () => {
+            assertCompletionsJSDoc({
+                command: protocol.CommandTypes.CompletionDetailsFull,
+                displayPartsForJSDoc: false,
+                tags: [{
+                    name: "param",
+                    text: "x - see {@link C}",
+                }],
+            });
+        });
+    });
+}

--- a/tests/baselines/reference/APISample_jsdoc.js
+++ b/tests/baselines/reference/APISample_jsdoc.js
@@ -35,7 +35,7 @@ function parseCommentsIntoDefinition(this: any,
     }
 
     // jsdocs are separate from comments
-    const jsdocs = symbol.getJsDocTags();
+    const jsdocs = symbol.getJsDocTags(this.checker);
     jsdocs.forEach(doc => {
         // if we have @TJS-... annotations, we have to parse them
         const { name, text } = doc;
@@ -59,7 +59,7 @@ function getAnnotations(this: any, node: ts.Node): Annotations | undefined {
         return undefined;
     }
 
-    const jsDocTags: ts.JSDocTagInfo[] = symbol.getJsDocTags();
+    const jsDocTags: ts.JSDocTagInfo[] = symbol.getJsDocTags(this.checker);
     if (!jsDocTags || !jsDocTags.length) {
         return undefined;
     }
@@ -143,7 +143,7 @@ function parseCommentsIntoDefinition(symbol, definition, otherAnnotations) {
         definition.description = comments.map(function (comment) { return comment.kind === "lineBreak" ? comment.text : comment.text.trim().replace(/\r\n/g, "\n"); }).join("");
     }
     // jsdocs are separate from comments
-    var jsdocs = symbol.getJsDocTags();
+    var jsdocs = symbol.getJsDocTags(this.checker);
     jsdocs.forEach(function (doc) {
         // if we have @TJS-... annotations, we have to parse them
         var name = doc.name, text = doc.text;
@@ -162,7 +162,7 @@ function getAnnotations(node) {
     if (!symbol) {
         return undefined;
     }
-    var jsDocTags = symbol.getJsDocTags();
+    var jsDocTags = symbol.getJsDocTags(this.checker);
     if (!jsDocTags || !jsDocTags.length) {
         return undefined;
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.@@ does not start a new tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.@@ does not start a new tag.json
@@ -20,7 +20,21 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": "is (@@fine@@and) is one comment",
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 19,
+                    "end": 52,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "is (@@fine@@and) is one comment"
+                },
+                "length": 1,
+                "pos": 19,
+                "end": 52,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
             "name": {
                 "kind": "Identifier",
                 "pos": 14,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.@@ does not start a new tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.@@ does not start a new tag.json
@@ -20,21 +20,7 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 19,
-                    "end": 52,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "is (@@fine@@and) is one comment"
-                },
-                "length": 1,
-                "pos": 19,
-                "end": 52,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            },
+            "comment": "is (@@fine@@and) is one comment",
             "name": {
                 "kind": "Identifier",
                 "pos": 14,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.@link tags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.@link tags.json
@@ -1,9 +1,425 @@
 {
     "kind": "JSDocComment",
     "pos": 0,
-    "end": 63,
+    "end": 674,
     "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
-    "comment": "{@link first link}\nInside {@link link text} thing"
+    "comment": {
+        "0": {
+            "kind": "JSDocText",
+            "pos": 0,
+            "end": 7,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "text": ""
+        },
+        "1": {
+            "kind": "JSDocLink",
+            "pos": 7,
+            "end": 21,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "name": {
+                "kind": "Identifier",
+                "pos": 14,
+                "end": 19,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "first"
+            },
+            "text": ""
+        },
+        "2": {
+            "kind": "JSDocText",
+            "pos": 21,
+            "end": 32,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "text": "\nInside "
+        },
+        "3": {
+            "kind": "JSDocLink",
+            "pos": 32,
+            "end": 49,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "name": {
+                "kind": "Identifier",
+                "pos": 39,
+                "end": 43,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "link"
+            },
+            "text": "text"
+        },
+        "4": {
+            "kind": "JSDocText",
+            "pos": 49,
+            "end": 59,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "text": " thing"
+        },
+        "length": 5,
+        "pos": 0,
+        "end": 59,
+        "hasTrailingComma": false,
+        "transformFlags": 0
+    },
+    "tags": {
+        "0": {
+            "kind": "JSDocParameterTag",
+            "pos": 59,
+            "end": 102,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 60,
+                "end": 65,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "param"
+            },
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 70,
+                    "end": 79,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "See also "
+                },
+                "1": {
+                    "kind": "JSDocLink",
+                    "pos": 79,
+                    "end": 98,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "name": {
+                        "kind": "FirstNode",
+                        "pos": 86,
+                        "end": 97,
+                        "modifierFlagsCache": 0,
+                        "transformFlags": 0,
+                        "left": {
+                            "kind": "Identifier",
+                            "pos": 86,
+                            "end": 87,
+                            "modifierFlagsCache": 0,
+                            "transformFlags": 0,
+                            "escapedText": "A"
+                        },
+                        "right": {
+                            "kind": "Identifier",
+                            "pos": 88,
+                            "end": 97,
+                            "modifierFlagsCache": 0,
+                            "transformFlags": 0,
+                            "escapedText": "Reference"
+                        }
+                    },
+                    "text": ""
+                },
+                "length": 2,
+                "pos": 70,
+                "end": 102,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
+            "name": {
+                "kind": "Identifier",
+                "pos": 66,
+                "end": 69,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "foo"
+            },
+            "isNameFirst": true,
+            "isBracketed": false
+        },
+        "1": {
+            "kind": "JSDocParameterTag",
+            "pos": 102,
+            "end": 589,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 103,
+                "end": 108,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "param"
+            },
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 113,
+                    "end": 120,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Or see "
+                },
+                "1": {
+                    "kind": "JSDocLink",
+                    "pos": 120,
+                    "end": 152,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "name": {
+                        "kind": "Identifier",
+                        "pos": 127,
+                        "end": 131,
+                        "modifierFlagsCache": 0,
+                        "transformFlags": 0,
+                        "escapedText": "http"
+                    },
+                    "text": "://www.zombocom.com "
+                },
+                "2": {
+                    "kind": "JSDocText",
+                    "pos": 152,
+                    "end": 156,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "\n"
+                },
+                "3": {
+                    "kind": "JSDocLink",
+                    "pos": 156,
+                    "end": 183,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "name": {
+                        "kind": "FirstNode",
+                        "pos": 163,
+                        "end": 181,
+                        "modifierFlagsCache": 0,
+                        "transformFlags": 0,
+                        "left": {
+                            "kind": "Identifier",
+                            "pos": 163,
+                            "end": 173,
+                            "modifierFlagsCache": 0,
+                            "transformFlags": 0,
+                            "escapedText": "Standalone"
+                        },
+                        "right": {
+                            "kind": "Identifier",
+                            "pos": 174,
+                            "end": 181,
+                            "modifierFlagsCache": 0,
+                            "transformFlags": 0,
+                            "escapedText": "Complex"
+                        }
+                    },
+                    "text": ""
+                },
+                "4": {
+                    "kind": "JSDocText",
+                    "pos": 183,
+                    "end": 203,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "\nThis empty one: "
+                },
+                "5": {
+                    "kind": "JSDocLink",
+                    "pos": 203,
+                    "end": 210,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": ""
+                },
+                "6": {
+                    "kind": "JSDocText",
+                    "pos": 210,
+                    "end": 244,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": " is OK.\nThis double-space one: "
+                },
+                "7": {
+                    "kind": "JSDocLink",
+                    "pos": 244,
+                    "end": 262,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "name": {
+                        "kind": "Identifier",
+                        "pos": 252,
+                        "end": 259,
+                        "modifierFlagsCache": 0,
+                        "transformFlags": 0,
+                        "escapedText": "doubled"
+                    },
+                    "text": ""
+                },
+                "8": {
+                    "kind": "JSDocText",
+                    "pos": 262,
+                    "end": 326,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": " is OK too.\nThis should work, despite being badly formatted: "
+                },
+                "9": {
+                    "kind": "JSDocLink",
+                    "pos": 326,
+                    "end": 340,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "name": {
+                        "kind": "FirstNode",
+                        "pos": 333,
+                        "end": 338,
+                        "modifierFlagsCache": 0,
+                        "transformFlags": 0,
+                        "left": {
+                            "kind": "Identifier",
+                            "pos": 333,
+                            "end": 335,
+                            "modifierFlagsCache": 0,
+                            "transformFlags": 0,
+                            "escapedText": "oh"
+                        },
+                        "right": {
+                            "kind": "Identifier",
+                            "pos": 336,
+                            "end": 338,
+                            "modifierFlagsCache": 0,
+                            "transformFlags": 0,
+                            "escapedText": "no"
+                        }
+                    },
+                    "text": ""
+                },
+                "10": {
+                    "kind": "JSDocText",
+                    "pos": 340,
+                    "end": 369,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "\nForgot to close this one "
+                },
+                "11": {
+                    "kind": "JSDocLink",
+                    "pos": 369,
+                    "end": 403,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "name": {
+                        "kind": "Identifier",
+                        "pos": 376,
+                        "end": 381,
+                        "modifierFlagsCache": 0,
+                        "transformFlags": 0,
+                        "escapedText": "https"
+                    },
+                    "text": "://typescriptlang.org"
+                },
+                "12": {
+                    "kind": "JSDocText",
+                    "pos": 403,
+                    "end": 526,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": " * But it's still OK.\nAlthough it skips the newline so parses the asterisks in the wrong state.\nThis shouldn't work: "
+                },
+                "13": {
+                    "kind": "JSDocLink",
+                    "pos": 526,
+                    "end": 541,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "* nope"
+                },
+                "14": {
+                    "kind": "JSDocText",
+                    "pos": 541,
+                    "end": 589,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": " * }, because of the intermediate asterisks."
+                },
+                "length": 15,
+                "pos": 113,
+                "end": 589,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
+            "name": {
+                "kind": "Identifier",
+                "pos": 109,
+                "end": 112,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "bar"
+            },
+            "isNameFirst": true,
+            "isBracketed": false
+        },
+        "2": {
+            "kind": "JSDocAuthorTag",
+            "pos": 589,
+            "end": 672,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "tagName": {
+                "kind": "Identifier",
+                "pos": 590,
+                "end": 596,
+                "modifierFlagsCache": 0,
+                "transformFlags": 0,
+                "escapedText": "author"
+            },
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 597,
+                    "end": 624,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Alfa Romero <a@parsing.com>"
+                },
+                "1": {
+                    "kind": "JSDocText",
+                    "pos": 624,
+                    "end": 643,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": " See my home page: "
+                },
+                "2": {
+                    "kind": "JSDocLink",
+                    "pos": 643,
+                    "end": 670,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "name": {
+                        "kind": "Identifier",
+                        "pos": 650,
+                        "end": 655,
+                        "modifierFlagsCache": 0,
+                        "transformFlags": 0,
+                        "escapedText": "https"
+                    },
+                    "text": "://example.com"
+                },
+                "length": 3,
+                "pos": 597,
+                "end": 672,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
+        },
+        "length": 3,
+        "pos": 59,
+        "end": 672,
+        "hasTrailingComma": false,
+        "transformFlags": 0
+    }
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial email address is not a tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial email address is not a tag.json
@@ -5,19 +5,5 @@
     "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
-    "comment": {
-        "0": {
-            "kind": "JSDocText",
-            "pos": 0,
-            "end": 19,
-            "modifierFlagsCache": 0,
-            "transformFlags": 0,
-            "text": "bill@example.com"
-        },
-        "length": 1,
-        "pos": 0,
-        "end": 19,
-        "hasTrailingComma": false,
-        "transformFlags": 0
-    }
+    "comment": "bill@example.com"
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial email address is not a tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial email address is not a tag.json
@@ -5,5 +5,19 @@
     "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
-    "comment": "bill@example.com"
+    "comment": {
+        "0": {
+            "kind": "JSDocText",
+            "pos": 0,
+            "end": 19,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "text": "bill@example.com"
+        },
+        "length": 1,
+        "pos": 0,
+        "end": 19,
+        "hasTrailingComma": false,
+        "transformFlags": 0
+    }
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star is not a tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star is not a tag.json
@@ -5,19 +5,5 @@
     "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
-    "comment": {
-        "0": {
-            "kind": "JSDocText",
-            "pos": 0,
-            "end": 6,
-            "modifierFlagsCache": 0,
-            "transformFlags": 0,
-            "text": "*@a"
-        },
-        "length": 1,
-        "pos": 0,
-        "end": 6,
-        "hasTrailingComma": false,
-        "transformFlags": 0
-    }
+    "comment": "*@a"
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star is not a tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star is not a tag.json
@@ -5,5 +5,19 @@
     "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
-    "comment": "*@a"
+    "comment": {
+        "0": {
+            "kind": "JSDocText",
+            "pos": 0,
+            "end": 6,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "text": "*@a"
+        },
+        "length": 1,
+        "pos": 0,
+        "end": 6,
+        "hasTrailingComma": false,
+        "transformFlags": 0
+    }
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star space is not a tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star space is not a tag.json
@@ -5,19 +5,5 @@
     "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
-    "comment": {
-        "0": {
-            "kind": "JSDocText",
-            "pos": 0,
-            "end": 7,
-            "modifierFlagsCache": 0,
-            "transformFlags": 0,
-            "text": "* @a"
-        },
-        "length": 1,
-        "pos": 0,
-        "end": 7,
-        "hasTrailingComma": false,
-        "transformFlags": 0
-    }
+    "comment": "* @a"
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star space is not a tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Initial star space is not a tag.json
@@ -5,5 +5,19 @@
     "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
-    "comment": "* @a"
+    "comment": {
+        "0": {
+            "kind": "JSDocText",
+            "pos": 0,
+            "end": 7,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "text": "* @a"
+        },
+        "length": 1,
+        "pos": 0,
+        "end": 7,
+        "hasTrailingComma": false,
+        "transformFlags": 0
+    }
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Nested @param tags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Nested @param tags.json
@@ -20,7 +20,21 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": "Doc doc",
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 24,
+                    "end": 34,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Doc doc"
+                },
+                "length": 1,
+                "pos": 24,
+                "end": 34,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 34,
@@ -48,7 +62,21 @@
                                 "transformFlags": 0,
                                 "escapedText": "param"
                             },
-                            "comment": "Doc for f",
+                            "comment": {
+                                "0": {
+                                    "kind": "JSDocText",
+                                    "pos": 54,
+                                    "end": 64,
+                                    "modifierFlagsCache": 0,
+                                    "transformFlags": 0,
+                                    "text": "Doc for f"
+                                },
+                                "length": 1,
+                                "pos": 54,
+                                "end": 64,
+                                "hasTrailingComma": false,
+                                "transformFlags": 0
+                            },
                             "typeExpression": {
                                 "kind": "JSDocTypeExpression",
                                 "pos": 41,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Nested @param tags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Nested @param tags.json
@@ -20,21 +20,7 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 24,
-                    "end": 34,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "Doc doc"
-                },
-                "length": 1,
-                "pos": 24,
-                "end": 34,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            },
+            "comment": "Doc doc",
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 34,
@@ -62,21 +48,7 @@
                                 "transformFlags": 0,
                                 "escapedText": "param"
                             },
-                            "comment": {
-                                "0": {
-                                    "kind": "JSDocText",
-                                    "pos": 54,
-                                    "end": 64,
-                                    "modifierFlagsCache": 0,
-                                    "transformFlags": 0,
-                                    "text": "Doc for f"
-                                },
-                                "length": 1,
-                                "pos": 54,
-                                "end": 64,
-                                "hasTrailingComma": false,
-                                "transformFlags": 0
-                            },
+                            "comment": "Doc for f",
                             "typeExpression": {
                                 "kind": "JSDocTypeExpression",
                                 "pos": 41,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argSynonymForParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argSynonymForParamTag.json
@@ -20,7 +20,21 @@
                 "transformFlags": 0,
                 "escapedText": "arg"
             },
-            "comment": "Description",
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 28,
+                    "end": 42,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Description"
+                },
+                "length": 1,
+                "pos": 28,
+                "end": 42,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 13,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argSynonymForParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argSynonymForParamTag.json
@@ -20,21 +20,7 @@
                 "transformFlags": 0,
                 "escapedText": "arg"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 28,
-                    "end": 42,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "Description"
-                },
-                "length": 1,
-                "pos": 28,
-                "end": 42,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            },
+            "comment": "Description",
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 13,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argumentSynonymForParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argumentSynonymForParamTag.json
@@ -20,21 +20,7 @@
                 "transformFlags": 0,
                 "escapedText": "argument"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 33,
-                    "end": 47,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "Description"
-                },
-                "length": 1,
-                "pos": 33,
-                "end": 47,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            },
+            "comment": "Description",
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 18,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argumentSynonymForParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argumentSynonymForParamTag.json
@@ -20,7 +20,21 @@
                 "transformFlags": 0,
                 "escapedText": "argument"
             },
-            "comment": "Description",
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 33,
+                    "end": 47,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Description"
+                },
+                "length": 1,
+                "pos": 33,
+                "end": 47,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 18,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.asteriskAfterPreamble.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.asteriskAfterPreamble.json
@@ -5,19 +5,5 @@
     "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
-    "comment": {
-        "0": {
-            "kind": "JSDocText",
-            "pos": 0,
-            "end": 21,
-            "modifierFlagsCache": 0,
-            "transformFlags": 0,
-            "text": "* @type {number}"
-        },
-        "length": 1,
-        "pos": 0,
-        "end": 21,
-        "hasTrailingComma": false,
-        "transformFlags": 0
-    }
+    "comment": "* @type {number}"
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.asteriskAfterPreamble.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.asteriskAfterPreamble.json
@@ -5,5 +5,19 @@
     "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
-    "comment": "* @type {number}"
+    "comment": {
+        "0": {
+            "kind": "JSDocText",
+            "pos": 0,
+            "end": 21,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "text": "* @type {number}"
+        },
+        "length": 1,
+        "pos": 0,
+        "end": 21,
+        "hasTrailingComma": false,
+        "transformFlags": 0
+    }
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.authorTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.authorTag.json
@@ -20,7 +20,21 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "John Doe <john.doe@example.com>"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 15,
+                    "end": 50,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "John Doe <john.doe@example.com>"
+                },
+                "length": 1,
+                "pos": 15,
+                "end": 50,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "1": {
             "kind": "JSDocAuthorTag",
@@ -36,7 +50,29 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "John Doe <john.doe@example.com> unexpected comment"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 58,
+                    "end": 89,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "John Doe <john.doe@example.com>"
+                },
+                "1": {
+                    "kind": "JSDocText",
+                    "pos": 89,
+                    "end": 112,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": " unexpected comment"
+                },
+                "length": 2,
+                "pos": 58,
+                "end": 112,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "2": {
             "kind": "JSDocAuthorTag",
@@ -52,7 +88,29 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "108 <108@actionbutton.net> Video Games Forever"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 120,
+                    "end": 146,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "108 <108@actionbutton.net>"
+                },
+                "1": {
+                    "kind": "JSDocText",
+                    "pos": 146,
+                    "end": 170,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": " Video Games Forever"
+                },
+                "length": 2,
+                "pos": 120,
+                "end": 170,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "3": {
             "kind": "JSDocAuthorTag",
@@ -68,7 +126,21 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "Multiple Ats <email@quoting@how@does@it@work>"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 178,
+                    "end": 227,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Multiple Ats <email@quoting@how@does@it@work>"
+                },
+                "length": 1,
+                "pos": 178,
+                "end": 227,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "4": {
             "kind": "JSDocAuthorTag",
@@ -84,7 +156,21 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "Multiple Open Carets <hi<there@<>"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 235,
+                    "end": 272,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Multiple Open Carets <hi<there@<>"
+                },
+                "length": 1,
+                "pos": 235,
+                "end": 272,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "5": {
             "kind": "JSDocAuthorTag",
@@ -100,7 +186,29 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "Multiple Close Carets <probably>invalid>but>who>cares>"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 280,
+                    "end": 312,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Multiple Close Carets <probably>"
+                },
+                "1": {
+                    "kind": "JSDocText",
+                    "pos": 312,
+                    "end": 338,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "invalid>but>who>cares>"
+                },
+                "length": 2,
+                "pos": 280,
+                "end": 338,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "6": {
             "kind": "JSDocAuthorTag",
@@ -116,7 +224,21 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "Unclosed Carets <joe@sloppy.gov"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 346,
+                    "end": 381,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Unclosed Carets <joe@sloppy.gov"
+                },
+                "length": 1,
+                "pos": 346,
+                "end": 381,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "7": {
             "kind": "JSDocAuthorTag",
@@ -132,7 +254,21 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "Multiple "
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 389,
+                    "end": 398,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Multiple "
+                },
+                "length": 1,
+                "pos": 389,
+                "end": 398,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "8": {
             "kind": "JSDocAuthorTag",
@@ -148,7 +284,21 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "On One <one@two.three>"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 406,
+                    "end": 429,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "On One <one@two.three>"
+                },
+                "length": 1,
+                "pos": 406,
+                "end": 429,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "9": {
             "kind": "JSDocAuthorTag",
@@ -164,7 +314,21 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "Line"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 437,
+                    "end": 445,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Line"
+                },
+                "length": 1,
+                "pos": 437,
+                "end": 445,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "10": {
             "kind": "JSDocAuthorTag",
@@ -179,6 +343,21 @@
                 "modifierFlagsCache": 0,
                 "transformFlags": 0,
                 "escapedText": "author"
+            },
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 453,
+                    "end": 453,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": ""
+                },
+                "length": 1,
+                "pos": 453,
+                "end": 453,
+                "hasTrailingComma": false,
+                "transformFlags": 0
             }
         },
         "11": {
@@ -194,6 +373,21 @@
                 "modifierFlagsCache": 0,
                 "transformFlags": 0,
                 "escapedText": "author"
+            },
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 461,
+                    "end": 461,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": ""
+                },
+                "length": 1,
+                "pos": 461,
+                "end": 461,
+                "hasTrailingComma": false,
+                "transformFlags": 0
             }
         },
         "12": {
@@ -210,7 +404,21 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "Empty authors"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 469,
+                    "end": 486,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Empty authors"
+                },
+                "length": 1,
+                "pos": 469,
+                "end": 486,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "13": {
             "kind": "JSDocAuthorTag",
@@ -225,6 +433,21 @@
                 "modifierFlagsCache": 0,
                 "transformFlags": 0,
                 "escapedText": "author"
+            },
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 497,
+                    "end": 497,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": ""
+                },
+                "length": 1,
+                "pos": 497,
+                "end": 497,
+                "hasTrailingComma": false,
+                "transformFlags": 0
             }
         },
         "14": {
@@ -241,7 +464,21 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "Comments"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 510,
+                    "end": 522,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Comments"
+                },
+                "length": 1,
+                "pos": 510,
+                "end": 522,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "15": {
             "kind": "JSDocAuthorTag",
@@ -257,7 +494,21 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "Early Close Caret > <a@b>"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 530,
+                    "end": 559,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Early Close Caret > <a@b>"
+                },
+                "length": 1,
+                "pos": 530,
+                "end": 559,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "16": {
             "kind": "JSDocAuthorTag",
@@ -273,12 +524,34 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "No Line Breaks:<the email"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 567,
+                    "end": 582,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "No Line Breaks:"
+                },
+                "1": {
+                    "kind": "JSDocText",
+                    "pos": 582,
+                    "end": 599,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "<the email"
+                },
+                "length": 2,
+                "pos": 567,
+                "end": 599,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "17": {
             "kind": "JSDocTag",
             "pos": 599,
-            "end": 607,
+            "end": 646,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -289,7 +562,21 @@
                 "transformFlags": 0,
                 "escapedText": "address"
             },
-            "comment": "> must be on the same line to parse"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 607,
+                    "end": 646,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "> must be on the same line to parse"
+                },
+                "length": 1,
+                "pos": 607,
+                "end": 646,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "18": {
             "kind": "JSDocAuthorTag",
@@ -305,7 +592,29 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": "Long Comment <long@comment.org> I\nwant to keep commenting down here, I dunno."
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 654,
+                    "end": 685,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Long Comment <long@comment.org>"
+                },
+                "1": {
+                    "kind": "JSDocText",
+                    "pos": 685,
+                    "end": 737,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": " I\nwant to keep commenting down here, I dunno."
+                },
+                "length": 2,
+                "pos": 654,
+                "end": 737,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "length": 19,
         "pos": 7,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.authorTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.authorTag.json
@@ -50,29 +50,7 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 58,
-                    "end": 89,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "John Doe <john.doe@example.com>"
-                },
-                "1": {
-                    "kind": "JSDocText",
-                    "pos": 89,
-                    "end": 112,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": " unexpected comment"
-                },
-                "length": 2,
-                "pos": 58,
-                "end": 112,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            }
+            "comment": "John Doe <john.doe@example.com> unexpected comment"
         },
         "2": {
             "kind": "JSDocAuthorTag",
@@ -88,29 +66,7 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 120,
-                    "end": 146,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "108 <108@actionbutton.net>"
-                },
-                "1": {
-                    "kind": "JSDocText",
-                    "pos": 146,
-                    "end": 170,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": " Video Games Forever"
-                },
-                "length": 2,
-                "pos": 120,
-                "end": 170,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            }
+            "comment": "108 <108@actionbutton.net> Video Games Forever"
         },
         "3": {
             "kind": "JSDocAuthorTag",
@@ -186,29 +142,7 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 280,
-                    "end": 312,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "Multiple Close Carets <probably>"
-                },
-                "1": {
-                    "kind": "JSDocText",
-                    "pos": 312,
-                    "end": 338,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "invalid>but>who>cares>"
-                },
-                "length": 2,
-                "pos": 280,
-                "end": 338,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            }
+            "comment": "Multiple Close Carets <probably>invalid>but>who>cares>"
         },
         "6": {
             "kind": "JSDocAuthorTag",
@@ -524,29 +458,7 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 567,
-                    "end": 582,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "No Line Breaks:"
-                },
-                "1": {
-                    "kind": "JSDocText",
-                    "pos": 582,
-                    "end": 599,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "<the email"
-                },
-                "length": 2,
-                "pos": 567,
-                "end": 599,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            }
+            "comment": "No Line Breaks:<the email"
         },
         "17": {
             "kind": "JSDocTag",
@@ -562,21 +474,7 @@
                 "transformFlags": 0,
                 "escapedText": "address"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 607,
-                    "end": 646,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "> must be on the same line to parse"
-                },
-                "length": 1,
-                "pos": 607,
-                "end": 646,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            }
+            "comment": "> must be on the same line to parse"
         },
         "18": {
             "kind": "JSDocAuthorTag",
@@ -592,29 +490,7 @@
                 "transformFlags": 0,
                 "escapedText": "author"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 654,
-                    "end": 685,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "Long Comment <long@comment.org>"
-                },
-                "1": {
-                    "kind": "JSDocText",
-                    "pos": 685,
-                    "end": 737,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": " I\nwant to keep commenting down here, I dunno."
-                },
-                "length": 2,
-                "pos": 654,
-                "end": 737,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            }
+            "comment": "Long Comment <long@comment.org> I\nwant to keep commenting down here, I dunno."
         },
         "length": 19,
         "pos": 7,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.consecutive newline tokens.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.consecutive newline tokens.json
@@ -9,7 +9,7 @@
         "0": {
             "kind": "JSDocTag",
             "pos": 7,
-            "end": 19,
+            "end": 53,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -20,11 +20,25 @@
                 "transformFlags": 0,
                 "escapedText": "example"
             },
-            "comment": "Some\n\ntext\r\nwith newlines."
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 19,
+                    "end": 53,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Some\n\ntext\r\nwith newlines."
+                },
+                "length": 1,
+                "pos": 19,
+                "end": 53,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "length": 1,
         "pos": 7,
-        "end": 19,
+        "end": 53,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.consecutive newline tokens.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.consecutive newline tokens.json
@@ -20,21 +20,7 @@
                 "transformFlags": 0,
                 "escapedText": "example"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 19,
-                    "end": 53,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "Some\n\ntext\r\nwith newlines."
-                },
-                "length": 1,
-                "pos": 19,
-                "end": 53,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            }
+            "comment": "Some\n\ntext\r\nwith newlines."
         },
         "length": 1,
         "pos": 7,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.leadingAsterisk.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.leadingAsterisk.json
@@ -9,7 +9,7 @@
         "0": {
             "kind": "JSDocTypeTag",
             "pos": 8,
-            "end": 22,
+            "end": 25,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -38,7 +38,7 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 22,
+        "end": 25,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.less-than and greater-than characters.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.less-than and greater-than characters.json
@@ -20,7 +20,21 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": "hi\n< > still part of the previous comment",
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 16,
+                    "end": 59,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "hi\n< > still part of the previous comment"
+                },
+                "length": 1,
+                "pos": 16,
+                "end": 59,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
             "name": {
                 "kind": "Identifier",
                 "pos": 14,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.less-than and greater-than characters.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.less-than and greater-than characters.json
@@ -20,21 +20,7 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 16,
-                    "end": 59,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "hi\n< > still part of the previous comment"
-                },
-                "length": 1,
-                "pos": 16,
-                "end": 59,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            },
+            "comment": "hi\n< > still part of the previous comment",
             "name": {
                 "kind": "Identifier",
                 "pos": 14,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.no space before @ is not a new tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.no space before @ is not a new tag.json
@@ -20,7 +20,21 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": "(@is@)",
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 19,
+                    "end": 29,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "(@is@)"
+                },
+                "length": 1,
+                "pos": 19,
+                "end": 29,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
             "name": {
                 "kind": "Identifier",
                 "pos": 14,
@@ -47,7 +61,21 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": "its@fine",
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 41,
+                    "end": 50,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "its@fine"
+                },
+                "length": 1,
+                "pos": 41,
+                "end": 50,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
             "name": {
                 "kind": "Identifier",
                 "pos": 36,
@@ -77,7 +105,7 @@
         "3": {
             "kind": "JSDocTag",
             "pos": 62,
-            "end": 75,
+            "end": 89,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -88,11 +116,25 @@
                 "transformFlags": 0,
                 "escapedText": "singlestar"
             },
-            "comment": "*@doublestar"
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 75,
+                    "end": 89,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "*@doublestar"
+                },
+                "length": 1,
+                "pos": 75,
+                "end": 89,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            }
         },
         "length": 4,
         "pos": 7,
-        "end": 75,
+        "end": 89,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.no space before @ is not a new tag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.no space before @ is not a new tag.json
@@ -20,21 +20,7 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 19,
-                    "end": 29,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "(@is@)"
-                },
-                "length": 1,
-                "pos": 19,
-                "end": 29,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            },
+            "comment": "(@is@)",
             "name": {
                 "kind": "Identifier",
                 "pos": 14,
@@ -61,21 +47,7 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 41,
-                    "end": 50,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "its@fine"
-                },
-                "length": 1,
-                "pos": 41,
-                "end": 50,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            },
+            "comment": "its@fine",
             "name": {
                 "kind": "Identifier",
                 "pos": 36,
@@ -116,21 +88,7 @@
                 "transformFlags": 0,
                 "escapedText": "singlestar"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 75,
-                    "end": 89,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "*@doublestar"
-                },
-                "length": 1,
-                "pos": 75,
-                "end": 89,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            }
+            "comment": "*@doublestar"
         },
         "length": 4,
         "pos": 7,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noLeadingAsterisk.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noLeadingAsterisk.json
@@ -9,7 +9,7 @@
         "0": {
             "kind": "JSDocTypeTag",
             "pos": 8,
-            "end": 22,
+            "end": 25,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -38,7 +38,7 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 22,
+        "end": 25,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noReturnType.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noReturnType.json
@@ -9,7 +9,7 @@
         "0": {
             "kind": "JSDocReturnTag",
             "pos": 8,
-            "end": 15,
+            "end": 18,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -24,7 +24,7 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 15,
+        "end": 18,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTag1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTag1.json
@@ -20,21 +20,7 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 30,
-                    "end": 57,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "Description text follows"
-                },
-                "length": 1,
-                "pos": 30,
-                "end": 57,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            },
+            "comment": "Description text follows",
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 15,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTag1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTag1.json
@@ -20,7 +20,21 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": "Description text follows",
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 30,
+                    "end": 57,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Description text follows"
+                },
+                "length": 1,
+                "pos": 30,
+                "end": 57,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 15,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName1.json
@@ -20,21 +20,7 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 31,
-                    "end": 59,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "Description text follows"
-                },
-                "length": 1,
-                "pos": 31,
-                "end": 59,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            },
+            "comment": "Description text follows",
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 15,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName1.json
@@ -20,7 +20,21 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": "Description text follows",
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 31,
+                    "end": 59,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Description text follows"
+                },
+                "length": 1,
+                "pos": 31,
+                "end": 59,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 15,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName2.json
@@ -20,7 +20,21 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": "Description text follows",
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 36,
+                    "end": 64,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Description text follows"
+                },
+                "length": 1,
+                "pos": 36,
+                "end": 64,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 15,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName2.json
@@ -20,21 +20,7 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 36,
-                    "end": 64,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "Description text follows"
-                },
-                "length": 1,
-                "pos": 36,
-                "end": 64,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            },
+            "comment": "Description text follows",
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 15,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType2.json
@@ -20,7 +20,21 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": "Description",
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 29,
+                    "end": 44,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Description"
+                },
+                "length": 1,
+                "pos": 29,
+                "end": 44,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 21,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType2.json
@@ -20,21 +20,7 @@
                 "transformFlags": 0,
                 "escapedText": "param"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 29,
-                    "end": 44,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "Description"
-                },
-                "length": 1,
-                "pos": 29,
-                "end": 44,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            },
+            "comment": "Description",
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 21,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag1.json
@@ -9,7 +9,7 @@
         "0": {
             "kind": "JSDocReturnTag",
             "pos": 8,
-            "end": 24,
+            "end": 27,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -38,7 +38,7 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 24,
+        "end": 27,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag2.json
@@ -9,7 +9,7 @@
         "0": {
             "kind": "JSDocReturnTag",
             "pos": 8,
-            "end": 24,
+            "end": 52,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -21,7 +21,21 @@
                 "originalKeywordKind": "ReturnKeyword",
                 "escapedText": "return"
             },
-            "comment": "Description text follows",
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 24,
+                    "end": 52,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Description text follows"
+                },
+                "length": 1,
+                "pos": 24,
+                "end": 52,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 16,
@@ -39,7 +53,7 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 24,
+        "end": 52,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag2.json
@@ -21,21 +21,7 @@
                 "originalKeywordKind": "ReturnKeyword",
                 "escapedText": "return"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 24,
-                    "end": 52,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "Description text follows"
-                },
-                "length": 1,
-                "pos": 24,
-                "end": 52,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            },
+            "comment": "Description text follows",
             "typeExpression": {
                 "kind": "JSDocTypeExpression",
                 "pos": 16,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnsTag1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnsTag1.json
@@ -9,7 +9,7 @@
         "0": {
             "kind": "JSDocReturnTag",
             "pos": 8,
-            "end": 25,
+            "end": 28,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -37,7 +37,7 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 25,
+        "end": 28,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag.json
@@ -9,7 +9,7 @@
         "0": {
             "kind": "JSDocTemplateTag",
             "pos": 8,
-            "end": 19,
+            "end": 22,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -45,7 +45,7 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 19,
+        "end": 22,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag2.json
@@ -9,7 +9,7 @@
         "0": {
             "kind": "JSDocTemplateTag",
             "pos": 8,
-            "end": 21,
+            "end": 24,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -60,7 +60,7 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 21,
+        "end": 24,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag3.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag3.json
@@ -9,7 +9,7 @@
         "0": {
             "kind": "JSDocTemplateTag",
             "pos": 8,
-            "end": 22,
+            "end": 25,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -60,7 +60,7 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 22,
+        "end": 25,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag4.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag4.json
@@ -9,7 +9,7 @@
         "0": {
             "kind": "JSDocTemplateTag",
             "pos": 8,
-            "end": 22,
+            "end": 25,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -60,7 +60,7 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 22,
+        "end": 25,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag5.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag5.json
@@ -9,7 +9,7 @@
         "0": {
             "kind": "JSDocTemplateTag",
             "pos": 8,
-            "end": 23,
+            "end": 26,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -60,7 +60,7 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 23,
+        "end": 26,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag6.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag6.json
@@ -9,7 +9,7 @@
         "0": {
             "kind": "JSDocTemplateTag",
             "pos": 8,
-            "end": 24,
+            "end": 58,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -20,7 +20,21 @@
                 "transformFlags": 0,
                 "escapedText": "template"
             },
-            "comment": "Description of type parameters.",
+            "comment": {
+                "0": {
+                    "kind": "JSDocText",
+                    "pos": 24,
+                    "end": 58,
+                    "modifierFlagsCache": 0,
+                    "transformFlags": 0,
+                    "text": "Description of type parameters."
+                },
+                "length": 1,
+                "pos": 24,
+                "end": 58,
+                "hasTrailingComma": false,
+                "transformFlags": 0
+            },
             "typeParameters": {
                 "0": {
                     "kind": "TypeParameter",
@@ -61,7 +75,7 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 24,
+        "end": 58,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag6.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag6.json
@@ -20,21 +20,7 @@
                 "transformFlags": 0,
                 "escapedText": "template"
             },
-            "comment": {
-                "0": {
-                    "kind": "JSDocText",
-                    "pos": 24,
-                    "end": 58,
-                    "modifierFlagsCache": 0,
-                    "transformFlags": 0,
-                    "text": "Description of type parameters."
-                },
-                "length": 1,
-                "pos": 24,
-                "end": 58,
-                "hasTrailingComma": false,
-                "transformFlags": 0
-            },
+            "comment": "Description of type parameters.",
             "typeParameters": {
                 "0": {
                     "kind": "TypeParameter",

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.threeAsterisks.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.threeAsterisks.json
@@ -5,5 +5,19 @@
     "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
-    "comment": "*"
+    "comment": {
+        "0": {
+            "kind": "JSDocText",
+            "pos": 0,
+            "end": 5,
+            "modifierFlagsCache": 0,
+            "transformFlags": 0,
+            "text": "*"
+        },
+        "length": 1,
+        "pos": 0,
+        "end": 5,
+        "hasTrailingComma": false,
+        "transformFlags": 0
+    }
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.threeAsterisks.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.threeAsterisks.json
@@ -5,19 +5,5 @@
     "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
-    "comment": {
-        "0": {
-            "kind": "JSDocText",
-            "pos": 0,
-            "end": 5,
-            "modifierFlagsCache": 0,
-            "transformFlags": 0,
-            "text": "*"
-        },
-        "length": 1,
-        "pos": 0,
-        "end": 5,
-        "hasTrailingComma": false,
-        "transformFlags": 0
-    }
+    "comment": "*"
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typeTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typeTag.json
@@ -9,7 +9,7 @@
         "0": {
             "kind": "JSDocTypeTag",
             "pos": 8,
-            "end": 22,
+            "end": 25,
             "modifierFlagsCache": 0,
             "transformFlags": 0,
             "tagName": {
@@ -38,7 +38,7 @@
         },
         "length": 1,
         "pos": 8,
-        "end": 22,
+        "end": 25,
         "hasTrailingComma": false,
         "transformFlags": 0
     }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -416,36 +416,38 @@ declare namespace ts {
         JSDocVariadicType = 309,
         JSDocNamepathType = 310,
         JSDocComment = 311,
-        JSDocTypeLiteral = 312,
-        JSDocSignature = 313,
-        JSDocTag = 314,
-        JSDocAugmentsTag = 315,
-        JSDocImplementsTag = 316,
-        JSDocAuthorTag = 317,
-        JSDocDeprecatedTag = 318,
-        JSDocClassTag = 319,
-        JSDocPublicTag = 320,
-        JSDocPrivateTag = 321,
-        JSDocProtectedTag = 322,
-        JSDocReadonlyTag = 323,
-        JSDocCallbackTag = 324,
-        JSDocEnumTag = 325,
-        JSDocParameterTag = 326,
-        JSDocReturnTag = 327,
-        JSDocThisTag = 328,
-        JSDocTypeTag = 329,
-        JSDocTemplateTag = 330,
-        JSDocTypedefTag = 331,
-        JSDocSeeTag = 332,
-        JSDocPropertyTag = 333,
-        SyntaxList = 334,
-        NotEmittedStatement = 335,
-        PartiallyEmittedExpression = 336,
-        CommaListExpression = 337,
-        MergeDeclarationMarker = 338,
-        EndOfDeclarationMarker = 339,
-        SyntheticReferenceExpression = 340,
-        Count = 341,
+        JSDocText = 312,
+        JSDocTypeLiteral = 313,
+        JSDocSignature = 314,
+        JSDocLink = 315,
+        JSDocTag = 316,
+        JSDocAugmentsTag = 317,
+        JSDocImplementsTag = 318,
+        JSDocAuthorTag = 319,
+        JSDocDeprecatedTag = 320,
+        JSDocClassTag = 321,
+        JSDocPublicTag = 322,
+        JSDocPrivateTag = 323,
+        JSDocProtectedTag = 324,
+        JSDocReadonlyTag = 325,
+        JSDocCallbackTag = 326,
+        JSDocEnumTag = 327,
+        JSDocParameterTag = 328,
+        JSDocReturnTag = 329,
+        JSDocThisTag = 330,
+        JSDocTypeTag = 331,
+        JSDocTemplateTag = 332,
+        JSDocTypedefTag = 333,
+        JSDocSeeTag = 334,
+        JSDocPropertyTag = 335,
+        SyntaxList = 336,
+        NotEmittedStatement = 337,
+        PartiallyEmittedExpression = 338,
+        CommaListExpression = 339,
+        MergeDeclarationMarker = 340,
+        EndOfDeclarationMarker = 341,
+        SyntheticReferenceExpression = 342,
+        Count = 343,
         FirstAssignment = 62,
         LastAssignment = 77,
         FirstCompoundAssignment = 63,
@@ -474,9 +476,9 @@ declare namespace ts {
         LastStatement = 248,
         FirstNode = 157,
         FirstJSDocNode = 301,
-        LastJSDocNode = 333,
-        FirstJSDocTagNode = 314,
-        LastJSDocTagNode = 333,
+        LastJSDocNode = 335,
+        FirstJSDocTagNode = 316,
+        LastJSDocTagNode = 335,
     }
     export type TriviaSyntaxKind = SyntaxKind.SingleLineCommentTrivia | SyntaxKind.MultiLineCommentTrivia | SyntaxKind.NewLineTrivia | SyntaxKind.WhitespaceTrivia | SyntaxKind.ShebangTrivia | SyntaxKind.ConflictMarkerTrivia;
     export type LiteralSyntaxKind = SyntaxKind.NumericLiteral | SyntaxKind.BigIntLiteral | SyntaxKind.StringLiteral | SyntaxKind.JsxText | SyntaxKind.JsxTextAllWhiteSpaces | SyntaxKind.RegularExpressionLiteral | SyntaxKind.NoSubstitutionTemplateLiteral;
@@ -1743,12 +1745,21 @@ declare namespace ts {
         readonly kind: SyntaxKind.JSDocComment;
         readonly parent: HasJSDoc;
         readonly tags?: NodeArray<JSDocTag>;
-        readonly comment?: string;
+        readonly comment?: NodeArray<JSDocText | JSDocLink>;
     }
     export interface JSDocTag extends Node {
         readonly parent: JSDoc | JSDocTypeLiteral;
         readonly tagName: Identifier;
-        readonly comment?: string;
+        readonly comment?: NodeArray<JSDocText | JSDocLink>;
+    }
+    export interface JSDocLink extends Node {
+        readonly kind: SyntaxKind.JSDocLink;
+        readonly name?: EntityName;
+        text: string;
+    }
+    export interface JSDocText extends Node {
+        readonly kind: SyntaxKind.JSDocText;
+        text: string;
     }
     export interface JSDocUnknownTag extends JSDocTag {
         readonly kind: SyntaxKind.JSDocTag;
@@ -3479,52 +3490,56 @@ declare namespace ts {
         updateJSDocTypeExpression(node: JSDocTypeExpression, type: TypeNode): JSDocTypeExpression;
         createJSDocNameReference(name: EntityName): JSDocNameReference;
         updateJSDocNameReference(node: JSDocNameReference, name: EntityName): JSDocNameReference;
+        createJSDocLink(name: EntityName | undefined, text: string): JSDocLink;
+        updateJSDocLink(node: JSDocLink, name: EntityName | undefined, text: string): JSDocLink;
         createJSDocTypeLiteral(jsDocPropertyTags?: readonly JSDocPropertyLikeTag[], isArrayType?: boolean): JSDocTypeLiteral;
         updateJSDocTypeLiteral(node: JSDocTypeLiteral, jsDocPropertyTags: readonly JSDocPropertyLikeTag[] | undefined, isArrayType: boolean | undefined): JSDocTypeLiteral;
         createJSDocSignature(typeParameters: readonly JSDocTemplateTag[] | undefined, parameters: readonly JSDocParameterTag[], type?: JSDocReturnTag): JSDocSignature;
         updateJSDocSignature(node: JSDocSignature, typeParameters: readonly JSDocTemplateTag[] | undefined, parameters: readonly JSDocParameterTag[], type: JSDocReturnTag | undefined): JSDocSignature;
-        createJSDocTemplateTag(tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment?: string): JSDocTemplateTag;
-        updateJSDocTemplateTag(node: JSDocTemplateTag, tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment: string | undefined): JSDocTemplateTag;
-        createJSDocTypedefTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression | JSDocTypeLiteral, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string): JSDocTypedefTag;
-        updateJSDocTypedefTag(node: JSDocTypedefTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | JSDocTypeLiteral | undefined, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | undefined): JSDocTypedefTag;
-        createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocParameterTag;
-        updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocParameterTag;
-        createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocPropertyTag;
-        updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocPropertyTag;
-        createJSDocTypeTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string): JSDocTypeTag;
-        updateJSDocTypeTag(node: JSDocTypeTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | undefined): JSDocTypeTag;
-        createJSDocSeeTag(tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string): JSDocSeeTag;
-        updateJSDocSeeTag(node: JSDocSeeTag, tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string): JSDocSeeTag;
-        createJSDocReturnTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression, comment?: string): JSDocReturnTag;
-        updateJSDocReturnTag(node: JSDocReturnTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | undefined, comment: string | undefined): JSDocReturnTag;
-        createJSDocThisTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string): JSDocThisTag;
-        updateJSDocThisTag(node: JSDocThisTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | undefined, comment: string | undefined): JSDocThisTag;
-        createJSDocEnumTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string): JSDocEnumTag;
-        updateJSDocEnumTag(node: JSDocEnumTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | undefined): JSDocEnumTag;
-        createJSDocCallbackTag(tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string): JSDocCallbackTag;
-        updateJSDocCallbackTag(node: JSDocCallbackTag, tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | undefined): JSDocCallbackTag;
-        createJSDocAugmentsTag(tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment?: string): JSDocAugmentsTag;
-        updateJSDocAugmentsTag(node: JSDocAugmentsTag, tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment: string | undefined): JSDocAugmentsTag;
-        createJSDocImplementsTag(tagName: Identifier | undefined, className: JSDocImplementsTag["class"], comment?: string): JSDocImplementsTag;
-        updateJSDocImplementsTag(node: JSDocImplementsTag, tagName: Identifier | undefined, className: JSDocImplementsTag["class"], comment: string | undefined): JSDocImplementsTag;
-        createJSDocAuthorTag(tagName: Identifier | undefined, comment?: string): JSDocAuthorTag;
-        updateJSDocAuthorTag(node: JSDocAuthorTag, tagName: Identifier | undefined, comment: string | undefined): JSDocAuthorTag;
-        createJSDocClassTag(tagName: Identifier | undefined, comment?: string): JSDocClassTag;
-        updateJSDocClassTag(node: JSDocClassTag, tagName: Identifier | undefined, comment: string | undefined): JSDocClassTag;
-        createJSDocPublicTag(tagName: Identifier | undefined, comment?: string): JSDocPublicTag;
-        updateJSDocPublicTag(node: JSDocPublicTag, tagName: Identifier | undefined, comment: string | undefined): JSDocPublicTag;
-        createJSDocPrivateTag(tagName: Identifier | undefined, comment?: string): JSDocPrivateTag;
-        updateJSDocPrivateTag(node: JSDocPrivateTag, tagName: Identifier | undefined, comment: string | undefined): JSDocPrivateTag;
-        createJSDocProtectedTag(tagName: Identifier | undefined, comment?: string): JSDocProtectedTag;
-        updateJSDocProtectedTag(node: JSDocProtectedTag, tagName: Identifier | undefined, comment: string | undefined): JSDocProtectedTag;
-        createJSDocReadonlyTag(tagName: Identifier | undefined, comment?: string): JSDocReadonlyTag;
-        updateJSDocReadonlyTag(node: JSDocReadonlyTag, tagName: Identifier | undefined, comment: string | undefined): JSDocReadonlyTag;
-        createJSDocUnknownTag(tagName: Identifier, comment?: string): JSDocUnknownTag;
-        updateJSDocUnknownTag(node: JSDocUnknownTag, tagName: Identifier, comment: string | undefined): JSDocUnknownTag;
-        createJSDocDeprecatedTag(tagName: Identifier, comment?: string): JSDocDeprecatedTag;
-        updateJSDocDeprecatedTag(node: JSDocDeprecatedTag, tagName: Identifier, comment?: string): JSDocDeprecatedTag;
-        createJSDocComment(comment?: string | undefined, tags?: readonly JSDocTag[] | undefined): JSDoc;
-        updateJSDocComment(node: JSDoc, comment: string | undefined, tags: readonly JSDocTag[] | undefined): JSDoc;
+        createJSDocTemplateTag(tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocTemplateTag;
+        updateJSDocTemplateTag(node: JSDocTemplateTag, tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocTemplateTag;
+        createJSDocTypedefTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression | JSDocTypeLiteral, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocTypedefTag;
+        updateJSDocTypedefTag(node: JSDocTypedefTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | JSDocTypeLiteral | undefined, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocTypedefTag;
+        createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocParameterTag;
+        updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocParameterTag;
+        createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocPropertyTag;
+        updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocPropertyTag;
+        createJSDocTypeTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocTypeTag;
+        updateJSDocTypeTag(node: JSDocTypeTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocTypeTag;
+        createJSDocSeeTag(tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocSeeTag;
+        updateJSDocSeeTag(node: JSDocSeeTag, tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocSeeTag;
+        createJSDocReturnTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocReturnTag;
+        updateJSDocReturnTag(node: JSDocReturnTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocReturnTag;
+        createJSDocThisTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocThisTag;
+        updateJSDocThisTag(node: JSDocThisTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocThisTag;
+        createJSDocEnumTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocEnumTag;
+        updateJSDocEnumTag(node: JSDocEnumTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocEnumTag;
+        createJSDocCallbackTag(tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocCallbackTag;
+        updateJSDocCallbackTag(node: JSDocCallbackTag, tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocCallbackTag;
+        createJSDocAugmentsTag(tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocAugmentsTag;
+        updateJSDocAugmentsTag(node: JSDocAugmentsTag, tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocAugmentsTag;
+        createJSDocImplementsTag(tagName: Identifier | undefined, className: JSDocImplementsTag["class"], comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocImplementsTag;
+        updateJSDocImplementsTag(node: JSDocImplementsTag, tagName: Identifier | undefined, className: JSDocImplementsTag["class"], comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocImplementsTag;
+        createJSDocAuthorTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocAuthorTag;
+        updateJSDocAuthorTag(node: JSDocAuthorTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocAuthorTag;
+        createJSDocClassTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocClassTag;
+        updateJSDocClassTag(node: JSDocClassTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocClassTag;
+        createJSDocPublicTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocPublicTag;
+        updateJSDocPublicTag(node: JSDocPublicTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocPublicTag;
+        createJSDocPrivateTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocPrivateTag;
+        updateJSDocPrivateTag(node: JSDocPrivateTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocPrivateTag;
+        createJSDocProtectedTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocProtectedTag;
+        updateJSDocProtectedTag(node: JSDocProtectedTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocProtectedTag;
+        createJSDocReadonlyTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocReadonlyTag;
+        updateJSDocReadonlyTag(node: JSDocReadonlyTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocReadonlyTag;
+        createJSDocUnknownTag(tagName: Identifier, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocUnknownTag;
+        updateJSDocUnknownTag(node: JSDocUnknownTag, tagName: Identifier, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocUnknownTag;
+        createJSDocDeprecatedTag(tagName: Identifier, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocDeprecatedTag;
+        updateJSDocDeprecatedTag(node: JSDocDeprecatedTag, tagName: Identifier, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocDeprecatedTag;
+        createJSDocText(text: string): JSDocText;
+        updateJSDocText(node: JSDocText, text: string): JSDocText;
+        createJSDocComment(comment?: string | NodeArray<JSDocText | JSDocLink> | undefined, tags?: readonly JSDocTag[] | undefined): JSDoc;
+        updateJSDocComment(node: JSDoc, comment: string | NodeArray<JSDocText | JSDocLink> | undefined, tags: readonly JSDocTag[] | undefined): JSDoc;
         createJsxElement(openingElement: JsxOpeningElement, children: readonly JsxChild[], closingElement: JsxClosingElement): JsxElement;
         updateJsxElement(node: JsxElement, openingElement: JsxOpeningElement, children: readonly JsxChild[], closingElement: JsxClosingElement): JsxElement;
         createJsxSelfClosingElement(tagName: JsxTagNameExpression, typeArguments: readonly TypeNode[] | undefined, attributes: JsxAttributes): JsxSelfClosingElement;
@@ -4207,6 +4222,8 @@ declare namespace ts {
     function getAllJSDocTags<T extends JSDocTag>(node: Node, predicate: (tag: JSDocTag) => tag is T): readonly T[];
     /** Gets all JSDoc tags of a specified kind */
     function getAllJSDocTagsOfKind(node: Node, kind: SyntaxKind): readonly JSDocTag[];
+    /** Gets the text of a jsdoc comment, flattening links to their text. */
+    function getTextOfJSDocComment(comment?: NodeArray<JSDocText | JSDocLink>): string | undefined;
     /**
      * Gets the effective type parameters. If the node was parsed in a
      * JavaScript file, gets the type parameters from the `@template` tag from JSDoc.
@@ -4526,6 +4543,7 @@ declare namespace ts {
     function isUnparsedSource(node: Node): node is UnparsedSource;
     function isJSDocTypeExpression(node: Node): node is JSDocTypeExpression;
     function isJSDocNameReference(node: Node): node is JSDocNameReference;
+    function isJSDocLink(node: Node): node is JSDocLink;
     function isJSDocAllType(node: Node): node is JSDocAllType;
     function isJSDocUnknownType(node: Node): node is JSDocUnknownType;
     function isJSDocNullableType(node: Node): node is JSDocNullableType;
@@ -5329,7 +5347,7 @@ declare namespace ts {
         getName(): string;
         getDeclarations(): Declaration[] | undefined;
         getDocumentationComment(typeChecker: TypeChecker | undefined): SymbolDisplayPart[];
-        getJsDocTags(): JSDocTagInfo[];
+        getJsDocTags(checker?: TypeChecker): JSDocTagInfo[];
     }
     interface Type {
         getFlags(): TypeFlags;
@@ -6021,15 +6039,21 @@ declare namespace ts {
         typeParameterName = 18,
         enumMemberName = 19,
         functionName = 20,
-        regularExpressionLiteral = 21
+        regularExpressionLiteral = 21,
+        link = 22,
+        linkName = 23,
+        linkText = 24
     }
     interface SymbolDisplayPart {
         text: string;
         kind: string;
     }
+    interface JSDocLinkDisplayPart extends SymbolDisplayPart {
+        target: DocumentSpan;
+    }
     interface JSDocTagInfo {
         name: string;
-        text?: string;
+        text?: SymbolDisplayPart[];
     }
     interface QuickInfo {
         kind: ScriptElementKind;
@@ -6318,7 +6342,13 @@ declare namespace ts {
          */
         jsxAttribute = "JSX attribute",
         /** String literal */
-        string = "string"
+        string = "string",
+        /** Jsdoc @link: in `{@link C link text}`, the before and after text "{@link " and "}" */
+        link = "link",
+        /** Jsdoc @link: in `{@link C link text}`, the entity name "C" */
+        linkName = "link name",
+        /** Jsdoc @link: in `{@link C link text}`, the link text "link text" */
+        linkText = "link text"
     }
     enum ScriptElementKindModifier {
         none = "",
@@ -7302,6 +7332,15 @@ declare namespace ts.server.protocol {
          */
         file: string;
     }
+    interface JSDocTagInfo {
+        /** Name of the JSDoc tag */
+        name: string;
+        /**
+         * Comment text after the JSDoc tag -- the text after the tag name until the next tag or end of comment
+         * Display parts when UserPreferences.displayPartsForJSDoc is true, flattened to string otherwise.
+         */
+        text?: string | SymbolDisplayPart[];
+    }
     interface TextSpanWithContext extends TextSpan {
         contextStart?: Location;
         contextEnd?: Location;
@@ -8022,6 +8061,7 @@ declare namespace ts.server.protocol {
      */
     interface QuickInfoRequest extends FileLocationRequest {
         command: CommandTypes.Quickinfo;
+        arguments: FileLocationRequestArgs;
     }
     /**
      * Body of QuickInfoResponse.
@@ -8049,8 +8089,9 @@ declare namespace ts.server.protocol {
         displayString: string;
         /**
          * Documentation associated with symbol.
+         * Display parts when UserPreferences.displayPartsForJSDoc is true, flattened to string otherwise.
          */
-        documentation: string;
+        documentation: string | SymbolDisplayPart[];
         /**
          * JSDoc tags associated with symbol.
          */
@@ -8240,6 +8281,11 @@ declare namespace ts.server.protocol {
          * The symbol's kind (such as 'className' or 'parameterName' or plain 'text').
          */
         kind: string;
+    }
+    /** A part of a symbol description that links from a jsdoc @link tag to a declaration */
+    interface JSDocLinkDisplayPart extends SymbolDisplayPart {
+        /** The location of the declaration that the @link tag links to. */
+        target: FileSpan;
     }
     /**
      * An item found in a completion response.
@@ -9162,6 +9208,7 @@ declare namespace ts.server.protocol {
         readonly provideRefactorNotApplicableReason?: boolean;
         readonly allowRenameOfImportPath?: boolean;
         readonly includePackageJsonAutoImports?: "auto" | "on" | "off";
+        readonly displayPartsForJSDoc?: boolean;
         readonly generateReturnInDocTemplate?: boolean;
     }
     interface CompilerOptions {
@@ -10137,6 +10184,9 @@ declare namespace ts.server {
         private mapDefinitionInfoLocations;
         private getDefinitionAndBoundSpan;
         private getEmitOutput;
+        private mapJSDocTagInfo;
+        private mapDisplayParts;
+        private mapSignatureHelpItems;
         private mapDefinitionInfo;
         private static mapToOriginalLocation;
         private toFileSpan;
@@ -10723,51 +10773,51 @@ declare namespace ts {
     /** @deprecated Use `factory.createJSDocTypeExpression` or the factory supplied by your transformation context instead. */
     const createJSDocTypeExpression: (type: TypeNode) => JSDocTypeExpression;
     /** @deprecated Use `factory.createJSDocTypeTag` or the factory supplied by your transformation context instead. */
-    const createJSDocTypeTag: (tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | undefined) => JSDocTypeTag;
+    const createJSDocTypeTag: (tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocTypeTag;
     /** @deprecated Use `factory.createJSDocReturnTag` or the factory supplied by your transformation context instead. */
-    const createJSDocReturnTag: (tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression | undefined, comment?: string | undefined) => JSDocReturnTag;
+    const createJSDocReturnTag: (tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocReturnTag;
     /** @deprecated Use `factory.createJSDocThisTag` or the factory supplied by your transformation context instead. */
-    const createJSDocThisTag: (tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | undefined) => JSDocThisTag;
+    const createJSDocThisTag: (tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocThisTag;
     /** @deprecated Use `factory.createJSDocComment` or the factory supplied by your transformation context instead. */
-    const createJSDocComment: (comment?: string | undefined, tags?: readonly JSDocTag[] | undefined) => JSDoc;
+    const createJSDocComment: (comment?: string | NodeArray<JSDocText | JSDocLink> | undefined, tags?: readonly JSDocTag[] | undefined) => JSDoc;
     /** @deprecated Use `factory.createJSDocParameterTag` or the factory supplied by your transformation context instead. */
-    const createJSDocParameterTag: (tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | undefined) => JSDocParameterTag;
+    const createJSDocParameterTag: (tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocParameterTag;
     /** @deprecated Use `factory.createJSDocClassTag` or the factory supplied by your transformation context instead. */
-    const createJSDocClassTag: (tagName: Identifier | undefined, comment?: string | undefined) => JSDocClassTag;
+    const createJSDocClassTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocClassTag;
     /** @deprecated Use `factory.createJSDocAugmentsTag` or the factory supplied by your transformation context instead. */
     const createJSDocAugmentsTag: (tagName: Identifier | undefined, className: ExpressionWithTypeArguments & {
         readonly expression: Identifier | PropertyAccessEntityNameExpression;
-    }, comment?: string | undefined) => JSDocAugmentsTag;
+    }, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocAugmentsTag;
     /** @deprecated Use `factory.createJSDocEnumTag` or the factory supplied by your transformation context instead. */
-    const createJSDocEnumTag: (tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | undefined) => JSDocEnumTag;
+    const createJSDocEnumTag: (tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocEnumTag;
     /** @deprecated Use `factory.createJSDocTemplateTag` or the factory supplied by your transformation context instead. */
-    const createJSDocTemplateTag: (tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment?: string | undefined) => JSDocTemplateTag;
+    const createJSDocTemplateTag: (tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocTemplateTag;
     /** @deprecated Use `factory.createJSDocTypedefTag` or the factory supplied by your transformation context instead. */
-    const createJSDocTypedefTag: (tagName: Identifier | undefined, typeExpression?: JSDocTypeLiteral | JSDocTypeExpression | undefined, fullName?: Identifier | JSDocNamespaceDeclaration | undefined, comment?: string | undefined) => JSDocTypedefTag;
+    const createJSDocTypedefTag: (tagName: Identifier | undefined, typeExpression?: JSDocTypeLiteral | JSDocTypeExpression | undefined, fullName?: Identifier | JSDocNamespaceDeclaration | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocTypedefTag;
     /** @deprecated Use `factory.createJSDocCallbackTag` or the factory supplied by your transformation context instead. */
-    const createJSDocCallbackTag: (tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName?: Identifier | JSDocNamespaceDeclaration | undefined, comment?: string | undefined) => JSDocCallbackTag;
+    const createJSDocCallbackTag: (tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName?: Identifier | JSDocNamespaceDeclaration | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocCallbackTag;
     /** @deprecated Use `factory.createJSDocSignature` or the factory supplied by your transformation context instead. */
     const createJSDocSignature: (typeParameters: readonly JSDocTemplateTag[] | undefined, parameters: readonly JSDocParameterTag[], type?: JSDocReturnTag | undefined) => JSDocSignature;
     /** @deprecated Use `factory.createJSDocPropertyTag` or the factory supplied by your transformation context instead. */
-    const createJSDocPropertyTag: (tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | undefined) => JSDocPropertyTag;
+    const createJSDocPropertyTag: (tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocPropertyTag;
     /** @deprecated Use `factory.createJSDocTypeLiteral` or the factory supplied by your transformation context instead. */
     const createJSDocTypeLiteral: (jsDocPropertyTags?: readonly JSDocPropertyLikeTag[] | undefined, isArrayType?: boolean | undefined) => JSDocTypeLiteral;
     /** @deprecated Use `factory.createJSDocImplementsTag` or the factory supplied by your transformation context instead. */
     const createJSDocImplementsTag: (tagName: Identifier | undefined, className: ExpressionWithTypeArguments & {
         readonly expression: Identifier | PropertyAccessEntityNameExpression;
-    }, comment?: string | undefined) => JSDocImplementsTag;
+    }, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocImplementsTag;
     /** @deprecated Use `factory.createJSDocAuthorTag` or the factory supplied by your transformation context instead. */
-    const createJSDocAuthorTag: (tagName: Identifier | undefined, comment?: string | undefined) => JSDocAuthorTag;
+    const createJSDocAuthorTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocAuthorTag;
     /** @deprecated Use `factory.createJSDocPublicTag` or the factory supplied by your transformation context instead. */
-    const createJSDocPublicTag: (tagName: Identifier | undefined, comment?: string | undefined) => JSDocPublicTag;
+    const createJSDocPublicTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocPublicTag;
     /** @deprecated Use `factory.createJSDocPrivateTag` or the factory supplied by your transformation context instead. */
-    const createJSDocPrivateTag: (tagName: Identifier | undefined, comment?: string | undefined) => JSDocPrivateTag;
+    const createJSDocPrivateTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocPrivateTag;
     /** @deprecated Use `factory.createJSDocProtectedTag` or the factory supplied by your transformation context instead. */
-    const createJSDocProtectedTag: (tagName: Identifier | undefined, comment?: string | undefined) => JSDocProtectedTag;
+    const createJSDocProtectedTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocProtectedTag;
     /** @deprecated Use `factory.createJSDocReadonlyTag` or the factory supplied by your transformation context instead. */
-    const createJSDocReadonlyTag: (tagName: Identifier | undefined, comment?: string | undefined) => JSDocReadonlyTag;
+    const createJSDocReadonlyTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocReadonlyTag;
     /** @deprecated Use `factory.createJSDocUnknownTag` or the factory supplied by your transformation context instead. */
-    const createJSDocTag: (tagName: Identifier, comment?: string | undefined) => JSDocUnknownTag;
+    const createJSDocTag: (tagName: Identifier, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocUnknownTag;
     /** @deprecated Use `factory.createJsxElement` or the factory supplied by your transformation context instead. */
     const createJsxElement: (openingElement: JsxOpeningElement, children: readonly JsxChild[], closingElement: JsxClosingElement) => JsxElement;
     /** @deprecated Use `factory.updateJsxElement` or the factory supplied by your transformation context instead. */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1745,12 +1745,12 @@ declare namespace ts {
         readonly kind: SyntaxKind.JSDocComment;
         readonly parent: HasJSDoc;
         readonly tags?: NodeArray<JSDocTag>;
-        readonly comment?: NodeArray<JSDocText | JSDocLink>;
+        readonly comment?: string | NodeArray<JSDocText | JSDocLink>;
     }
     export interface JSDocTag extends Node {
         readonly parent: JSDoc | JSDocTypeLiteral;
         readonly tagName: Identifier;
-        readonly comment?: NodeArray<JSDocText | JSDocLink>;
+        readonly comment?: string | NodeArray<JSDocText | JSDocLink>;
     }
     export interface JSDocLink extends Node {
         readonly kind: SyntaxKind.JSDocLink;
@@ -4223,7 +4223,7 @@ declare namespace ts {
     /** Gets all JSDoc tags of a specified kind */
     function getAllJSDocTagsOfKind(node: Node, kind: SyntaxKind): readonly JSDocTag[];
     /** Gets the text of a jsdoc comment, flattening links to their text. */
-    function getTextOfJSDocComment(comment?: NodeArray<JSDocText | JSDocLink>): string | undefined;
+    function getTextOfJSDocComment(comment?: string | NodeArray<JSDocText | JSDocLink>): string | undefined;
     /**
      * Gets the effective type parameters. If the node was parsed in a
      * JavaScript file, gets the type parameters from the `@template` tag from JSDoc.

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -416,36 +416,38 @@ declare namespace ts {
         JSDocVariadicType = 309,
         JSDocNamepathType = 310,
         JSDocComment = 311,
-        JSDocTypeLiteral = 312,
-        JSDocSignature = 313,
-        JSDocTag = 314,
-        JSDocAugmentsTag = 315,
-        JSDocImplementsTag = 316,
-        JSDocAuthorTag = 317,
-        JSDocDeprecatedTag = 318,
-        JSDocClassTag = 319,
-        JSDocPublicTag = 320,
-        JSDocPrivateTag = 321,
-        JSDocProtectedTag = 322,
-        JSDocReadonlyTag = 323,
-        JSDocCallbackTag = 324,
-        JSDocEnumTag = 325,
-        JSDocParameterTag = 326,
-        JSDocReturnTag = 327,
-        JSDocThisTag = 328,
-        JSDocTypeTag = 329,
-        JSDocTemplateTag = 330,
-        JSDocTypedefTag = 331,
-        JSDocSeeTag = 332,
-        JSDocPropertyTag = 333,
-        SyntaxList = 334,
-        NotEmittedStatement = 335,
-        PartiallyEmittedExpression = 336,
-        CommaListExpression = 337,
-        MergeDeclarationMarker = 338,
-        EndOfDeclarationMarker = 339,
-        SyntheticReferenceExpression = 340,
-        Count = 341,
+        JSDocText = 312,
+        JSDocTypeLiteral = 313,
+        JSDocSignature = 314,
+        JSDocLink = 315,
+        JSDocTag = 316,
+        JSDocAugmentsTag = 317,
+        JSDocImplementsTag = 318,
+        JSDocAuthorTag = 319,
+        JSDocDeprecatedTag = 320,
+        JSDocClassTag = 321,
+        JSDocPublicTag = 322,
+        JSDocPrivateTag = 323,
+        JSDocProtectedTag = 324,
+        JSDocReadonlyTag = 325,
+        JSDocCallbackTag = 326,
+        JSDocEnumTag = 327,
+        JSDocParameterTag = 328,
+        JSDocReturnTag = 329,
+        JSDocThisTag = 330,
+        JSDocTypeTag = 331,
+        JSDocTemplateTag = 332,
+        JSDocTypedefTag = 333,
+        JSDocSeeTag = 334,
+        JSDocPropertyTag = 335,
+        SyntaxList = 336,
+        NotEmittedStatement = 337,
+        PartiallyEmittedExpression = 338,
+        CommaListExpression = 339,
+        MergeDeclarationMarker = 340,
+        EndOfDeclarationMarker = 341,
+        SyntheticReferenceExpression = 342,
+        Count = 343,
         FirstAssignment = 62,
         LastAssignment = 77,
         FirstCompoundAssignment = 63,
@@ -474,9 +476,9 @@ declare namespace ts {
         LastStatement = 248,
         FirstNode = 157,
         FirstJSDocNode = 301,
-        LastJSDocNode = 333,
-        FirstJSDocTagNode = 314,
-        LastJSDocTagNode = 333,
+        LastJSDocNode = 335,
+        FirstJSDocTagNode = 316,
+        LastJSDocTagNode = 335,
     }
     export type TriviaSyntaxKind = SyntaxKind.SingleLineCommentTrivia | SyntaxKind.MultiLineCommentTrivia | SyntaxKind.NewLineTrivia | SyntaxKind.WhitespaceTrivia | SyntaxKind.ShebangTrivia | SyntaxKind.ConflictMarkerTrivia;
     export type LiteralSyntaxKind = SyntaxKind.NumericLiteral | SyntaxKind.BigIntLiteral | SyntaxKind.StringLiteral | SyntaxKind.JsxText | SyntaxKind.JsxTextAllWhiteSpaces | SyntaxKind.RegularExpressionLiteral | SyntaxKind.NoSubstitutionTemplateLiteral;
@@ -1743,12 +1745,21 @@ declare namespace ts {
         readonly kind: SyntaxKind.JSDocComment;
         readonly parent: HasJSDoc;
         readonly tags?: NodeArray<JSDocTag>;
-        readonly comment?: string;
+        readonly comment?: NodeArray<JSDocText | JSDocLink>;
     }
     export interface JSDocTag extends Node {
         readonly parent: JSDoc | JSDocTypeLiteral;
         readonly tagName: Identifier;
-        readonly comment?: string;
+        readonly comment?: NodeArray<JSDocText | JSDocLink>;
+    }
+    export interface JSDocLink extends Node {
+        readonly kind: SyntaxKind.JSDocLink;
+        readonly name?: EntityName;
+        text: string;
+    }
+    export interface JSDocText extends Node {
+        readonly kind: SyntaxKind.JSDocText;
+        text: string;
     }
     export interface JSDocUnknownTag extends JSDocTag {
         readonly kind: SyntaxKind.JSDocTag;
@@ -3479,52 +3490,56 @@ declare namespace ts {
         updateJSDocTypeExpression(node: JSDocTypeExpression, type: TypeNode): JSDocTypeExpression;
         createJSDocNameReference(name: EntityName): JSDocNameReference;
         updateJSDocNameReference(node: JSDocNameReference, name: EntityName): JSDocNameReference;
+        createJSDocLink(name: EntityName | undefined, text: string): JSDocLink;
+        updateJSDocLink(node: JSDocLink, name: EntityName | undefined, text: string): JSDocLink;
         createJSDocTypeLiteral(jsDocPropertyTags?: readonly JSDocPropertyLikeTag[], isArrayType?: boolean): JSDocTypeLiteral;
         updateJSDocTypeLiteral(node: JSDocTypeLiteral, jsDocPropertyTags: readonly JSDocPropertyLikeTag[] | undefined, isArrayType: boolean | undefined): JSDocTypeLiteral;
         createJSDocSignature(typeParameters: readonly JSDocTemplateTag[] | undefined, parameters: readonly JSDocParameterTag[], type?: JSDocReturnTag): JSDocSignature;
         updateJSDocSignature(node: JSDocSignature, typeParameters: readonly JSDocTemplateTag[] | undefined, parameters: readonly JSDocParameterTag[], type: JSDocReturnTag | undefined): JSDocSignature;
-        createJSDocTemplateTag(tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment?: string): JSDocTemplateTag;
-        updateJSDocTemplateTag(node: JSDocTemplateTag, tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment: string | undefined): JSDocTemplateTag;
-        createJSDocTypedefTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression | JSDocTypeLiteral, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string): JSDocTypedefTag;
-        updateJSDocTypedefTag(node: JSDocTypedefTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | JSDocTypeLiteral | undefined, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | undefined): JSDocTypedefTag;
-        createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocParameterTag;
-        updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocParameterTag;
-        createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string): JSDocPropertyTag;
-        updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | undefined): JSDocPropertyTag;
-        createJSDocTypeTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string): JSDocTypeTag;
-        updateJSDocTypeTag(node: JSDocTypeTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | undefined): JSDocTypeTag;
-        createJSDocSeeTag(tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string): JSDocSeeTag;
-        updateJSDocSeeTag(node: JSDocSeeTag, tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string): JSDocSeeTag;
-        createJSDocReturnTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression, comment?: string): JSDocReturnTag;
-        updateJSDocReturnTag(node: JSDocReturnTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | undefined, comment: string | undefined): JSDocReturnTag;
-        createJSDocThisTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string): JSDocThisTag;
-        updateJSDocThisTag(node: JSDocThisTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | undefined, comment: string | undefined): JSDocThisTag;
-        createJSDocEnumTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string): JSDocEnumTag;
-        updateJSDocEnumTag(node: JSDocEnumTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | undefined): JSDocEnumTag;
-        createJSDocCallbackTag(tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string): JSDocCallbackTag;
-        updateJSDocCallbackTag(node: JSDocCallbackTag, tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | undefined): JSDocCallbackTag;
-        createJSDocAugmentsTag(tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment?: string): JSDocAugmentsTag;
-        updateJSDocAugmentsTag(node: JSDocAugmentsTag, tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment: string | undefined): JSDocAugmentsTag;
-        createJSDocImplementsTag(tagName: Identifier | undefined, className: JSDocImplementsTag["class"], comment?: string): JSDocImplementsTag;
-        updateJSDocImplementsTag(node: JSDocImplementsTag, tagName: Identifier | undefined, className: JSDocImplementsTag["class"], comment: string | undefined): JSDocImplementsTag;
-        createJSDocAuthorTag(tagName: Identifier | undefined, comment?: string): JSDocAuthorTag;
-        updateJSDocAuthorTag(node: JSDocAuthorTag, tagName: Identifier | undefined, comment: string | undefined): JSDocAuthorTag;
-        createJSDocClassTag(tagName: Identifier | undefined, comment?: string): JSDocClassTag;
-        updateJSDocClassTag(node: JSDocClassTag, tagName: Identifier | undefined, comment: string | undefined): JSDocClassTag;
-        createJSDocPublicTag(tagName: Identifier | undefined, comment?: string): JSDocPublicTag;
-        updateJSDocPublicTag(node: JSDocPublicTag, tagName: Identifier | undefined, comment: string | undefined): JSDocPublicTag;
-        createJSDocPrivateTag(tagName: Identifier | undefined, comment?: string): JSDocPrivateTag;
-        updateJSDocPrivateTag(node: JSDocPrivateTag, tagName: Identifier | undefined, comment: string | undefined): JSDocPrivateTag;
-        createJSDocProtectedTag(tagName: Identifier | undefined, comment?: string): JSDocProtectedTag;
-        updateJSDocProtectedTag(node: JSDocProtectedTag, tagName: Identifier | undefined, comment: string | undefined): JSDocProtectedTag;
-        createJSDocReadonlyTag(tagName: Identifier | undefined, comment?: string): JSDocReadonlyTag;
-        updateJSDocReadonlyTag(node: JSDocReadonlyTag, tagName: Identifier | undefined, comment: string | undefined): JSDocReadonlyTag;
-        createJSDocUnknownTag(tagName: Identifier, comment?: string): JSDocUnknownTag;
-        updateJSDocUnknownTag(node: JSDocUnknownTag, tagName: Identifier, comment: string | undefined): JSDocUnknownTag;
-        createJSDocDeprecatedTag(tagName: Identifier, comment?: string): JSDocDeprecatedTag;
-        updateJSDocDeprecatedTag(node: JSDocDeprecatedTag, tagName: Identifier, comment?: string): JSDocDeprecatedTag;
-        createJSDocComment(comment?: string | undefined, tags?: readonly JSDocTag[] | undefined): JSDoc;
-        updateJSDocComment(node: JSDoc, comment: string | undefined, tags: readonly JSDocTag[] | undefined): JSDoc;
+        createJSDocTemplateTag(tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocTemplateTag;
+        updateJSDocTemplateTag(node: JSDocTemplateTag, tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocTemplateTag;
+        createJSDocTypedefTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression | JSDocTypeLiteral, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocTypedefTag;
+        updateJSDocTypedefTag(node: JSDocTypedefTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | JSDocTypeLiteral | undefined, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocTypedefTag;
+        createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocParameterTag;
+        updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocParameterTag;
+        createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocPropertyTag;
+        updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocPropertyTag;
+        createJSDocTypeTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocTypeTag;
+        updateJSDocTypeTag(node: JSDocTypeTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocTypeTag;
+        createJSDocSeeTag(tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocSeeTag;
+        updateJSDocSeeTag(node: JSDocSeeTag, tagName: Identifier | undefined, nameExpression: JSDocNameReference | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocSeeTag;
+        createJSDocReturnTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocReturnTag;
+        updateJSDocReturnTag(node: JSDocReturnTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocReturnTag;
+        createJSDocThisTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocThisTag;
+        updateJSDocThisTag(node: JSDocThisTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocThisTag;
+        createJSDocEnumTag(tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocEnumTag;
+        updateJSDocEnumTag(node: JSDocEnumTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocEnumTag;
+        createJSDocCallbackTag(tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocCallbackTag;
+        updateJSDocCallbackTag(node: JSDocCallbackTag, tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocCallbackTag;
+        createJSDocAugmentsTag(tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocAugmentsTag;
+        updateJSDocAugmentsTag(node: JSDocAugmentsTag, tagName: Identifier | undefined, className: JSDocAugmentsTag["class"], comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocAugmentsTag;
+        createJSDocImplementsTag(tagName: Identifier | undefined, className: JSDocImplementsTag["class"], comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocImplementsTag;
+        updateJSDocImplementsTag(node: JSDocImplementsTag, tagName: Identifier | undefined, className: JSDocImplementsTag["class"], comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocImplementsTag;
+        createJSDocAuthorTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocAuthorTag;
+        updateJSDocAuthorTag(node: JSDocAuthorTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocAuthorTag;
+        createJSDocClassTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocClassTag;
+        updateJSDocClassTag(node: JSDocClassTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocClassTag;
+        createJSDocPublicTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocPublicTag;
+        updateJSDocPublicTag(node: JSDocPublicTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocPublicTag;
+        createJSDocPrivateTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocPrivateTag;
+        updateJSDocPrivateTag(node: JSDocPrivateTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocPrivateTag;
+        createJSDocProtectedTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocProtectedTag;
+        updateJSDocProtectedTag(node: JSDocProtectedTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocProtectedTag;
+        createJSDocReadonlyTag(tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocReadonlyTag;
+        updateJSDocReadonlyTag(node: JSDocReadonlyTag, tagName: Identifier | undefined, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocReadonlyTag;
+        createJSDocUnknownTag(tagName: Identifier, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocUnknownTag;
+        updateJSDocUnknownTag(node: JSDocUnknownTag, tagName: Identifier, comment: string | NodeArray<JSDocText | JSDocLink> | undefined): JSDocUnknownTag;
+        createJSDocDeprecatedTag(tagName: Identifier, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocDeprecatedTag;
+        updateJSDocDeprecatedTag(node: JSDocDeprecatedTag, tagName: Identifier, comment?: string | NodeArray<JSDocText | JSDocLink>): JSDocDeprecatedTag;
+        createJSDocText(text: string): JSDocText;
+        updateJSDocText(node: JSDocText, text: string): JSDocText;
+        createJSDocComment(comment?: string | NodeArray<JSDocText | JSDocLink> | undefined, tags?: readonly JSDocTag[] | undefined): JSDoc;
+        updateJSDocComment(node: JSDoc, comment: string | NodeArray<JSDocText | JSDocLink> | undefined, tags: readonly JSDocTag[] | undefined): JSDoc;
         createJsxElement(openingElement: JsxOpeningElement, children: readonly JsxChild[], closingElement: JsxClosingElement): JsxElement;
         updateJsxElement(node: JsxElement, openingElement: JsxOpeningElement, children: readonly JsxChild[], closingElement: JsxClosingElement): JsxElement;
         createJsxSelfClosingElement(tagName: JsxTagNameExpression, typeArguments: readonly TypeNode[] | undefined, attributes: JsxAttributes): JsxSelfClosingElement;
@@ -4207,6 +4222,8 @@ declare namespace ts {
     function getAllJSDocTags<T extends JSDocTag>(node: Node, predicate: (tag: JSDocTag) => tag is T): readonly T[];
     /** Gets all JSDoc tags of a specified kind */
     function getAllJSDocTagsOfKind(node: Node, kind: SyntaxKind): readonly JSDocTag[];
+    /** Gets the text of a jsdoc comment, flattening links to their text. */
+    function getTextOfJSDocComment(comment?: NodeArray<JSDocText | JSDocLink>): string | undefined;
     /**
      * Gets the effective type parameters. If the node was parsed in a
      * JavaScript file, gets the type parameters from the `@template` tag from JSDoc.
@@ -4526,6 +4543,7 @@ declare namespace ts {
     function isUnparsedSource(node: Node): node is UnparsedSource;
     function isJSDocTypeExpression(node: Node): node is JSDocTypeExpression;
     function isJSDocNameReference(node: Node): node is JSDocNameReference;
+    function isJSDocLink(node: Node): node is JSDocLink;
     function isJSDocAllType(node: Node): node is JSDocAllType;
     function isJSDocUnknownType(node: Node): node is JSDocUnknownType;
     function isJSDocNullableType(node: Node): node is JSDocNullableType;
@@ -5329,7 +5347,7 @@ declare namespace ts {
         getName(): string;
         getDeclarations(): Declaration[] | undefined;
         getDocumentationComment(typeChecker: TypeChecker | undefined): SymbolDisplayPart[];
-        getJsDocTags(): JSDocTagInfo[];
+        getJsDocTags(checker?: TypeChecker): JSDocTagInfo[];
     }
     interface Type {
         getFlags(): TypeFlags;
@@ -6021,15 +6039,21 @@ declare namespace ts {
         typeParameterName = 18,
         enumMemberName = 19,
         functionName = 20,
-        regularExpressionLiteral = 21
+        regularExpressionLiteral = 21,
+        link = 22,
+        linkName = 23,
+        linkText = 24
     }
     interface SymbolDisplayPart {
         text: string;
         kind: string;
     }
+    interface JSDocLinkDisplayPart extends SymbolDisplayPart {
+        target: DocumentSpan;
+    }
     interface JSDocTagInfo {
         name: string;
-        text?: string;
+        text?: SymbolDisplayPart[];
     }
     interface QuickInfo {
         kind: ScriptElementKind;
@@ -6318,7 +6342,13 @@ declare namespace ts {
          */
         jsxAttribute = "JSX attribute",
         /** String literal */
-        string = "string"
+        string = "string",
+        /** Jsdoc @link: in `{@link C link text}`, the before and after text "{@link " and "}" */
+        link = "link",
+        /** Jsdoc @link: in `{@link C link text}`, the entity name "C" */
+        linkName = "link name",
+        /** Jsdoc @link: in `{@link C link text}`, the link text "link text" */
+        linkText = "link text"
     }
     enum ScriptElementKindModifier {
         none = "",
@@ -6979,51 +7009,51 @@ declare namespace ts {
     /** @deprecated Use `factory.createJSDocTypeExpression` or the factory supplied by your transformation context instead. */
     const createJSDocTypeExpression: (type: TypeNode) => JSDocTypeExpression;
     /** @deprecated Use `factory.createJSDocTypeTag` or the factory supplied by your transformation context instead. */
-    const createJSDocTypeTag: (tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | undefined) => JSDocTypeTag;
+    const createJSDocTypeTag: (tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocTypeTag;
     /** @deprecated Use `factory.createJSDocReturnTag` or the factory supplied by your transformation context instead. */
-    const createJSDocReturnTag: (tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression | undefined, comment?: string | undefined) => JSDocReturnTag;
+    const createJSDocReturnTag: (tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocReturnTag;
     /** @deprecated Use `factory.createJSDocThisTag` or the factory supplied by your transformation context instead. */
-    const createJSDocThisTag: (tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | undefined) => JSDocThisTag;
+    const createJSDocThisTag: (tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocThisTag;
     /** @deprecated Use `factory.createJSDocComment` or the factory supplied by your transformation context instead. */
-    const createJSDocComment: (comment?: string | undefined, tags?: readonly JSDocTag[] | undefined) => JSDoc;
+    const createJSDocComment: (comment?: string | NodeArray<JSDocText | JSDocLink> | undefined, tags?: readonly JSDocTag[] | undefined) => JSDoc;
     /** @deprecated Use `factory.createJSDocParameterTag` or the factory supplied by your transformation context instead. */
-    const createJSDocParameterTag: (tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | undefined) => JSDocParameterTag;
+    const createJSDocParameterTag: (tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocParameterTag;
     /** @deprecated Use `factory.createJSDocClassTag` or the factory supplied by your transformation context instead. */
-    const createJSDocClassTag: (tagName: Identifier | undefined, comment?: string | undefined) => JSDocClassTag;
+    const createJSDocClassTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocClassTag;
     /** @deprecated Use `factory.createJSDocAugmentsTag` or the factory supplied by your transformation context instead. */
     const createJSDocAugmentsTag: (tagName: Identifier | undefined, className: ExpressionWithTypeArguments & {
         readonly expression: Identifier | PropertyAccessEntityNameExpression;
-    }, comment?: string | undefined) => JSDocAugmentsTag;
+    }, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocAugmentsTag;
     /** @deprecated Use `factory.createJSDocEnumTag` or the factory supplied by your transformation context instead. */
-    const createJSDocEnumTag: (tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | undefined) => JSDocEnumTag;
+    const createJSDocEnumTag: (tagName: Identifier | undefined, typeExpression: JSDocTypeExpression, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocEnumTag;
     /** @deprecated Use `factory.createJSDocTemplateTag` or the factory supplied by your transformation context instead. */
-    const createJSDocTemplateTag: (tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment?: string | undefined) => JSDocTemplateTag;
+    const createJSDocTemplateTag: (tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocTemplateTag;
     /** @deprecated Use `factory.createJSDocTypedefTag` or the factory supplied by your transformation context instead. */
-    const createJSDocTypedefTag: (tagName: Identifier | undefined, typeExpression?: JSDocTypeLiteral | JSDocTypeExpression | undefined, fullName?: Identifier | JSDocNamespaceDeclaration | undefined, comment?: string | undefined) => JSDocTypedefTag;
+    const createJSDocTypedefTag: (tagName: Identifier | undefined, typeExpression?: JSDocTypeLiteral | JSDocTypeExpression | undefined, fullName?: Identifier | JSDocNamespaceDeclaration | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocTypedefTag;
     /** @deprecated Use `factory.createJSDocCallbackTag` or the factory supplied by your transformation context instead. */
-    const createJSDocCallbackTag: (tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName?: Identifier | JSDocNamespaceDeclaration | undefined, comment?: string | undefined) => JSDocCallbackTag;
+    const createJSDocCallbackTag: (tagName: Identifier | undefined, typeExpression: JSDocSignature, fullName?: Identifier | JSDocNamespaceDeclaration | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocCallbackTag;
     /** @deprecated Use `factory.createJSDocSignature` or the factory supplied by your transformation context instead. */
     const createJSDocSignature: (typeParameters: readonly JSDocTemplateTag[] | undefined, parameters: readonly JSDocParameterTag[], type?: JSDocReturnTag | undefined) => JSDocSignature;
     /** @deprecated Use `factory.createJSDocPropertyTag` or the factory supplied by your transformation context instead. */
-    const createJSDocPropertyTag: (tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | undefined) => JSDocPropertyTag;
+    const createJSDocPropertyTag: (tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression | undefined, isNameFirst?: boolean | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocPropertyTag;
     /** @deprecated Use `factory.createJSDocTypeLiteral` or the factory supplied by your transformation context instead. */
     const createJSDocTypeLiteral: (jsDocPropertyTags?: readonly JSDocPropertyLikeTag[] | undefined, isArrayType?: boolean | undefined) => JSDocTypeLiteral;
     /** @deprecated Use `factory.createJSDocImplementsTag` or the factory supplied by your transformation context instead. */
     const createJSDocImplementsTag: (tagName: Identifier | undefined, className: ExpressionWithTypeArguments & {
         readonly expression: Identifier | PropertyAccessEntityNameExpression;
-    }, comment?: string | undefined) => JSDocImplementsTag;
+    }, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocImplementsTag;
     /** @deprecated Use `factory.createJSDocAuthorTag` or the factory supplied by your transformation context instead. */
-    const createJSDocAuthorTag: (tagName: Identifier | undefined, comment?: string | undefined) => JSDocAuthorTag;
+    const createJSDocAuthorTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocAuthorTag;
     /** @deprecated Use `factory.createJSDocPublicTag` or the factory supplied by your transformation context instead. */
-    const createJSDocPublicTag: (tagName: Identifier | undefined, comment?: string | undefined) => JSDocPublicTag;
+    const createJSDocPublicTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocPublicTag;
     /** @deprecated Use `factory.createJSDocPrivateTag` or the factory supplied by your transformation context instead. */
-    const createJSDocPrivateTag: (tagName: Identifier | undefined, comment?: string | undefined) => JSDocPrivateTag;
+    const createJSDocPrivateTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocPrivateTag;
     /** @deprecated Use `factory.createJSDocProtectedTag` or the factory supplied by your transformation context instead. */
-    const createJSDocProtectedTag: (tagName: Identifier | undefined, comment?: string | undefined) => JSDocProtectedTag;
+    const createJSDocProtectedTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocProtectedTag;
     /** @deprecated Use `factory.createJSDocReadonlyTag` or the factory supplied by your transformation context instead. */
-    const createJSDocReadonlyTag: (tagName: Identifier | undefined, comment?: string | undefined) => JSDocReadonlyTag;
+    const createJSDocReadonlyTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocReadonlyTag;
     /** @deprecated Use `factory.createJSDocUnknownTag` or the factory supplied by your transformation context instead. */
-    const createJSDocTag: (tagName: Identifier, comment?: string | undefined) => JSDocUnknownTag;
+    const createJSDocTag: (tagName: Identifier, comment?: string | NodeArray<JSDocText | JSDocLink> | undefined) => JSDocUnknownTag;
     /** @deprecated Use `factory.createJsxElement` or the factory supplied by your transformation context instead. */
     const createJsxElement: (openingElement: JsxOpeningElement, children: readonly JsxChild[], closingElement: JsxClosingElement) => JsxElement;
     /** @deprecated Use `factory.updateJsxElement` or the factory supplied by your transformation context instead. */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1745,12 +1745,12 @@ declare namespace ts {
         readonly kind: SyntaxKind.JSDocComment;
         readonly parent: HasJSDoc;
         readonly tags?: NodeArray<JSDocTag>;
-        readonly comment?: NodeArray<JSDocText | JSDocLink>;
+        readonly comment?: string | NodeArray<JSDocText | JSDocLink>;
     }
     export interface JSDocTag extends Node {
         readonly parent: JSDoc | JSDocTypeLiteral;
         readonly tagName: Identifier;
-        readonly comment?: NodeArray<JSDocText | JSDocLink>;
+        readonly comment?: string | NodeArray<JSDocText | JSDocLink>;
     }
     export interface JSDocLink extends Node {
         readonly kind: SyntaxKind.JSDocLink;
@@ -4223,7 +4223,7 @@ declare namespace ts {
     /** Gets all JSDoc tags of a specified kind */
     function getAllJSDocTagsOfKind(node: Node, kind: SyntaxKind): readonly JSDocTag[];
     /** Gets the text of a jsdoc comment, flattening links to their text. */
-    function getTextOfJSDocComment(comment?: NodeArray<JSDocText | JSDocLink>): string | undefined;
+    function getTextOfJSDocComment(comment?: string | NodeArray<JSDocText | JSDocLink>): string | undefined;
     /**
      * Gets the effective type parameters. If the node was parsed in a
      * JavaScript file, gets the type parameters from the `@template` tag from JSDoc.

--- a/tests/baselines/reference/completionEntryForUnionMethod.baseline
+++ b/tests/baselines/reference/completionEntryForUnionMethod.baseline
@@ -1,0 +1,6133 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/completionEntryForUnionMethod.ts",
+      "position": 41,
+      "name": ""
+    },
+    "completionList": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": true,
+      "isNewIdentifierLocation": false,
+      "optionalReplacementSpan": {
+        "start": 38,
+        "length": 3
+      },
+      "entries": [
+        {
+          "name": "length",
+          "kind": "property",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "property",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "length",
+              "kind": "propertyName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Gets or sets the length of the array. This is a number one higher than the highest index in the array.",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "toString",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "toString",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Returns a string representation of an array.",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "toLocaleString",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "toLocaleString",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Returns a string representation of an array. The elements are converted to string using their toLocalString methods.",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "pop",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "pop",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "|",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Removes the last element from an array and returns it.\r\nIf the array is empty, undefined is returned and the array is not modified.",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "push",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "push",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "items",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "never",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Appends new elements to the end of an array, and returns the new length of the array.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "items",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "New elements to add to the array.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "concat",
+          "kind": "property",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "property",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "concat",
+              "kind": "propertyName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "{",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "...",
+              "kind": "punctuation"
+            },
+            {
+              "text": "items",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "ConcatArray",
+              "kind": "interfaceName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "...",
+              "kind": "punctuation"
+            },
+            {
+              "text": "items",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "|",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "ConcatArray",
+              "kind": "interfaceName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "}",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "|",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "{",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "...",
+              "kind": "punctuation"
+            },
+            {
+              "text": "items",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "ConcatArray",
+              "kind": "interfaceName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "...",
+              "kind": "punctuation"
+            },
+            {
+              "text": "items",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "|",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "ConcatArray",
+              "kind": "interfaceName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "...",
+              "kind": "text"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "}",
+              "kind": "punctuation"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Combines two or more arrays.\r\nThis method returns a new array without modifying any existing arrays.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "items",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Additional arrays and/or items to add to the end of the array.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "items",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Additional arrays and/or items to add to the end of the array.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "join",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "join",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "separator",
+              "kind": "parameterName"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Adds all the elements of an array into a string, separated by the specified separator string.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "separator",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string used to separate one element of the array from the next in the resulting string. If omitted, the array elements are separated with a comma.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "reverse",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "reverse",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "|",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Reverses the elements in an array in place.\r\nThis method mutates the array and returns a reference to the same array.",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "shift",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "shift",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "|",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Removes the first element from an array and returns it.\r\nIf the array is empty, undefined is returned and the array is not modified.",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "slice",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "slice",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "start",
+              "kind": "parameterName"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "end",
+              "kind": "parameterName"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "|",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Returns a copy of a section of an array.\r\nFor both start and end, a negative index can be used to indicate an offset from the end of the array.\r\nFor example, -2 refers to the second to last element of the array.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "start",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "The beginning index of the specified portion of the array.\r\nIf start is undefined, then the slice begins at index 0.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "end",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "The end index of the specified portion of the array. This is exclusive of the element at the index 'end'.\r\nIf end is undefined, then the slice extends to the end of the array.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "sort",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "sort",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "compareFn",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "a",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "b",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "&",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "a",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "b",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "|",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Sorts an array in place.\r\nThis method mutates the array and returns a reference to the same array.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "compareFn",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Function used to determine the order of the elements. It is expected to return\r\na negative value if first argument is less than second argument, zero if they're equal and a positive\r\nvalue otherwise. If omitted, the elements are sorted in ascending, ASCII character order.\r\n```ts\r\n[11,2,22,1].sort((a, b) => a - b)\r\n```",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "splice",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "splice",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "start",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "deleteCount",
+              "kind": "parameterName"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "|",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "+",
+              "kind": "operator"
+            },
+            {
+              "text": "2",
+              "kind": "numericLiteral"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "overloads",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "start",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "The zero-based location in the array from which to start removing elements.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "deleteCount",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "The number of elements to remove.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "returns",
+              "text": [
+                {
+                  "text": "An array containing the elements that were deleted.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "unshift",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "unshift",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "items",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "never",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Inserts new elements at the start of an array, and returns the new length of the array.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "items",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Elements to insert at the start of the array.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "indexOf",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "indexOf",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "searchElement",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "never",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "fromIndex",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Returns the index of the first occurrence of a value in an array, or -1 if it is not present.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "searchElement",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "The value to locate in the array.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "fromIndex",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "The array index at which to begin the search. If fromIndex is omitted, the search starts at index 0.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "lastIndexOf",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "lastIndexOf",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "searchElement",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "never",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "fromIndex",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Returns the index of the last occurrence of a specified value in an array, or -1 if it is not present.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "searchElement",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "The value to locate in the array.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "fromIndex",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "The array index at which to begin searching backward. If fromIndex is omitted, the search starts at the last index in the array.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "every",
+          "kind": "property",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "property",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "every",
+              "kind": "propertyName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "{",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "S",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "extends",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "predicate",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "index",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "value",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "is",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "S",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "thisArg",
+              "kind": "parameterName"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "any",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "is",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "S",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "predicate",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "index",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "unknown",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "thisArg",
+              "kind": "parameterName"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "any",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "}",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "|",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "{",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "...",
+              "kind": "propertyName"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "}",
+              "kind": "punctuation"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Determines whether all the members of an array satisfy the specified test.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "predicate",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A function that accepts up to three arguments. The every method calls\r\nthe predicate function for each element in the array until the predicate returns a value\r\nwhich is coercible to the Boolean value false, or until the end of the array.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "thisArg",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "An object to which the this keyword can refer in the predicate function.\r\nIf thisArg is omitted, undefined is used as the this value.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "predicate",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A function that accepts up to three arguments. The every method calls\r\nthe predicate function for each element in the array until the predicate returns a value\r\nwhich is coercible to the Boolean value false, or until the end of the array.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "thisArg",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "An object to which the this keyword can refer in the predicate function.\r\nIf thisArg is omitted, undefined is used as the this value.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "some",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "some",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "predicate",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "index",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "unknown",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "&",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "index",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "unknown",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "thisArg",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "any",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Determines whether the specified callback function returns true for any element of an array.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "predicate",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A function that accepts up to three arguments. The some method calls\r\nthe predicate function for each element in the array until the predicate returns a value\r\nwhich is coercible to the Boolean value true, or until the end of the array.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "thisArg",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "An object to which the this keyword can refer in the predicate function.\r\nIf thisArg is omitted, undefined is used as the this value.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "forEach",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "forEach",
+              "kind": "propertyName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "callbackfn",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "index",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "&",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "index",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "thisArg",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "any",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Performs the specified action for each element in an array.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "callbackfn",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "thisArg",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "map",
+          "kind": "method",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "method",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "map",
+              "kind": "propertyName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "unknown",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "callbackfn",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "index",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "unknown",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "&",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "index",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "unknown",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "thisArg",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "any",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "unknown",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Calls a defined callback function on each element of an array, and returns an array that contains the results.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "callbackfn",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "thisArg",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "filter",
+          "kind": "property",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "property",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "filter",
+              "kind": "propertyName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "{",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "S",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "extends",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "predicate",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "index",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "value",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "is",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "S",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "thisArg",
+              "kind": "parameterName"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "any",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "S",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "predicate",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "value",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "index",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "unknown",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "thisArg",
+              "kind": "parameterName"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "any",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "}",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "|",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "{",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "...",
+              "kind": "propertyName"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "}",
+              "kind": "punctuation"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Returns the elements of an array that meet the condition specified in a callback function.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "predicate",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "thisArg",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "predicate",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "thisArg",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "reduce",
+          "kind": "property",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "property",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "reduce",
+              "kind": "propertyName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "{",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "callbackfn",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "previousValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "currentValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "currentIndex",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "callbackfn",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "previousValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "currentValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "currentIndex",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "initialValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "U",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "callbackfn",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "previousValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "U",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "currentValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "currentIndex",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "U",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "initialValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "U",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "U",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "}",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "|",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "{",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "...",
+              "kind": "propertyName"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "}",
+              "kind": "punctuation"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "callbackfn",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "initialValue",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "callbackfn",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "initialValue",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "reduceRight",
+          "kind": "property",
+          "kindModifiers": "declare",
+          "sortText": "1",
+          "displayParts": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "property",
+              "kind": "text"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Array",
+              "kind": "localName"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ".",
+              "kind": "punctuation"
+            },
+            {
+              "text": "reduceRight",
+              "kind": "propertyName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "{",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "callbackfn",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "previousValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "currentValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "currentIndex",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "callbackfn",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "previousValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "currentValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "currentIndex",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "initialValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "U",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "callbackfn",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "previousValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "U",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "currentValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "currentIndex",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "array",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "=>",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "U",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "initialValue",
+              "kind": "parameterName"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "U",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "U",
+              "kind": "typeParameterName"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "}",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "|",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "{",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "    ",
+              "kind": "space"
+            },
+            {
+              "text": "...",
+              "kind": "propertyName"
+            },
+            {
+              "text": ";",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\n",
+              "kind": "lineBreak"
+            },
+            {
+              "text": "}",
+              "kind": "punctuation"
+            }
+          ],
+          "documentation": [
+            {
+              "text": "Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.",
+              "kind": "text"
+            }
+          ],
+          "tags": [
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "callbackfn",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "initialValue",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "callbackfn",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.",
+                  "kind": "text"
+                }
+              ]
+            },
+            {
+              "name": "param",
+              "text": [
+                {
+                  "text": "initialValue",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/completionsCommentsClass.baseline
+++ b/tests/baselines/reference/completionsCommentsClass.baseline
@@ -95,7 +95,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -191,11 +204,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -263,7 +302,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -331,7 +383,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -399,7 +464,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -467,7 +545,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -535,7 +626,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -603,7 +707,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -703,7 +820,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -771,7 +901,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -839,7 +982,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },

--- a/tests/baselines/reference/completionsCommentsClassMembers.baseline
+++ b/tests/baselines/reference/completionsCommentsClassMembers.baseline
@@ -9034,7 +9034,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -9130,11 +9143,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -9202,7 +9241,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -9270,7 +9322,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -9338,7 +9403,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -9406,7 +9484,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -9474,7 +9565,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -9542,7 +9646,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -9642,7 +9759,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -9710,7 +9840,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -9778,7 +9921,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14024,7 +14180,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14120,11 +14289,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14192,7 +14387,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14260,7 +14468,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14328,7 +14549,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14396,7 +14630,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14464,7 +14711,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14532,7 +14792,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14632,7 +14905,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14700,7 +14986,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14768,7 +15067,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -22422,7 +22734,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -22518,11 +22843,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -22590,7 +22941,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -22658,7 +23022,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -22726,7 +23103,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -22794,7 +23184,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -22862,7 +23265,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -22930,7 +23346,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -23030,7 +23459,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -23098,7 +23540,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -23166,7 +23621,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26272,7 +26740,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26368,11 +26849,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26440,7 +26947,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26508,7 +27028,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26576,7 +27109,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26644,7 +27190,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26712,7 +27271,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26780,7 +27352,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26880,7 +27465,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26948,7 +27546,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -27016,7 +27627,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -30122,7 +30746,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -30218,11 +30855,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -30290,7 +30953,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -30358,7 +31034,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -30426,7 +31115,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -30494,7 +31196,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -30562,7 +31277,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -30630,7 +31358,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -30730,7 +31471,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -30798,7 +31552,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -30866,7 +31633,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -33972,7 +34752,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -34068,11 +34861,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -34140,7 +34959,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -34208,7 +35040,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -34276,7 +35121,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -34344,7 +35202,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -34412,7 +35283,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -34480,7 +35364,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -34580,7 +35477,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -34648,7 +35558,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -34716,7 +35639,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -37822,7 +38758,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -37918,11 +38867,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -37990,7 +38965,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -38058,7 +39046,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -38126,7 +39127,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -38194,7 +39208,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -38262,7 +39289,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -38330,7 +39370,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -38430,7 +39483,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -38498,7 +39564,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -38566,7 +39645,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -41672,7 +42764,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -41768,11 +42873,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -41840,7 +42971,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -41908,7 +43052,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -41976,7 +43133,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -42044,7 +43214,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -42112,7 +43295,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -42180,7 +43376,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -42280,7 +43489,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -42348,7 +43570,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -42416,7 +43651,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -48922,7 +50170,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is first parameter a"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is first parameter a",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/completionsCommentsCommentParsing.baseline
+++ b/tests/baselines/reference/completionsCommentsCommentParsing.baseline
@@ -95,7 +95,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -191,11 +204,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -263,7 +302,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -331,7 +383,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -399,7 +464,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -467,7 +545,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -535,7 +626,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -603,7 +707,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -703,7 +820,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -771,7 +901,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -839,7 +982,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -3106,11 +3262,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b second number"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "second number",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -3286,30 +3468,76 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
             },
             {
               "name": "param",
-              "text": "e LastParam"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "LastParam",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
@@ -3408,7 +3636,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "b about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "about b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -3692,27 +3933,97 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is about b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is optional param c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d this is optional param d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "e this is optional param e"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param e",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": " { () => string; } } f this is optional param f"
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "{ () => string; } } f this is optional param f",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -3780,15 +4091,38 @@
           "tags": [
             {
               "name": "paramTag",
-              "text": "{ number } a this is input number of paramTag"
+              "text": [
+                {
+                  "text": "{ number } a this is input number of paramTag",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a this is input number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is input number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returnType",
-              "text": "{ number } it is return type"
+              "text": [
+                {
+                  "text": "{ number } it is return type",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -3880,15 +4214,46 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is a"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is a",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "paramTag",
-              "text": "{ number } g this is optional param g"
+              "text": [
+                {
+                  "text": "{ number } g this is optional param g",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -3980,11 +4345,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "foo is string"
+              "text": [
+                {
+                  "text": "foo",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is string",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "bar is second string"
+              "text": [
+                {
+                  "text": "bar",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is second string",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4124,11 +4515,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a it is first parameter"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is first parameter",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c it is third parameter"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is third parameter",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4336,15 +4753,54 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is info about a\nspanning on two lines and aligned perfectly"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about a\nspanning on two lines and aligned perfectly",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is info about b\nnot aligned text about parameter will eat only one space"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nnot aligned text about parameter will eat only one space",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -5331,7 +5787,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -5427,11 +5896,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -5499,7 +5994,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -5567,7 +6075,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -5635,7 +6156,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -5703,7 +6237,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -5771,7 +6318,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -5839,7 +6399,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -5939,7 +6512,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -6007,7 +6593,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -6075,7 +6674,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -9309,11 +9921,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b second number"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "second number",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -9489,30 +10127,76 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
             },
             {
               "name": "param",
-              "text": "e LastParam"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "LastParam",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
@@ -9611,7 +10295,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "b about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "about b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -9895,27 +10592,97 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is about b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is optional param c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d this is optional param d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "e this is optional param e"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param e",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": " { () => string; } } f this is optional param f"
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "{ () => string; } } f this is optional param f",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -9983,15 +10750,38 @@
           "tags": [
             {
               "name": "paramTag",
-              "text": "{ number } a this is input number of paramTag"
+              "text": [
+                {
+                  "text": "{ number } a this is input number of paramTag",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a this is input number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is input number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returnType",
-              "text": "{ number } it is return type"
+              "text": [
+                {
+                  "text": "{ number } it is return type",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -10083,15 +10873,46 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is a"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is a",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "paramTag",
-              "text": "{ number } g this is optional param g"
+              "text": [
+                {
+                  "text": "{ number } g this is optional param g",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -10183,11 +11004,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "foo is string"
+              "text": [
+                {
+                  "text": "foo",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is string",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "bar is second string"
+              "text": [
+                {
+                  "text": "bar",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is second string",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -10327,11 +11174,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a it is first parameter"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is first parameter",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c it is third parameter"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is third parameter",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -10539,15 +11412,54 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is info about a\nspanning on two lines and aligned perfectly"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about a\nspanning on two lines and aligned perfectly",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is info about b\nnot aligned text about parameter will eat only one space"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nnot aligned text about parameter will eat only one space",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11300,7 +12212,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11396,11 +12321,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11468,7 +12419,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11536,7 +12500,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11604,7 +12581,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11672,7 +12662,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11740,7 +12743,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11808,7 +12824,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11908,7 +12937,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11976,7 +13018,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -12044,7 +13099,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14311,11 +15379,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b second number"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "second number",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14491,30 +15585,76 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
             },
             {
               "name": "param",
-              "text": "e LastParam"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "LastParam",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
@@ -14613,7 +15753,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "b about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "about b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14897,27 +16050,97 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is about b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is optional param c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d this is optional param d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "e this is optional param e"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param e",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": " { () => string; } } f this is optional param f"
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "{ () => string; } } f this is optional param f",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -14985,15 +16208,38 @@
           "tags": [
             {
               "name": "paramTag",
-              "text": "{ number } a this is input number of paramTag"
+              "text": [
+                {
+                  "text": "{ number } a this is input number of paramTag",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a this is input number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is input number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returnType",
-              "text": "{ number } it is return type"
+              "text": [
+                {
+                  "text": "{ number } it is return type",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -15085,15 +16331,46 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is a"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is a",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "paramTag",
-              "text": "{ number } g this is optional param g"
+              "text": [
+                {
+                  "text": "{ number } g this is optional param g",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -15185,11 +16462,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "foo is string"
+              "text": [
+                {
+                  "text": "foo",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is string",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "bar is second string"
+              "text": [
+                {
+                  "text": "bar",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is second string",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -15329,11 +16632,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a it is first parameter"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is first parameter",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c it is third parameter"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is third parameter",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -15541,15 +16870,54 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is info about a\nspanning on two lines and aligned perfectly"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about a\nspanning on two lines and aligned perfectly",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is info about b\nnot aligned text about parameter will eat only one space"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nnot aligned text about parameter will eat only one space",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -16320,7 +17688,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -16416,11 +17797,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -16488,7 +17895,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -16556,7 +17976,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -16624,7 +18057,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -16692,7 +18138,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -16760,7 +18219,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -16828,7 +18300,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -16928,7 +18413,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -16996,7 +18494,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -17064,7 +18575,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -19331,11 +20855,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b second number"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "second number",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -19511,30 +21061,76 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
             },
             {
               "name": "param",
-              "text": "e LastParam"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "LastParam",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
@@ -19633,7 +21229,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "b about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "about b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -19917,27 +21526,97 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is about b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is optional param c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d this is optional param d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "e this is optional param e"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param e",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": " { () => string; } } f this is optional param f"
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "{ () => string; } } f this is optional param f",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -20005,15 +21684,38 @@
           "tags": [
             {
               "name": "paramTag",
-              "text": "{ number } a this is input number of paramTag"
+              "text": [
+                {
+                  "text": "{ number } a this is input number of paramTag",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a this is input number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is input number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returnType",
-              "text": "{ number } it is return type"
+              "text": [
+                {
+                  "text": "{ number } it is return type",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -20105,15 +21807,46 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is a"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is a",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "paramTag",
-              "text": "{ number } g this is optional param g"
+              "text": [
+                {
+                  "text": "{ number } g this is optional param g",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -20205,11 +21938,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "foo is string"
+              "text": [
+                {
+                  "text": "foo",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is string",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "bar is second string"
+              "text": [
+                {
+                  "text": "bar",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is second string",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -20349,11 +22108,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a it is first parameter"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is first parameter",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c it is third parameter"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is third parameter",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -20561,15 +22346,54 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is info about a\nspanning on two lines and aligned perfectly"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about a\nspanning on two lines and aligned perfectly",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is info about b\nnot aligned text about parameter will eat only one space"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nnot aligned text about parameter will eat only one space",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -21318,7 +23142,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -21414,11 +23251,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -21486,7 +23349,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -21554,7 +23430,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -21622,7 +23511,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -21690,7 +23592,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -21758,7 +23673,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -21826,7 +23754,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -21926,7 +23867,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -21994,7 +23948,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -22062,7 +24029,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -24329,11 +26309,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b second number"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "second number",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -24509,30 +26515,76 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
             },
             {
               "name": "param",
-              "text": "e LastParam"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "LastParam",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
@@ -24631,7 +26683,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "b about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "about b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -24915,27 +26980,97 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is about b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is optional param c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d this is optional param d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "e this is optional param e"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param e",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": " { () => string; } } f this is optional param f"
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "{ () => string; } } f this is optional param f",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -25003,15 +27138,38 @@
           "tags": [
             {
               "name": "paramTag",
-              "text": "{ number } a this is input number of paramTag"
+              "text": [
+                {
+                  "text": "{ number } a this is input number of paramTag",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a this is input number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is input number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returnType",
-              "text": "{ number } it is return type"
+              "text": [
+                {
+                  "text": "{ number } it is return type",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -25103,15 +27261,46 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is a"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is a",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "paramTag",
-              "text": "{ number } g this is optional param g"
+              "text": [
+                {
+                  "text": "{ number } g this is optional param g",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -25203,11 +27392,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "foo is string"
+              "text": [
+                {
+                  "text": "foo",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is string",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "bar is second string"
+              "text": [
+                {
+                  "text": "bar",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is second string",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -25347,11 +27562,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a it is first parameter"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is first parameter",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c it is third parameter"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is third parameter",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -25559,15 +27800,54 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is info about a\nspanning on two lines and aligned perfectly"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about a\nspanning on two lines and aligned perfectly",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is info about b\nnot aligned text about parameter will eat only one space"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nnot aligned text about parameter will eat only one space",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26566,7 +28846,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26662,11 +28955,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26734,7 +29053,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26802,7 +29134,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26870,7 +29215,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -26938,7 +29296,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -27006,7 +29377,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -27074,7 +29458,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -27174,7 +29571,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -27242,7 +29652,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -27310,7 +29733,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -30544,11 +32980,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b second number"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "second number",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -30724,30 +33186,76 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
             },
             {
               "name": "param",
-              "text": "e LastParam"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "LastParam",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
@@ -30846,7 +33354,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "b about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "about b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -31130,27 +33651,97 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is about b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is optional param c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d this is optional param d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "e this is optional param e"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param e",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": " { () => string; } } f this is optional param f"
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "{ () => string; } } f this is optional param f",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -31218,15 +33809,38 @@
           "tags": [
             {
               "name": "paramTag",
-              "text": "{ number } a this is input number of paramTag"
+              "text": [
+                {
+                  "text": "{ number } a this is input number of paramTag",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a this is input number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is input number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returnType",
-              "text": "{ number } it is return type"
+              "text": [
+                {
+                  "text": "{ number } it is return type",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -31318,15 +33932,46 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is a"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is a",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "paramTag",
-              "text": "{ number } g this is optional param g"
+              "text": [
+                {
+                  "text": "{ number } g this is optional param g",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -31418,11 +34063,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "foo is string"
+              "text": [
+                {
+                  "text": "foo",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is string",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "bar is second string"
+              "text": [
+                {
+                  "text": "bar",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is second string",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -31562,11 +34233,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a it is first parameter"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is first parameter",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c it is third parameter"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is third parameter",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -31774,15 +34471,54 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is info about a\nspanning on two lines and aligned perfectly"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about a\nspanning on two lines and aligned perfectly",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is info about b\nnot aligned text about parameter will eat only one space"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nnot aligned text about parameter will eat only one space",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -32535,7 +35271,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -32631,11 +35380,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -32703,7 +35478,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -32771,7 +35559,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -32839,7 +35640,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -32907,7 +35721,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -32975,7 +35802,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -33043,7 +35883,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -33143,7 +35996,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -33211,7 +36077,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -33279,7 +36158,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -35546,11 +38438,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b second number"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "second number",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -35726,30 +38644,76 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
             },
             {
               "name": "param",
-              "text": "e LastParam"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "LastParam",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
@@ -35848,7 +38812,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "b about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "about b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -36132,27 +39109,97 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is about b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is optional param c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d this is optional param d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "e this is optional param e"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param e",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": " { () => string; } } f this is optional param f"
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "{ () => string; } } f this is optional param f",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -36220,15 +39267,38 @@
           "tags": [
             {
               "name": "paramTag",
-              "text": "{ number } a this is input number of paramTag"
+              "text": [
+                {
+                  "text": "{ number } a this is input number of paramTag",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a this is input number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is input number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returnType",
-              "text": "{ number } it is return type"
+              "text": [
+                {
+                  "text": "{ number } it is return type",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -36320,15 +39390,46 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is a"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is a",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "paramTag",
-              "text": "{ number } g this is optional param g"
+              "text": [
+                {
+                  "text": "{ number } g this is optional param g",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -36420,11 +39521,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "foo is string"
+              "text": [
+                {
+                  "text": "foo",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is string",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "bar is second string"
+              "text": [
+                {
+                  "text": "bar",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is second string",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -36564,11 +39691,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a it is first parameter"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is first parameter",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c it is third parameter"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is third parameter",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -36776,15 +39929,54 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is info about a\nspanning on two lines and aligned perfectly"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about a\nspanning on two lines and aligned perfectly",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is info about b\nnot aligned text about parameter will eat only one space"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nnot aligned text about parameter will eat only one space",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },

--- a/tests/baselines/reference/completionsCommentsFunctionDeclaration.baseline
+++ b/tests/baselines/reference/completionsCommentsFunctionDeclaration.baseline
@@ -95,7 +95,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -191,11 +204,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -263,7 +302,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -331,7 +383,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -399,7 +464,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -467,7 +545,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -535,7 +626,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -603,7 +707,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -703,7 +820,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -771,7 +901,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -839,7 +982,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -3562,7 +3718,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "a a string"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "a string",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4434,7 +4603,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4530,11 +4712,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4602,7 +4810,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4670,7 +4891,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4738,7 +4972,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4806,7 +5053,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4874,7 +5134,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4942,7 +5215,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -5042,7 +5328,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -5110,7 +5409,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -5178,7 +5490,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -6934,7 +7259,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "a a string"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "a string",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -7608,7 +7946,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -7704,11 +8055,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -7776,7 +8153,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -7844,7 +8234,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -7912,7 +8315,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -7980,7 +8396,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8048,7 +8477,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8116,7 +8558,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8216,7 +8671,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8284,7 +8752,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8352,7 +8833,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11075,7 +11569,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "a a string"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "a string",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },

--- a/tests/baselines/reference/completionsCommentsFunctionExpression.baseline
+++ b/tests/baselines/reference/completionsCommentsFunctionExpression.baseline
@@ -95,7 +95,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -191,11 +204,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -263,7 +302,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -331,7 +383,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -399,7 +464,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -467,7 +545,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -535,7 +626,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -603,7 +707,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -703,7 +820,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -771,7 +901,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -839,7 +982,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -2744,19 +2900,55 @@
           "tags": [
             {
               "name": "param",
-              "text": "s param on expression"
+              "text": [
+                {
+                  "text": "s",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "param on expression",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returns",
-              "text": "return on expression"
+              "text": [
+                {
+                  "text": "return on expression",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "s the first parameter!"
+              "text": [
+                {
+                  "text": "s",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "the first parameter!",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returns",
-              "text": "the parameter's length"
+              "text": [
+                {
+                  "text": "the parameter's length",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -3640,7 +3832,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -3736,11 +3941,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -3808,7 +4039,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -3876,7 +4120,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -3944,7 +4201,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4012,7 +4282,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4080,7 +4363,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4148,7 +4444,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4248,7 +4557,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4316,7 +4638,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -4384,7 +4719,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -7256,19 +7604,55 @@
           "tags": [
             {
               "name": "param",
-              "text": "s param on expression"
+              "text": [
+                {
+                  "text": "s",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "param on expression",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returns",
-              "text": "return on expression"
+              "text": [
+                {
+                  "text": "return on expression",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "s the first parameter!"
+              "text": [
+                {
+                  "text": "s",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "the first parameter!",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returns",
-              "text": "the parameter's length"
+              "text": [
+                {
+                  "text": "the parameter's length",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8140,7 +8524,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8236,11 +8633,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8308,7 +8731,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8376,7 +8812,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8444,7 +8893,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8512,7 +8974,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8580,7 +9055,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8648,7 +9136,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8748,7 +9249,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8816,7 +9330,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -8884,7 +9411,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -10789,19 +11329,55 @@
           "tags": [
             {
               "name": "param",
-              "text": "s param on expression"
+              "text": [
+                {
+                  "text": "s",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "param on expression",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returns",
-              "text": "return on expression"
+              "text": [
+                {
+                  "text": "return on expression",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "s the first parameter!"
+              "text": [
+                {
+                  "text": "s",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "the first parameter!",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returns",
-              "text": "the parameter's length"
+              "text": [
+                {
+                  "text": "the parameter's length",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11685,7 +12261,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11781,11 +12370,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string to convert into a number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string to convert into a number.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "radix A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal."
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value between 2 and 36 that specifies the base of the number in `string`.\r\nIf this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.\r\nAll other strings are considered decimal.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11853,7 +12468,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string that contains a floating-point number."
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string that contains a floating-point number.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11921,7 +12549,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number A numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -11989,7 +12630,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "number Any numeric value."
+              "text": [
+                {
+                  "text": "number",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Any numeric value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -12057,7 +12711,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURI A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "encodedURI",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -12125,7 +12792,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "encodedURIComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "encodedURIComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -12193,7 +12873,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uri A value representing an encoded URI."
+              "text": [
+                {
+                  "text": "uri",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -12293,7 +12986,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "uriComponent A value representing an encoded URI component."
+              "text": [
+                {
+                  "text": "uriComponent",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A value representing an encoded URI component.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -12361,7 +13067,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -12429,7 +13148,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "string A string value"
+              "text": [
+                {
+                  "text": "string",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -15301,19 +16033,55 @@
           "tags": [
             {
               "name": "param",
-              "text": "s param on expression"
+              "text": [
+                {
+                  "text": "s",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "param on expression",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returns",
-              "text": "return on expression"
+              "text": [
+                {
+                  "text": "return on expression",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "s the first parameter!"
+              "text": [
+                {
+                  "text": "s",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "the first parameter!",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returns",
-              "text": "the parameter's length"
+              "text": [
+                {
+                  "text": "the parameter's length",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },

--- a/tests/baselines/reference/completionsSalsaMethodsOnAssignedFunctionExpressions.baseline
+++ b/tests/baselines/reference/completionsSalsaMethodsOnAssignedFunctionExpressions.baseline
@@ -405,7 +405,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "a Parameter definition."
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Parameter definition.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },

--- a/tests/baselines/reference/enumTagCircularReference.errors.txt
+++ b/tests/baselines/reference/enumTagCircularReference.errors.txt
@@ -3,7 +3,7 @@ tests/cases/conformance/jsdoc/bug27142.js(1,5): error TS2456: Type alias 'E' cir
 
 ==== tests/cases/conformance/jsdoc/bug27142.js (1 errors) ====
     /** @enum {E} */
-        ~~~~~~~~~
+        ~~~~~~~~~~
 !!! error TS2456: Type alias 'E' circularly references itself.
     const E = { x: 0 };
     

--- a/tests/baselines/reference/findAllRefs_importType_js.1.baseline.jsonc
+++ b/tests/baselines/reference/findAllRefs_importType_js.1.baseline.jsonc
@@ -142,7 +142,7 @@
         "fileName": "/b.js",
         "contextSpan": {
           "start": 4,
-          "length": 21
+          "length": 22
         },
         "isWriteAccess": false,
         "isDefinition": false

--- a/tests/baselines/reference/findAllRefs_importType_js.baseline.jsonc
+++ b/tests/baselines/reference/findAllRefs_importType_js.baseline.jsonc
@@ -44,7 +44,7 @@
         "fileName": "/b.js",
         "contextSpan": {
           "start": 4,
-          "length": 21
+          "length": 22
         },
         "isWriteAccess": false,
         "isDefinition": false
@@ -57,7 +57,7 @@
         "fileName": "/b.js",
         "contextSpan": {
           "start": 46,
-          "length": 23
+          "length": 24
         },
         "isWriteAccess": false,
         "isDefinition": false

--- a/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit1.errors.txt
+++ b/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit1.errors.txt
@@ -18,7 +18,7 @@ tests/cases/conformance/jsdoc/declarations/file.js(6,5): error TS4084: Exported 
     
 ==== tests/cases/conformance/jsdoc/declarations/file.js (3 errors) ====
     /** @typedef {import('./base')} BaseFactory */
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS4084: Exported type alias 'BaseFactory' has or is using private name 'Base' from module "tests/cases/conformance/jsdoc/declarations/base".
     /**
      * @callback BaseFactoryFactory
@@ -29,7 +29,7 @@ tests/cases/conformance/jsdoc/declarations/file.js(6,5): error TS4084: Exported 
     ~
 !!! error TS4084: Exported type alias 'BaseFactoryFactory' has or is using private name 'Base' from module "tests/cases/conformance/jsdoc/declarations/base".
     /** @enum {import('./base')} */
-        ~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS4084: Exported type alias 'couldntThinkOfAny' has or is using private name 'Base' from module "tests/cases/conformance/jsdoc/declarations/base".
     const couldntThinkOfAny = {}
     

--- a/tests/baselines/reference/jsDocAliasQuickInfo.baseline
+++ b/tests/baselines/reference/jsDocAliasQuickInfo.baseline
@@ -55,7 +55,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{number}"
+          "text": [
+            {
+              "text": "{number}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -116,7 +121,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{number}"
+          "text": [
+            {
+              "text": "{number}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -157,7 +167,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{number}"
+          "text": [
+            {
+              "text": "{number}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/jsDocDontBreakWithNamespaces.baseline
+++ b/tests/baselines/reference/jsDocDontBreakWithNamespaces.baseline
@@ -52,7 +52,12 @@
           "tags": [
             {
               "name": "returns",
-              "text": "Websocket server object"
+              "text": [
+                {
+                  "text": "Websocket server object",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -181,7 +186,12 @@
           "tags": [
             {
               "name": "type",
-              "text": "{function(module:xxxx, module:xxxx): module:xxxxx}"
+              "text": [
+                {
+                  "text": "{function(module:xxxx, module:xxxx): module:xxxxx}",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/jsDocFunctionSignatures5.baseline
+++ b/tests/baselines/reference/jsDocFunctionSignatures5.baseline
@@ -182,23 +182,80 @@
           "tags": [
             {
               "name": "param",
-              "text": "basePath The base path where the search will be performed."
+              "text": [
+                {
+                  "text": "basePath",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "The base path where the search will be performed.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "pattern A string defining a regexp of a glob pattern."
+              "text": [
+                {
+                  "text": "pattern",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A string defining a regexp of a glob pattern.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "type The search pattern type, can be a regexp or a glob."
+              "text": [
+                {
+                  "text": "type",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "The search pattern type, can be a regexp or a glob.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "options A object containing options to the search."
+              "text": [
+                {
+                  "text": "options",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A object containing options to the search.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "return",
-              "text": "A list containing the filtered paths."
+              "text": [
+                {
+                  "text": "A list containing the filtered paths.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/jsDocFunctionSignatures6.baseline
+++ b/tests/baselines/reference/jsDocFunctionSignatures6.baseline
@@ -177,19 +177,71 @@
           "tags": [
             {
               "name": "param",
-              "text": "p1 - A string param"
+              "text": [
+                {
+                  "text": "p1",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- A string param",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "p2 - An optional param"
+              "text": [
+                {
+                  "text": "p2",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- An optional param",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "p3 - Another optional param"
+              "text": [
+                {
+                  "text": "p3",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- Another optional param",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "p4 - An optional param with a default value"
+              "text": [
+                {
+                  "text": "p4",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- An optional param with a default value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -381,19 +433,71 @@
           "tags": [
             {
               "name": "param",
-              "text": "p1 - A string param"
+              "text": [
+                {
+                  "text": "p1",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- A string param",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "p2 - An optional param"
+              "text": [
+                {
+                  "text": "p2",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- An optional param",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "p3 - Another optional param"
+              "text": [
+                {
+                  "text": "p3",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- Another optional param",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "p4 - An optional param with a default value"
+              "text": [
+                {
+                  "text": "p4",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- An optional param with a default value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -585,19 +689,71 @@
           "tags": [
             {
               "name": "param",
-              "text": "p1 - A string param"
+              "text": [
+                {
+                  "text": "p1",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- A string param",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "p2 - An optional param"
+              "text": [
+                {
+                  "text": "p2",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- An optional param",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "p3 - Another optional param"
+              "text": [
+                {
+                  "text": "p3",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- Another optional param",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "p4 - An optional param with a default value"
+              "text": [
+                {
+                  "text": "p4",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- An optional param with a default value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -789,19 +945,71 @@
           "tags": [
             {
               "name": "param",
-              "text": "p1 - A string param"
+              "text": [
+                {
+                  "text": "p1",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- A string param",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "p2 - An optional param"
+              "text": [
+                {
+                  "text": "p2",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- An optional param",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "p3 - Another optional param"
+              "text": [
+                {
+                  "text": "p3",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- Another optional param",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "p4 - An optional param with a default value"
+              "text": [
+                {
+                  "text": "p4",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "- An optional param with a default value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/jsDocTags.baseline
+++ b/tests/baselines/reference/jsDocTags.baseline
@@ -70,7 +70,12 @@
       "tags": [
         {
           "name": "myjsdoctag",
-          "text": "this is a comment"
+          "text": [
+            {
+              "text": "this is a comment",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -116,7 +121,12 @@
       "tags": [
         {
           "name": "mytag",
-          "text": "comment1 comment2"
+          "text": [
+            {
+              "text": "comment1 comment2",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -192,7 +202,12 @@
       "tags": [
         {
           "name": "mytag",
-          "text": "comment1 comment2"
+          "text": [
+            {
+              "text": "comment1 comment2",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -345,7 +360,12 @@
       "tags": [
         {
           "name": "returns",
-          "text": "a value"
+          "text": [
+            {
+              "text": "a value",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -438,11 +458,29 @@
       "tags": [
         {
           "name": "param",
-          "text": "foo A value."
+          "text": [
+            {
+              "text": "foo",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "A value.",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "returns",
-          "text": "Another value"
+          "text": [
+            {
+              "text": "Another value",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "mytag"
@@ -508,7 +546,12 @@
       "tags": [
         {
           "name": "mytag",
-          "text": "comment1 comment2"
+          "text": [
+            {
+              "text": "comment1 comment2",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -571,11 +614,21 @@
       "tags": [
         {
           "name": "mytag1",
-          "text": "some comments\nsome more comments about mytag1"
+          "text": [
+            {
+              "text": "some comments\nsome more comments about mytag1",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "mytag2",
-          "text": "here all the comments are on a new line"
+          "text": [
+            {
+              "text": "here all the comments are on a new line",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "mytag3"

--- a/tests/baselines/reference/jsDocTypeTagQuickInfo1.baseline
+++ b/tests/baselines/reference/jsDocTypeTagQuickInfo1.baseline
@@ -42,7 +42,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{String}"
+          "text": [
+            {
+              "text": "{String}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -90,7 +95,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{Number}"
+          "text": [
+            {
+              "text": "{Number}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -138,7 +148,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{Boolean}"
+          "text": [
+            {
+              "text": "{Boolean}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -186,7 +201,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{Void}"
+          "text": [
+            {
+              "text": "{Void}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -234,7 +254,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{Undefined}"
+          "text": [
+            {
+              "text": "{Undefined}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -282,7 +307,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{Null}"
+          "text": [
+            {
+              "text": "{Null}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -338,7 +368,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{Array}"
+          "text": [
+            {
+              "text": "{Array}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -398,7 +433,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{Promise}"
+          "text": [
+            {
+              "text": "{Promise}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -446,7 +486,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{Object}"
+          "text": [
+            {
+              "text": "{Object}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -494,7 +539,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{Function}"
+          "text": [
+            {
+              "text": "{Function}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -542,7 +592,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{*}"
+          "text": [
+            {
+              "text": "{*}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -590,7 +645,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{?}"
+          "text": [
+            {
+              "text": "{?}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -654,7 +714,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{String|Number}"
+          "text": [
+            {
+              "text": "{String|Number}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/jsDocTypeTagQuickInfo2.baseline
+++ b/tests/baselines/reference/jsDocTypeTagQuickInfo2.baseline
@@ -42,7 +42,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{string}"
+          "text": [
+            {
+              "text": "{string}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -90,7 +95,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{number}"
+          "text": [
+            {
+              "text": "{number}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -138,7 +148,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{boolean}"
+          "text": [
+            {
+              "text": "{boolean}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -186,7 +201,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{void}"
+          "text": [
+            {
+              "text": "{void}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -234,7 +254,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{undefined}"
+          "text": [
+            {
+              "text": "{undefined}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -282,7 +307,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{null}"
+          "text": [
+            {
+              "text": "{null}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -338,7 +368,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{array}"
+          "text": [
+            {
+              "text": "{array}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -398,7 +433,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{promise}"
+          "text": [
+            {
+              "text": "{promise}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -446,7 +486,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{?number}"
+          "text": [
+            {
+              "text": "{?number}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -494,7 +539,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{function}"
+          "text": [
+            {
+              "text": "{function}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -578,7 +628,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{function (number): number}"
+          "text": [
+            {
+              "text": "{function (number): number}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -642,7 +697,12 @@
       "tags": [
         {
           "name": "type",
-          "text": "{string | number}"
+          "text": [
+            {
+              "text": "{string | number}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/jsDocTypedefQuickInfo1.baseline
+++ b/tests/baselines/reference/jsDocTypedefQuickInfo1.baseline
@@ -50,7 +50,12 @@
       "tags": [
         {
           "name": "param",
-          "text": "opts"
+          "text": [
+            {
+              "text": "opts",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/jsdocImportTypeNodeNamespace.errors.txt
+++ b/tests/baselines/reference/jsdocImportTypeNodeNamespace.errors.txt
@@ -12,7 +12,7 @@ tests/cases/compiler/Main.js(2,14): error TS2352: Conversion of type 'string' to
 ==== tests/cases/compiler/Main.js (1 errors) ====
     export default function () {
       return /** @type {import('./GeometryType.js').default} */ ('Point');
-                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2352: Conversion of type 'string' to type 'typeof _default' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     }
     

--- a/tests/baselines/reference/jsdocLink1.baseline
+++ b/tests/baselines/reference/jsdocLink1.baseline
@@ -1,0 +1,208 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsdocLink1.ts",
+      "position": 189,
+      "name": ""
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 189,
+        "length": 2
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "CC",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "C",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/tests/cases/fourslash/jsdocLink1.ts",
+            "textSpan": {
+              "start": 0,
+              "length": 11
+            }
+          }
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        }
+      ],
+      "tags": [
+        {
+          "name": "wat",
+          "text": [
+            {
+              "text": "Makes a ",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "C",
+              "kind": "linkName",
+              "target": {
+                "fileName": "/tests/cases/fourslash/jsdocLink1.ts",
+                "textSpan": {
+                  "start": 0,
+                  "length": 11
+                }
+              }
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            },
+            {
+              "text": ". A default one.\n",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "C",
+              "kind": "linkName",
+              "target": {
+                "fileName": "/tests/cases/fourslash/jsdocLink1.ts",
+                "textSpan": {
+                  "start": 0,
+                  "length": 11
+                }
+              }
+            },
+            {
+              "text": "()",
+              "kind": "linkText"
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            },
+            {
+              "text": "\n",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "C",
+              "kind": "linkName",
+              "target": {
+                "fileName": "/tests/cases/fourslash/jsdocLink1.ts",
+                "textSpan": {
+                  "start": 0,
+                  "length": 11
+                }
+              }
+            },
+            {
+              "text": "|postfix text",
+              "kind": "linkText"
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            },
+            {
+              "text": "\n",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "unformattedpostfix text",
+              "kind": "linkText"
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            }
+          ]
+        },
+        {
+          "name": "see",
+          "text": [
+            {
+              "text": "",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "C",
+              "kind": "linkName",
+              "target": {
+                "fileName": "/tests/cases/fourslash/jsdocLink1.ts",
+                "textSpan": {
+                  "start": 0,
+                  "length": 11
+                }
+              }
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            },
+            {
+              "text": " its great",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/jsdocLink2.baseline
+++ b/tests/baselines/reference/jsdocLink2.baseline
@@ -1,0 +1,208 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/script.ts",
+      "position": 177,
+      "name": ""
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 177,
+        "length": 2
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "CC",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "C",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/tests/cases/fourslash/jsdocLink2.ts",
+            "textSpan": {
+              "start": 0,
+              "length": 11
+            }
+          }
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        }
+      ],
+      "tags": [
+        {
+          "name": "wat",
+          "text": [
+            {
+              "text": "Makes a ",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "C",
+              "kind": "linkName",
+              "target": {
+                "fileName": "/tests/cases/fourslash/jsdocLink2.ts",
+                "textSpan": {
+                  "start": 0,
+                  "length": 11
+                }
+              }
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            },
+            {
+              "text": ". A default one.\n",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "C",
+              "kind": "linkName",
+              "target": {
+                "fileName": "/tests/cases/fourslash/jsdocLink2.ts",
+                "textSpan": {
+                  "start": 0,
+                  "length": 11
+                }
+              }
+            },
+            {
+              "text": "()",
+              "kind": "linkText"
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            },
+            {
+              "text": "\n",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "C",
+              "kind": "linkName",
+              "target": {
+                "fileName": "/tests/cases/fourslash/jsdocLink2.ts",
+                "textSpan": {
+                  "start": 0,
+                  "length": 11
+                }
+              }
+            },
+            {
+              "text": "|postfix text",
+              "kind": "linkText"
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            },
+            {
+              "text": "\n",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "unformattedpostfix text",
+              "kind": "linkText"
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            }
+          ]
+        },
+        {
+          "name": "see",
+          "text": [
+            {
+              "text": "",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "C",
+              "kind": "linkName",
+              "target": {
+                "fileName": "/tests/cases/fourslash/jsdocLink2.ts",
+                "textSpan": {
+                  "start": 0,
+                  "length": 11
+                }
+              }
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            },
+            {
+              "text": " its great",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/jsdocLink3.baseline
+++ b/tests/baselines/reference/jsdocLink3.baseline
@@ -1,0 +1,208 @@
+[
+  {
+    "marker": {
+      "fileName": "/module1.ts",
+      "position": 210,
+      "name": ""
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 210,
+        "length": 2
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "CC",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "C",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/jsdocLink3.ts",
+            "textSpan": {
+              "start": 0,
+              "length": 18
+            }
+          }
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        }
+      ],
+      "tags": [
+        {
+          "name": "wat",
+          "text": [
+            {
+              "text": "Makes a ",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "C",
+              "kind": "linkName",
+              "target": {
+                "fileName": "/jsdocLink3.ts",
+                "textSpan": {
+                  "start": 0,
+                  "length": 18
+                }
+              }
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            },
+            {
+              "text": ". A default one.\n",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "C",
+              "kind": "linkName",
+              "target": {
+                "fileName": "/jsdocLink3.ts",
+                "textSpan": {
+                  "start": 0,
+                  "length": 18
+                }
+              }
+            },
+            {
+              "text": "()",
+              "kind": "linkText"
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            },
+            {
+              "text": "\n",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "C",
+              "kind": "linkName",
+              "target": {
+                "fileName": "/jsdocLink3.ts",
+                "textSpan": {
+                  "start": 0,
+                  "length": 18
+                }
+              }
+            },
+            {
+              "text": "|postfix text",
+              "kind": "linkText"
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            },
+            {
+              "text": "\n",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "unformattedpostfix text",
+              "kind": "linkText"
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            }
+          ]
+        },
+        {
+          "name": "see",
+          "text": [
+            {
+              "text": "",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "C",
+              "kind": "linkName",
+              "target": {
+                "fileName": "/jsdocLink3.ts",
+                "textSpan": {
+                  "start": 0,
+                  "length": 18
+                }
+              }
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            },
+            {
+              "text": " its great",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/jsdocLink_findAllReferences1.baseline.jsonc
+++ b/tests/baselines/reference/jsdocLink_findAllReferences1.baseline.jsonc
@@ -1,0 +1,73 @@
+// === /tests/cases/fourslash/jsdocLink_findAllReferences1.ts ===
+// interface [|A|] {}
+// /**
+//  * {@link [|A|]()} is ok
+//  */
+// declare const a: [|A|]
+
+[
+  {
+    "definition": {
+      "containerKind": "",
+      "containerName": "",
+      "fileName": "/tests/cases/fourslash/jsdocLink_findAllReferences1.ts",
+      "kind": "interface",
+      "name": "interface A",
+      "textSpan": {
+        "start": 10,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "interface",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "A",
+          "kind": "interfaceName"
+        }
+      ],
+      "contextSpan": {
+        "start": 0,
+        "length": 14
+      }
+    },
+    "references": [
+      {
+        "textSpan": {
+          "start": 10,
+          "length": 1
+        },
+        "fileName": "/tests/cases/fourslash/jsdocLink_findAllReferences1.ts",
+        "contextSpan": {
+          "start": 0,
+          "length": 14
+        },
+        "isWriteAccess": true,
+        "isDefinition": true
+      },
+      {
+        "textSpan": {
+          "start": 29,
+          "length": 1
+        },
+        "fileName": "/tests/cases/fourslash/jsdocLink_findAllReferences1.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      },
+      {
+        "textSpan": {
+          "start": 61,
+          "length": 1
+        },
+        "fileName": "/tests/cases/fourslash/jsdocLink_findAllReferences1.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      }
+    ]
+  }
+]

--- a/tests/baselines/reference/jsdocLink_rename1.baseline
+++ b/tests/baselines/reference/jsdocLink_rename1.baseline
@@ -1,0 +1,7 @@
+/*====== /tests/cases/fourslash/jsdocLink_rename1.ts ======*/
+
+interface [|RENAME|] {}
+/**
+ * {@link RENAME()} is ok
+ */
+declare const a: RENAME

--- a/tests/baselines/reference/jsdocReturnsTag.baseline
+++ b/tests/baselines/reference/jsdocReturnsTag.baseline
@@ -114,19 +114,39 @@
           "tags": [
             {
               "name": "template",
-              "text": "T"
+              "text": [
+                {
+                  "text": "T",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "l"
+              "text": [
+                {
+                  "text": "l",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "x"
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returns",
-              "text": "The names of the found item(s)."
+              "text": [
+                {
+                  "text": "The names of the found item(s).",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/jsdocTypeTagCast.errors.txt
+++ b/tests/baselines/reference/jsdocTypeTagCast.errors.txt
@@ -26,7 +26,7 @@ tests/cases/conformance/jsdoc/b.js(67,8): error TS2454: Variable 'numOrStr' is u
     var W = /** @type {string} */(/** @type {*} */ (4));
     
     var W = /** @type {string} */(4); // Error
-                ~~~~~~~~~~~~~~
+                ~~~~~~~~~~~~~~~
 !!! error TS2352: Conversion of type 'number' to type 'string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     
     /** @type {*} */
@@ -69,7 +69,7 @@ tests/cases/conformance/jsdoc/b.js(67,8): error TS2454: Variable 'numOrStr' is u
     someBase = /** @type {SomeBase} */(someDerived);
     someBase = /** @type {SomeBase} */(someBase);
     someBase = /** @type {SomeBase} */(someOther); // Error
-                   ~~~~~~~~~~~~~~~~
+                   ~~~~~~~~~~~~~~~~~
 !!! error TS2352: Conversion of type 'SomeOther' to type 'SomeBase' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'p' is missing in type 'SomeOther' but required in type 'SomeBase'.
 !!! related TS2728 tests/cases/conformance/jsdoc/b.js:17:9: 'p' is declared here.
@@ -77,17 +77,17 @@ tests/cases/conformance/jsdoc/b.js(67,8): error TS2454: Variable 'numOrStr' is u
     someDerived = /** @type {SomeDerived} */(someDerived);
     someDerived = /** @type {SomeDerived} */(someBase);
     someDerived = /** @type {SomeDerived} */(someOther); // Error
-                      ~~~~~~~~~~~~~~~~~~~
+                      ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2352: Conversion of type 'SomeOther' to type 'SomeDerived' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Type 'SomeOther' is missing the following properties from type 'SomeDerived': x, p
     
     someOther = /** @type {SomeOther} */(someDerived); // Error
-                    ~~~~~~~~~~~~~~~~~
+                    ~~~~~~~~~~~~~~~~~~
 !!! error TS2352: Conversion of type 'SomeDerived' to type 'SomeOther' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'q' is missing in type 'SomeDerived' but required in type 'SomeOther'.
 !!! related TS2728 tests/cases/conformance/jsdoc/b.js:28:9: 'q' is declared here.
     someOther = /** @type {SomeOther} */(someBase); // Error
-                    ~~~~~~~~~~~~~~~~~
+                    ~~~~~~~~~~~~~~~~~~
 !!! error TS2352: Conversion of type 'SomeBase' to type 'SomeOther' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'q' is missing in type 'SomeBase' but required in type 'SomeOther'.
 !!! related TS2728 tests/cases/conformance/jsdoc/b.js:28:9: 'q' is declared here.

--- a/tests/baselines/reference/linkTagEmit1.js
+++ b/tests/baselines/reference/linkTagEmit1.js
@@ -1,0 +1,64 @@
+//// [tests/cases/conformance/jsdoc/linkTagEmit1.ts] ////
+
+//// [declarations.d.ts]
+declare namespace NS {
+    type R = number
+}
+//// [linkTagEmit1.js]
+/** @typedef {number} N */
+/**
+ * @typedef {Object} D1
+ * @property {1} e Just link to {@link NS.R} this time
+ * @property {1} m Wyatt Earp loved {@link N integers} I bet.
+ */
+
+/** @typedef {number} Z @see N {@link N} */
+
+/**
+ * @param {number} integer {@link Z}
+ */
+function computeCommonSourceDirectoryOfFilenames(integer) {
+    return integer + 1 // pls pls pls
+}
+
+
+//// [linkTagEmit1.js]
+/** @typedef {number} N */
+/**
+ * @typedef {Object} D1
+ * @property {1} e Just link to {@link NS.R} this time
+ * @property {1} m Wyatt Earp loved {@link N integers} I bet.
+ */
+/** @typedef {number} Z @see N {@link N} */
+/**
+ * @param {number} integer {@link Z}
+ */
+function computeCommonSourceDirectoryOfFilenames(integer) {
+    return integer + 1; // pls pls pls
+}
+
+
+//// [linkTagEmit1.d.ts]
+/** @typedef {number} N */
+/**
+ * @typedef {Object} D1
+ * @property {1} e Just link to {@link NS.R} this time
+ * @property {1} m Wyatt Earp loved {@link N integers} I bet.
+ */
+/** @typedef {number} Z @see N {@link N} */
+/**
+ * @param {number} integer {@link Z}
+ */
+declare function computeCommonSourceDirectoryOfFilenames(integer: number): number;
+type N = number;
+type D1 = {
+    /**
+     * Just link to {@link NS.R } this time
+     */
+    e: 1;
+    /**
+     * Wyatt Earp loved {@link N integers} I bet.
+     */
+    m: 1;
+};
+type Z = number;

--- a/tests/baselines/reference/linkTagEmit1.symbols
+++ b/tests/baselines/reference/linkTagEmit1.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/conformance/jsdoc/declarations.d.ts ===
+declare namespace NS {
+>NS : Symbol(NS, Decl(declarations.d.ts, 0, 0))
+
+    type R = number
+>R : Symbol(R, Decl(declarations.d.ts, 0, 22))
+}
+=== tests/cases/conformance/jsdoc/linkTagEmit1.js ===
+/** @typedef {number} N */
+/**
+ * @typedef {Object} D1
+ * @property {1} e Just link to {@link NS.R} this time
+ * @property {1} m Wyatt Earp loved {@link N integers} I bet.
+ */
+
+/** @typedef {number} Z @see N {@link N} */
+
+/**
+ * @param {number} integer {@link Z}
+ */
+function computeCommonSourceDirectoryOfFilenames(integer) {
+>computeCommonSourceDirectoryOfFilenames : Symbol(computeCommonSourceDirectoryOfFilenames, Decl(linkTagEmit1.js, 0, 0))
+>integer : Symbol(integer, Decl(linkTagEmit1.js, 12, 49))
+
+    return integer + 1 // pls pls pls
+>integer : Symbol(integer, Decl(linkTagEmit1.js, 12, 49))
+}
+

--- a/tests/baselines/reference/linkTagEmit1.types
+++ b/tests/baselines/reference/linkTagEmit1.types
@@ -1,0 +1,28 @@
+=== tests/cases/conformance/jsdoc/declarations.d.ts ===
+declare namespace NS {
+    type R = number
+>R : number
+}
+=== tests/cases/conformance/jsdoc/linkTagEmit1.js ===
+/** @typedef {number} N */
+/**
+ * @typedef {Object} D1
+ * @property {1} e Just link to {@link NS.R} this time
+ * @property {1} m Wyatt Earp loved {@link N integers} I bet.
+ */
+
+/** @typedef {number} Z @see N {@link N} */
+
+/**
+ * @param {number} integer {@link Z}
+ */
+function computeCommonSourceDirectoryOfFilenames(integer) {
+>computeCommonSourceDirectoryOfFilenames : (integer: number) => number
+>integer : number
+
+    return integer + 1 // pls pls pls
+>integer + 1 : number
+>integer : number
+>1 : 1
+}
+

--- a/tests/baselines/reference/parseLinkTag.js
+++ b/tests/baselines/reference/parseLinkTag.js
@@ -1,0 +1,16 @@
+//// [parseLinkTag.ts]
+/** trailing @link tag {@link */
+var x;
+/** @returns trailing @link tag {@link */
+function f() {
+    return x
+}
+
+
+//// [parseLinkTag.js]
+/** trailing @link tag {@link */
+var x;
+/** @returns trailing @link tag {@link */
+function f() {
+    return x;
+}

--- a/tests/baselines/reference/parseLinkTag.symbols
+++ b/tests/baselines/reference/parseLinkTag.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/jsdoc/parseLinkTag.ts ===
+/** trailing @link tag {@link */
+var x;
+>x : Symbol(x, Decl(parseLinkTag.ts, 1, 3))
+
+/** @returns trailing @link tag {@link */
+function f() {
+>f : Symbol(f, Decl(parseLinkTag.ts, 1, 6))
+
+    return x
+>x : Symbol(x, Decl(parseLinkTag.ts, 1, 3))
+}
+

--- a/tests/baselines/reference/parseLinkTag.types
+++ b/tests/baselines/reference/parseLinkTag.types
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/jsdoc/parseLinkTag.ts ===
+/** trailing @link tag {@link */
+var x;
+>x : any
+
+/** @returns trailing @link tag {@link */
+function f() {
+>f : () => any
+
+    return x
+>x : any
+}
+

--- a/tests/baselines/reference/quickInfoAlias.baseline
+++ b/tests/baselines/reference/quickInfoAlias.baseline
@@ -79,7 +79,12 @@
       "tags": [
         {
           "name": "tag",
-          "text": "Tag text"
+          "text": [
+            {
+              "text": "Tag text",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -164,7 +169,12 @@
       "tags": [
         {
           "name": "tag",
-          "text": "Tag text"
+          "text": [
+            {
+              "text": "Tag text",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/quickInfoCommentsClassMembers.baseline
+++ b/tests/baselines/reference/quickInfoCommentsClassMembers.baseline
@@ -5585,7 +5585,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "a this is first parameter a"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is first parameter a",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -5746,7 +5759,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "a this is first parameter a"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is first parameter a",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -5815,7 +5841,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "a this is first parameter a"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is first parameter a",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/quickInfoCommentsCommentParsing.baseline
+++ b/tests/baselines/reference/quickInfoCommentsCommentParsing.baseline
@@ -800,7 +800,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "a first number"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "first number",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -861,7 +874,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "b second number"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "second number",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -962,11 +988,37 @@
       "tags": [
         {
           "name": "param",
-          "text": "a first number"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "first number",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "b second number"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "second number",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -1027,7 +1079,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "a first number"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "first number",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -1083,7 +1148,12 @@
       "tags": [
         {
           "name": "param",
-          "text": "b"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -1139,7 +1209,12 @@
       "tags": [
         {
           "name": "param",
-          "text": "c"
+          "text": [
+            {
+              "text": "c",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -1195,7 +1270,12 @@
       "tags": [
         {
           "name": "param",
-          "text": "d"
+          "text": [
+            {
+              "text": "d",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -1256,7 +1336,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "e LastParam"
+          "text": [
+            {
+              "text": "e",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "LastParam",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -1441,30 +1534,76 @@
       "tags": [
         {
           "name": "param",
-          "text": ""
+          "text": [
+            {
+              "text": "",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "a first number"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "first number",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "b"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "c"
+          "text": [
+            {
+              "text": "c",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "d"
+          "text": [
+            {
+              "text": "d",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "anotherTag"
         },
         {
           "name": "param",
-          "text": "e LastParam"
+          "text": [
+            {
+              "text": "e",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "LastParam",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "anotherTag"
@@ -1672,7 +1811,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "b about b"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "about b",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -1777,7 +1929,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "b about b"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "about b",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -1888,7 +2053,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "b this is about b"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is about b",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -1969,7 +2147,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "c this is optional param c"
+          "text": [
+            {
+              "text": "c",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is optional param c",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -2050,7 +2241,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "d this is optional param d"
+          "text": [
+            {
+              "text": "d",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is optional param d",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -2131,7 +2335,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "e this is optional param e"
+          "text": [
+            {
+              "text": "e",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is optional param e",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -2494,27 +2711,97 @@
       "tags": [
         {
           "name": "param",
-          "text": ""
+          "text": [
+            {
+              "text": "",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "b this is about b"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is about b",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "c this is optional param c"
+          "text": [
+            {
+              "text": "c",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is optional param c",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "d this is optional param d"
+          "text": [
+            {
+              "text": "d",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is optional param d",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "e this is optional param e"
+          "text": [
+            {
+              "text": "e",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is optional param e",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": " { () => string; } } f this is optional param f"
+          "text": [
+            {
+              "text": "",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "{ () => string; } } f this is optional param f",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -2575,7 +2862,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "a this is input number"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is input number",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -2652,15 +2952,38 @@
       "tags": [
         {
           "name": "paramTag",
-          "text": "{ number } a this is input number of paramTag"
+          "text": [
+            {
+              "text": "{ number } a this is input number of paramTag",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "a this is input number"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is input number",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "returnType",
-          "text": "{ number } it is return type"
+          "text": [
+            {
+              "text": "{ number } it is return type",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -2721,7 +3044,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "a this is a"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is a",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -2782,7 +3118,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "b this is b"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is b",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -2883,15 +3232,46 @@
       "tags": [
         {
           "name": "param",
-          "text": "a this is a"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is a",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "paramTag",
-          "text": "{ number } g this is optional param g"
+          "text": [
+            {
+              "text": "{ number } g this is optional param g",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "b this is b"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is b",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -2952,7 +3332,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "foo is string"
+          "text": [
+            {
+              "text": "foo",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "is string",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -3013,7 +3406,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "bar is second string"
+          "text": [
+            {
+              "text": "bar",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "is second string",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -3114,11 +3520,37 @@
       "tags": [
         {
           "name": "param",
-          "text": "foo is string"
+          "text": [
+            {
+              "text": "foo",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "is string",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "bar is second string"
+          "text": [
+            {
+              "text": "bar",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "is second string",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -3187,7 +3619,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "a it is first parameter"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "it is first parameter",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -3303,7 +3748,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "c it is third parameter"
+          "text": [
+            {
+              "text": "c",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "it is third parameter",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -3502,11 +3960,37 @@
       "tags": [
         {
           "name": "param",
-          "text": "a it is first parameter"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "it is first parameter",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "c it is third parameter"
+          "text": [
+            {
+              "text": "c",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "it is third parameter",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -3677,7 +4161,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "a this is info about a\nspanning on two lines and aligned perfectly"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is info about a\nspanning on two lines and aligned perfectly",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -3738,7 +4235,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "b this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -3799,7 +4309,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "c this is info about b\nnot aligned text about parameter will eat only one space"
+          "text": [
+            {
+              "text": "c",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is info about b\nnot aligned text about parameter will eat only one space",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -3924,15 +4447,54 @@
       "tags": [
         {
           "name": "param",
-          "text": "a this is info about a\nspanning on two lines and aligned perfectly"
+          "text": [
+            {
+              "text": "a",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is info about a\nspanning on two lines and aligned perfectly",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "b this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "c this is info about b\nnot aligned text about parameter will eat only one space"
+          "text": [
+            {
+              "text": "c",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "this is info about b\nnot aligned text about parameter will eat only one space",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/quickInfoCommentsFunctionExpression.baseline
+++ b/tests/baselines/reference/quickInfoCommentsFunctionExpression.baseline
@@ -387,7 +387,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "b inner parameter"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "inner parameter",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -448,7 +461,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "b inner parameter"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "inner parameter",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -609,7 +635,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "b inner parameter"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "inner parameter",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -714,7 +753,20 @@
       "tags": [
         {
           "name": "param",
-          "text": "b inner parameter"
+          "text": [
+            {
+              "text": "b",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "inner parameter",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -811,19 +863,55 @@
       "tags": [
         {
           "name": "param",
-          "text": "s param on expression"
+          "text": [
+            {
+              "text": "s",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "param on expression",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "returns",
-          "text": "return on expression"
+          "text": [
+            {
+              "text": "return on expression",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "s the first parameter!"
+          "text": [
+            {
+              "text": "s",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "the first parameter!",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "returns",
-          "text": "the parameter's length"
+          "text": [
+            {
+              "text": "the parameter's length",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -920,19 +1008,55 @@
       "tags": [
         {
           "name": "param",
-          "text": "s param on expression"
+          "text": [
+            {
+              "text": "s",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "param on expression",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "returns",
-          "text": "return on expression"
+          "text": [
+            {
+              "text": "return on expression",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "s the first parameter!"
+          "text": [
+            {
+              "text": "s",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "the first parameter!",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "returns",
-          "text": "the parameter's length"
+          "text": [
+            {
+              "text": "the parameter's length",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/quickInfoDisplayPartsParameters.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsParameters.baseline
@@ -158,7 +158,12 @@
       "tags": [
         {
           "name": "return",
-          "text": "*crunch*"
+          "text": [
+            {
+              "text": "*crunch*",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/quickInfoForJSDocCodefence.baseline
+++ b/tests/baselines/reference/quickInfoForJSDocCodefence.baseline
@@ -50,7 +50,12 @@
       "tags": [
         {
           "name": "example",
-          "text": "```\n1 + 2\n```"
+          "text": [
+            {
+              "text": "```\n1 + 2\n```",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -106,7 +111,12 @@
       "tags": [
         {
           "name": "example",
-          "text": "``\n1 + 2\n`"
+          "text": [
+            {
+              "text": "``\n1 + 2\n`",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/quickInfoForJSDocUnknownTag.baseline
+++ b/tests/baselines/reference/quickInfoForJSDocUnknownTag.baseline
@@ -50,7 +50,12 @@
       "tags": [
         {
           "name": "example",
-          "text": "if (true) {\n    foo()\n}"
+          "text": [
+            {
+              "text": "if (true) {\n    foo()\n}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -106,7 +111,12 @@
       "tags": [
         {
           "name": "example",
-          "text": "{\n    foo()\n}"
+          "text": [
+            {
+              "text": "{\n    foo()\n}",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -162,7 +172,12 @@
       "tags": [
         {
           "name": "example",
-          "text": "  x y\n  12345\n     b"
+          "text": [
+            {
+              "text": "  x y\n  12345\n     b",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -221,7 +236,12 @@
         },
         {
           "name": "example",
-          "text": "  x y\n  12345\n     b"
+          "text": [
+            {
+              "text": "  x y\n  12345\n     b",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -280,7 +300,12 @@
         },
         {
           "name": "example",
-          "text": "x y\n12345\n   b"
+          "text": [
+            {
+              "text": "x y\n12345\n   b",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/quickInfoJSDocTags.baseline
+++ b/tests/baselines/reference/quickInfoJSDocTags.baseline
@@ -71,7 +71,12 @@
       "tags": [
         {
           "name": "myjsdoctag",
-          "text": "this is a comment"
+          "text": [
+            {
+              "text": "this is a comment",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -119,7 +124,12 @@
       "tags": [
         {
           "name": "mytag",
-          "text": "comment1 comment2"
+          "text": [
+            {
+              "text": "comment1 comment2",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -196,7 +206,12 @@
       "tags": [
         {
           "name": "mytag",
-          "text": "comment1 comment2"
+          "text": [
+            {
+              "text": "comment1 comment2",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -353,7 +368,12 @@
       "tags": [
         {
           "name": "returns",
-          "text": "a value"
+          "text": [
+            {
+              "text": "a value",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -448,11 +468,29 @@
       "tags": [
         {
           "name": "param",
-          "text": "foo A value."
+          "text": [
+            {
+              "text": "foo",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "A value.",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "returns",
-          "text": "Another value"
+          "text": [
+            {
+              "text": "Another value",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "mytag"
@@ -519,7 +557,12 @@
       "tags": [
         {
           "name": "mytag",
-          "text": "comment1 comment2"
+          "text": [
+            {
+              "text": "comment1 comment2",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }
@@ -583,11 +626,21 @@
       "tags": [
         {
           "name": "mytag1",
-          "text": "some comments\nsome more comments about mytag1"
+          "text": [
+            {
+              "text": "some comments\nsome more comments about mytag1",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "mytag2",
-          "text": "here all the comments are on a new line"
+          "text": [
+            {
+              "text": "here all the comments are on a new line",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "mytag3"

--- a/tests/baselines/reference/quickInfoJsDocTags1.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags1.baseline
@@ -71,39 +71,124 @@
       "tags": [
         {
           "name": "author",
-          "text": "Me <me@domain.tld>"
+          "text": [
+            {
+              "text": "Me <me@domain.tld>",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "augments",
-          "text": "C<T> Augments it"
+          "text": [
+            {
+              "text": "C<T>",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "Augments it",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "template",
-          "text": "T A template"
+          "text": [
+            {
+              "text": "T",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "A template",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "type",
-          "text": "{number | string} A type"
+          "text": [
+            {
+              "text": "{number | string}",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "A type",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "typedef",
-          "text": "NumOrStr"
+          "text": [
+            {
+              "text": "NumOrStr",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "property",
-          "text": "{number} x The prop"
+          "text": [
+            {
+              "text": "{number} x The prop",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "x The param"
+          "text": [
+            {
+              "text": "x",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "The param",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "returns",
-          "text": "The result"
+          "text": [
+            {
+              "text": "The result",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "see",
-          "text": "x (the parameter)"
+          "text": [
+            {
+              "text": "x",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(the parameter)",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/quickInfoJsDocTags3.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags3.baseline
@@ -71,23 +71,72 @@
       "tags": [
         {
           "name": "author",
-          "text": "Me <me@domain.tld>"
+          "text": [
+            {
+              "text": "Me <me@domain.tld>",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "see",
-          "text": "x (the parameter)"
+          "text": [
+            {
+              "text": "x",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(the parameter)",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "x - x comment"
+          "text": [
+            {
+              "text": "x",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "- x comment",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "y - y comment"
+          "text": [
+            {
+              "text": "y",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "- y comment",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "throws",
-          "text": "{Error} comment"
+          "text": [
+            {
+              "text": "{Error} comment",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/quickInfoJsDocTags4.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags4.baseline
@@ -111,23 +111,72 @@
       "tags": [
         {
           "name": "author",
-          "text": "Me <me@domain.tld>"
+          "text": [
+            {
+              "text": "Me <me@domain.tld>",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "see",
-          "text": "x (the parameter)"
+          "text": [
+            {
+              "text": "x",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(the parameter)",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "x - x comment"
+          "text": [
+            {
+              "text": "x",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "- x comment",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "y - y comment"
+          "text": [
+            {
+              "text": "y",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "- y comment",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "returns",
-          "text": "The result"
+          "text": [
+            {
+              "text": "The result",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/quickInfoJsDocTags5.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags5.baseline
@@ -111,23 +111,72 @@
       "tags": [
         {
           "name": "author",
-          "text": "Me <me@domain.tld>"
+          "text": [
+            {
+              "text": "Me <me@domain.tld>",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "see",
-          "text": "x (the parameter)"
+          "text": [
+            {
+              "text": "x",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(the parameter)",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "x - x comment"
+          "text": [
+            {
+              "text": "x",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "- x comment",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "y - y comment"
+          "text": [
+            {
+              "text": "y",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "- y comment",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "returns",
-          "text": "The result"
+          "text": [
+            {
+              "text": "The result",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/quickInfoJsDocTags6.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTags6.baseline
@@ -111,23 +111,72 @@
       "tags": [
         {
           "name": "author",
-          "text": "Me <me@domain.tld>"
+          "text": [
+            {
+              "text": "Me <me@domain.tld>",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "see",
-          "text": "x (the parameter)"
+          "text": [
+            {
+              "text": "x",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "(the parameter)",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "x - x comment"
+          "text": [
+            {
+              "text": "x",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "- x comment",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "param",
-          "text": "y - y comment"
+          "text": [
+            {
+              "text": "y",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "- y comment",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "returns",
-          "text": "The result"
+          "text": [
+            {
+              "text": "The result",
+              "kind": "text"
+            }
+          ]
         },
         {
           "name": "inheritDoc"

--- a/tests/baselines/reference/quickInfoJsDocTagsFunctionOverload01.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTagsFunctionOverload01.baseline
@@ -182,7 +182,12 @@
       "tags": [
         {
           "name": "tag",
-          "text": "Tag text"
+          "text": [
+            {
+              "text": "Tag text",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/quickInfoJsDocTagsFunctionOverload03.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTagsFunctionOverload03.baseline
@@ -177,7 +177,12 @@
       "tags": [
         {
           "name": "tag",
-          "text": "Tag text"
+          "text": [
+            {
+              "text": "Tag text",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/quickInfoJsDocTagsFunctionOverload05.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTagsFunctionOverload05.baseline
@@ -172,7 +172,12 @@
       "tags": [
         {
           "name": "tag",
-          "text": "Tag text"
+          "text": [
+            {
+              "text": "Tag text",
+              "kind": "text"
+            }
+          ]
         }
       ]
     }

--- a/tests/baselines/reference/quickInfoJsDocTextFormatting1.baseline
+++ b/tests/baselines/reference/quickInfoJsDocTextFormatting1.baseline
@@ -111,11 +111,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "var1 **Highlighted text**"
+              "text": [
+                {
+                  "text": "var1",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "**Highlighted text**",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "var2 Another **Highlighted text**"
+              "text": [
+                {
+                  "text": "var2",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Another **Highlighted text**",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -241,11 +267,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "var1 *Regular text with an asterisk"
+              "text": [
+                {
+                  "text": "var1",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "*Regular text with an asterisk",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "var2 Another *Regular text with an asterisk"
+              "text": [
+                {
+                  "text": "var2",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Another *Regular text with an asterisk",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -371,11 +423,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "var1 *Regular text with an asterisk"
+              "text": [
+                {
+                  "text": "var1",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "*Regular text with an asterisk",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "var2 Another *Regular text with an asterisk"
+              "text": [
+                {
+                  "text": "var2",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Another *Regular text with an asterisk",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -501,11 +579,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "var1 **Highlighted text**"
+              "text": [
+                {
+                  "text": "var1",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "**Highlighted text**",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "var2 Another **Highlighted text**"
+              "text": [
+                {
+                  "text": "var2",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Another **Highlighted text**",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -631,11 +735,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "var1 **Highlighted text**"
+              "text": [
+                {
+                  "text": "var1",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "**Highlighted text**",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "var2 Another **Highlighted text**"
+              "text": [
+                {
+                  "text": "var2",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "Another **Highlighted text**",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/signatureHelpCommentsClass.baseline
+++ b/tests/baselines/reference/signatureHelpCommentsClass.baseline
@@ -412,7 +412,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is my a"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is my a",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/signatureHelpCommentsCommentParsing.baseline
+++ b/tests/baselines/reference/signatureHelpCommentsCommentParsing.baseline
@@ -1029,11 +1029,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b second number"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "second number",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -1164,11 +1190,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b second number"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "second number",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -1383,30 +1435,76 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
             },
             {
               "name": "param",
-              "text": "e LastParam"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "LastParam",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
@@ -1624,30 +1722,76 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
             },
             {
               "name": "param",
-              "text": "e LastParam"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "LastParam",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
@@ -1865,30 +2009,76 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
             },
             {
               "name": "param",
-              "text": "e LastParam"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "LastParam",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
@@ -2106,30 +2296,76 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
             },
             {
               "name": "param",
-              "text": "e LastParam"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "LastParam",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
@@ -2347,30 +2583,76 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a first number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "first number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
             },
             {
               "name": "param",
-              "text": "e LastParam"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "LastParam",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "anotherTag"
@@ -2470,7 +2752,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "b about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "about b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -2636,7 +2931,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "b about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "about b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -3038,27 +3346,97 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is about b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is optional param c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d this is optional param d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "e this is optional param e"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param e",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": " { () => string; } } f this is optional param f"
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "{ () => string; } } f this is optional param f",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -3391,27 +3769,97 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is about b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is optional param c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d this is optional param d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "e this is optional param e"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param e",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": " { () => string; } } f this is optional param f"
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "{ () => string; } } f this is optional param f",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -3744,27 +4192,97 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is about b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is optional param c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d this is optional param d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "e this is optional param e"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param e",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": " { () => string; } } f this is optional param f"
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "{ () => string; } } f this is optional param f",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -4097,27 +4615,97 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is about b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is optional param c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d this is optional param d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "e this is optional param e"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param e",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": " { () => string; } } f this is optional param f"
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "{ () => string; } } f this is optional param f",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -4450,27 +5038,97 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is about b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is optional param c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d this is optional param d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "e this is optional param e"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param e",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": " { () => string; } } f this is optional param f"
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "{ () => string; } } f this is optional param f",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -4803,27 +5461,97 @@
           "tags": [
             {
               "name": "param",
-              "text": ""
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is about b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is about b",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is optional param c"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param c",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "d this is optional param d"
+              "text": [
+                {
+                  "text": "d",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param d",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "e this is optional param e"
+              "text": [
+                {
+                  "text": "e",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is optional param e",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": " { () => string; } } f this is optional param f"
+              "text": [
+                {
+                  "text": "",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "{ () => string; } } f this is optional param f",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -4925,15 +5653,38 @@
           "tags": [
             {
               "name": "paramTag",
-              "text": "{ number } a this is input number of paramTag"
+              "text": [
+                {
+                  "text": "{ number } a this is input number of paramTag",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a this is input number"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is input number",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returnType",
-              "text": "{ number } it is return type"
+              "text": [
+                {
+                  "text": "{ number } it is return type",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -5064,15 +5815,46 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is a"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is a",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "paramTag",
-              "text": "{ number } g this is optional param g"
+              "text": [
+                {
+                  "text": "{ number } g this is optional param g",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -5203,15 +5985,46 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is a"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is a",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "paramTag",
-              "text": "{ number } g this is optional param g"
+              "text": [
+                {
+                  "text": "{ number } g this is optional param g",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is b"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is b",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -5342,11 +6155,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "foo is string"
+              "text": [
+                {
+                  "text": "foo",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is string",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "bar is second string"
+              "text": [
+                {
+                  "text": "bar",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is second string",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -5477,11 +6316,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "foo is string"
+              "text": [
+                {
+                  "text": "foo",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is string",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "bar is second string"
+              "text": [
+                {
+                  "text": "bar",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "is second string",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -5680,11 +6545,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a it is first parameter"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is first parameter",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c it is third parameter"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is third parameter",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -5876,11 +6767,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a it is first parameter"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is first parameter",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c it is third parameter"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is third parameter",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -6072,11 +6989,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a it is first parameter"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is first parameter",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c it is third parameter"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is third parameter",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -6268,11 +7211,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "a it is first parameter"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is first parameter",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c it is third parameter"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "it is third parameter",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -6566,15 +7535,54 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is info about a\nspanning on two lines and aligned perfectly"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about a\nspanning on two lines and aligned perfectly",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is info about b\nnot aligned text about parameter will eat only one space"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nnot aligned text about parameter will eat only one space",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -6734,15 +7742,54 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is info about a\nspanning on two lines and aligned perfectly"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about a\nspanning on two lines and aligned perfectly",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is info about b\nnot aligned text about parameter will eat only one space"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nnot aligned text about parameter will eat only one space",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -6902,15 +7949,54 @@
           "tags": [
             {
               "name": "param",
-              "text": "a this is info about a\nspanning on two lines and aligned perfectly"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about a\nspanning on two lines and aligned perfectly",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "c this is info about b\nnot aligned text about parameter will eat only one space"
+              "text": [
+                {
+                  "text": "c",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "this is info about b\nnot aligned text about parameter will eat only one space",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/signatureHelpCommentsFunctionDeclaration.baseline
+++ b/tests/baselines/reference/signatureHelpCommentsFunctionDeclaration.baseline
@@ -406,7 +406,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "a a string"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "a string",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/signatureHelpCommentsFunctionExpression.baseline
+++ b/tests/baselines/reference/signatureHelpCommentsFunctionExpression.baseline
@@ -379,19 +379,55 @@
           "tags": [
             {
               "name": "param",
-              "text": "s param on expression"
+              "text": [
+                {
+                  "text": "s",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "param on expression",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returns",
-              "text": "return on expression"
+              "text": [
+                {
+                  "text": "return on expression",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "s the first parameter!"
+              "text": [
+                {
+                  "text": "s",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "the first parameter!",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "returns",
-              "text": "the parameter's length"
+              "text": [
+                {
+                  "text": "the parameter's length",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/signatureHelpConstructorCallParamProperties.baseline
+++ b/tests/baselines/reference/signatureHelpConstructorCallParamProperties.baseline
@@ -87,7 +87,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "radius The radius of the circle."
+              "text": [
+                {
+                  "text": "radius",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "The radius of the circle.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/signatureHelpJSDocCallbackTag.baseline
+++ b/tests/baselines/reference/signatureHelpJSDocCallbackTag.baseline
@@ -1,0 +1,548 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/server/jsdocCallbackTag.js",
+      "position": 480,
+      "name": "4"
+    },
+    "signatureHelp": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "t",
+              "kind": "localName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "eventName",
+              "documentation": [
+                {
+                  "text": "- So many words",
+                  "kind": "text"
+                }
+              ],
+              "displayParts": [
+                {
+                  "text": "eventName",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "string",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "eventName2",
+              "documentation": [
+                {
+                  "text": "- Silence is golden",
+                  "kind": "text"
+                }
+              ],
+              "displayParts": [
+                {
+                  "text": "eventName2",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "string",
+                  "kind": "keyword"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "|",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "eventName3",
+              "documentation": [
+                {
+                  "text": "- Osterreich mos def",
+                  "kind": "text"
+                }
+              ],
+              "displayParts": [
+                {
+                  "text": "eventName3",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "any",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": [
+            {
+              "name": "type",
+              "text": [
+                {
+                  "text": "{FooHandler} callback",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "applicableSpan": {
+        "start": {
+          "line": 22,
+          "offset": 3
+        },
+        "end": {
+          "line": 22,
+          "offset": 17
+        }
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 3
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/server/jsdocCallbackTag.js",
+      "position": 485,
+      "name": "5"
+    },
+    "signatureHelp": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "t",
+              "kind": "localName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "eventName",
+              "documentation": [
+                {
+                  "text": "- So many words",
+                  "kind": "text"
+                }
+              ],
+              "displayParts": [
+                {
+                  "text": "eventName",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "string",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "eventName2",
+              "documentation": [
+                {
+                  "text": "- Silence is golden",
+                  "kind": "text"
+                }
+              ],
+              "displayParts": [
+                {
+                  "text": "eventName2",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "string",
+                  "kind": "keyword"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "|",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "eventName3",
+              "documentation": [
+                {
+                  "text": "- Osterreich mos def",
+                  "kind": "text"
+                }
+              ],
+              "displayParts": [
+                {
+                  "text": "eventName3",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "any",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": [
+            {
+              "name": "type",
+              "text": [
+                {
+                  "text": "{FooHandler} callback",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "applicableSpan": {
+        "start": {
+          "line": 22,
+          "offset": 3
+        },
+        "end": {
+          "line": 22,
+          "offset": 17
+        }
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 1,
+      "argumentCount": 3
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/server/jsdocCallbackTag.js",
+      "position": 489,
+      "name": "6"
+    },
+    "signatureHelp": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "t",
+              "kind": "localName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "eventName",
+              "documentation": [
+                {
+                  "text": "- So many words",
+                  "kind": "text"
+                }
+              ],
+              "displayParts": [
+                {
+                  "text": "eventName",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "string",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "eventName2",
+              "documentation": [
+                {
+                  "text": "- Silence is golden",
+                  "kind": "text"
+                }
+              ],
+              "displayParts": [
+                {
+                  "text": "eventName2",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "string",
+                  "kind": "keyword"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "|",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "eventName3",
+              "documentation": [
+                {
+                  "text": "- Osterreich mos def",
+                  "kind": "text"
+                }
+              ],
+              "displayParts": [
+                {
+                  "text": "eventName3",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "any",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": [
+            {
+              "name": "type",
+              "text": [
+                {
+                  "text": "{FooHandler} callback",
+                  "kind": "text"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "applicableSpan": {
+        "start": {
+          "line": 22,
+          "offset": 3
+        },
+        "end": {
+          "line": 22,
+          "offset": 17
+        }
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 2,
+      "argumentCount": 3
+    }
+  }
+]

--- a/tests/baselines/reference/signatureHelpJSDocTags.baseline
+++ b/tests/baselines/reference/signatureHelpJSDocTags.baseline
@@ -82,7 +82,12 @@
           "tags": [
             {
               "name": "myjsdoctag",
-              "text": "this is a comment"
+              "text": [
+                {
+                  "text": "this is a comment",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -154,7 +159,12 @@
           "tags": [
             {
               "name": "mytag",
-              "text": "comment1 comment2"
+              "text": [
+                {
+                  "text": "comment1 comment2",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -287,7 +297,12 @@
           "tags": [
             {
               "name": "returns",
-              "text": "a value"
+              "text": [
+                {
+                  "text": "a value",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/signatureHelpJSMissingPropertyAccess.baseline
+++ b/tests/baselines/reference/signatureHelpJSMissingPropertyAccess.baseline
@@ -280,11 +280,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array."
+              "text": [
+                {
+                  "text": "predicate",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value."
+              "text": [
+                {
+                  "text": "thisArg",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         },
@@ -517,11 +543,37 @@
           "tags": [
             {
               "name": "param",
-              "text": "predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array."
+              "text": [
+                {
+                  "text": "predicate",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value."
+              "text": [
+                {
+                  "text": "thisArg",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/signatureHelpTypeArguments2.baseline
+++ b/tests/baselines/reference/signatureHelpTypeArguments2.baseline
@@ -193,23 +193,80 @@
           "tags": [
             {
               "name": "template",
-              "text": "T some documentation 2"
+              "text": [
+                {
+                  "text": "T",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "some documentation 2",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "template",
-              "text": "W"
+              "text": [
+                {
+                  "text": "W",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "template",
-              "text": "U, V others"
+              "text": [
+                {
+                  "text": "U, V",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "others",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a ok"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "ok",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b not ok"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "not ok",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -417,23 +474,80 @@
           "tags": [
             {
               "name": "template",
-              "text": "T some documentation 2"
+              "text": [
+                {
+                  "text": "T",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "some documentation 2",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "template",
-              "text": "W"
+              "text": [
+                {
+                  "text": "W",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "template",
-              "text": "U, V others"
+              "text": [
+                {
+                  "text": "U, V",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "others",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a ok"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "ok",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b not ok"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "not ok",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -641,23 +755,80 @@
           "tags": [
             {
               "name": "template",
-              "text": "T some documentation 2"
+              "text": [
+                {
+                  "text": "T",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "some documentation 2",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "template",
-              "text": "W"
+              "text": [
+                {
+                  "text": "W",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "template",
-              "text": "U, V others"
+              "text": [
+                {
+                  "text": "U, V",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "others",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a ok"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "ok",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b not ok"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "not ok",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }
@@ -865,23 +1036,80 @@
           "tags": [
             {
               "name": "template",
-              "text": "T some documentation 2"
+              "text": [
+                {
+                  "text": "T",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "some documentation 2",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "template",
-              "text": "W"
+              "text": [
+                {
+                  "text": "W",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "template",
-              "text": "U, V others"
+              "text": [
+                {
+                  "text": "U, V",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "others",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "a ok"
+              "text": [
+                {
+                  "text": "a",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "ok",
+                  "kind": "text"
+                }
+              ]
             },
             {
               "name": "param",
-              "text": "b not ok"
+              "text": [
+                {
+                  "text": "b",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "not ok",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/signatureHelpWithUnknown.baseline
+++ b/tests/baselines/reference/signatureHelpWithUnknown.baseline
@@ -87,7 +87,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "x A String value that contains valid JavaScript code."
+              "text": [
+                {
+                  "text": "x",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "A String value that contains valid JavaScript code.",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/smartSelection_JSDocTags1.baseline
+++ b/tests/baselines/reference/smartSelection_JSDocTags1.baseline
@@ -16,7 +16,8 @@ function foo() { return [] }
              Array<{ value: string }> 
 
 
-   @returns {Array<{ value: string }>}
+   @returns {Array<{ value: string }>}↲
+•  
 
 
 /**

--- a/tests/baselines/reference/smartSelection_JSDocTags2.baseline
+++ b/tests/baselines/reference/smartSelection_JSDocTags2.baseline
@@ -7,7 +7,8 @@ const foo;
           string 
 
 
-   @type {string}
+   @type {string}↲
+•  
 
 
 /**

--- a/tests/baselines/reference/smartSelection_JSDocTags9.baseline
+++ b/tests/baselines/reference/smartSelection_JSDocTags9.baseline
@@ -8,7 +8,7 @@ const Foo = {
            number    
 
 
-    @enum {number}   
+    @enum {number}•  
 
 
 /** @enum {number} */

--- a/tests/baselines/reference/trailingCommaSignatureHelp.baseline
+++ b/tests/baselines/reference/trailingCommaSignatureHelp.baseline
@@ -180,7 +180,20 @@
           "tags": [
             {
               "name": "param",
-              "text": "radix The radix"
+              "text": [
+                {
+                  "text": "radix",
+                  "kind": "text"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "The radix",
+                  "kind": "text"
+                }
+              ]
             }
           ]
         }

--- a/tests/baselines/reference/unusedTypeParameters_templateTag.errors.txt
+++ b/tests/baselines/reference/unusedTypeParameters_templateTag.errors.txt
@@ -3,7 +3,7 @@
 
 ==== /a.js (1 errors) ====
     /** @template T */
-        ~~~~~~~~~~~
+        ~~~~~~~~~~~~
 !!! error TS6133: 'T' is declared but its value is never read.
     function f() {}
     

--- a/tests/baselines/reference/unusedTypeParameters_templateTag2.errors.txt
+++ b/tests/baselines/reference/unusedTypeParameters_templateTag2.errors.txt
@@ -9,8 +9,9 @@
      * @template T
      * @template V
        ~~~~~~~~~~~
-!!! error TS6133: 'V' is declared but its value is never read.
      */
+    ~
+!!! error TS6133: 'V' is declared but its value is never read.
     class C1 {
         constructor() {
             /** @type {T} */
@@ -21,8 +22,9 @@
     /**
      * @template T,V
        ~~~~~~~~~~~~~
-!!! error TS6205: All type parameters are unused.
      */
+    ~
+!!! error TS6205: All type parameters are unused.
     class C2 {
         constructor() { }
     }

--- a/tests/cases/compiler/APISample_jsdoc.ts
+++ b/tests/cases/compiler/APISample_jsdoc.ts
@@ -39,7 +39,7 @@ function parseCommentsIntoDefinition(this: any,
     }
 
     // jsdocs are separate from comments
-    const jsdocs = symbol.getJsDocTags();
+    const jsdocs = symbol.getJsDocTags(this.checker);
     jsdocs.forEach(doc => {
         // if we have @TJS-... annotations, we have to parse them
         const { name, text } = doc;
@@ -63,7 +63,7 @@ function getAnnotations(this: any, node: ts.Node): Annotations | undefined {
         return undefined;
     }
 
-    const jsDocTags: ts.JSDocTagInfo[] = symbol.getJsDocTags();
+    const jsDocTags: ts.JSDocTagInfo[] = symbol.getJsDocTags(this.checker);
     if (!jsDocTags || !jsDocTags.length) {
         return undefined;
     }

--- a/tests/cases/conformance/jsdoc/linkTagEmit1.ts
+++ b/tests/cases/conformance/jsdoc/linkTagEmit1.ts
@@ -1,0 +1,23 @@
+// @checkJs: true
+// @outdir: foo
+// @declaration: true
+// @filename: declarations.d.ts
+declare namespace NS {
+    type R = number
+}
+// @filename: linkTagEmit1.js
+/** @typedef {number} N */
+/**
+ * @typedef {Object} D1
+ * @property {1} e Just link to {@link NS.R} this time
+ * @property {1} m Wyatt Earp loved {@link N integers} I bet.
+ */
+
+/** @typedef {number} Z @see N {@link N} */
+
+/**
+ * @param {number} integer {@link Z}
+ */
+function computeCommonSourceDirectoryOfFilenames(integer) {
+    return integer + 1 // pls pls pls
+}

--- a/tests/cases/conformance/jsdoc/parseLinkTag.ts
+++ b/tests/cases/conformance/jsdoc/parseLinkTag.ts
@@ -1,0 +1,6 @@
+/** trailing @link tag {@link */
+var x;
+/** @returns trailing @link tag {@link */
+function f() {
+    return x
+}

--- a/tests/cases/fourslash/codeFixInferFromUsageJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageJS.ts
@@ -9,4 +9,4 @@
 ////    foo += 2;
 ////}
 
-verify.rangeAfterCodeFix("/** @type {number} */\nvar foo;",/*includeWhiteSpace*/ undefined, /*errorCode*/ undefined, 0);
+verify.rangeAfterCodeFix("/**\n * @type {number}\n*/\nvar foo;",/*includeWhiteSpace*/ undefined, /*errorCode*/ undefined, 0);

--- a/tests/cases/fourslash/codeFixInferFromUsageMemberJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageMemberJS.ts
@@ -30,7 +30,9 @@ verify.codeFixAll({
          * @type {number[] | undefined}
          */
         this.p = undefined;
-        /** @type {number[] | undefined} */
+        /**
+         * @type {number[] | undefined}
+         */
         this.q = undefined
     }
     method() {

--- a/tests/cases/fourslash/codeFixInferFromUsageVariable2JS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageVariable2JS.ts
@@ -10,7 +10,9 @@
 ////    x++;
 ////}|]
 
-verify.rangeAfterCodeFix(`/** @type {number} */
+verify.rangeAfterCodeFix(`/**
+ * @type {number}
+ */
 var x;
 function f() {
     x++;

--- a/tests/cases/fourslash/codeFixInferFromUsageVariableJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageVariableJS.ts
@@ -11,4 +11,4 @@
 ////    x++;
 ////}
 
-verify.rangeAfterCodeFix("/** @type {number } */\nvar x;", /*includeWhiteSpace*/ undefined, /*errorCode*/ undefined, 0);
+verify.rangeAfterCodeFix("/**\n * @type {number}\n*/\nvar x;", /*includeWhiteSpace*/ undefined, /*errorCode*/ undefined, 0);

--- a/tests/cases/fourslash/codeFixInferFromUsage_allJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsage_allJS.ts
@@ -40,7 +40,9 @@ function g(z) {
     return z * 2;
 }
 
-/** @type {number | null} */
+/**
+ * @type {number | null}
+ */
 let x = null;
 function h() {
     if (!x) x = 2;

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_all_delete_js.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_all_delete_js.ts
@@ -40,35 +40,29 @@ verify.codeFixAll({
     fixId: "unusedIdentifier_delete",
     fixAllDescription: ts.Diagnostics.Delete_all_unused_declarations.message,
     newFileContent:
-`/** Parameter doc comment */
+`/** */
 function f() {}
 
 /**
  * Doc
- * Comment
- */
+ * */
 function g() {}
 
 /**
  * Doc
- * Comment
- * Comment
- */
+ * */
 function h() {}
 
 /**
  * Doc
- * Comment
- */
+ * */
 function h2() {}
 
-/** Comment @return {void} */
+/** @return {void} */
 function i() {}
 
 /**
 Doc
-comment
-comment
 @param {number} x
 */
 function j(x) { return x; }`,

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_delete_templateTag.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_delete_templateTag.ts
@@ -55,7 +55,6 @@ verify.codeFix({
     description: "Remove template tag",
     newFileContent:
 `/**
- * Comment
- */
+ * */
 function both() {}`,
 });

--- a/tests/cases/fourslash/completionEntryForUnionMethod.ts
+++ b/tests/cases/fourslash/completionEntryForUnionMethod.ts
@@ -7,15 +7,4 @@ const text = "(method) Array<T>.map<unknown>(callbackfn: ((value: string, index:
 const documentation = "Calls a defined callback function on each element of an array, and returns an array that contains the results.";
 
 verify.quickInfoAt("", text, documentation);
-verify.completions({
-    marker: "",
-    includes: {
-        name: "map",
-        text,
-        documentation,
-        tags: [
-            { name: "param", text: "callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array." },
-            { name: "param", text: "thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value." }
-        ],
-    },
-});
+verify.baselineCompletions()

--- a/tests/cases/fourslash/findAllRefsJsDocTypeDef_js.ts
+++ b/tests/cases/fourslash/findAllRefsJsDocTypeDef_js.ts
@@ -5,7 +5,7 @@
 // @allowJs: true
 
 // @Filename: /a.js
-/////** [|@typedef {number} [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 0 |}T|]|] */
+/////** [|@typedef {number} [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 0 |}T|] |]*/
 ////
 /////**
 //// * @return {[|T|]}

--- a/tests/cases/fourslash/findAllRefsTypedef_importType.ts
+++ b/tests/cases/fourslash/findAllRefsTypedef_importType.ts
@@ -4,7 +4,7 @@
 
 // @Filename: /a.js
 ////module.exports = 0;
-/////** [|@typedef {number} [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 0 |}Foo|]|] */
+/////** [|@typedef {number} [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 0 |}Foo|] |]*/
 ////const dummy = 0;
 
 // @Filename: /b.js

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -745,7 +745,7 @@ declare namespace FourSlashInterface {
 
     interface JSDocTagInfo {
         readonly name: string;
-        readonly text: string | undefined;
+        readonly text: string | ts.SymbolDisplayPart[] | undefined;
     }
 
     interface GenerateTypesOptions {

--- a/tests/cases/fourslash/getJavaScriptCompletions16.ts
+++ b/tests/cases/fourslash/getJavaScriptCompletions16.ts
@@ -30,7 +30,7 @@ edit.backspace();
 verify.signatureHelp({
     marker: "sig",
     text: "Something(a: number, b: any): Something",
-    tags: [{ name: "param", text: "a" }],
+    tags: [{ name: "param", text: [{ kind: "text", text: "a" }] }],
 });
 
 goTo.marker('method');

--- a/tests/cases/fourslash/gotoDefinitionLinkTag1.ts
+++ b/tests/cases/fourslash/gotoDefinitionLinkTag1.ts
@@ -1,0 +1,56 @@
+///<reference path="fourslash.ts" />
+
+// @Filename: foo.ts
+//// interface [|/*def1*/Foo|] {
+////     foo: string
+//// }
+
+//// namespace NS {
+////     export interface [|/*def2*/Bar|] {
+////         baz: Foo
+////     }
+//// }
+
+//// /** {@link /*use1*/[|Foo|]} foooo*/
+//// const a = ""
+
+//// /** {@link NS./*use2*/[|Bar|]} ns.bar*/
+//// const b = ""
+
+//// /** {@link /*use3*/[|Foo|] f1}*/
+//// const c = ""
+
+//// /** {@link NS./*use4*/[|Bar|] ns.bar}*/
+//// const [|/*def3*/d|] = ""
+
+//// /** {@link /*use5*/[|d|] }dd*/
+//// const e = ""
+
+// Without lookahead, ambiguous between suffix type and link tag
+//// /** @param x {@link /*use6*/[|Foo|]} */
+//// function foo(x) { }
+
+// @Filename: bar.ts
+//// /** {@link /*use7*/[|Foo|] }dd*/
+//// const f = ""
+
+goTo.marker("use1");
+verify.goToDefinitionIs("def1");
+
+goTo.marker("use2");
+verify.goToDefinitionIs("def2");
+
+goTo.marker("use3");
+verify.goToDefinitionIs("def1");
+
+goTo.marker("use4");
+verify.goToDefinitionIs("def2");
+
+goTo.marker("use5");
+verify.goToDefinitionIs("def3");
+
+goTo.marker("use6");
+verify.goToDefinitionIs("def1");
+
+goTo.marker("use7");
+verify.goToDefinitionIs("def1");

--- a/tests/cases/fourslash/importJsNodeModule3.ts
+++ b/tests/cases/fourslash/importJsNodeModule3.ts
@@ -37,7 +37,7 @@ verify.signatureHelp({
     text: "z(a: number | boolean, b: string[]): string",
     parameterDocComment: "The first param",
     tags: [
-        { name: "param", text: "a The first param" },
-        { name: "param", text: "b The second param" },
+        { name: "param", text: [{ kind: "text", text: "a" }, { kind: "space", text: " " }, { kind: "text", text: "The first param" }] },
+        { name: "param", text: [{ kind: "text", text: "b" }, { kind: "space", text: " " }, { kind: "text", text: "The second param" }] },
     ],
 });

--- a/tests/cases/fourslash/jsDocDontBreakWithNamespaces.ts
+++ b/tests/cases/fourslash/jsDocDontBreakWithNamespaces.ts
@@ -19,30 +19,3 @@
 
 // #31298
 verify.baselineSignatureHelp()
-
-
-verify.signatureHelp({
-  marker: "foo",
-  text: "foo(): any",
-  docComment: "",
-  tags: [
-    { name: "returns", text: "Websocket server object" },
-  ],
-});
-
-verify.signatureHelp({
-  marker: "bar",
-  text: "bar(): void",
-  docComment: "",
-  tags: [],
-});
-
-
-verify.signatureHelp({
-  marker: "zee",
-  text: "zee(): any",
-  docComment: "",
-  tags: [
-    { name: "type", text: "{function(module:xxxx, module:xxxx): module:xxxxx}" },
-  ],
-});

--- a/tests/cases/fourslash/jsdocLink1.ts
+++ b/tests/cases/fourslash/jsdocLink1.ts
@@ -1,0 +1,16 @@
+///<reference path="fourslash.ts" />
+
+//// class C {
+//// }
+//// /**
+////  * {@link C}
+////  * @wat Makes a {@link C}. A default one.
+////  * {@link C()}
+////  * {@link C|postfix text}
+////  * {@link unformatted postfix text}
+////  * @see {@link C} its great
+////  */
+//// function /**/CC() {
+//// }
+
+verify.baselineQuickInfo();

--- a/tests/cases/fourslash/jsdocLink2.ts
+++ b/tests/cases/fourslash/jsdocLink2.ts
@@ -1,0 +1,18 @@
+///<reference path="fourslash.ts" />
+
+// @Filename: jsdocLink2.ts
+//// class C {
+//// }
+// @Filename: script.ts
+//// /**
+////  * {@link C}
+////  * @wat Makes a {@link C}. A default one.
+////  * {@link C()}
+////  * {@link C|postfix text}
+////  * {@link unformatted postfix text}
+////  * @see {@link C} its great
+////  */
+//// function /**/CC() {
+//// }
+
+verify.baselineQuickInfo();

--- a/tests/cases/fourslash/jsdocLink3.ts
+++ b/tests/cases/fourslash/jsdocLink3.ts
@@ -1,0 +1,19 @@
+///<reference path="fourslash.ts" />
+
+// @Filename: /jsdocLink3.ts
+//// export class C {
+//// }
+// @Filename: /module1.ts
+//// import { C } from './jsdocLink3'
+//// /**
+////  * {@link C}
+////  * @wat Makes a {@link C}. A default one.
+////  * {@link C()}
+////  * {@link C|postfix text}
+////  * {@link unformatted postfix text}
+////  * @see {@link C} its great
+////  */
+//// function /**/CC() {
+//// }
+
+verify.baselineQuickInfo();

--- a/tests/cases/fourslash/jsdocLink_findAllReferences1.ts
+++ b/tests/cases/fourslash/jsdocLink_findAllReferences1.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts'/>
+
+//// interface A/**/ {}
+//// /**
+////  * {@link A()} is ok
+////  */
+//// declare const a: A
+
+verify.baselineFindAllReferences("");

--- a/tests/cases/fourslash/jsdocLink_rename1.ts
+++ b/tests/cases/fourslash/jsdocLink_rename1.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts'/>
+
+//// interface A/**/ {}
+//// /**
+////  * {@link A()} is ok
+////  */
+//// declare const a: A
+
+verify.baselineRename('', {})

--- a/tests/cases/fourslash/jsdocTypedefTagSemanticMeaning0.ts
+++ b/tests/cases/fourslash/jsdocTypedefTagSemanticMeaning0.ts
@@ -3,7 +3,7 @@
 // @allowJs: true
 // @Filename: a.js
 
-/////** [|@typedef {number} [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 0 |}T|]|] */
+/////** [|@typedef {number} [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 0 |}T|] |]*/
 
 ////[|const [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 2 |}T|] = 1;|]
 

--- a/tests/cases/fourslash/server/completionEntryDetailAcrossFiles01.ts
+++ b/tests/cases/fourslash/server/completionEntryDetailAcrossFiles01.ts
@@ -14,7 +14,15 @@
 //// import a = require("./a");
 //// a.fo/*2*/
 
-const entry = (text: string): FourSlashInterface.ExpectedCompletionEntry => ({ name: "foo", text, documentation: "Modify the parameter", tags: [{ name: "param", text: "p1" }] });
+const entry = (text: string): FourSlashInterface.ExpectedCompletionEntry => ({
+    name: "foo",
+    text,
+    documentation: "Modify the parameter",
+    tags: [{
+        name: "param",
+        text: "p1",
+    }]
+});
 verify.completions(
     { marker: "1", includes: entry("var foo: (p1: string) => void") },
     { marker: "2", exact: entry("(alias) var foo: (p1: string) => void\nimport a.foo") },

--- a/tests/cases/fourslash/server/completionEntryDetailAcrossFiles02.ts
+++ b/tests/cases/fourslash/server/completionEntryDetailAcrossFiles02.ts
@@ -15,6 +15,16 @@
 //// a.fo/*2*/
 
 verify.completions(
-    { marker: "1", includes: { name: "foo", text: "var foo: (p1: string) => void", documentation: "Modify the parameter", tags: [{ name: "param", text: "p1" }] } },
-    { marker: "2", exact: { name: "foo", text: "(alias) var foo: (p1: string) => void\nimport a.foo", documentation: "Modify the parameter", tags: [{ name: "param", text: "p1" }] } },
+    { marker: "1", includes: {
+        name: "foo",
+        text: "var foo: (p1: string) => void",
+        documentation: "Modify the parameter",
+        tags: [{ name: "param", text: "p1" }]
+    } },
+    { marker: "2", exact: {
+        name: "foo",
+        text: "(alias) var foo: (p1: string) => void\nimport a.foo",
+        documentation: "Modify the parameter",
+        tags: [{ name: "param", text: "p1" }]
+    } },
 );

--- a/tests/cases/fourslash/server/completions02.ts
+++ b/tests/cases/fourslash/server/completions02.ts
@@ -10,9 +10,9 @@
 const sortedFunctionMembers = completion.functionMembersWithPrototype.slice().sort((a, b) => a.name.localeCompare(b.name));
 const exact: ReadonlyArray<FourSlashInterface.ExpectedCompletionEntry> = [
     ...sortedFunctionMembers.map(e =>
-        e.name === "arguments" ? { ...e, kind: "property", kindModifiers: "declare" } :
+        e.name === "arguments" ? { ...e, kind: "property", kindModifiers: "declare", tags: [] } :
         e.name === "prototype" ? { ...e, kindModifiers: undefined } : e),
-    { name: "x", text: "var Foo.x: number" },
+    { name: "x", text: "var Foo.x: number", tags: [] },
 ];
 verify.completions({ marker: "", exact });
 

--- a/tests/cases/fourslash/server/completionsImport_defaultAndNamedConflict_server.ts
+++ b/tests/cases/fourslash/server/completionsImport_defaultAndNamedConflict_server.ts
@@ -21,7 +21,8 @@ verify.completions({
       kind: "const",
       kindModifiers: "export",
       hasAction: true,
-      sortText: completion.SortText.AutoImportSuggestions
+      sortText: completion.SortText.AutoImportSuggestions,
+      tags: []
     },
     {
       name: "someModule",
@@ -31,7 +32,8 @@ verify.completions({
       kind: "property",
       kindModifiers: "export",
       hasAction: true,
-      sortText: completion.SortText.AutoImportSuggestions
+      sortText: completion.SortText.AutoImportSuggestions,
+      tags: []
     },
   ],
   preferences: {

--- a/tests/cases/fourslash/server/jsdocCallbackTag.ts
+++ b/tests/cases/fourslash/server/jsdocCallbackTag.ts
@@ -33,19 +33,3 @@ goTo.marker("3");
 verify.quickInfoIs("type FooHandler2 = (eventName?: string | undefined, eventName2?: string) => any", "- What, another one?");
 goTo.marker("8");
 verify.quickInfoIs("type FooHandler = (eventName: string, eventName2: number | string, eventName3: any) => number", "- A kind of magic");
-verify.signatureHelp({
-    marker: '4',
-    text: "t(eventName: string, eventName2: string | number, eventName3: any): number",
-    parameterDocComment: "- So many words",
-    tags: [{ name: "type", text: "{FooHandler} callback" }]
-});
-verify.signatureHelp({
-    marker: '5',
-    parameterDocComment: "- Silence is golden",
-    tags: [{ name: "type", text: "{FooHandler} callback" }]
-});
-verify.signatureHelp({
-    marker: '6',
-    parameterDocComment: "- Osterreich mos def",
-    tags: [{ name: "type", text: "{FooHandler} callback" }]
-});

--- a/tests/cases/fourslash/server/jsdocTypedefTagRename02.ts
+++ b/tests/cases/fourslash/server/jsdocTypedefTagRename02.ts
@@ -3,7 +3,7 @@
 // @allowNonTsExtensions: true
 // @Filename: jsDocTypedef_form2.js
 ////
-//// /** [|@typedef {(string | number)} [|{| "contextRangeIndex": 0 |}NumberLike|]|] */
+//// /** [|@typedef {(string | number)} [|{| "contextRangeIndex": 0 |}NumberLike|] |]*/
 ////
 //// /** @type {[|NumberLike|]} */
 //// var numberLike;

--- a/tests/cases/fourslash/server/signatureHelpJSDocCallbackTag.ts
+++ b/tests/cases/fourslash/server/signatureHelpJSDocCallbackTag.ts
@@ -1,0 +1,28 @@
+/// <reference path="../fourslash.ts"/>
+
+// @allowNonTsExtensions: true
+// @Filename: jsdocCallbackTag.js
+//// /**
+////  * @callback FooHandler - A kind of magic
+////  * @param {string} eventName - So many words
+////  * @param eventName2 {number | string} - Silence is golden
+////  * @param eventName3 - Osterreich mos def
+////  * @return {number} - DIVEKICK
+////  */
+//// /**
+////  * @type {FooHandler} callback
+////  */
+//// var t;
+////
+//// /**
+////  * @callback FooHandler2 - What, another one?
+////  * @param {string=} eventName - it keeps happening
+////  * @param {string} [eventName2] - i WARNED you dog
+////  */
+//// /**
+////  * @type {FooHandler2} callback
+////  */
+//// var t2;
+//// t(/*4*/"!", /*5*/12, /*6*/false);
+
+verify.baselineSignatureHelp()

--- a/tests/cases/fourslash/signatureHelpWhenEditingCallExpression.ts
+++ b/tests/cases/fourslash/signatureHelpWhenEditingCallExpression.ts
@@ -10,8 +10,8 @@
 ////fo/*1*/
 
 const tags: ReadonlyArray<FourSlashInterface.JSDocTagInfo> = [
-    { name: "param", text: "start The start" },
-    { name: "param", text: "end The end\nMore text" },
+    { name: "param", text: [{ kind: "text", text: "start" }, { kind: "space", text: " " }, { kind: "text", text: "The start" }] },
+    { name: "param", text: [{ kind: "text", text: "end" }, { kind: "space", text: " " }, { kind: "text", text: "The end\nMore text" }] },
 ];
 verify.noSignatureHelp("1");
 edit.insert("o");

--- a/tests/cases/fourslash/syntacticClassificationForJSDocTemplateTag.ts
+++ b/tests/cases/fourslash/syntacticClassificationForJSDocTemplateTag.ts
@@ -1,6 +1,6 @@
 /// <reference path="fourslash.ts"/>
 
-/////** @template T */
+/////** @template T baring strait */
 ////function ident<T>: T {
 ////}
 
@@ -10,7 +10,8 @@ verify.syntacticClassificationsAre(
     c.punctuation("@"),
     c.docCommentTagName("template"),
     c.typeParameterName("T"),
-    c.comment(" */"),
+    c.comment("baring strait "),
+    c.comment("*/"),
     c.keyword("function"),
     c.identifier("ident"),
     c.punctuation("<"),

--- a/tests/cases/fourslash/syntacticClassificationsDocComment1.ts
+++ b/tests/cases/fourslash/syntacticClassificationsDocComment1.ts
@@ -11,7 +11,7 @@ verify.syntacticClassificationsAre(
     c.punctuation("{"),
     c.keyword("number"),
     c.punctuation("}"),
-    c.comment(" */"),
+    c.comment("*/"),
     c.keyword("var"),
     c.identifier("v"),
     c.punctuation(";"));


### PR DESCRIPTION
Same as #41877, but with an additional commit to fix parsing unterminated `@link` tags that go to the end of a comment.

Note that local runs of activex-libreoffice show memory usage 100 MB -> 118 MB and 226k -> 290k nodes, an 18% increase in memory and 28% increase in node count. That's quite a bit, although activex-libreoffice uses jsdoc and `@link` heavily.

I'm going to make sure that DT succeeds with this build and also look at memory use from the perf tests.