### PR TITLE
fix(43313): Remove braces refactoring produces broken code if returning an object literal with type casting

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2477,8 +2477,10 @@ namespace ts {
     }
 
     /* @internal */
-    export function needsParentheses(expression: Expression) {
-        return isBinaryExpression(expression) && expression.operatorToken.kind === SyntaxKind.CommaToken || isObjectLiteralExpression(expression);
+    export function needsParentheses(expression: Expression): boolean {
+        return isBinaryExpression(expression) && expression.operatorToken.kind === SyntaxKind.CommaToken
+            || isObjectLiteralExpression(expression)
+            || isAsExpression(expression) && isObjectLiteralExpression(expression.expression);
     }
 
     export function getContextualTypeFromParent(node: Expression, checker: TypeChecker): Type | undefined {

--- a/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction29.ts
+++ b/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction29.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+////const a = /*a*/()/*b*/ => {
+////    return {} as {}
+////};
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Add or remove braces in an arrow function",
+    actionName: "Remove braces from arrow function",
+    actionDescription: "Remove braces from arrow function",
+    newContent: `const a = () => ({} as {});`,
+});

--- a/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction30.ts
+++ b/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction30.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+////const a = /*a*/()/*b*/ => {
+////    return {} as object
+////};
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Add or remove braces in an arrow function",
+    actionName: "Remove braces from arrow function",
+    actionDescription: "Remove braces from arrow function",
+    newContent: `const a = () => ({} as object);`,
+});


### PR DESCRIPTION
Fixes #43313


