### PR TITLE
Don't use _fs.realpathSync.native on windows, a semi-revert of #41292

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1186,7 +1186,6 @@ namespace ts {
             let activeSession: import("inspector").Session | "stopping" | undefined;
             let profilePath = "./profile.cpuprofile";
 
-            const realpathSync = process.platform !== "win32" ? _fs.realpathSync.native : _fs.realpathSync;
 
             const Buffer: {
                 new (input: string, encoding?: string): any;
@@ -1199,6 +1198,8 @@ namespace ts {
 
             const platform: string = _os.platform();
             const useCaseSensitiveFileNames = isFileSystemCaseSensitive();
+            const realpathSync = useCaseSensitiveFileNames ? _fs.realpathSync : (_fs.realpathSync.native ?? _fs.realpathSync);
+
             const fsSupportsRecursiveFsWatch = isNode4OrLater && (process.platform === "win32" || process.platform === "darwin");
             const getCurrentDirectory = memoize(() => process.cwd());
             const { watchFile, watchDirectory } = createSystemWatchFunctions({

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1186,7 +1186,7 @@ namespace ts {
             let activeSession: import("inspector").Session | "stopping" | undefined;
             let profilePath = "./profile.cpuprofile";
 
-            const realpathSync = _fs.realpathSync.native ?? _fs.realpathSync;
+            const realpathSync = process.platform !== "win32" ? _fs.realpathSync.native : _fs.realpathSync;
 
             const Buffer: {
                 new (input: string, encoding?: string): any;


### PR DESCRIPTION
Patch hotfix for https://github.com/microsoft/TypeScript/issues/43105 reverting #41292

Roughly: `realpathSync.native` returns uppercased drive labels on Windows which differs from `realpathSync`. without the native suffix. 

This triggers at least one or two bugs further down the line (e.g. #43342 ) and doing a lot of symlink work assuming maybe `c:/x/y/z.ts` is a symlink to `C:/x/y/z.ts`, that code crashes because it assumes you'd never pass matching paths to the symlink guessing codepaths.

4.3 can get a more thorough fix which ideally should keep `realpathSync.native`