### PR TITLE
`getSemanticDocumentHighlights`: don't fail...

### DIFF
--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -32,9 +32,11 @@ namespace ts {
             const referenceEntries = FindAllReferences.getReferenceEntriesForNode(position, node, program, sourceFilesToSearch, cancellationToken, /*options*/ undefined, sourceFilesSet);
             if (!referenceEntries) return undefined;
             const map = arrayToMultiMap(referenceEntries.map(FindAllReferences.toHighlightSpan), e => e.fileName, e => e.span);
-            return arrayFrom(map.entries(), ([fileName, highlightSpans]) => {
+            return mapDefined(arrayFrom(map.entries()), ([fileName, highlightSpans]) => {
                 if (!sourceFilesSet.has(fileName)) {
-                    Debug.assert(program.redirectTargetsMap.has(fileName));
+                    if (!program.redirectTargetsMap.has(fileName)) {
+                        return undefined;
+                    }
                     const redirectTarget = program.getSourceFile(fileName);
                     const redirect = find(sourceFilesToSearch, f => !!f.redirectInfo && f.redirectInfo.redirectTarget === redirectTarget)!;
                     fileName = redirect.fileName;

--- a/tests/cases/fourslash/documentHighlights_33722.ts
+++ b/tests/cases/fourslash/documentHighlights_33722.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /y.ts
+////class Foo {
+////  private foo() {}
+////}
+////
+////const f = () => new Foo();
+////export default f;
+
+// @Filename: /x.ts
+////import y from "./y";
+////
+////y().[|foo|]();
+
+const [r] = test.ranges();
+verify.documentHighlightsOf(r, [], { filesToSearch: ["/x.ts"] });


### PR DESCRIPTION
...when missing `program.redirectTargetsMap` info.  This assertion fails
in the added test case -- looks like there is no entry in
`program.redirectTargetsMap` when it comes from a file that is no in the
project.  So in this case don't follow the (missing) info, and instead
drop the highlight.

Fixes #33722.
