### PR TITLE
Use 'abstract new' in InstanceType and ConstructorParameters

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1508,7 +1508,7 @@ type Parameters<T extends (...args: any) => any> = T extends (...args: infer P) 
 /**
  * Obtain the parameters of a constructor function type in a tuple
  */
-type ConstructorParameters<T extends new (...args: any) => any> = T extends new (...args: infer P) => any ? P : never;
+type ConstructorParameters<T extends abstract new (...args: any) => any> = T extends abstract new (...args: infer P) => any ? P : never;
 
 /**
  * Obtain the return type of a function type
@@ -1518,7 +1518,7 @@ type ReturnType<T extends (...args: any) => any> = T extends (...args: any) => i
 /**
  * Obtain the return type of a constructor function type
  */
-type InstanceType<T extends new (...args: any) => any> = T extends new (...args: any) => infer R ? R : any;
+type InstanceType<T extends abstract new (...args: any) => any> = T extends abstract new (...args: any) => infer R ? R : any;
 
 /**
  * Convert string literal type to uppercase

--- a/tests/baselines/reference/inferTypes1.errors.txt
+++ b/tests/baselines/reference/inferTypes1.errors.txt
@@ -1,13 +1,9 @@
 tests/cases/conformance/types/conditional/inferTypes1.ts(36,23): error TS2344: Type 'string' does not satisfy the constraint '(...args: any) => any'.
 tests/cases/conformance/types/conditional/inferTypes1.ts(37,23): error TS2344: Type 'Function' does not satisfy the constraint '(...args: any) => any'.
   Type 'Function' provides no match for the signature '(...args: any): any'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(43,25): error TS2344: Type 'string' does not satisfy the constraint 'new (...args: any) => any'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(44,25): error TS2344: Type 'Function' does not satisfy the constraint 'new (...args: any) => any'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(43,25): error TS2344: Type 'string' does not satisfy the constraint 'abstract new (...args: any) => any'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(44,25): error TS2344: Type 'Function' does not satisfy the constraint 'abstract new (...args: any) => any'.
   Type 'Function' provides no match for the signature 'new (...args: any): any'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(45,25): error TS2344: Type 'typeof Abstract' does not satisfy the constraint 'new (...args: any) => any'.
-  Cannot assign an abstract constructor type to a non-abstract constructor type.
-tests/cases/conformance/types/conditional/inferTypes1.ts(47,42): error TS2344: Type 'abstract new (x: string, ...args: T) => T[]' does not satisfy the constraint 'new (...args: any) => any'.
-  Cannot assign an abstract constructor type to a non-abstract constructor type.
 tests/cases/conformance/types/conditional/inferTypes1.ts(55,25): error TS2344: Type '(x: string, y: string) => number' does not satisfy the constraint '(x: any) => any'.
 tests/cases/conformance/types/conditional/inferTypes1.ts(56,25): error TS2344: Type 'Function' does not satisfy the constraint '(x: any) => any'.
   Type 'Function' provides no match for the signature '(x: any): any'.
@@ -25,7 +21,7 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(153,40): error TS2322: 
   Type 'T' is not assignable to type 'symbol'.
 
 
-==== tests/cases/conformance/types/conditional/inferTypes1.ts (18 errors) ====
+==== tests/cases/conformance/types/conditional/inferTypes1.ts (16 errors) ====
     type Unpacked<T> =
         T extends (infer U)[] ? U :
         T extends (...args: any[]) => infer U ? U :
@@ -75,20 +71,14 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(153,40): error TS2322: 
     type U12 = InstanceType<never>;  // never
     type U13 = InstanceType<string>;  // Error
                             ~~~~~~
-!!! error TS2344: Type 'string' does not satisfy the constraint 'new (...args: any) => any'.
+!!! error TS2344: Type 'string' does not satisfy the constraint 'abstract new (...args: any) => any'.
     type U14 = InstanceType<Function>;  // Error
                             ~~~~~~~~
-!!! error TS2344: Type 'Function' does not satisfy the constraint 'new (...args: any) => any'.
+!!! error TS2344: Type 'Function' does not satisfy the constraint 'abstract new (...args: any) => any'.
 !!! error TS2344:   Type 'Function' provides no match for the signature 'new (...args: any): any'.
     type U15 = InstanceType<typeof Abstract>;  // Abstract
-                            ~~~~~~~~~~~~~~~
-!!! error TS2344: Type 'typeof Abstract' does not satisfy the constraint 'new (...args: any) => any'.
-!!! error TS2344:   Cannot assign an abstract constructor type to a non-abstract constructor type.
     type U16<T extends any[]> = InstanceType<new (x: string, ...args: T) => T[]>;  // T[]
     type U17<T extends any[]> = InstanceType<abstract new (x: string, ...args: T) => T[]>;  // T[]
-                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2344: Type 'abstract new (x: string, ...args: T) => T[]' does not satisfy the constraint 'new (...args: any) => any'.
-!!! error TS2344:   Cannot assign an abstract constructor type to a non-abstract constructor type.
     
     type ArgumentType<T extends (x: any) => any> = T extends (a: infer A) => any ? A : any;
     

--- a/tests/baselines/reference/inferTypes1.types
+++ b/tests/baselines/reference/inferTypes1.types
@@ -117,7 +117,7 @@ type U14 = InstanceType<Function>;  // Error
 >U14 : any
 
 type U15 = InstanceType<typeof Abstract>;  // Abstract
->U15 : any
+>U15 : Abstract
 >Abstract : typeof Abstract
 
 type U16<T extends any[]> = InstanceType<new (x: string, ...args: T) => T[]>;  // T[]
@@ -126,7 +126,7 @@ type U16<T extends any[]> = InstanceType<new (x: string, ...args: T) => T[]>;  /
 >args : T
 
 type U17<T extends any[]> = InstanceType<abstract new (x: string, ...args: T) => T[]>;  // T[]
->U17 : any
+>U17 : T[]
 >x : string
 >args : T
 


### PR DESCRIPTION
This finishes up the remaining work from #36392 to update `ConstructorParameters` and `InstanceType` to use abstract constructor types so that you can retrieve parameter lists and instance types from abstract classes:

```ts
abstract class C {
  constructor(x: number) {}
}

// before: error
// after: [x: number]
type P = ConstructorParameters<C>;

// before: error
// after: C
type I = InstanceType<C>;
```
