### PR TITLE
Added BindingElement to isSomeImportDeclaration

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23811,7 +23811,7 @@ namespace ts {
                 }
             }
             else if (isAlias) {
-                declaration = symbol.declarations?.find(isSomeImportDeclaration);
+                declaration = getDeclarationOfAliasSymbol(symbol);
             }
             else {
                 return type;
@@ -41662,22 +41662,6 @@ namespace ts {
                 return isIdentifier(name);
             default:
                 return isDeclarationName(name);
-        }
-    }
-
-    function isSomeImportDeclaration(decl: Node): boolean {
-        switch (decl.kind) {
-            case SyntaxKind.ImportClause: // For default import
-            case SyntaxKind.ImportEqualsDeclaration:
-            case SyntaxKind.NamespaceImport:
-            case SyntaxKind.ImportSpecifier: // For rename import `x as y`
-            case SyntaxKind.BindingElement: // For commonjs import.
-                return true;
-            case SyntaxKind.Identifier:
-                // For regular import, `decl` is an Identifier under the ImportSpecifier.
-                return decl.parent.kind === SyntaxKind.ImportSpecifier;
-            default:
-                return false;
         }
     }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2491,6 +2491,7 @@ namespace ts {
          * module.exports = <EntityNameExpression>
          * {<Identifier>}
          * {name: <EntityNameExpression>}
+         * const { x } = require ...
          */
         function isAliasSymbolDeclaration(node: Node): boolean {
             return node.kind === SyntaxKind.ImportEqualsDeclaration
@@ -41670,6 +41671,7 @@ namespace ts {
             case SyntaxKind.ImportEqualsDeclaration:
             case SyntaxKind.NamespaceImport:
             case SyntaxKind.ImportSpecifier: // For rename import `x as y`
+            case SyntaxKind.BindingElement: // For commonjs import.
                 return true;
             case SyntaxKind.Identifier:
                 // For regular import, `decl` is an Identifier under the ImportSpecifier.

--- a/tests/baselines/reference/commonJsImportBindingElementNarrowType.symbols
+++ b/tests/baselines/reference/commonJsImportBindingElementNarrowType.symbols
@@ -1,0 +1,20 @@
+=== /bar.js ===
+const { a } = require("./foo");
+>a : Symbol(a, Decl(bar.js, 0, 7))
+>require : Symbol(require)
+>"./foo" : Symbol("/foo", Decl(foo.d.ts, 0, 0))
+
+if (a) {
+>a : Symbol(a, Decl(bar.js, 0, 7))
+
+  var x = a + 1;
+>x : Symbol(x, Decl(bar.js, 2, 5))
+>a : Symbol(a, Decl(bar.js, 0, 7))
+}
+=== /foo.d.ts ===
+// Regresion test for GH#41957
+
+
+export const a: number | null;
+>a : Symbol(a, Decl(foo.d.ts, 3, 12))
+

--- a/tests/baselines/reference/commonJsImportBindingElementNarrowType.types
+++ b/tests/baselines/reference/commonJsImportBindingElementNarrowType.types
@@ -1,0 +1,24 @@
+=== /bar.js ===
+const { a } = require("./foo");
+>a : number | null
+>require("./foo") : typeof import("/foo")
+>require : any
+>"./foo" : "./foo"
+
+if (a) {
+>a : number | null
+
+  var x = a + 1;
+>x : number
+>a + 1 : number
+>a : number
+>1 : 1
+}
+=== /foo.d.ts ===
+// Regresion test for GH#41957
+
+
+export const a: number | null;
+>a : number | null
+>null : null
+

--- a/tests/cases/conformance/externalModules/commonJsImportBindingElementNarrowType.ts
+++ b/tests/cases/conformance/externalModules/commonJsImportBindingElementNarrowType.ts
@@ -1,0 +1,15 @@
+// Regresion test for GH#41957
+
+// @allowJs: true
+// @checkJs: true
+// @strictNullChecks: true
+// @noEmit: true
+
+// @Filename: /foo.d.ts
+export const a: number | null;
+
+// @Filename: /bar.js
+const { a } = require("./foo");
+if (a) {
+  var x = a + 1;
+}


### PR DESCRIPTION
Fixes #41957

CommonJs imports are now declared as aliases. I have added the `BindingElement` kind when looking for import declarations when the import is destructuring.
