### PR TITLE
Remote duplicated initialization of 'diagnostics'

### DIFF
--- a/src/harness/compilerImpl.ts
+++ b/src/harness/compilerImpl.ts
@@ -135,8 +135,6 @@ namespace compiler {
                     }
                 }
             }
-
-            this.diagnostics = diagnostics;
         }
 
         public get vfs(): vfs.FileSystem {


### PR DESCRIPTION
This line of code is already present at the top of the constructor