### PR TITLE
Fix length of `JSDocTypedefTag`

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7997,7 +7997,7 @@ namespace ts {
                     }
 
                     const typedefTag = factory.createJSDocTypedefTag(tagName, typeExpression, fullName, comment);
-                    return finishNode(typedefTag, start);
+                    return finishNode(typedefTag, start, end);
                 }
 
                 function parseJSDocTypeNameWithNamespace(nested?: boolean) {

--- a/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit1.errors.txt
+++ b/tests/baselines/reference/jsDeclarationsParameterTagReusesInputNodeInEmit1.errors.txt
@@ -18,7 +18,7 @@ tests/cases/conformance/jsdoc/declarations/file.js(6,5): error TS4084: Exported 
     
 ==== tests/cases/conformance/jsdoc/declarations/file.js (3 errors) ====
     /** @typedef {import('./base')} BaseFactory */
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS4084: Exported type alias 'BaseFactory' has or is using private name 'Base' from module "tests/cases/conformance/jsdoc/declarations/base".
     /**
      * @callback BaseFactoryFactory

--- a/tests/baselines/reference/jsDocSignature-43394.baseline
+++ b/tests/baselines/reference/jsDocSignature-43394.baseline
@@ -1,0 +1,9 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsDocSignature-43394.ts",
+      "position": 58,
+      "name": ""
+    }
+  }
+]

--- a/tests/cases/fourslash/findAllRefsJsDocTypeDef_js.ts
+++ b/tests/cases/fourslash/findAllRefsJsDocTypeDef_js.ts
@@ -5,7 +5,7 @@
 // @allowJs: true
 
 // @Filename: /a.js
-/////** [|@typedef {number} [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 0 |}T|] |]*/
+/////** [|@typedef {number} [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 0 |}T|]|] */
 ////
 /////**
 //// * @return {[|T|]}

--- a/tests/cases/fourslash/findAllRefsTypedef_importType.ts
+++ b/tests/cases/fourslash/findAllRefsTypedef_importType.ts
@@ -4,7 +4,7 @@
 
 // @Filename: /a.js
 ////module.exports = 0;
-/////** [|@typedef {number} [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 0 |}Foo|] |]*/
+/////** [|@typedef {number} [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 0 |}Foo|]|] */
 ////const dummy = 0;
 
 // @Filename: /b.js

--- a/tests/cases/fourslash/jsDocSignature-43394.ts
+++ b/tests/cases/fourslash/jsDocSignature-43394.ts
@@ -1,0 +1,9 @@
+///<reference path="fourslash.ts" />
+
+/////**
+//// * @typedef {Object} Foo
+//// * @property {number} ...
+//// * /**/@typedef {number} Bar
+//// */
+
+verify.baselineSignatureHelp();

--- a/tests/cases/fourslash/jsdocTypedefTagSemanticMeaning0.ts
+++ b/tests/cases/fourslash/jsdocTypedefTagSemanticMeaning0.ts
@@ -3,7 +3,7 @@
 // @allowJs: true
 // @Filename: a.js
 
-/////** [|@typedef {number} [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 0 |}T|] |]*/
+/////** [|@typedef {number} [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 0 |}T|]|] */
 
 ////[|const [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeIndex": 2 |}T|] = 1;|]
 

--- a/tests/cases/fourslash/server/jsdocTypedefTagRename02.ts
+++ b/tests/cases/fourslash/server/jsdocTypedefTagRename02.ts
@@ -3,7 +3,7 @@
 // @allowNonTsExtensions: true
 // @Filename: jsDocTypedef_form2.js
 ////
-//// /** [|@typedef {(string | number)} [|{| "contextRangeIndex": 0 |}NumberLike|] |]*/
+//// /** [|@typedef {(string | number)} [|{| "contextRangeIndex": 0 |}NumberLike|]|] */
 ////
 //// /** @type {[|NumberLike|]} */
 //// var numberLike;


### PR DESCRIPTION
(Accidentally broken in dcc27eb.)

Fixes #43394 and microsoft/tsserverfuzzer#309.
