### PR TITLE
Do not covariantly mix in constraints from contravarrying positions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12849,9 +12849,13 @@ namespace ts {
 
         function getConditionalFlowTypeOfType(type: Type, node: Node) {
             let constraints: Type[] | undefined;
+            let covariant = true;
             while (node && !isStatement(node) && node.kind !== SyntaxKind.JSDocComment) {
                 const parent = node.parent;
-                if (parent.kind === SyntaxKind.ConditionalType && node === (<ConditionalTypeNode>parent).trueType) {
+                if (parent.kind === SyntaxKind.Parameter || parent.kind === SyntaxKind.TypeOperator && (parent as TypeOperatorNode).operator === SyntaxKind.KeyOfKeyword) {
+                    covariant = !covariant;
+                }
+                if (covariant && parent.kind === SyntaxKind.ConditionalType && node === (<ConditionalTypeNode>parent).trueType) {
                     const constraint = getImpliedConstraint(type, (<ConditionalTypeNode>parent).checkType, (<ConditionalTypeNode>parent).extendsType);
                     if (constraint) {
                         constraints = append(constraints, constraint);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12852,7 +12852,9 @@ namespace ts {
             let covariant = true;
             while (node && !isStatement(node) && node.kind !== SyntaxKind.JSDocComment) {
                 const parent = node.parent;
-                if (parent.kind === SyntaxKind.Parameter || parent.kind === SyntaxKind.TypeOperator && (parent as TypeOperatorNode).operator === SyntaxKind.KeyOfKeyword) {
+                // only consider variance flipped by parameter locations - `keyof` types would usually be considered variance inverting, but
+                // often get used in indexed accesses where they behave sortof invariantly, but our checking is lax
+                if (parent.kind === SyntaxKind.Parameter) {
                     covariant = !covariant;
                 }
                 if (covariant && parent.kind === SyntaxKind.ConditionalType && node === (<ConditionalTypeNode>parent).trueType) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12857,7 +12857,9 @@ namespace ts {
                 if (parent.kind === SyntaxKind.Parameter) {
                     covariant = !covariant;
                 }
-                if (covariant && parent.kind === SyntaxKind.ConditionalType && node === (<ConditionalTypeNode>parent).trueType) {
+                // Always substitute on type parameters, regardless of variance, since even
+                // in contravarrying positions, they may be reliant on subtuted constraints to be valid
+                if ((covariant || type.flags & TypeFlags.TypeParameter) && parent.kind === SyntaxKind.ConditionalType && node === (<ConditionalTypeNode>parent).trueType) {
                     const constraint = getImpliedConstraint(type, (<ConditionalTypeNode>parent).checkType, (<ConditionalTypeNode>parent).extendsType);
                     if (constraint) {
                         constraints = append(constraints, constraint);

--- a/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.js
+++ b/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.js
@@ -1,0 +1,20 @@
+//// [callOfConditionalTypeWithConcreteBranches.ts]
+type Q<T> = number extends T ? (n: number) => void : never;
+function fn<T>(arg: Q<T>) {
+  // Expected: OK
+  // Actual: Cannot convert 10 to number & T
+  arg(10);
+}
+// Legal invocations are not problematic
+fn<string | number>(m => m.toFixed());
+fn<number>(m => m.toFixed());
+
+//// [callOfConditionalTypeWithConcreteBranches.js]
+function fn(arg) {
+    // Expected: OK
+    // Actual: Cannot convert 10 to number & T
+    arg(10);
+}
+// Legal invocations are not problematic
+fn(function (m) { return m.toFixed(); });
+fn(function (m) { return m.toFixed(); });

--- a/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.js
+++ b/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.js
@@ -9,6 +9,15 @@ function fn<T>(arg: Q<T>) {
 fn<string | number>(m => m.toFixed());
 fn<number>(m => m.toFixed());
 
+// Ensure the following real-world example that relies on substitution still works
+type ExtractParameters<T> = "parameters" extends keyof T
+  // The above allows "parameters" to index `T` since all later
+  // instances are actually implicitly `"parameters" & keyof T`
+  ?  {
+        [K in keyof T["parameters"]]: T["parameters"][K];
+      }[keyof T["parameters"]]
+  : {};
+
 //// [callOfConditionalTypeWithConcreteBranches.js]
 function fn(arg) {
     // Expected: OK

--- a/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.js
+++ b/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.js
@@ -18,6 +18,7 @@ type ExtractParameters<T> = "parameters" extends keyof T
       }[keyof T["parameters"]]
   : {};
 
+// Original example, but with inverted variance
 type Q2<T> = number extends T ? (cb: (n: number) => void) => void : never;
 function fn2<T>(arg: Q2<T>) {
   function useT(_arg: T): void {}
@@ -28,6 +29,10 @@ function fn2<T>(arg: Q2<T>) {
 fn2<string | number>(m => m(42));
 fn2<number>(m => m(42));
 
+// webidl-conversions example where substituion must occur, despite contravariance of the position
+// due to the invariant usage in `Parameters`
+
+type X<V> = V extends (...args: any[]) => any ? (...args: Parameters<V>) => void : Function;
 
 //// [callOfConditionalTypeWithConcreteBranches.js]
 function fn(arg) {

--- a/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.js
+++ b/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.js
@@ -18,6 +18,17 @@ type ExtractParameters<T> = "parameters" extends keyof T
       }[keyof T["parameters"]]
   : {};
 
+type Q2<T> = number extends T ? (cb: (n: number) => void) => void : never;
+function fn2<T>(arg: Q2<T>) {
+  function useT(_arg: T): void {}
+  // Expected: OK
+  arg(arg => useT(arg));
+}
+// Legal invocations are not problematic
+fn2<string | number>(m => m(42));
+fn2<number>(m => m(42));
+
+
 //// [callOfConditionalTypeWithConcreteBranches.js]
 function fn(arg) {
     // Expected: OK
@@ -27,3 +38,11 @@ function fn(arg) {
 // Legal invocations are not problematic
 fn(function (m) { return m.toFixed(); });
 fn(function (m) { return m.toFixed(); });
+function fn2(arg) {
+    function useT(_arg) { }
+    // Expected: OK
+    arg(function (arg) { return useT(arg); });
+}
+// Legal invocations are not problematic
+fn2(function (m) { return m(42); });
+fn2(function (m) { return m(42); });

--- a/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.symbols
+++ b/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.symbols
@@ -52,40 +52,54 @@ type ExtractParameters<T> = "parameters" extends keyof T
 
   : {};
 
+// Original example, but with inverted variance
 type Q2<T> = number extends T ? (cb: (n: number) => void) => void : never;
 >Q2 : Symbol(Q2, Decl(callOfConditionalTypeWithConcreteBranches.ts, 17, 7))
->T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 19, 8))
->T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 19, 8))
->cb : Symbol(cb, Decl(callOfConditionalTypeWithConcreteBranches.ts, 19, 33))
->n : Symbol(n, Decl(callOfConditionalTypeWithConcreteBranches.ts, 19, 38))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 8))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 8))
+>cb : Symbol(cb, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 33))
+>n : Symbol(n, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 38))
 
 function fn2<T>(arg: Q2<T>) {
->fn2 : Symbol(fn2, Decl(callOfConditionalTypeWithConcreteBranches.ts, 19, 74))
->T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 13))
->arg : Symbol(arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 16))
+>fn2 : Symbol(fn2, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 74))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 21, 13))
+>arg : Symbol(arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 21, 16))
 >Q2 : Symbol(Q2, Decl(callOfConditionalTypeWithConcreteBranches.ts, 17, 7))
->T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 13))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 21, 13))
 
   function useT(_arg: T): void {}
->useT : Symbol(useT, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 29))
->_arg : Symbol(_arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 21, 16))
->T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 13))
+>useT : Symbol(useT, Decl(callOfConditionalTypeWithConcreteBranches.ts, 21, 29))
+>_arg : Symbol(_arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 22, 16))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 21, 13))
 
   // Expected: OK
   arg(arg => useT(arg));
->arg : Symbol(arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 16))
->arg : Symbol(arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 23, 6))
->useT : Symbol(useT, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 29))
->arg : Symbol(arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 23, 6))
+>arg : Symbol(arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 21, 16))
+>arg : Symbol(arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 24, 6))
+>useT : Symbol(useT, Decl(callOfConditionalTypeWithConcreteBranches.ts, 21, 29))
+>arg : Symbol(arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 24, 6))
 }
 // Legal invocations are not problematic
 fn2<string | number>(m => m(42));
->fn2 : Symbol(fn2, Decl(callOfConditionalTypeWithConcreteBranches.ts, 19, 74))
->m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 26, 21))
->m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 26, 21))
+>fn2 : Symbol(fn2, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 74))
+>m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 27, 21))
+>m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 27, 21))
 
 fn2<number>(m => m(42));
->fn2 : Symbol(fn2, Decl(callOfConditionalTypeWithConcreteBranches.ts, 19, 74))
->m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 27, 12))
->m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 27, 12))
+>fn2 : Symbol(fn2, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 74))
+>m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 28, 12))
+>m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 28, 12))
+
+// webidl-conversions example where substituion must occur, despite contravariance of the position
+// due to the invariant usage in `Parameters`
+
+type X<V> = V extends (...args: any[]) => any ? (...args: Parameters<V>) => void : Function;
+>X : Symbol(X, Decl(callOfConditionalTypeWithConcreteBranches.ts, 28, 24))
+>V : Symbol(V, Decl(callOfConditionalTypeWithConcreteBranches.ts, 33, 7))
+>V : Symbol(V, Decl(callOfConditionalTypeWithConcreteBranches.ts, 33, 7))
+>args : Symbol(args, Decl(callOfConditionalTypeWithConcreteBranches.ts, 33, 23))
+>args : Symbol(args, Decl(callOfConditionalTypeWithConcreteBranches.ts, 33, 49))
+>Parameters : Symbol(Parameters, Decl(lib.es5.d.ts, --, --))
+>V : Symbol(V, Decl(callOfConditionalTypeWithConcreteBranches.ts, 33, 7))
+>Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 

--- a/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.symbols
+++ b/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.symbols
@@ -1,0 +1,34 @@
+=== tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts ===
+type Q<T> = number extends T ? (n: number) => void : never;
+>Q : Symbol(Q, Decl(callOfConditionalTypeWithConcreteBranches.ts, 0, 0))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 0, 7))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 0, 7))
+>n : Symbol(n, Decl(callOfConditionalTypeWithConcreteBranches.ts, 0, 32))
+
+function fn<T>(arg: Q<T>) {
+>fn : Symbol(fn, Decl(callOfConditionalTypeWithConcreteBranches.ts, 0, 59))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 1, 12))
+>arg : Symbol(arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 1, 15))
+>Q : Symbol(Q, Decl(callOfConditionalTypeWithConcreteBranches.ts, 0, 0))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 1, 12))
+
+  // Expected: OK
+  // Actual: Cannot convert 10 to number & T
+  arg(10);
+>arg : Symbol(arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 1, 15))
+}
+// Legal invocations are not problematic
+fn<string | number>(m => m.toFixed());
+>fn : Symbol(fn, Decl(callOfConditionalTypeWithConcreteBranches.ts, 0, 59))
+>m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 7, 20))
+>m.toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
+>m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 7, 20))
+>toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
+
+fn<number>(m => m.toFixed());
+>fn : Symbol(fn, Decl(callOfConditionalTypeWithConcreteBranches.ts, 0, 59))
+>m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 8, 11))
+>m.toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
+>m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 8, 11))
+>toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
+

--- a/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.symbols
+++ b/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.symbols
@@ -32,3 +32,22 @@ fn<number>(m => m.toFixed());
 >m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 8, 11))
 >toFixed : Symbol(Number.toFixed, Decl(lib.es5.d.ts, --, --))
 
+// Ensure the following real-world example that relies on substitution still works
+type ExtractParameters<T> = "parameters" extends keyof T
+>ExtractParameters : Symbol(ExtractParameters, Decl(callOfConditionalTypeWithConcreteBranches.ts, 8, 29))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 11, 23))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 11, 23))
+
+  // The above allows "parameters" to index `T` since all later
+  // instances are actually implicitly `"parameters" & keyof T`
+  ?  {
+        [K in keyof T["parameters"]]: T["parameters"][K];
+>K : Symbol(K, Decl(callOfConditionalTypeWithConcreteBranches.ts, 15, 9))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 11, 23))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 11, 23))
+>K : Symbol(K, Decl(callOfConditionalTypeWithConcreteBranches.ts, 15, 9))
+
+      }[keyof T["parameters"]]
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 11, 23))
+
+  : {};

--- a/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.symbols
+++ b/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.symbols
@@ -51,3 +51,41 @@ type ExtractParameters<T> = "parameters" extends keyof T
 >T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 11, 23))
 
   : {};
+
+type Q2<T> = number extends T ? (cb: (n: number) => void) => void : never;
+>Q2 : Symbol(Q2, Decl(callOfConditionalTypeWithConcreteBranches.ts, 17, 7))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 19, 8))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 19, 8))
+>cb : Symbol(cb, Decl(callOfConditionalTypeWithConcreteBranches.ts, 19, 33))
+>n : Symbol(n, Decl(callOfConditionalTypeWithConcreteBranches.ts, 19, 38))
+
+function fn2<T>(arg: Q2<T>) {
+>fn2 : Symbol(fn2, Decl(callOfConditionalTypeWithConcreteBranches.ts, 19, 74))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 13))
+>arg : Symbol(arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 16))
+>Q2 : Symbol(Q2, Decl(callOfConditionalTypeWithConcreteBranches.ts, 17, 7))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 13))
+
+  function useT(_arg: T): void {}
+>useT : Symbol(useT, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 29))
+>_arg : Symbol(_arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 21, 16))
+>T : Symbol(T, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 13))
+
+  // Expected: OK
+  arg(arg => useT(arg));
+>arg : Symbol(arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 16))
+>arg : Symbol(arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 23, 6))
+>useT : Symbol(useT, Decl(callOfConditionalTypeWithConcreteBranches.ts, 20, 29))
+>arg : Symbol(arg, Decl(callOfConditionalTypeWithConcreteBranches.ts, 23, 6))
+}
+// Legal invocations are not problematic
+fn2<string | number>(m => m(42));
+>fn2 : Symbol(fn2, Decl(callOfConditionalTypeWithConcreteBranches.ts, 19, 74))
+>m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 26, 21))
+>m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 26, 21))
+
+fn2<number>(m => m(42));
+>fn2 : Symbol(fn2, Decl(callOfConditionalTypeWithConcreteBranches.ts, 19, 74))
+>m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 27, 12))
+>m : Symbol(m, Decl(callOfConditionalTypeWithConcreteBranches.ts, 27, 12))
+

--- a/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.types
+++ b/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.types
@@ -45,3 +45,46 @@ type ExtractParameters<T> = "parameters" extends keyof T
         [K in keyof T["parameters"]]: T["parameters"][K];
       }[keyof T["parameters"]]
   : {};
+
+type Q2<T> = number extends T ? (cb: (n: number) => void) => void : never;
+>Q2 : Q2<T>
+>cb : (n: number) => void
+>n : number
+
+function fn2<T>(arg: Q2<T>) {
+>fn2 : <T>(arg: Q2<T>) => void
+>arg : Q2<T>
+
+  function useT(_arg: T): void {}
+>useT : (_arg: T) => void
+>_arg : T
+
+  // Expected: OK
+  arg(arg => useT(arg));
+>arg(arg => useT(arg)) : void
+>arg : Q2<T>
+>arg => useT(arg) : (arg: T & number) => void
+>arg : T & number
+>useT(arg) : void
+>useT : (_arg: T) => void
+>arg : T & number
+}
+// Legal invocations are not problematic
+fn2<string | number>(m => m(42));
+>fn2<string | number>(m => m(42)) : void
+>fn2 : <T>(arg: Q2<T>) => void
+>m => m(42) : (m: (n: number) => void) => void
+>m : (n: number) => void
+>m(42) : void
+>m : (n: number) => void
+>42 : 42
+
+fn2<number>(m => m(42));
+>fn2<number>(m => m(42)) : void
+>fn2 : <T>(arg: Q2<T>) => void
+>m => m(42) : (m: (n: number) => void) => void
+>m : (n: number) => void
+>m(42) : void
+>m : (n: number) => void
+>42 : 42
+

--- a/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.types
+++ b/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts ===
+type Q<T> = number extends T ? (n: number) => void : never;
+>Q : Q<T>
+>n : number
+
+function fn<T>(arg: Q<T>) {
+>fn : <T>(arg: Q<T>) => void
+>arg : Q<T>
+
+  // Expected: OK
+  // Actual: Cannot convert 10 to number & T
+  arg(10);
+>arg(10) : void
+>arg : Q<T>
+>10 : 10
+}
+// Legal invocations are not problematic
+fn<string | number>(m => m.toFixed());
+>fn<string | number>(m => m.toFixed()) : void
+>fn : <T>(arg: Q<T>) => void
+>m => m.toFixed() : (m: number) => string
+>m : number
+>m.toFixed() : string
+>m.toFixed : (fractionDigits?: number) => string
+>m : number
+>toFixed : (fractionDigits?: number) => string
+
+fn<number>(m => m.toFixed());
+>fn<number>(m => m.toFixed()) : void
+>fn : <T>(arg: Q<T>) => void
+>m => m.toFixed() : (m: number) => string
+>m : number
+>m.toFixed() : string
+>m.toFixed : (fractionDigits?: number) => string
+>m : number
+>toFixed : (fractionDigits?: number) => string
+

--- a/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.types
+++ b/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.types
@@ -35,3 +35,13 @@ fn<number>(m => m.toFixed());
 >m : number
 >toFixed : (fractionDigits?: number) => string
 
+// Ensure the following real-world example that relies on substitution still works
+type ExtractParameters<T> = "parameters" extends keyof T
+>ExtractParameters : ExtractParameters<T>
+
+  // The above allows "parameters" to index `T` since all later
+  // instances are actually implicitly `"parameters" & keyof T`
+  ?  {
+        [K in keyof T["parameters"]]: T["parameters"][K];
+      }[keyof T["parameters"]]
+  : {};

--- a/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.types
+++ b/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.types
@@ -46,6 +46,7 @@ type ExtractParameters<T> = "parameters" extends keyof T
       }[keyof T["parameters"]]
   : {};
 
+// Original example, but with inverted variance
 type Q2<T> = number extends T ? (cb: (n: number) => void) => void : never;
 >Q2 : Q2<T>
 >cb : (n: number) => void
@@ -87,4 +88,12 @@ fn2<number>(m => m(42));
 >m(42) : void
 >m : (n: number) => void
 >42 : 42
+
+// webidl-conversions example where substituion must occur, despite contravariance of the position
+// due to the invariant usage in `Parameters`
+
+type X<V> = V extends (...args: any[]) => any ? (...args: Parameters<V>) => void : Function;
+>X : X<V>
+>args : any[]
+>args : Parameters<V>
 

--- a/tests/baselines/reference/conditionalTypes2.errors.txt
+++ b/tests/baselines/reference/conditionalTypes2.errors.txt
@@ -13,13 +13,6 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(24,5): error TS23
             Type 'keyof B' is not assignable to type 'keyof A'.
               Type 'string | number | symbol' is not assignable to type 'keyof A'.
                 Type 'string' is not assignable to type 'keyof A'.
-                  Type 'string' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
-                    Type 'keyof B' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
-                      Type 'string | number | symbol' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
-                        Type 'string' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
-                          Type 'keyof B' is not assignable to type 'number'.
-                            Type 'string | number | symbol' is not assignable to type 'number'.
-                              Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/conditional/conditionalTypes2.ts(25,5): error TS2322: Type 'Invariant<A>' is not assignable to type 'Invariant<B>'.
   Types of property 'foo' are incompatible.
     Type 'A extends string ? keyof A : A' is not assignable to type 'B extends string ? keyof B : B'.
@@ -81,13 +74,6 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(75,12): error TS2
 !!! error TS2322:             Type 'keyof B' is not assignable to type 'keyof A'.
 !!! error TS2322:               Type 'string | number | symbol' is not assignable to type 'keyof A'.
 !!! error TS2322:                 Type 'string' is not assignable to type 'keyof A'.
-!!! error TS2322:                   Type 'string' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
-!!! error TS2322:                     Type 'keyof B' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
-!!! error TS2322:                       Type 'string | number | symbol' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
-!!! error TS2322:                         Type 'string' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
-!!! error TS2322:                           Type 'keyof B' is not assignable to type 'number'.
-!!! error TS2322:                             Type 'string | number | symbol' is not assignable to type 'number'.
-!!! error TS2322:                               Type 'string' is not assignable to type 'number'.
         b = a;  // Error
         ~
 !!! error TS2322: Type 'Invariant<A>' is not assignable to type 'Invariant<B>'.

--- a/tests/baselines/reference/conditionalTypes2.errors.txt
+++ b/tests/baselines/reference/conditionalTypes2.errors.txt
@@ -13,6 +13,13 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(24,5): error TS23
             Type 'keyof B' is not assignable to type 'keyof A'.
               Type 'string | number | symbol' is not assignable to type 'keyof A'.
                 Type 'string' is not assignable to type 'keyof A'.
+                  Type 'string' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
+                    Type 'keyof B' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
+                      Type 'string | number | symbol' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
+                        Type 'string' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
+                          Type 'keyof B' is not assignable to type 'number'.
+                            Type 'string | number | symbol' is not assignable to type 'number'.
+                              Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/conditional/conditionalTypes2.ts(25,5): error TS2322: Type 'Invariant<A>' is not assignable to type 'Invariant<B>'.
   Types of property 'foo' are incompatible.
     Type 'A extends string ? keyof A : A' is not assignable to type 'B extends string ? keyof B : B'.
@@ -74,6 +81,13 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(75,12): error TS2
 !!! error TS2322:             Type 'keyof B' is not assignable to type 'keyof A'.
 !!! error TS2322:               Type 'string | number | symbol' is not assignable to type 'keyof A'.
 !!! error TS2322:                 Type 'string' is not assignable to type 'keyof A'.
+!!! error TS2322:                   Type 'string' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
+!!! error TS2322:                     Type 'keyof B' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
+!!! error TS2322:                       Type 'string | number | symbol' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
+!!! error TS2322:                         Type 'string' is not assignable to type 'number | "toString" | "charAt" | "charCodeAt" | "concat" | "indexOf" | "lastIndexOf" | "localeCompare" | "match" | "replace" | "search" | "slice" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "length" | "substr" | "valueOf"'.
+!!! error TS2322:                           Type 'keyof B' is not assignable to type 'number'.
+!!! error TS2322:                             Type 'string | number | symbol' is not assignable to type 'number'.
+!!! error TS2322:                               Type 'string' is not assignable to type 'number'.
         b = a;  // Error
         ~
 !!! error TS2322: Type 'Invariant<A>' is not assignable to type 'Invariant<B>'.

--- a/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
+++ b/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
@@ -27,3 +27,8 @@ function fn2<T>(arg: Q2<T>) {
 // Legal invocations are not problematic
 fn2<string | number>(m => m(42));
 fn2<number>(m => m(42));
+
+// webidl-conversions example where substituion must occur, despite contravariance of the position
+// due to the invariant usage in `Parameters`
+
+type X<V> = V extends (...args: any[]) => any ? (...args: Parameters<V>) => void : Function;

--- a/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
+++ b/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
@@ -16,3 +16,14 @@ type ExtractParameters<T> = "parameters" extends keyof T
         [K in keyof T["parameters"]]: T["parameters"][K];
       }[keyof T["parameters"]]
   : {};
+
+// Original example, but with inverted variance
+type Q2<T> = number extends T ? (cb: (n: number) => void) => void : never;
+function fn2<T>(arg: Q2<T>) {
+  function useT(_arg: T): void {}
+  // Expected: OK
+  arg(arg => useT(arg));
+}
+// Legal invocations are not problematic
+fn2<string | number>(m => m(42));
+fn2<number>(m => m(42));

--- a/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
+++ b/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
@@ -7,3 +7,12 @@ function fn<T>(arg: Q<T>) {
 // Legal invocations are not problematic
 fn<string | number>(m => m.toFixed());
 fn<number>(m => m.toFixed());
+
+// Ensure the following real-world example that relies on substitution still works
+type ExtractParameters<T> = "parameters" extends keyof T
+  // The above allows "parameters" to index `T` since all later
+  // instances are actually implicitly `"parameters" & keyof T`
+  ?  {
+        [K in keyof T["parameters"]]: T["parameters"][K];
+      }[keyof T["parameters"]]
+  : {};

--- a/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
+++ b/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
@@ -1,0 +1,9 @@
+type Q<T> = number extends T ? (n: number) => void : never;
+function fn<T>(arg: Q<T>) {
+  // Expected: OK
+  // Actual: Cannot convert 10 to number & T
+  arg(10);
+}
+// Legal invocations are not problematic
+fn<string | number>(m => m.toFixed());
+fn<number>(m => m.toFixed());


### PR DESCRIPTION
When calculating substitutions within a conditional.

Fixes #43427
