### PR TITLE
Only issue matching token errors on non-dupe locations

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1548,7 +1548,7 @@ namespace ts {
         function parseExpectedMatchingBrackets(openKind: SyntaxKind, closeKind: SyntaxKind, openPosition: number) {
             if (token() === closeKind) {
                 nextToken();
-                return true;
+                return;
             }
             const lastError = parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(closeKind));
             if (lastError) {
@@ -1557,7 +1557,6 @@ namespace ts {
                     createDetachedDiagnostic(fileName, openPosition, 1, Diagnostics.The_parser_expected_to_find_a_1_to_match_the_0_token_here, tokenToString(openKind), tokenToString(closeKind))
                 );
             }
-            return false;
         }
 
         function parseOptional(t: SyntaxKind): boolean {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1335,24 +1335,30 @@ namespace ts {
             return inContext(NodeFlags.AwaitContext);
         }
 
-        function parseErrorAtCurrentToken(message: DiagnosticMessage, arg0?: any): void {
-            parseErrorAt(scanner.getTokenPos(), scanner.getTextPos(), message, arg0);
+        function parseErrorAtCurrentToken(message: DiagnosticMessage, arg0?: any): DiagnosticWithDetachedLocation | false {
+            return parseErrorAt(scanner.getTokenPos(), scanner.getTextPos(), message, arg0);
         }
 
-        function parseErrorAtPosition(start: number, length: number, message: DiagnosticMessage, arg0?: any): void {
+        function parseErrorAtPosition(start: number, length: number, message: DiagnosticMessage, arg0?: any): DiagnosticWithDetachedLocation | false {
             // Don't report another error if it would just be at the same position as the last error.
             const lastError = lastOrUndefined(parseDiagnostics);
+            let result: DiagnosticWithDetachedLocation | false;
             if (!lastError || start !== lastError.start) {
-                parseDiagnostics.push(createDetachedDiagnostic(fileName, start, length, message, arg0));
+                result = createDetachedDiagnostic(fileName, start, length, message, arg0)
+                parseDiagnostics.push(result);
+            }
+            else {
+                result = false;
             }
 
             // Mark that we've encountered an error.  We'll set an appropriate bit on the next
             // node we finish so that it can't be reused incrementally.
             parseErrorBeforeNextFinishedNode = true;
+            return result
         }
 
-        function parseErrorAt(start: number, end: number, message: DiagnosticMessage, arg0?: any): void {
-            parseErrorAtPosition(start, end - start, message, arg0);
+        function parseErrorAt(start: number, end: number, message: DiagnosticMessage, arg0?: any): DiagnosticWithDetachedLocation | false {
+            return parseErrorAtPosition(start, end - start, message, arg0);
         }
 
         function parseErrorAtRange(range: TextRange, message: DiagnosticMessage, arg0?: any): void {
@@ -1533,6 +1539,24 @@ namespace ts {
             return false;
         }
 
+        /** Like parseExpected, but returns true=succeed, diagnostic=fail, false=fail+failed to log error */
+        function parseTokenForError(kind: SyntaxKind, diagnosticMessage?: DiagnosticMessage, shouldAdvance = true): DiagnosticWithDetachedLocation | boolean {
+            if (token() === kind) {
+                if (shouldAdvance) {
+                    nextToken();
+                }
+                return true;
+            }
+
+            // Report specific message if provided with one.  Otherwise, report generic fallback message.
+            if (diagnosticMessage) {
+                return parseErrorAtCurrentToken(diagnosticMessage);
+            }
+            else {
+                return parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(kind));
+            }
+        }
+
         function parseExpectedJSDoc(kind: JSDocSyntaxKind) {
             if (token() === kind) {
                 nextTokenJSDoc();
@@ -1543,17 +1567,16 @@ namespace ts {
         }
 
         function parseExpectedMatchingBrackets(openKind: SyntaxKind, closeKind: SyntaxKind, openPosition: number) {
-            if (!parseExpected(closeKind)) {
-                const lastError = lastOrUndefined(parseDiagnostics);
-                if (lastError && lastError.code === Diagnostics._0_expected.code) {
-                    addRelatedInfo(
-                        lastError,
-                        createDetachedDiagnostic(fileName, openPosition, 1, Diagnostics.The_parser_expected_to_find_a_1_to_match_the_0_token_here, tokenToString(openKind), tokenToString(closeKind))
-                    );
-                }
+            const lastError = parseTokenForError(closeKind);
+            if (typeof lastError === 'boolean')
+                return lastError
+            else {
+                addRelatedInfo(
+                    lastError,
+                    createDetachedDiagnostic(fileName, openPosition, 1, Diagnostics.The_parser_expected_to_find_a_1_to_match_the_0_token_here, tokenToString(openKind), tokenToString(closeKind))
+                );
                 return false;
             }
-            return true;
         }
 
         function parseOptional(t: SyntaxKind): boolean {
@@ -5513,15 +5536,7 @@ namespace ts {
             parseExpected(SyntaxKind.OpenBraceToken);
             const multiLine = scanner.hasPrecedingLineBreak();
             const properties = parseDelimitedList(ParsingContext.ObjectLiteralMembers, parseObjectLiteralElement, /*considerSemicolonAsDelimiter*/ true);
-            if (!parseExpected(SyntaxKind.CloseBraceToken)) {
-                const lastError = lastOrUndefined(parseDiagnostics);
-                if (lastError && lastError.code === Diagnostics._0_expected.code) {
-                    addRelatedInfo(
-                        lastError,
-                        createDetachedDiagnostic(fileName, openBracePosition, 1, Diagnostics.The_parser_expected_to_find_a_1_to_match_the_0_token_here, tokenToString(SyntaxKind.OpenBraceToken), tokenToString(SyntaxKind.CloseBraceToken))
-                    );
-                }
-            }
+            parseExpectedMatchingBrackets(SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken, openBracePosition);
             return finishNode(factory.createObjectLiteralExpression(properties, multiLine), pos);
         }
 
@@ -7984,13 +7999,9 @@ namespace ts {
                             hasChildren = true;
                             if (child.kind === SyntaxKind.JSDocTypeTag) {
                                 if (childTypeTag) {
-                                    parseErrorAtCurrentToken(Diagnostics.A_JSDoc_typedef_comment_may_not_contain_multiple_type_tags);
-                                    const lastError = lastOrUndefined(parseDiagnostics);
+                                    const lastError = parseErrorAtCurrentToken(Diagnostics.A_JSDoc_typedef_comment_may_not_contain_multiple_type_tags);
                                     if (lastError) {
-                                        addRelatedInfo(
-                                            lastError,
-                                            createDetachedDiagnostic(fileName, 0, 0, Diagnostics.The_tag_was_first_specified_here)
-                                        );
+                                        addRelatedInfo(lastError, createDetachedDiagnostic(fileName, 0, 0, Diagnostics.The_tag_was_first_specified_here));
                                     }
                                     break;
                                 }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1347,9 +1347,6 @@ namespace ts {
                 result = createDetachedDiagnostic(fileName, start, length, message, arg0);
                 parseDiagnostics.push(result);
             }
-            else {
-                result = undefined;
-            }
 
             // Mark that we've encountered an error.  We'll set an appropriate bit on the next
             // node we finish so that it can't be reused incrementally.

--- a/tests/baselines/reference/constructorWithIncompleteTypeAnnotation.errors.txt
+++ b/tests/baselines/reference/constructorWithIncompleteTypeAnnotation.errors.txt
@@ -505,7 +505,6 @@ tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(261,1): error TS
 !!! error TS1135: Argument expression expected.
                                     ~
 !!! error TS1005: '(' expected.
-!!! related TS1007 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts:257:33: The parser expected to find a ')' to match the '(' token here.
                                       ~~~~~~
 !!! error TS2693: 'string' only refers to a type, but is being used as a value here.
                                               ~~~

--- a/tests/baselines/reference/destructuringParameterDeclaration2.errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration2.errors.txt
@@ -39,7 +39,6 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
 !!! error TS2322: Type 'string' is not assignable to type 'number'.
                                 ~
 !!! error TS1005: ',' expected.
-!!! related TS1007 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts:7:4: The parser expected to find a ']' to match the '[' token here.
     a0([1, 2, [["world"]], "string"]);  // Error
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '[number, number, string[][], string]' is not assignable to parameter of type '[number, number, string[][]]'.

--- a/tests/baselines/reference/errorRecoveryWithDotFollowedByNamespaceKeyword.errors.txt
+++ b/tests/baselines/reference/errorRecoveryWithDotFollowedByNamespaceKeyword.errors.txt
@@ -17,4 +17,3 @@ tests/cases/compiler/errorRecoveryWithDotFollowedByNamespaceKeyword.ts(9,2): err
      
 !!! error TS1005: '}' expected.
 !!! related TS1007 tests/cases/compiler/errorRecoveryWithDotFollowedByNamespaceKeyword.ts:3:19: The parser expected to find a '}' to match the '{' token here.
-!!! related TS1007 tests/cases/compiler/errorRecoveryWithDotFollowedByNamespaceKeyword.ts:2:20: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/nestedClassDeclaration.errors.txt
+++ b/tests/baselines/reference/nestedClassDeclaration.errors.txt
@@ -32,7 +32,6 @@ tests/cases/conformance/classes/nestedClassDeclaration.ts(17,1): error TS1128: D
 !!! error TS2304: Cannot find name 'C4'.
                  ~
 !!! error TS1005: ',' expected.
-!!! related TS1007 tests/cases/conformance/classes/nestedClassDeclaration.ts:14:9: The parser expected to find a '}' to match the '{' token here.
         }
     }
     ~

--- a/tests/baselines/reference/objectLiteralWithSemicolons4.errors.txt
+++ b/tests/baselines/reference/objectLiteralWithSemicolons4.errors.txt
@@ -10,4 +10,3 @@ tests/cases/compiler/objectLiteralWithSemicolons4.ts(3,1): error TS1005: ',' exp
     ;
     ~
 !!! error TS1005: ',' expected.
-!!! related TS1007 tests/cases/compiler/objectLiteralWithSemicolons4.ts:1:9: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/objectSpreadNegativeParse.errors.txt
+++ b/tests/baselines/reference/objectSpreadNegativeParse.errors.txt
@@ -28,7 +28,6 @@ tests/cases/conformance/types/spread/objectSpreadNegativeParse.ts(4,20): error T
 !!! error TS2304: Cannot find name 'matchMedia'.
                                ~
 !!! error TS1005: ',' expected.
-!!! related TS1007 tests/cases/conformance/types/spread/objectSpreadNegativeParse.ts:3:10: The parser expected to find a '}' to match the '{' token here.
                                   ~
 !!! error TS1128: Declaration or statement expected.
     let o10 = { ...get x() { return 12; }};

--- a/tests/baselines/reference/parseErrorIncorrectReturnToken.errors.txt
+++ b/tests/baselines/reference/parseErrorIncorrectReturnToken.errors.txt
@@ -25,7 +25,6 @@ tests/cases/compiler/parseErrorIncorrectReturnToken.ts(12,1): error TS1128: Decl
         m(n: number) => string {
                      ~~
 !!! error TS1005: '{' expected.
-!!! related TS1007 tests/cases/compiler/parseErrorIncorrectReturnToken.ts:8:9: The parser expected to find a '}' to match the '{' token here.
                         ~~~~~~
 !!! error TS2693: 'string' only refers to a type, but is being used as a value here.
                                ~

--- a/tests/baselines/reference/parserErrorRecoveryArrayLiteralExpression3.errors.txt
+++ b/tests/baselines/reference/parserErrorRecoveryArrayLiteralExpression3.errors.txt
@@ -8,7 +8,6 @@ tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrayLiteralExpressions
     var texCoords = [2, 2, 0.5000001192092895, 0.8749999 ; 403953552, 0.5000001192092895, 0.8749999403953552];
                                                          ~
 !!! error TS1005: ',' expected.
-!!! related TS1007 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrayLiteralExpressions/parserErrorRecoveryArrayLiteralExpression3.ts:1:17: The parser expected to find a ']' to match the '[' token here.
                                                            ~~~~~~~~~
 !!! error TS2695: Left side of comma operator is unused and has no side effects.
                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/baselines/reference/parserFuzz1.errors.txt
+++ b/tests/baselines/reference/parserFuzz1.errors.txt
@@ -21,4 +21,3 @@ tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserFuzz1.ts(2,15): e
 !!! error TS1005: ';' expected.
                   
 !!! error TS1005: '{' expected.
-!!! related TS1007 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserFuzz1.ts:1:9: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/reservedWords2.errors.txt
+++ b/tests/baselines/reference/reservedWords2.errors.txt
@@ -105,7 +105,6 @@ tests/cases/compiler/reservedWords2.ts(12,17): error TS1138: Parameter declarati
 !!! error TS1005: ';' expected.
                      ~
 !!! error TS1005: '(' expected.
-!!! related TS1007 tests/cases/compiler/reservedWords2.ts:9:18: The parser expected to find a ')' to match the '(' token here.
                        ~
 !!! error TS1128: Declaration or statement expected.
     enum void {}

--- a/tests/baselines/reference/tsbuild/noEmitOnError/initial-build/syntax-errors-with-incremental.js
+++ b/tests/baselines/reference/tsbuild/noEmitOnError/initial-build/syntax-errors-with-incremental.js
@@ -47,11 +47,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/src/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 
 Found 1 error.
 
@@ -80,11 +75,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/src/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 
 Found 1 error.

--- a/tests/baselines/reference/tsbuild/noEmitOnError/initial-build/syntax-errors.js
+++ b/tests/baselines/reference/tsbuild/noEmitOnError/initial-build/syntax-errors.js
@@ -47,11 +47,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/src/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 
 Found 1 error.
 
@@ -80,11 +75,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/src/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 
 Found 1 error.

--- a/tests/baselines/reference/tsbuild/watchMode/noEmitOnError/does-not-emit-any-files-on-error-with-incremental.js
+++ b/tests/baselines/reference/tsbuild/watchMode/noEmitOnError/does-not-emit-any-files-on-error-with-incremental.js
@@ -56,11 +56,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:35 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -112,11 +107,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:42 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tsbuild/watchMode/noEmitOnError/does-not-emit-any-files-on-error.js
+++ b/tests/baselines/reference/tsbuild/watchMode/noEmitOnError/does-not-emit-any-files-on-error.js
@@ -56,11 +56,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:35 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -112,11 +107,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:42 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tsc/incremental/initial-build/with-noEmitOnError-syntax-errors.js
+++ b/tests/baselines/reference/tsc/incremental/initial-build/with-noEmitOnError-syntax-errors.js
@@ -47,11 +47,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/src/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 
 Found 1 error.
 
@@ -165,11 +160,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/src/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 
 Found 1 error.

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/with-noEmitOnError-with-incremental.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -185,11 +180,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependencies/with-noEmitOnError.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -103,11 +98,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/with-noEmitOnError-with-incremental.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -186,11 +181,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/assumeChangesOnlyAffectDirectDependenciesAndD/with-noEmitOnError.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -103,11 +98,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/with-noEmitOnError-with-incremental.js
@@ -49,11 +49,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -190,11 +185,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/default/with-noEmitOnError.js
@@ -49,11 +49,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -109,11 +104,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/with-noEmitOnError-with-incremental.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -185,11 +180,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/defaultAndD/with-noEmitOnError.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -103,11 +98,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/assumeChangesOnlyAffectDirectDependencies/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/assumeChangesOnlyAffectDirectDependencies/with-noEmitOnError-with-incremental.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -185,11 +180,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/assumeChangesOnlyAffectDirectDependencies/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/assumeChangesOnlyAffectDirectDependencies/with-noEmitOnError.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -185,11 +180,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/assumeChangesOnlyAffectDirectDependenciesAndD/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/assumeChangesOnlyAffectDirectDependenciesAndD/with-noEmitOnError-with-incremental.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -186,11 +181,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/assumeChangesOnlyAffectDirectDependenciesAndD/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/assumeChangesOnlyAffectDirectDependenciesAndD/with-noEmitOnError.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -186,11 +181,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/default/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/default/with-noEmitOnError-with-incremental.js
@@ -49,11 +49,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -190,11 +185,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/default/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/default/with-noEmitOnError.js
@@ -49,11 +49,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -190,11 +185,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/defaultAndD/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/defaultAndD/with-noEmitOnError-with-incremental.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -185,11 +180,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/defaultAndD/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/defaultAndD/with-noEmitOnError.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -185,11 +180,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/isolatedModules/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/isolatedModules/with-noEmitOnError-with-incremental.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -185,11 +180,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/isolatedModules/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/isolatedModules/with-noEmitOnError.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -185,11 +180,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/isolatedModulesAndD/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/isolatedModulesAndD/with-noEmitOnError-with-incremental.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -186,11 +181,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/isolatedModulesAndD/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/incremental/isolatedModulesAndD/with-noEmitOnError.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -186,11 +181,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/with-noEmitOnError-with-incremental.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -185,11 +180,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModules/with-noEmitOnError.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -103,11 +98,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/with-noEmitOnError-with-incremental.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/with-noEmitOnError-with-incremental.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -186,11 +181,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:44 AM[0m] Found 1 error. Watching for file changes.
 

--- a/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/with-noEmitOnError.js
+++ b/tests/baselines/reference/tscWatch/emitAndErrorUpdates/isolatedModulesAndD/with-noEmitOnError.js
@@ -43,11 +43,6 @@ Output::
 [7m4[0m ;
 [7m [0m [91m~[0m
 
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
-
 [[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 
 
@@ -103,11 +98,6 @@ Output::
 
 [7m4[0m ;
 [7m [0m [91m~[0m
-
-  [96msrc/main.ts[0m:[93m2[0m:[93m11[0m
-    [7m2[0m const a = {
-    [7m [0m [96m          ~[0m
-    The parser expected to find a '}' to match the '{' token here.
 
 [[90m12:00:37 AM[0m] Found 1 error. Watching for file changes.
 


### PR DESCRIPTION
Instead of unconditionally retrieving the last error and attaching a related span, `parseErrorAt` and friends now return the last error and
return `false` when there is none.

Also make one more place use parseExpectedMatchingBrackets that I missed last time.

Previously open questions:

1. Does returning a value slowdown `parseErrorAt` and friends?
2. Would returning Diagnostic | undefined be faster than Diagnostic | false?
3. Would it slow down parseExpected to delegate to parseTokenForError and convert the return to boolean?

Answers:

1. No.
2. No, but it reads better, so I did.
3. I decided to inline parseTokenForError, so this is moot.

Fixes [comment](https://github.com/microsoft/TypeScript/pull/40884#issuecomment-811200773) on #40884.