### PR TITLE
Server commands from tsserver log file

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -3672,6 +3672,7 @@ export class Session<TMessage = string> implements EventSender {
         let relevantFile: protocol.FileRequestArgs | undefined;
         try {
             request = this.parseMessage(message);
+            console.log(`${request.seq}:: ${request.command}`);
             relevantFile = request.arguments && (request as protocol.FileRequest).arguments.file ? (request as protocol.FileRequest).arguments : undefined;
 
             tracing?.instant(tracing.Phase.Session, "request", { seq: request.seq, command: request.command });
@@ -3712,7 +3713,7 @@ export class Session<TMessage = string> implements EventSender {
                 this.doOutput({ canceled: true }, request!.command, request!.seq, /*success*/ true);
                 return;
             }
-
+            console.log(`${request?.seq}:: ${request?.command}:: Exception`, err);
             this.logErrorWorker(err, this.toStringMessage(message), relevantFile);
             perfLogger?.logStopCommand("" + (request && request.command), "Error: " + err);
             tracing?.instant(tracing.Phase.Session, "commandError", { seq: request?.seq, command: request?.command, message: (err as Error).message });

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -5,6 +5,8 @@ import {
     Debug,
     directorySeparator,
     DirectoryWatcherCallback,
+    emptyArray,
+    endsWith,
     FileWatcher,
     getDirectoryPath,
     getRootLength,
@@ -469,11 +471,14 @@ function startNodeSession(options: StartSessionOptions, logger: ts.server.Logger
         createInterface(options: ReadLineOptions): NodeJS.EventEmitter;
     } = require("readline");
 
-    const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout,
-        terminal: false,
-    });
+    const fs: {
+        readFileSync(path: string, options: { encoding: string; flag?: string; } | string): string;
+        writeFileSync(path: string, data: string): string;
+    } = require("fs");
+
+    const stream: {
+        Readable: { from(str: string): NodeJS.ReadStream; };
+    } = require("stream");
 
     class NodeTypingsInstallerAdapter extends ts.server.TypingsInstallerAdapter {
         protected override installer!: NodeChildProcess;
@@ -698,6 +703,12 @@ function startNodeSession(options: StartSessionOptions, logger: ts.server.Logger
         startTracing("server", traceDir);
     }
 
+    const inputStream = getInputReadStream(ts.server.findArgument("--inputRequestsFile"), ts.server.findArgument("--inputLogFile"), ts.server.findArgument("--createRequestsFile"));
+    const rl = readline.createInterface({
+        input: inputStream || process.stdin,
+        output: process.stdout,
+        terminal: false,
+    });
     const ioSession = useNodeIpc ? new IpcIOSession() : new IOSession();
     process.on("uncaughtException", err => {
         ioSession.logError(err, "unknown");
@@ -706,6 +717,47 @@ function startNodeSession(options: StartSessionOptions, logger: ts.server.Logger
     (process as any).noAsar = true;
     // Start listening
     ioSession.listen();
+
+    function getInputReadStream(inputRequestsFile: string | undefined, inputLogFile: string | undefined, requestFile: string | undefined) {
+        if (!inputRequestsFile && !inputLogFile) return undefined;
+        let result: any[];
+        if (inputRequestsFile) {
+            const text = fs.readFileSync(stripQuotes(inputRequestsFile), "utf8");
+            try {
+                result = text ? JSON.parse(text) : emptyArray;
+            }
+            catch (e) {
+                result = [];
+            }
+        }
+        else {
+            const lines = fs.readFileSync(stripQuotes(inputLogFile!), "utf8")?.split(/\r?\n/) || [];
+            result = [];
+            for (let i = 0; i < lines.length; i++) {
+                const line = lines[i];
+                if (!endsWith(line, "] request:")) continue;
+                const texts: string[] = [];
+                for (i++; i < lines.length; i++) {
+                    if (lines[i].search(/((Info)|(Perf)|(Err))\s[0-9]+\s*\[/) === 0) {
+                        i--;
+                        break;
+                    }
+                    texts.push(lines[i]);
+                }
+                const text = texts.join("");
+                try {
+                    const json = JSON.parse(text);
+                    if (json && json.type === "request") {
+                        result.push(json);
+                    }
+                }
+                catch (e) {} // eslint-disable-line no-empty
+            }
+        }
+        if (requestFile) fs.writeFileSync(stripQuotes(requestFile), JSON.stringify(result, /*replacer*/ undefined, " "));
+        console.log(`Requests:: ${result.length}`);
+        return stream.Readable.from(result.map(r => JSON.stringify(r)).join("\n"));
+    }
 
     function getGlobalTypingsCacheLocation() {
         switch (process.platform) {

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -31,9 +31,9 @@ function start({ args, logger, cancellationToken, serverMode, unknownServerMode,
     // the log. This is so that language service plugins which use
     // console.log don't break the message passing between tsserver
     // and the client
-    console.log = (...args) => logger.msg(args.length === 1 ? args[0] : args.join(", "), ts.server.Msg.Info);
-    console.warn = (...args) => logger.msg(args.length === 1 ? args[0] : args.join(", "), ts.server.Msg.Err);
-    console.error = (...args) => logger.msg(args.length === 1 ? args[0] : args.join(", "), ts.server.Msg.Err);
+    // console.log = (...args) => logger.msg(args.length === 1 ? args[0] : args.join(", "), ts.server.Msg.Info);
+    // console.warn = (...args) => logger.msg(args.length === 1 ? args[0] : args.join(", "), ts.server.Msg.Err);
+    // console.error = (...args) => logger.msg(args.length === 1 ? args[0] : args.join(", "), ts.server.Msg.Err);
 
     startServer(
         {


### PR DESCRIPTION
This is just draft so people can find it easily. Never to be merged. 

-  `--inputLogFile pathToTsserverLogToRun.log` to `tsserver.js` when running to run the commands from the log in sequence.
- `--createRequestsFile pathToRequests.log` to store only requests so that you can use then later to run and easy to edit only requests
- `--inputRequestsFile pathToRequests.log` to use previously stored requests as input commands