### PR TITLE
Add @link jsdoc auto-complete

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -44,6 +44,7 @@ namespace ts.JsDoc {
         "kind",
         "lends",
         "license",
+        "link",
         "listens",
         "member",
         "memberof",

--- a/tests/cases/fourslash/completionInJsDoc.ts
+++ b/tests/cases/fourslash/completionInJsDoc.ts
@@ -53,6 +53,10 @@
 ////   */
 ////
 //// /** @param /*16*/ */
+////
+//// /**
+////   * jsdoc inline tag {@/*17*/}
+////   */
 
 verify.completions(
     { marker: ["1", "2"], includes: ["constructor", "param", "type", "method", "template"] },
@@ -60,4 +64,5 @@ verify.completions(
     { marker: ["4", "5", "8"], includes: { name: "number", sortText: completion.SortText.GlobalsOrKeywords } },
     { marker: ["6", "7", "14"], exact: undefined },
     { marker: ["9", "10", "11", "12", "13"], includes: ["@argument", "@returns"] },
+    { marker: ["17"], includes: ["link", "tutorial"] },
 );


### PR DESCRIPTION
Fixes #43465

![2021-04-01 15_35_57-● index ts - 43465-jsdoc-no-link-auto-complete - Visual Studio Code](https://user-images.githubusercontent.com/11912225/113244186-3b5a7880-9300-11eb-85b7-af1b54482af8.png)
