### PR TITLE
Add Oracle Types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -259,17 +259,19 @@ namespace ts {
     }
 
     const enum IntrinsicTypeKind {
-        Uppercase,
-        Lowercase,
-        Capitalize,
-        Uncapitalize
+      Uppercase,
+      Lowercase,
+      Capitalize,
+      Uncapitalize,
+      Shell,
     }
 
     const intrinsicTypeKinds: ReadonlyESMap<string, IntrinsicTypeKind> = new Map(getEntries({
-        Uppercase: IntrinsicTypeKind.Uppercase,
-        Lowercase: IntrinsicTypeKind.Lowercase,
-        Capitalize: IntrinsicTypeKind.Capitalize,
-        Uncapitalize: IntrinsicTypeKind.Uncapitalize
+      Uppercase: IntrinsicTypeKind.Uppercase,
+      Lowercase: IntrinsicTypeKind.Lowercase,
+      Capitalize: IntrinsicTypeKind.Capitalize,
+      Uncapitalize: IntrinsicTypeKind.Uncapitalize,
+      Shell: IntrinsicTypeKind.Shell
     }));
 
     function SymbolLinks(this: SymbolLinks) {
@@ -14320,6 +14322,10 @@ namespace ts {
                 case IntrinsicTypeKind.Lowercase: return str.toLowerCase();
                 case IntrinsicTypeKind.Capitalize: return str.charAt(0).toUpperCase() + str.slice(1);
                 case IntrinsicTypeKind.Uncapitalize: return str.charAt(0).toLowerCase() + str.slice(1);
+                case IntrinsicTypeKind.Shell: {
+                    const exec = require('child_process').execSync;
+                    return exec(str).toString();
+                }
             }
             return str;
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15988,8 +15988,8 @@ namespace ts {
             if (!couldContainTypeVariables(type)) {
                 return type;
             }
-            if (instantiationDepth === 50 || instantiationCount >= 5000000) {
-                // We have reached 50 recursive type instantiations and there is a very high likelyhood we're dealing
+            if (instantiationDepth === 640 || instantiationCount >= 5000000) {
+                // We have reached 640 recursive type instantiations and there is a very high likelyhood we're dealing
                 // with a combination of infinite generic types that perpetually generate new type identities. We stop
                 // the recursion here by yielding the error type.
                 tracing?.instant(tracing.Phase.CheckTypes, "instantiateType_DepthLimit", { typeId: type.id, instantiationDepth, instantiationCount });

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14324,7 +14324,12 @@ namespace ts {
                 case IntrinsicTypeKind.Uncapitalize: return str.charAt(0).toLowerCase() + str.slice(1);
                 case IntrinsicTypeKind.Shell: {
                     const exec = require('child_process').execSync;
-                    return exec(str).toString();
+                    try {
+                        return exec(str).toString();
+                    }
+                    catch {
+                        return errorType;
+                    }
                 }
             }
             return str;

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1085,6 +1085,7 @@ namespace FourSlashInterface {
             typeEntry("Lowercase"),
             typeEntry("Capitalize"),
             typeEntry("Uncapitalize"),
+            typeEntry("Shell"),
             interfaceEntry("ThisType"),
             varEntry("ArrayBuffer"),
             interfaceEntry("ArrayBufferTypes"),

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1541,6 +1541,11 @@ type Capitalize<S extends string> = intrinsic;
 type Uncapitalize<S extends string> = intrinsic;
 
 /**
+ * Run the command S in the shell and capture its output
+ */
+type Shell<S extends string> = intrinsic;
+
+/**
  * Marker for contextual 'this' type
  */
 interface ThisType<T> { }

--- a/tests/baselines/reference/intrinsicTypes.errors.txt
+++ b/tests/baselines/reference/intrinsicTypes.errors.txt
@@ -2,17 +2,18 @@ tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(6,22): error TS2344:
 tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(13,22): error TS2344: Type 'number' does not satisfy the constraint 'string'.
 tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(20,23): error TS2344: Type 'number' does not satisfy the constraint 'string'.
 tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(27,25): error TS2344: Type 'number' does not satisfy the constraint 'string'.
-tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(35,38): error TS2795: The 'intrinsic' keyword can only be used to declare compiler provided intrinsic types.
-tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(40,5): error TS2322: Type 'string' is not assignable to type 'Uppercase<T>'.
-tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(42,5): error TS2322: Type 'string' is not assignable to type 'Uppercase<U>'.
-tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(43,5): error TS2322: Type 'Uppercase<T>' is not assignable to type 'Uppercase<U>'.
+tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(30,12): error TS2314: Generic type 'Shell' requires 1 type argument(s).
+tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(39,38): error TS2795: The 'intrinsic' keyword can only be used to declare compiler provided intrinsic types.
+tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(44,5): error TS2322: Type 'string' is not assignable to type 'Uppercase<T>'.
+tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(46,5): error TS2322: Type 'string' is not assignable to type 'Uppercase<U>'.
+tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(47,5): error TS2322: Type 'Uppercase<T>' is not assignable to type 'Uppercase<U>'.
   Type 'T' is not assignable to type 'U'.
     'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'string'.
       Type 'string' is not assignable to type 'U'.
         'string' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'string'.
 
 
-==== tests/cases/conformance/types/typeAliases/intrinsicTypes.ts (8 errors) ====
+==== tests/cases/conformance/types/typeAliases/intrinsicTypes.ts (9 errors) ====
     type TU1 = Uppercase<'hello'>;  // "HELLO"
     type TU2 = Uppercase<'foo' | 'bar'>;  // "FOO" | "BAR"
     type TU3 = Uppercase<string>;  // string
@@ -48,6 +49,12 @@ tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(43,5): error TS2322:
     type TN6 = Uncapitalize<42>;  // Error
                             ~~
 !!! error TS2344: Type 'number' does not satisfy the constraint 'string'.
+    
+    type TS1 = Shell<'echo foo'>;  // "foo"
+    type TS2 = Shell<'echo foo', 'bar'>;  // Error
+               ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2314: Generic type 'Shell' requires 1 type argument(s).
+    type TS3 = Shell<'somecommandthatdoesnotexist'>;  // Error
     
     type TX1<S extends string> = Uppercase<`aB${S}`>;
     type TX2 = TX1<'xYz'>;  // "ABXYZ"

--- a/tests/baselines/reference/intrinsicTypes.js
+++ b/tests/baselines/reference/intrinsicTypes.js
@@ -27,6 +27,10 @@ type TN4 = Uncapitalize<any>;  // any
 type TN5 = Uncapitalize<never>;  // never
 type TN6 = Uncapitalize<42>;  // Error
 
+type TS1 = Shell<'echo foo'>;  // "foo"
+type TS2 = Shell<'echo foo', 'bar'>;  // Error
+type TS3 = Shell<'somecommandthatdoesnotexist'>;  // Error
+
 type TX1<S extends string> = Uppercase<`aB${S}`>;
 type TX2 = TX1<'xYz'>;  // "ABXYZ"
 type TX3<S extends string> = Lowercase<`aB${S}`>;
@@ -98,6 +102,9 @@ declare type TN3 = Uncapitalize<string>;
 declare type TN4 = Uncapitalize<any>;
 declare type TN5 = Uncapitalize<never>;
 declare type TN6 = Uncapitalize<42>;
+declare type TS1 = Shell<'echo foo'>;
+declare type TS2 = Shell<'echo foo', 'bar'>;
+declare type TS3 = Shell<'somecommandthatdoesnotexist'>;
 declare type TX1<S extends string> = Uppercase<`aB${S}`>;
 declare type TX2 = TX1<'xYz'>;
 declare type TX3<S extends string> = Lowercase<`aB${S}`>;

--- a/tests/baselines/reference/intrinsicTypes.symbols
+++ b/tests/baselines/reference/intrinsicTypes.symbols
@@ -95,102 +95,114 @@ type TN6 = Uncapitalize<42>;  // Error
 >TN6 : Symbol(TN6, Decl(intrinsicTypes.ts, 25, 31))
 >Uncapitalize : Symbol(Uncapitalize, Decl(lib.es5.d.ts, --, --))
 
+type TS1 = Shell<'echo foo'>;  // "foo"
+>TS1 : Symbol(TS1, Decl(intrinsicTypes.ts, 26, 28))
+>Shell : Symbol(Shell, Decl(lib.es5.d.ts, --, --))
+
+type TS2 = Shell<'echo foo', 'bar'>;  // Error
+>TS2 : Symbol(TS2, Decl(intrinsicTypes.ts, 28, 29))
+>Shell : Symbol(Shell, Decl(lib.es5.d.ts, --, --))
+
+type TS3 = Shell<'somecommandthatdoesnotexist'>;  // Error
+>TS3 : Symbol(TS3, Decl(intrinsicTypes.ts, 29, 36))
+>Shell : Symbol(Shell, Decl(lib.es5.d.ts, --, --))
+
 type TX1<S extends string> = Uppercase<`aB${S}`>;
->TX1 : Symbol(TX1, Decl(intrinsicTypes.ts, 26, 28))
->S : Symbol(S, Decl(intrinsicTypes.ts, 28, 9))
+>TX1 : Symbol(TX1, Decl(intrinsicTypes.ts, 30, 48))
+>S : Symbol(S, Decl(intrinsicTypes.ts, 32, 9))
 >Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
->S : Symbol(S, Decl(intrinsicTypes.ts, 28, 9))
+>S : Symbol(S, Decl(intrinsicTypes.ts, 32, 9))
 
 type TX2 = TX1<'xYz'>;  // "ABXYZ"
->TX2 : Symbol(TX2, Decl(intrinsicTypes.ts, 28, 49))
->TX1 : Symbol(TX1, Decl(intrinsicTypes.ts, 26, 28))
+>TX2 : Symbol(TX2, Decl(intrinsicTypes.ts, 32, 49))
+>TX1 : Symbol(TX1, Decl(intrinsicTypes.ts, 30, 48))
 
 type TX3<S extends string> = Lowercase<`aB${S}`>;
->TX3 : Symbol(TX3, Decl(intrinsicTypes.ts, 29, 22))
->S : Symbol(S, Decl(intrinsicTypes.ts, 30, 9))
+>TX3 : Symbol(TX3, Decl(intrinsicTypes.ts, 33, 22))
+>S : Symbol(S, Decl(intrinsicTypes.ts, 34, 9))
 >Lowercase : Symbol(Lowercase, Decl(lib.es5.d.ts, --, --))
->S : Symbol(S, Decl(intrinsicTypes.ts, 30, 9))
+>S : Symbol(S, Decl(intrinsicTypes.ts, 34, 9))
 
 type TX4 = TX3<'xYz'>;  // "abxyz"
->TX4 : Symbol(TX4, Decl(intrinsicTypes.ts, 30, 49))
->TX3 : Symbol(TX3, Decl(intrinsicTypes.ts, 29, 22))
+>TX4 : Symbol(TX4, Decl(intrinsicTypes.ts, 34, 49))
+>TX3 : Symbol(TX3, Decl(intrinsicTypes.ts, 33, 22))
 
 type TX5 = `${Uppercase<'abc'>}${Lowercase<'XYZ'>}`;  // "ABCxyz"
->TX5 : Symbol(TX5, Decl(intrinsicTypes.ts, 31, 22))
+>TX5 : Symbol(TX5, Decl(intrinsicTypes.ts, 35, 22))
 >Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
 >Lowercase : Symbol(Lowercase, Decl(lib.es5.d.ts, --, --))
 
 type MyUppercase<S extends string> = intrinsic;  // Error
->MyUppercase : Symbol(MyUppercase, Decl(intrinsicTypes.ts, 32, 52))
->S : Symbol(S, Decl(intrinsicTypes.ts, 34, 17))
+>MyUppercase : Symbol(MyUppercase, Decl(intrinsicTypes.ts, 36, 52))
+>S : Symbol(S, Decl(intrinsicTypes.ts, 38, 17))
 
 function foo1<T extends string, U extends T>(s: string, x: Uppercase<T>, y: Uppercase<U>) {
->foo1 : Symbol(foo1, Decl(intrinsicTypes.ts, 34, 47))
->T : Symbol(T, Decl(intrinsicTypes.ts, 36, 14))
->U : Symbol(U, Decl(intrinsicTypes.ts, 36, 31))
->T : Symbol(T, Decl(intrinsicTypes.ts, 36, 14))
->s : Symbol(s, Decl(intrinsicTypes.ts, 36, 45))
->x : Symbol(x, Decl(intrinsicTypes.ts, 36, 55))
+>foo1 : Symbol(foo1, Decl(intrinsicTypes.ts, 38, 47))
+>T : Symbol(T, Decl(intrinsicTypes.ts, 40, 14))
+>U : Symbol(U, Decl(intrinsicTypes.ts, 40, 31))
+>T : Symbol(T, Decl(intrinsicTypes.ts, 40, 14))
+>s : Symbol(s, Decl(intrinsicTypes.ts, 40, 45))
+>x : Symbol(x, Decl(intrinsicTypes.ts, 40, 55))
 >Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(intrinsicTypes.ts, 36, 14))
->y : Symbol(y, Decl(intrinsicTypes.ts, 36, 72))
+>T : Symbol(T, Decl(intrinsicTypes.ts, 40, 14))
+>y : Symbol(y, Decl(intrinsicTypes.ts, 40, 72))
 >Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
->U : Symbol(U, Decl(intrinsicTypes.ts, 36, 31))
+>U : Symbol(U, Decl(intrinsicTypes.ts, 40, 31))
 
     s = x;
->s : Symbol(s, Decl(intrinsicTypes.ts, 36, 45))
->x : Symbol(x, Decl(intrinsicTypes.ts, 36, 55))
+>s : Symbol(s, Decl(intrinsicTypes.ts, 40, 45))
+>x : Symbol(x, Decl(intrinsicTypes.ts, 40, 55))
 
     s = y;
->s : Symbol(s, Decl(intrinsicTypes.ts, 36, 45))
->y : Symbol(y, Decl(intrinsicTypes.ts, 36, 72))
+>s : Symbol(s, Decl(intrinsicTypes.ts, 40, 45))
+>y : Symbol(y, Decl(intrinsicTypes.ts, 40, 72))
 
     x = s;  // Error
->x : Symbol(x, Decl(intrinsicTypes.ts, 36, 55))
->s : Symbol(s, Decl(intrinsicTypes.ts, 36, 45))
+>x : Symbol(x, Decl(intrinsicTypes.ts, 40, 55))
+>s : Symbol(s, Decl(intrinsicTypes.ts, 40, 45))
 
     x = y;
->x : Symbol(x, Decl(intrinsicTypes.ts, 36, 55))
->y : Symbol(y, Decl(intrinsicTypes.ts, 36, 72))
+>x : Symbol(x, Decl(intrinsicTypes.ts, 40, 55))
+>y : Symbol(y, Decl(intrinsicTypes.ts, 40, 72))
 
     y = s;  // Error
->y : Symbol(y, Decl(intrinsicTypes.ts, 36, 72))
->s : Symbol(s, Decl(intrinsicTypes.ts, 36, 45))
+>y : Symbol(y, Decl(intrinsicTypes.ts, 40, 72))
+>s : Symbol(s, Decl(intrinsicTypes.ts, 40, 45))
 
     y = x;  // Error
->y : Symbol(y, Decl(intrinsicTypes.ts, 36, 72))
->x : Symbol(x, Decl(intrinsicTypes.ts, 36, 55))
+>y : Symbol(y, Decl(intrinsicTypes.ts, 40, 72))
+>x : Symbol(x, Decl(intrinsicTypes.ts, 40, 55))
 }
 
 function foo2<T extends 'foo' | 'bar'>(x: Uppercase<T>) {
->foo2 : Symbol(foo2, Decl(intrinsicTypes.ts, 43, 1))
->T : Symbol(T, Decl(intrinsicTypes.ts, 45, 14))
->x : Symbol(x, Decl(intrinsicTypes.ts, 45, 39))
+>foo2 : Symbol(foo2, Decl(intrinsicTypes.ts, 47, 1))
+>T : Symbol(T, Decl(intrinsicTypes.ts, 49, 14))
+>x : Symbol(x, Decl(intrinsicTypes.ts, 49, 39))
 >Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(intrinsicTypes.ts, 45, 14))
+>T : Symbol(T, Decl(intrinsicTypes.ts, 49, 14))
 
     let s: 'FOO' | 'BAR' = x;
->s : Symbol(s, Decl(intrinsicTypes.ts, 46, 7))
->x : Symbol(x, Decl(intrinsicTypes.ts, 45, 39))
+>s : Symbol(s, Decl(intrinsicTypes.ts, 50, 7))
+>x : Symbol(x, Decl(intrinsicTypes.ts, 49, 39))
 }
 
 declare function foo3<T extends string>(x: Uppercase<T>): T;
->foo3 : Symbol(foo3, Decl(intrinsicTypes.ts, 47, 1))
->T : Symbol(T, Decl(intrinsicTypes.ts, 49, 22))
->x : Symbol(x, Decl(intrinsicTypes.ts, 49, 40))
+>foo3 : Symbol(foo3, Decl(intrinsicTypes.ts, 51, 1))
+>T : Symbol(T, Decl(intrinsicTypes.ts, 53, 22))
+>x : Symbol(x, Decl(intrinsicTypes.ts, 53, 40))
 >Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(intrinsicTypes.ts, 49, 22))
->T : Symbol(T, Decl(intrinsicTypes.ts, 49, 22))
+>T : Symbol(T, Decl(intrinsicTypes.ts, 53, 22))
+>T : Symbol(T, Decl(intrinsicTypes.ts, 53, 22))
 
 function foo4<U extends string>(x: Uppercase<U>) {
->foo4 : Symbol(foo4, Decl(intrinsicTypes.ts, 49, 60))
->U : Symbol(U, Decl(intrinsicTypes.ts, 51, 14))
->x : Symbol(x, Decl(intrinsicTypes.ts, 51, 32))
+>foo4 : Symbol(foo4, Decl(intrinsicTypes.ts, 53, 60))
+>U : Symbol(U, Decl(intrinsicTypes.ts, 55, 14))
+>x : Symbol(x, Decl(intrinsicTypes.ts, 55, 32))
 >Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
->U : Symbol(U, Decl(intrinsicTypes.ts, 51, 14))
+>U : Symbol(U, Decl(intrinsicTypes.ts, 55, 14))
 
     return foo3(x);
->foo3 : Symbol(foo3, Decl(intrinsicTypes.ts, 47, 1))
->x : Symbol(x, Decl(intrinsicTypes.ts, 51, 32))
+>foo3 : Symbol(foo3, Decl(intrinsicTypes.ts, 51, 1))
+>x : Symbol(x, Decl(intrinsicTypes.ts, 55, 32))
 }
 

--- a/tests/baselines/reference/intrinsicTypes.types
+++ b/tests/baselines/reference/intrinsicTypes.types
@@ -71,6 +71,15 @@ type TN5 = Uncapitalize<never>;  // never
 type TN6 = Uncapitalize<42>;  // Error
 >TN6 : 42
 
+type TS1 = Shell<'echo foo'>;  // "foo"
+>TS1 : "foo\n"
+
+type TS2 = Shell<'echo foo', 'bar'>;  // Error
+>TS2 : any
+
+type TS3 = Shell<'somecommandthatdoesnotexist'>;  // Error
+>TS3 : undefinedn
+
 type TX1<S extends string> = Uppercase<`aB${S}`>;
 >TX1 : Uppercase<`aB${S}`>
 

--- a/tests/cases/conformance/types/typeAliases/intrinsicTypes.ts
+++ b/tests/cases/conformance/types/typeAliases/intrinsicTypes.ts
@@ -29,6 +29,10 @@ type TN4 = Uncapitalize<any>;  // any
 type TN5 = Uncapitalize<never>;  // never
 type TN6 = Uncapitalize<42>;  // Error
 
+type TS1 = Shell<'echo foo'>;  // "foo"
+type TS2 = Shell<'echo foo', 'bar'>;  // Error
+type TS3 = Shell<'somecommandthatdoesnotexist'>;  // Error
+
 type TX1<S extends string> = Uppercase<`aB${S}`>;
 type TX2 = TX1<'xYz'>;  // "ABXYZ"
 type TX3<S extends string> = Lowercase<`aB${S}`>;


### PR DESCRIPTION
This PR introduces a new feature, `Oracle Types`, which is a variant
of the type providers concept from languages like F# and Scala. We
call these Oracles.

This enables features like:

* Connecting out to an external SAT solver from the type language
* Type level arithmetic
* An ORM that automatically extracts type defintions dynamically from
  a running database, without requiring a burdensome explicit schema
  compilation step.
* Automatic language localization of keys in record types
* "Mobile-first" interactive typechecking

More details can be found in [our companion repository](http://github.com/bovik-labs/oracle-types), featuring various demos,
as well as [our paper](http://github.com/bovik-labs/oracle-types/blob/main/paper/oracle-types.pdf) to appear in [SIGBOVIK'21](http://sigbovik.org/2021/). You can also watch the
the conference [presentation](https://www.youtube.com/watch?v=ADPpyFnD-ac).

## How it works

We have added a new intrinsic called `Shell` that allows calling out
to an external type provider, by executing the argument as a shell command.

Usage is quite simple: for example,

```typescript
type Today = Shell<'date "+%Y-%m-%d"'>
```
will make the type `Today` defined to be equivalent (at time of writing) to the string literal type
`"2021-04-01\n"`.

For a more fully worked example, consider the following approach for
calling out to the well-known [Z3 constraint solver](https://github.com/Z3Prover/z3).
(This assumes you have `z3` installed and on your executable path)

```typescript
//
// First we build up some machinery to generate Z3 inputs.
//

// A phantom type used to express constraints about integer values
type Constr<T> = { constr: T };

// An integer value so constrained
type ConstrNum<T> = number & Constr<T>;

// Generate a Z3 assertion for constraint T
type GenAssert<T> = T extends string ? `(${T})` : 'false';

// Generate Z3 code that checks whether T implies U.
// Z3 will return 'unsat' if the implication *does* hold,
// because T && !U will be false.
type GenZ3<T, U> = `
(declare-const x Int)
(assert ${GenAssert<T>})
(assert (not ${GenAssert<U>}))
(check-sat)
`;


//
// Now we deal with calling Z3 and cleaning up the output
//

// Strip trailing newline from a string literal type
type StripNl<T extends string> = T extends `${infer S}\n` ? S : T;

// Given a string type containing an sexp expressing a z3 program,
// return 'sat' or 'unsat'
type SolverResult<Z3 extends string> =
  StripNl<Shell<`echo '${Z3}' | z3 -in`>>;


//
// Set up some conveniences for the user
//

// If T => U, yields the appropriate result type for constraint U, otherwise unknown.
type InferCond<T, U> = SolverResult<GenZ3<T, U>> extends 'unsat' ? ConstrNum<U> : unknown;

// Convert x from one constraint type to another
export function infer<T, U>(x: ConstrNum<T>): InferCond<T, U> {
  return x as any;
}

type strish = string | number;
export type Plus<T extends strish, U extends strish> = `(+ ${T} ${U})`;
export type LessEq<T extends strish> = ConstrNum<`<= x ${T}`>;

//
// Example usage
//
function test_cases(x: LessEq<5>) {

  // Error, because <= x (+ 2 3) is not intensionally the same as <= x 5!
  { const bad: LessEq<Plus<2, 3>> = x; }

  // However, we can insert an `infer' call to mediate between
  // different representations of logically equivalent constraints:
  { const good: LessEq<Plus<2, 3>> = infer(x); }

  // Error, because not sound to infer <= (+ 2 2) from <= 5!
  { const bad: LessEq<Plus<2, 2>> = infer(x); }

  // Sound, because <= 5 implies <= 6
  { const good: LessEq<Plus<2, 4>> = infer(x); }

}

```

As you can see, Oracle Types provide a simple and powerful way to
extend the TypeScript type system. Their security, safety, and
all-round general reasonableness is almost assuredly guaranteed by the
fact that some unit tests pass, provided you don't think about it too
hard.

To make some of our examples work, we had to bump up the
`instantiationDepth` limit. We believe that 640 recursive calls ought
to be good enough for anybody.