### PR TITLE
fix(43495): noImplicitOverride quick fix puts the keyword in the wrong spot

### DIFF
--- a/src/services/codefixes/fixOverrideModifier.ts
+++ b/src/services/codefixes/fixOverrideModifier.ts
@@ -81,7 +81,11 @@ namespace ts.codefix {
 
     function doAddOverrideModifierChange(changeTracker: textChanges.ChangeTracker, sourceFile: SourceFile, pos: number) {
         const classElement = findContainerClassElement(sourceFile, pos);
-        changeTracker.insertModifierBefore(sourceFile, SyntaxKind.OverrideKeyword, classElement);
+        const accessibilityModifier = find(classElement.modifiers || emptyArray, m => isAccessibilityModifier(m.kind));
+        const modifierPos = accessibilityModifier ? accessibilityModifier.end :
+            classElement.decorators ? skipTrivia(sourceFile.text, classElement.decorators.end) : classElement.getStart(sourceFile);
+        const options = accessibilityModifier ? { prefix: " " } : { suffix: " " };
+        changeTracker.insertModifierAt(sourceFile, modifierPos, SyntaxKind.OverrideKeyword, options);
     }
 
     function doRemoveOverrideModifierChange(changeTracker: textChanges.ChangeTracker, sourceFile: SourceFile, pos: number) {

--- a/tests/cases/fourslash/codeFixOverrideModifier13.ts
+++ b/tests/cases/fourslash/codeFixOverrideModifier13.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts' />
+
+// @noImplicitOverride: true
+
+////class A {
+////    foo() {}
+////}
+////
+////class B extends A {
+////    [|public foo() {}|]
+////}
+
+verify.codeFix({
+    description: "Add 'override' modifier",
+    newRangeContent: "public override foo() {}",
+    index: 0
+})

--- a/tests/cases/fourslash/codeFixOverrideModifier14.ts
+++ b/tests/cases/fourslash/codeFixOverrideModifier14.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts' />
+
+// @noImplicitOverride: true
+
+////class A {
+////    protected async foo() {}
+////}
+////
+////class B extends A {
+////    [|protected async foo() {}|]
+////}
+
+verify.codeFix({
+    description: "Add 'override' modifier",
+    newRangeContent: "protected override async foo() {}",
+    index: 0
+})

--- a/tests/cases/fourslash/codeFixOverrideModifier15.ts
+++ b/tests/cases/fourslash/codeFixOverrideModifier15.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+// @experimentalDecorators: true
+// @noImplicitOverride: true
+
+////function decorator() {
+////    return (target: any, key: any, descriptor: PropertyDescriptor) => descriptor;
+////}
+////class A {
+////    foo() {}
+////}
+////class B extends A {
+////    @decorator()
+////    [|public foo() {}|]
+////}
+
+verify.codeFix({
+    description: "Add 'override' modifier",
+    newRangeContent: "public override foo() {}",
+    index: 0
+})

--- a/tests/cases/fourslash/codeFixOverrideModifier16.ts
+++ b/tests/cases/fourslash/codeFixOverrideModifier16.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @experimentalDecorators: true
+// @noImplicitOverride: true
+
+////function decorator() {
+////    return (target: any, key: any, descriptor: PropertyDescriptor) => descriptor;
+////}
+////class A {
+////    foo() {}
+////}
+////class B extends A {
+////    @decorator()
+////    // comment
+////    [|foo() {}|]
+////}
+
+verify.codeFix({
+    description: "Add 'override' modifier",
+    newRangeContent: "override foo() {}",
+    index: 0
+})

--- a/tests/cases/fourslash/codeFixOverrideModifier17.ts
+++ b/tests/cases/fourslash/codeFixOverrideModifier17.ts
@@ -1,0 +1,24 @@
+/// <reference path='fourslash.ts' />
+
+// @experimentalDecorators: true
+// @noImplicitOverride: true
+
+////function decorator() {
+////    return (target: any, key: any, descriptor: PropertyDescriptor) => descriptor;
+////}
+////class A {
+////    foo() {}
+////}
+////class B extends A {
+////    @decorator()
+////    /**
+////     * comment
+////     */
+////    [|foo() {}|]
+////}
+
+verify.codeFix({
+    description: "Add 'override' modifier",
+    newRangeContent: "override foo() {}",
+    index: 0
+})

--- a/tests/cases/fourslash/codeFixOverrideModifier18.ts
+++ b/tests/cases/fourslash/codeFixOverrideModifier18.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts' />
+
+// @noImplicitOverride: true
+
+////class A {
+////    static foo() {}
+////}
+////class B extends A {
+////    [|static foo() {}|]
+////}
+
+verify.not.codeFixAvailable("fixAddOverrideModifier");


### PR DESCRIPTION
Fixes #43495