### PR TITLE
Fix sending correct symbol when using commonjs require and destructuring

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1475,7 +1475,7 @@ namespace ts.FindAllReferences {
 
             if (!hasMatchingMeaning(referenceLocation, state)) return;
 
-            const referenceSymbol = state.checker.getSymbolAtLocation(referenceLocation);
+            let referenceSymbol = state.checker.getSymbolAtLocation(referenceLocation);
             if (!referenceSymbol) {
                 return;
             }
@@ -1511,6 +1511,11 @@ namespace ts.FindAllReferences {
                 default:
                     Debug.assertNever(state.specialSearchKind);
             }
+
+            // Use the parent symbol if the location is commonjs require syntax on javascript files only.
+            referenceSymbol = isInJSFile(referenceLocation) && isRequireVariableDeclaration(referenceLocation.parent)
+                ? referenceLocation.parent.symbol
+                : referenceSymbol;
 
             getImportOrExportReferences(referenceLocation, referenceSymbol, search, state);
         }

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1513,7 +1513,7 @@ namespace ts.FindAllReferences {
             }
 
             // Use the parent symbol if the location is commonjs require syntax on javascript files only.
-            referenceSymbol = isInJSFile(referenceLocation) && isRequireVariableDeclaration(referenceLocation.parent)
+            referenceSymbol = isInJSFile(referenceLocation) && referenceLocation.parent.kind === SyntaxKind.BindingElement && isRequireVariableDeclaration(referenceLocation.parent)
                 ? referenceLocation.parent.symbol
                 : referenceSymbol;
 

--- a/tests/baselines/reference/findAllReferencesJsRequireDestructuring.baseline.jsonc
+++ b/tests/baselines/reference/findAllReferencesJsRequireDestructuring.baseline.jsonc
@@ -1,0 +1,89 @@
+// === /tests/cases/fourslash/bar.js ===
+// const { /*FIND ALL REFS*/[|foo|]: bar } = require('./foo');
+
+// === /tests/cases/fourslash/foo.js ===
+// module.exports = {
+//     [|foo|]: '1'
+// };
+
+[
+  {
+    "definition": {
+      "containerKind": "",
+      "containerName": "",
+      "fileName": "/tests/cases/fourslash/foo.js",
+      "kind": "property",
+      "name": "(property) foo: string",
+      "textSpan": {
+        "start": 23,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "foo",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "contextSpan": {
+        "start": 23,
+        "length": 8
+      }
+    },
+    "references": [
+      {
+        "textSpan": {
+          "start": 23,
+          "length": 3
+        },
+        "fileName": "/tests/cases/fourslash/foo.js",
+        "contextSpan": {
+          "start": 23,
+          "length": 8
+        },
+        "isWriteAccess": true,
+        "isDefinition": true
+      },
+      {
+        "textSpan": {
+          "start": 8,
+          "length": 3
+        },
+        "fileName": "/tests/cases/fourslash/bar.js",
+        "contextSpan": {
+          "start": 0,
+          "length": 38
+        },
+        "isWriteAccess": false,
+        "isDefinition": false
+      }
+    ]
+  }
+]

--- a/tests/cases/fourslash/findAllReferencesJsRequireDestructuring.ts
+++ b/tests/cases/fourslash/findAllReferencesJsRequireDestructuring.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @noEmit: true
+// @checkJs: true
+
+// @Filename: foo.js
+//// module.exports = {
+////     foo: '1'
+//// };
+
+// @Filename: bar.js
+//// const { /*1*/foo: bar } = require('./foo');
+
+verify.baselineFindAllReferences("1");


### PR DESCRIPTION
Fixes #42828

When using destructuring on a commonjs require syntax, the server throws a debug as the symbol is not flagged as "Alias". Instead now we look for the parent symbol which is correctly flagged.
