### PR TITLE
Completion list for type literals in type arguments

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -546,6 +546,7 @@ namespace ts {
                 return node && getContextualTypeForJsxAttribute(node);
             },
             isContextSensitive,
+            getTypeOfPropertyOfContextualType,
             getFullyQualifiedName,
             getResolvedSignature: (node, candidatesOutArray, argumentCount) =>
                 getResolvedSignatureWorker(node, candidatesOutArray, argumentCount, CheckMode.Normal),

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4127,6 +4127,7 @@ namespace ts {
         /* @internal */ getContextualTypeForArgumentAtIndex(call: CallLikeExpression, argIndex: number): Type | undefined;
         /* @internal */ getContextualTypeForJsxAttribute(attribute: JsxAttribute | JsxSpreadAttribute): Type | undefined;
         /* @internal */ isContextSensitive(node: Expression | MethodDeclaration | ObjectLiteralElementLike | JsxAttributeLike): boolean;
+        /* @internal */ getTypeOfPropertyOfContextualType(type: Type, name: __String): Type | undefined;
 
         /**
          * returns unknownSignature in the case of an error.

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -153,9 +153,9 @@ namespace ts.Completions {
             return stringCompletions;
         }
 
-        const typeLiteralCompletions = getTypeLiteralInTypeArgumentCompletions(sourceFile, position, contextToken, typeChecker, compilerOptions, log, preferences);
-        if (typeLiteralCompletions) {
-            return typeLiteralCompletions;
+        const objectTypeLiteralCompletions = getObjectTypeLiteralInTypeArgumentCompletions(sourceFile, position, contextToken, typeChecker, compilerOptions, log, preferences);
+        if (objectTypeLiteralCompletions) {
+            return objectTypeLiteralCompletions;
         }
 
         if (contextToken && isBreakOrContinueStatement(contextToken.parent)
@@ -988,56 +988,51 @@ namespace ts.Completions {
         return !!symbol.declarations?.some(d => d.kind === SyntaxKind.SourceFile);
     }
 
-    function getTypeLiteralInTypeArgumentCompletions(sourceFile: SourceFile, position: number, contextToken: Node | undefined, checker: TypeChecker, options: CompilerOptions, log: Log, preferences: UserPreferences): CompletionInfo | undefined{
+    function getObjectTypeLiteralInTypeArgumentCompletions(sourceFile: SourceFile, position: number, contextToken: Node | undefined, checker: TypeChecker, options: CompilerOptions, log: Log, preferences: UserPreferences): CompletionInfo | undefined{
         if (!contextToken) return undefined;
 
         const typeLiteralNode = tryGetTypeLiteralNode(contextToken);
+        if (!typeLiteralNode) return undefined;
 
-        if (typeLiteralNode) {
-            const intersectionTypeNode = isIntersectionTypeNode(typeLiteralNode.parent) ? typeLiteralNode.parent : undefined;
-            const containerTypeNode = intersectionTypeNode || typeLiteralNode;
+        const intersectionTypeNode = isIntersectionTypeNode(typeLiteralNode.parent) ? typeLiteralNode.parent : undefined;
+        const containerTypeNode = intersectionTypeNode || typeLiteralNode;
 
-            const containerExpectedType = tryGetTypeArgumentSubType(containerTypeNode, checker);
-            if (!containerExpectedType) {
-                return undefined;
-            }
+        const containerExpectedType = tryGetTypeArgumentSubType(containerTypeNode, checker);
+        if (!containerExpectedType) return undefined;
 
-            const containerActualType = checker.getTypeFromTypeNode(containerTypeNode);
+        const containerActualType = checker.getTypeFromTypeNode(containerTypeNode);
 
-            const members = getPropertiesForCompletion(containerExpectedType, checker);
-            const existingMembers = getPropertiesForCompletion(containerActualType, checker);
+        const members = getPropertiesForCompletion(containerExpectedType, checker);
+        const existingMembers = getPropertiesForCompletion(containerActualType, checker);
 
-            const existingMemberEscapedNames: Set<__String> = new Set();
-            forEach(existingMembers, s => existingMemberEscapedNames.add(s.escapedName));
+        const existingMemberEscapedNames: Set<__String> = new Set();
+        forEach(existingMembers, s => existingMemberEscapedNames.add(s.escapedName));
 
-            const missingMembers = filter(members, s => !existingMemberEscapedNames.has(s.escapedName));
+        const missingMembers = filter(members, s => !existingMemberEscapedNames.has(s.escapedName));
 
-            const location = getTouchingToken(sourceFile, position);
+        const location = getTouchingToken(sourceFile, position);
 
-            const entries: CompletionEntry[] = [];
-            getCompletionEntriesFromSymbols(
-                missingMembers,
-                entries,
-                /* contextToken */ undefined,
-                location,
-                sourceFile,
-                checker,
-                options.target!,
-                log,
-                CompletionKind.MemberLike,
-                preferences,
-                options
-            );
+        const entries: CompletionEntry[] = [];
+        getCompletionEntriesFromSymbols(
+            missingMembers,
+            entries,
+            /* contextToken */ undefined,
+            location,
+            sourceFile,
+            checker,
+            options.target!,
+            log,
+            CompletionKind.MemberLike,
+            preferences,
+            options
+        );
 
-            return {
-                isGlobalCompletion: false,
-                isMemberCompletion: true,
-                isNewIdentifierLocation: false,
-                entries
-            };
-        }
-
-        return undefined;
+        return {
+            isGlobalCompletion: false,
+            isMemberCompletion: true,
+            isNewIdentifierLocation: false,
+            entries
+        };
     }
 
     function getCompletionData(
@@ -2943,18 +2938,16 @@ namespace ts.Completions {
         }
 
         const t = tryGetTypeArgumentSubType(node.parent, checker);
-        if (t) {
-            switch (node.kind) {
-                case SyntaxKind.PropertySignature:
-                    return checker.getTypeOfPropertyOfContextualType(t, node.symbol.escapedName);
-                case SyntaxKind.IntersectionType:
-                case SyntaxKind.TypeLiteral:
-                case SyntaxKind.UnionType:
-                    return t;
-            }
-        }
+        if (!t) return undefined;
 
-        return undefined;
+        switch (node.kind) {
+            case SyntaxKind.PropertySignature:
+                return checker.getTypeOfPropertyOfContextualType(t, node.symbol.escapedName);
+            case SyntaxKind.IntersectionType:
+            case SyntaxKind.TypeLiteral:
+            case SyntaxKind.UnionType:
+                return t;
+        }
     }
 
     // TODO: GH#19856 Would like to return `node is Node & { parent: (ClassElement | TypeElement) & { parent: ObjectTypeDeclaration } }` but then compilation takes > 10 minutes

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter1.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter1.ts
@@ -3,6 +3,11 @@
 ////interface Foo {
 ////    one: string;
 ////    two: number;
+////    333: symbol;
+////    '4four': boolean;
+////    '5 five': object;
+////    number: string;
+////    Object: number;
 ////}
 ////
 ////interface Bar<T extends Foo> {
@@ -11,4 +16,8 @@
 ////
 ////var foobar: Bar<{/**/
 
-verify.completions({ marker: "", exact: ["one", "two"] });
+verify.completions({
+    marker: "",
+    exact: ["one", "two", "\"333\"", "\"4four\"", "\"5 five\"", "number", "Object"],
+    isNewIdentifierLocation: true
+});

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter1.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter1.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+////interface Foo {
+////    one: string;
+////    two: number;
+////}
+////
+////interface Bar<T extends Foo> {
+////    foo: T;
+////}
+////
+////var foobar: Bar<{/**/
+
+verify.completions({ marker: "", exact: ["one", "two"] });

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter2.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter2.ts
@@ -11,4 +11,4 @@
 ////
 ////var foobar: Bar<{ on/**/
 
-verify.completions({ marker: "", exact: ["one", "two"] });
+verify.completions({ marker: "", exact: ["one", "two"], isNewIdentifierLocation: true });

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter2.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter2.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+////interface Foo {
+////    one: string;
+////    two: number;
+////}
+////
+////interface Bar<T extends Foo> {
+////    foo: T;
+////}
+////
+////var foobar: Bar<{ on/**/
+
+verify.completions({ marker: "", exact: ["one", "two"] });

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter3.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter3.ts
@@ -11,4 +11,4 @@
 ////
 ////var foobar: Bar<{ one: string, /**/
 
-verify.completions({ marker: "", exact: "two" });
+verify.completions({ marker: "", exact: "two", isNewIdentifierLocation: true });

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter3.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter3.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+////interface Foo {
+////    one: string;
+////    two: number;
+////}
+////
+////interface Bar<T extends Foo> {
+////    foo: T;
+////}
+////
+////var foobar: Bar<{ one: string, /**/
+
+verify.completions({ marker: "", exact: "two" });

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter4.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter4.ts
@@ -11,4 +11,4 @@
 ////
 ////var foobar: Bar<{ one: string } & {/**/
 
-verify.completions({ marker: "", exact: "two" });
+verify.completions({ marker: "", exact: "two", isNewIdentifierLocation: true });

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter4.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter4.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+////interface Foo {
+////    one: string;
+////    two: number;
+////}
+////
+////interface Bar<T extends Foo> {
+////    foo: T;
+////}
+////
+////var foobar: Bar<{ one: string } & {/**/
+
+verify.completions({ marker: "", exact: "two" });

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter5.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter5.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+////interface Foo {
+////    one: string;
+////    two: number;
+////}
+////
+////interface Bar<T extends Foo> {
+////    foo: T;
+////}
+////
+////var foobar: Bar<{ prop1: string } & {/**/
+
+verify.completions({ marker: "", exact: ["one", "two"] });

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter5.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter5.ts
@@ -11,4 +11,4 @@
 ////
 ////var foobar: Bar<{ prop1: string } & {/**/
 
-verify.completions({ marker: "", exact: ["one", "two"] });
+verify.completions({ marker: "", exact: ["one", "two"], isNewIdentifierLocation: true });

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter6.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter6.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+////interface Foo {
+////    one: string;
+////    two: number;
+////}
+////
+////interface Bar<T extends Foo> {
+////    foo: T;
+////}
+////
+////var foobar: Bar<{ one: string } | {/**/
+
+verify.completions({ marker: "", exact: ["one", "two"] });

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter6.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter6.ts
@@ -11,4 +11,4 @@
 ////
 ////var foobar: Bar<{ one: string } | {/**/
 
-verify.completions({ marker: "", exact: ["one", "two"] });
+verify.completions({ marker: "", exact: ["one", "two"], isNewIdentifierLocation: true });

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter7.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter7.ts
@@ -14,4 +14,4 @@
 ////var foobar: Bar<{
 ////    two: {/**/
 
-verify.completions({ marker: "", exact: "three" });
+verify.completions({ marker: "", exact: "three", isNewIdentifierLocation: true });

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter7.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter7.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+////interface Foo {
+////    one: string;
+////    two: {
+////        three: number;
+////    }
+////}
+////
+////interface Bar<T extends Foo> {
+////    foo: T;
+////}
+////
+////var foobar: Bar<{
+////    two: {/**/
+
+verify.completions({ marker: "", exact: "three" });

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter8.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter8.ts
@@ -26,8 +26,8 @@
 ////}>;
 
 verify.completions(
-    { marker: "4", exact: "four" },
-    { marker: "0", exact: [] },
-    { marker: "1", exact: "one" },
+    { marker: "4", exact: "four", isNewIdentifierLocation: true },
+    { marker: "0", exact: [], isNewIdentifierLocation: true },
+    { marker: "1", exact: "one", isNewIdentifierLocation: true },
 );
 

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter8.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter8.ts
@@ -1,0 +1,33 @@
+/// <reference path="fourslash.ts" />
+
+////interface Foo {
+////    one: string;
+////    two: {
+////        three: {
+////            four: number;
+////            five: string;
+////        }
+////    }
+////}
+////
+////interface Bar<T extends Foo> {
+////    foo: T;
+////}
+////
+////var foobar: Bar<{
+////    two: {
+////        three: {
+////            five: string,
+////            /*4*/
+////        },
+////        /*0*/
+////    },
+////    /*1*/
+////}>;
+
+verify.completions(
+    { marker: "4", exact: "four" },
+    { marker: "0", exact: [] },
+    { marker: "1", exact: "one" },
+);
+

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter9.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter9.ts
@@ -21,5 +21,5 @@
 ////}>;
 
 verify.completions({ marker: "g", includes: ["Foo", "Bar", ...completion.globalTypes] });
-verify.completions({ marker: "4", exact: "four" });
+verify.completions({ marker: "4", exact: "four", isNewIdentifierLocation: true });
 

--- a/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter9.ts
+++ b/tests/cases/fourslash/completionListInTypeLiteralInTypeParameter9.ts
@@ -1,0 +1,25 @@
+/// <reference path="fourslash.ts" />
+
+////interface Foo {
+////    one: string;
+////    two: {
+////        three: {
+////            four: number;
+////            five: string;
+////        }
+////    }
+////}
+////
+////interface Bar<T extends Foo> {
+////    foo: T;
+////}
+////
+////var foobar: Bar<{
+////    two: {
+////        three: { five:/*g*/ } & {/*4*/},
+////    }
+////}>;
+
+verify.completions({ marker: "g", includes: ["Foo", "Bar", ...completion.globalTypes] });
+verify.completions({ marker: "4", exact: "four" });
+


### PR DESCRIPTION
This PR aims to provide some type literal completion for type arguments, as suggested in https://github.com/microsoft/TypeScript/issues/33302. It takes in mind intersection and union types, as well as nested type literals.
