### PR TITLE
fix(43535): TypeScript preserves 'override' modifier in JavaScript output

### DIFF
--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -968,6 +968,7 @@ namespace ts {
                 case SyntaxKind.BigIntKeyword:
                 case SyntaxKind.NeverKeyword:
                 case SyntaxKind.ObjectKeyword:
+                case SyntaxKind.OverrideKeyword:
                 case SyntaxKind.StringKeyword:
                 case SyntaxKind.BooleanKeyword:
                 case SyntaxKind.SymbolKeyword:

--- a/tests/baselines/reference/override12(target=es2015).js
+++ b/tests/baselines/reference/override12(target=es2015).js
@@ -1,0 +1,45 @@
+//// [override12.ts]
+class A {
+    public m1(): number {
+        return 0;
+    }
+
+    public m2(): number {
+        return 0;
+    }
+
+    public m3(): void {}
+}
+
+class B extends A {
+    override m1() {
+        return 10;
+    }
+
+    override m2(): number {
+        return 30;
+    }
+
+    override m3(): void {}
+}
+
+
+//// [override12.js]
+class A {
+    m1() {
+        return 0;
+    }
+    m2() {
+        return 0;
+    }
+    m3() { }
+}
+class B extends A {
+    m1() {
+        return 10;
+    }
+    m2() {
+        return 30;
+    }
+    m3() { }
+}

--- a/tests/baselines/reference/override12(target=es2015).symbols
+++ b/tests/baselines/reference/override12(target=es2015).symbols
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/override/override12.ts ===
+class A {
+>A : Symbol(A, Decl(override12.ts, 0, 0))
+
+    public m1(): number {
+>m1 : Symbol(A.m1, Decl(override12.ts, 0, 9))
+
+        return 0;
+    }
+
+    public m2(): number {
+>m2 : Symbol(A.m2, Decl(override12.ts, 3, 5))
+
+        return 0;
+    }
+
+    public m3(): void {}
+>m3 : Symbol(A.m3, Decl(override12.ts, 7, 5))
+}
+
+class B extends A {
+>B : Symbol(B, Decl(override12.ts, 10, 1))
+>A : Symbol(A, Decl(override12.ts, 0, 0))
+
+    override m1() {
+>m1 : Symbol(B.m1, Decl(override12.ts, 12, 19))
+
+        return 10;
+    }
+
+    override m2(): number {
+>m2 : Symbol(B.m2, Decl(override12.ts, 15, 5))
+
+        return 30;
+    }
+
+    override m3(): void {}
+>m3 : Symbol(B.m3, Decl(override12.ts, 19, 5))
+}
+

--- a/tests/baselines/reference/override12(target=es2015).types
+++ b/tests/baselines/reference/override12(target=es2015).types
@@ -1,0 +1,44 @@
+=== tests/cases/conformance/override/override12.ts ===
+class A {
+>A : A
+
+    public m1(): number {
+>m1 : () => number
+
+        return 0;
+>0 : 0
+    }
+
+    public m2(): number {
+>m2 : () => number
+
+        return 0;
+>0 : 0
+    }
+
+    public m3(): void {}
+>m3 : () => void
+}
+
+class B extends A {
+>B : B
+>A : A
+
+    override m1() {
+>m1 : () => number
+
+        return 10;
+>10 : 10
+    }
+
+    override m2(): number {
+>m2 : () => number
+
+        return 30;
+>30 : 30
+    }
+
+    override m3(): void {}
+>m3 : () => void
+}
+

--- a/tests/baselines/reference/override12(target=esnext).js
+++ b/tests/baselines/reference/override12(target=esnext).js
@@ -1,0 +1,45 @@
+//// [override12.ts]
+class A {
+    public m1(): number {
+        return 0;
+    }
+
+    public m2(): number {
+        return 0;
+    }
+
+    public m3(): void {}
+}
+
+class B extends A {
+    override m1() {
+        return 10;
+    }
+
+    override m2(): number {
+        return 30;
+    }
+
+    override m3(): void {}
+}
+
+
+//// [override12.js]
+class A {
+    m1() {
+        return 0;
+    }
+    m2() {
+        return 0;
+    }
+    m3() { }
+}
+class B extends A {
+    m1() {
+        return 10;
+    }
+    m2() {
+        return 30;
+    }
+    m3() { }
+}

--- a/tests/baselines/reference/override12(target=esnext).symbols
+++ b/tests/baselines/reference/override12(target=esnext).symbols
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/override/override12.ts ===
+class A {
+>A : Symbol(A, Decl(override12.ts, 0, 0))
+
+    public m1(): number {
+>m1 : Symbol(A.m1, Decl(override12.ts, 0, 9))
+
+        return 0;
+    }
+
+    public m2(): number {
+>m2 : Symbol(A.m2, Decl(override12.ts, 3, 5))
+
+        return 0;
+    }
+
+    public m3(): void {}
+>m3 : Symbol(A.m3, Decl(override12.ts, 7, 5))
+}
+
+class B extends A {
+>B : Symbol(B, Decl(override12.ts, 10, 1))
+>A : Symbol(A, Decl(override12.ts, 0, 0))
+
+    override m1() {
+>m1 : Symbol(B.m1, Decl(override12.ts, 12, 19))
+
+        return 10;
+    }
+
+    override m2(): number {
+>m2 : Symbol(B.m2, Decl(override12.ts, 15, 5))
+
+        return 30;
+    }
+
+    override m3(): void {}
+>m3 : Symbol(B.m3, Decl(override12.ts, 19, 5))
+}
+

--- a/tests/baselines/reference/override12(target=esnext).types
+++ b/tests/baselines/reference/override12(target=esnext).types
@@ -1,0 +1,44 @@
+=== tests/cases/conformance/override/override12.ts ===
+class A {
+>A : A
+
+    public m1(): number {
+>m1 : () => number
+
+        return 0;
+>0 : 0
+    }
+
+    public m2(): number {
+>m2 : () => number
+
+        return 0;
+>0 : 0
+    }
+
+    public m3(): void {}
+>m3 : () => void
+}
+
+class B extends A {
+>B : B
+>A : A
+
+    override m1() {
+>m1 : () => number
+
+        return 10;
+>10 : 10
+    }
+
+    override m2(): number {
+>m2 : () => number
+
+        return 30;
+>30 : 30
+    }
+
+    override m3(): void {}
+>m3 : () => void
+}
+

--- a/tests/cases/conformance/override/override12.ts
+++ b/tests/cases/conformance/override/override12.ts
@@ -1,0 +1,26 @@
+// @noImplicitOverride: true
+// @target: es2015,esnext
+
+class A {
+    public m1(): number {
+        return 0;
+    }
+
+    public m2(): number {
+        return 0;
+    }
+
+    public m3(): void {}
+}
+
+class B extends A {
+    override m1() {
+        return 10;
+    }
+
+    override m2(): number {
+        return 30;
+    }
+
+    override m3(): void {}
+}


### PR DESCRIPTION
Fixes #43535