### PR TITLE
Trim indexed access and type variable constraint error output

### DIFF
--- a/tests/baselines/reference/errorInfoForRelatedIndexTypesNoConstraintElaboration.errors.txt
+++ b/tests/baselines/reference/errorInfoForRelatedIndexTypesNoConstraintElaboration.errors.txt
@@ -1,0 +1,18 @@
+tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts(6,15): error TS2322: Type 'IntrinsicElements[T1]' is not assignable to type 'IntrinsicElements[T2]'.
+  Type 'T1' is not assignable to type 'T2'.
+    'T1' is assignable to the constraint of type 'T2', but 'T2' could be instantiated with a different subtype of constraint 'keyof IntrinsicElements'.
+
+
+==== tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts (1 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    
+    class I<T1 extends keyof JSX.IntrinsicElements, T2 extends keyof JSX.IntrinsicElements> {
+        M() {
+            let c1: JSX.IntrinsicElements[T1] = {};
+            const c2: JSX.IntrinsicElements[T2] = c1;
+                  ~~
+!!! error TS2322: Type 'IntrinsicElements[T1]' is not assignable to type 'IntrinsicElements[T2]'.
+!!! error TS2322:   Type 'T1' is not assignable to type 'T2'.
+!!! error TS2322:     'T1' is assignable to the constraint of type 'T2', but 'T2' could be instantiated with a different subtype of constraint 'keyof IntrinsicElements'.
+        }
+    }

--- a/tests/baselines/reference/errorInfoForRelatedIndexTypesNoConstraintElaboration.js
+++ b/tests/baselines/reference/errorInfoForRelatedIndexTypesNoConstraintElaboration.js
@@ -1,0 +1,21 @@
+//// [errorInfoForRelatedIndexTypesNoConstraintElaboration.ts]
+/// <reference path="/.lib/react16.d.ts" />
+
+class I<T1 extends keyof JSX.IntrinsicElements, T2 extends keyof JSX.IntrinsicElements> {
+    M() {
+        let c1: JSX.IntrinsicElements[T1] = {};
+        const c2: JSX.IntrinsicElements[T2] = c1;
+    }
+}
+
+//// [errorInfoForRelatedIndexTypesNoConstraintElaboration.js]
+/// <reference path="react16.d.ts" />
+var I = /** @class */ (function () {
+    function I() {
+    }
+    I.prototype.M = function () {
+        var c1 = {};
+        var c2 = c1;
+    };
+    return I;
+}());

--- a/tests/baselines/reference/errorInfoForRelatedIndexTypesNoConstraintElaboration.symbols
+++ b/tests/baselines/reference/errorInfoForRelatedIndexTypesNoConstraintElaboration.symbols
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts ===
+/// <reference path="react16.d.ts" />
+
+class I<T1 extends keyof JSX.IntrinsicElements, T2 extends keyof JSX.IntrinsicElements> {
+>I : Symbol(I, Decl(errorInfoForRelatedIndexTypesNoConstraintElaboration.ts, 0, 0))
+>T1 : Symbol(T1, Decl(errorInfoForRelatedIndexTypesNoConstraintElaboration.ts, 2, 8))
+>JSX : Symbol(JSX, Decl(react16.d.ts, 2493, 12))
+>IntrinsicElements : Symbol(JSX.IntrinsicElements, Decl(react16.d.ts, 2514, 86))
+>T2 : Symbol(T2, Decl(errorInfoForRelatedIndexTypesNoConstraintElaboration.ts, 2, 47))
+>JSX : Symbol(JSX, Decl(react16.d.ts, 2493, 12))
+>IntrinsicElements : Symbol(JSX.IntrinsicElements, Decl(react16.d.ts, 2514, 86))
+
+    M() {
+>M : Symbol(I.M, Decl(errorInfoForRelatedIndexTypesNoConstraintElaboration.ts, 2, 89))
+
+        let c1: JSX.IntrinsicElements[T1] = {};
+>c1 : Symbol(c1, Decl(errorInfoForRelatedIndexTypesNoConstraintElaboration.ts, 4, 11))
+>JSX : Symbol(JSX, Decl(react16.d.ts, 2493, 12))
+>IntrinsicElements : Symbol(JSX.IntrinsicElements, Decl(react16.d.ts, 2514, 86))
+>T1 : Symbol(T1, Decl(errorInfoForRelatedIndexTypesNoConstraintElaboration.ts, 2, 8))
+
+        const c2: JSX.IntrinsicElements[T2] = c1;
+>c2 : Symbol(c2, Decl(errorInfoForRelatedIndexTypesNoConstraintElaboration.ts, 5, 13))
+>JSX : Symbol(JSX, Decl(react16.d.ts, 2493, 12))
+>IntrinsicElements : Symbol(JSX.IntrinsicElements, Decl(react16.d.ts, 2514, 86))
+>T2 : Symbol(T2, Decl(errorInfoForRelatedIndexTypesNoConstraintElaboration.ts, 2, 47))
+>c1 : Symbol(c1, Decl(errorInfoForRelatedIndexTypesNoConstraintElaboration.ts, 4, 11))
+    }
+}

--- a/tests/baselines/reference/errorInfoForRelatedIndexTypesNoConstraintElaboration.types
+++ b/tests/baselines/reference/errorInfoForRelatedIndexTypesNoConstraintElaboration.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts ===
+/// <reference path="react16.d.ts" />
+
+class I<T1 extends keyof JSX.IntrinsicElements, T2 extends keyof JSX.IntrinsicElements> {
+>I : I<T1, T2>
+>JSX : any
+>JSX : any
+
+    M() {
+>M : () => void
+
+        let c1: JSX.IntrinsicElements[T1] = {};
+>c1 : JSX.IntrinsicElements[T1]
+>JSX : any
+>{} : {}
+
+        const c2: JSX.IntrinsicElements[T2] = c1;
+>c2 : JSX.IntrinsicElements[T2]
+>JSX : any
+>c1 : JSX.IntrinsicElements[T1]
+    }
+}

--- a/tests/baselines/reference/genericTypeAssertions6.errors.txt
+++ b/tests/baselines/reference/genericTypeAssertions6.errors.txt
@@ -4,8 +4,6 @@ tests/cases/compiler/genericTypeAssertions6.ts(9,13): error TS2352: Conversion o
   'U' could be instantiated with an arbitrary type which could be unrelated to 'T'.
 tests/cases/compiler/genericTypeAssertions6.ts(19,17): error TS2352: Conversion of type 'U' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-    Type 'Date' is not comparable to type 'T'.
-      'Date' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
 
 
 ==== tests/cases/compiler/genericTypeAssertions6.ts (3 errors) ====
@@ -37,8 +35,6 @@ tests/cases/compiler/genericTypeAssertions6.ts(19,17): error TS2352: Conversion 
                     ~~~~~~~~~~~~~~~~
 !!! error TS2352: Conversion of type 'U' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-!!! error TS2352:     Type 'Date' is not comparable to type 'T'.
-!!! error TS2352:       'Date' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
         }
     }
     

--- a/tests/baselines/reference/intrinsicTypes.errors.txt
+++ b/tests/baselines/reference/intrinsicTypes.errors.txt
@@ -8,8 +8,6 @@ tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(42,5): error TS2322:
 tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(43,5): error TS2322: Type 'Uppercase<T>' is not assignable to type 'Uppercase<U>'.
   Type 'T' is not assignable to type 'U'.
     'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'string'.
-      Type 'string' is not assignable to type 'U'.
-        'string' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'string'.
 
 
 ==== tests/cases/conformance/types/typeAliases/intrinsicTypes.ts (8 errors) ====
@@ -74,8 +72,6 @@ tests/cases/conformance/types/typeAliases/intrinsicTypes.ts(43,5): error TS2322:
 !!! error TS2322: Type 'Uppercase<T>' is not assignable to type 'Uppercase<U>'.
 !!! error TS2322:   Type 'T' is not assignable to type 'U'.
 !!! error TS2322:     'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'string'.
-!!! error TS2322:       Type 'string' is not assignable to type 'U'.
-!!! error TS2322:         'string' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'string'.
     }
     
     function foo2<T extends 'foo' | 'bar'>(x: Uppercase<T>) {

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
@@ -53,12 +53,6 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(111,5): error
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(114,5): error TS2322: Type 'T[K]' is not assignable to type 'T[J]'.
   Type 'K' is not assignable to type 'J'.
     'K' is assignable to the constraint of type 'J', but 'J' could be instantiated with a different subtype of constraint 'string'.
-      Type 'Extract<keyof T, string>' is not assignable to type 'J'.
-        'Extract<keyof T, string>' is assignable to the constraint of type 'J', but 'J' could be instantiated with a different subtype of constraint 'string'.
-          Type 'string & keyof T' is not assignable to type 'J'.
-            'string & keyof T' is assignable to the constraint of type 'J', but 'J' could be instantiated with a different subtype of constraint 'string'.
-              Type 'string' is not assignable to type 'J'.
-                'string' is assignable to the constraint of type 'J', but 'J' could be instantiated with a different subtype of constraint 'string'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(117,5): error TS2322: Type 'T[K]' is not assignable to type 'U[J]'.
   Type 'T' is not assignable to type 'U'.
     'U' could be instantiated with an arbitrary type which could be unrelated to 'T'.
@@ -273,12 +267,6 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(142,5): error
 !!! error TS2322: Type 'T[K]' is not assignable to type 'T[J]'.
 !!! error TS2322:   Type 'K' is not assignable to type 'J'.
 !!! error TS2322:     'K' is assignable to the constraint of type 'J', but 'J' could be instantiated with a different subtype of constraint 'string'.
-!!! error TS2322:       Type 'Extract<keyof T, string>' is not assignable to type 'J'.
-!!! error TS2322:         'Extract<keyof T, string>' is assignable to the constraint of type 'J', but 'J' could be instantiated with a different subtype of constraint 'string'.
-!!! error TS2322:           Type 'string & keyof T' is not assignable to type 'J'.
-!!! error TS2322:             'string & keyof T' is assignable to the constraint of type 'J', but 'J' could be instantiated with a different subtype of constraint 'string'.
-!!! error TS2322:               Type 'string' is not assignable to type 'J'.
-!!! error TS2322:                 'string' is assignable to the constraint of type 'J', but 'J' could be instantiated with a different subtype of constraint 'string'.
     
         tk = uj;
         uj = tk; // error

--- a/tests/baselines/reference/objectTypeWithRecursiveWrappedPropertyCheckedNominally.errors.txt
+++ b/tests/baselines/reference/objectTypeWithRecursiveWrappedPropertyCheckedNominally.errors.txt
@@ -6,16 +6,10 @@ tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRec
     Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts(30,5): error TS2322: Type 'U' is not assignable to type 'T'.
   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'List<number>'.
-    Type 'MyList<number>' is not assignable to type 'T'.
-      'MyList<number>' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'List<number>'.
 tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts(31,5): error TS2322: Type 'T' is not assignable to type 'U'.
   'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'MyList<number>'.
-    Type 'List<number>' is not assignable to type 'U'.
-      'List<number>' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'MyList<number>'.
 tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts(42,5): error TS2322: Type 'U' is not assignable to type 'T'.
   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'MyList<number>'.
-    Type 'MyList<number>' is not assignable to type 'T'.
-      'T' could be instantiated with an arbitrary type which could be unrelated to 'MyList<number>'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts (5 errors) ====
@@ -60,14 +54,10 @@ tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRec
         ~
 !!! error TS2322: Type 'U' is not assignable to type 'T'.
 !!! error TS2322:   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'List<number>'.
-!!! error TS2322:     Type 'MyList<number>' is not assignable to type 'T'.
-!!! error TS2322:       'MyList<number>' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'List<number>'.
         u = t; // error
         ~
 !!! error TS2322: Type 'T' is not assignable to type 'U'.
 !!! error TS2322:   'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'MyList<number>'.
-!!! error TS2322:     Type 'List<number>' is not assignable to type 'U'.
-!!! error TS2322:       'List<number>' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'MyList<number>'.
     
         var a: List<number>;
         var b: MyList<number>;
@@ -82,8 +72,6 @@ tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRec
         ~
 !!! error TS2322: Type 'U' is not assignable to type 'T'.
 !!! error TS2322:   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'MyList<number>'.
-!!! error TS2322:     Type 'MyList<number>' is not assignable to type 'T'.
-!!! error TS2322:       'T' could be instantiated with an arbitrary type which could be unrelated to 'MyList<number>'.
         u = t; // was error, ok after constraint made illegal, doesn't matter
     
         var a: List<number>;

--- a/tests/baselines/reference/subtypesOfTypeParameterWithConstraints.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithConstraints.errors.txt
@@ -18,22 +18,14 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(112,5): error TS2416: Property 'foo' in type 'D19<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
   Type 'U' is not assignable to type 'T'.
     'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-      Type 'V' is not assignable to type 'T'.
-        'V' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-          Type 'Date' is not assignable to type 'T'.
-            'Date' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(134,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(134,5): error TS2416: Property 'foo' in type 'D23<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
   Type 'V' is not assignable to type 'T'.
     'V' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-      Type 'Date' is not assignable to type 'T'.
-        'Date' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(139,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(139,5): error TS2416: Property 'foo' in type 'D24<T, U, V>' is not assignable to the same property in base type 'C3<U>'.
   Type 'V' is not assignable to type 'U'.
     'V' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Date'.
-      Type 'Date' is not assignable to type 'U'.
-        'Date' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(156,5): error TS2411: Property 'foo' of type 'Date' is not assignable to string index type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(156,5): error TS2416: Property 'foo' in type 'D27<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
   Type 'Date' is not assignable to type 'T'.
@@ -191,10 +183,6 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2416: Property 'foo' in type 'D19<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
 !!! error TS2416:   Type 'U' is not assignable to type 'T'.
 !!! error TS2416:     'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-!!! error TS2416:       Type 'V' is not assignable to type 'T'.
-!!! error TS2416:         'V' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-!!! error TS2416:           Type 'Date' is not assignable to type 'T'.
-!!! error TS2416:             'Date' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
     }
     
     class D20<T extends U, U extends V, V extends Date> extends C3<U> {
@@ -223,8 +211,6 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2416: Property 'foo' in type 'D23<T, U, V>' is not assignable to the same property in base type 'C3<T>'.
 !!! error TS2416:   Type 'V' is not assignable to type 'T'.
 !!! error TS2416:     'V' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-!!! error TS2416:       Type 'Date' is not assignable to type 'T'.
-!!! error TS2416:         'Date' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
     }
     
     class D24<T extends U, U extends V, V extends Date> extends C3<U> {
@@ -236,8 +222,6 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2416: Property 'foo' in type 'D24<T, U, V>' is not assignable to the same property in base type 'C3<U>'.
 !!! error TS2416:   Type 'V' is not assignable to type 'U'.
 !!! error TS2416:     'V' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Date'.
-!!! error TS2416:       Type 'Date' is not assignable to type 'U'.
-!!! error TS2416:         'Date' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Date'.
     }
     
     class D25<T extends U, U extends V, V extends Date> extends C3<V> {

--- a/tests/baselines/reference/subtypesOfTypeParameterWithConstraints4.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithConstraints4.errors.txt
@@ -5,8 +5,6 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(57,5): error TS2416: Property 'foo' in type 'D5<T, U, V>' is not assignable to the same property in base type 'B1<T>'.
   Type 'U' is not assignable to type 'T'.
     'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Foo'.
-      Type 'Foo' is not assignable to type 'T'.
-        'T' could be instantiated with an arbitrary type which could be unrelated to 'Foo'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(62,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(62,5): error TS2416: Property 'foo' in type 'D6<T, U, V>' is not assignable to the same property in base type 'B1<T>'.
   Type 'V' is not assignable to type 'T'.
@@ -15,8 +13,6 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(67,5): error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'B1<U>'.
   Type 'T' is not assignable to type 'U'.
     'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Foo'.
-      Type 'Foo' is not assignable to type 'U'.
-        'U' could be instantiated with an arbitrary type which could be unrelated to 'Foo'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(77,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(77,5): error TS2416: Property 'foo' in type 'D9<T, U, V>' is not assignable to the same property in base type 'B1<U>'.
   Type 'V' is not assignable to type 'U'.
@@ -92,8 +88,6 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2416: Property 'foo' in type 'D5<T, U, V>' is not assignable to the same property in base type 'B1<T>'.
 !!! error TS2416:   Type 'U' is not assignable to type 'T'.
 !!! error TS2416:     'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Foo'.
-!!! error TS2416:       Type 'Foo' is not assignable to type 'T'.
-!!! error TS2416:         'T' could be instantiated with an arbitrary type which could be unrelated to 'Foo'.
     }
     
     class D6<T extends Foo, U extends Foo, V> extends B1<T> {
@@ -116,8 +110,6 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2416: Property 'foo' in type 'D7<T, U, V>' is not assignable to the same property in base type 'B1<U>'.
 !!! error TS2416:   Type 'T' is not assignable to type 'U'.
 !!! error TS2416:     'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Foo'.
-!!! error TS2416:       Type 'Foo' is not assignable to type 'U'.
-!!! error TS2416:         'U' could be instantiated with an arbitrary type which could be unrelated to 'Foo'.
     }
     
     class D8<T extends Foo, U extends Foo, V> extends B1<U> {

--- a/tests/baselines/reference/templateLiteralTypes1.errors.txt
+++ b/tests/baselines/reference/templateLiteralTypes1.errors.txt
@@ -2,8 +2,6 @@ tests/cases/conformance/types/literal/templateLiteralTypes1.ts(40,5): error TS23
 tests/cases/conformance/types/literal/templateLiteralTypes1.ts(45,5): error TS2322: Type '{ [P in B as `p_${P}`]: T; }' is not assignable to type '{ [Q in A as `p_${Q}`]: U; }'.
   Type 'A' is not assignable to type 'B'.
     'A' is assignable to the constraint of type 'B', but 'B' could be instantiated with a different subtype of constraint 'string'.
-      Type 'string' is not assignable to type 'B'.
-        'string' is assignable to the constraint of type 'B', but 'B' could be instantiated with a different subtype of constraint 'string'.
 tests/cases/conformance/types/literal/templateLiteralTypes1.ts(165,15): error TS1338: 'infer' declarations are only permitted in the 'extends' clause of a conditional type.
 tests/cases/conformance/types/literal/templateLiteralTypes1.ts(197,16): error TS2590: Expression produces a union type that is too complex to represent.
 tests/cases/conformance/types/literal/templateLiteralTypes1.ts(201,16): error TS2590: Expression produces a union type that is too complex to represent.
@@ -62,8 +60,6 @@ tests/cases/conformance/types/literal/templateLiteralTypes1.ts(205,16): error TS
 !!! error TS2322: Type '{ [P in B as `p_${P}`]: T; }' is not assignable to type '{ [Q in A as `p_${Q}`]: U; }'.
 !!! error TS2322:   Type 'A' is not assignable to type 'B'.
 !!! error TS2322:     'A' is assignable to the constraint of type 'B', but 'B' could be instantiated with a different subtype of constraint 'string'.
-!!! error TS2322:       Type 'string' is not assignable to type 'B'.
-!!! error TS2322:         'string' is assignable to the constraint of type 'B', but 'B' could be instantiated with a different subtype of constraint 'string'.
     }
     
     // String transformations using recursive conditional types

--- a/tests/baselines/reference/typeParameterAssignability2.errors.txt
+++ b/tests/baselines/reference/typeParameterAssignability2.errors.txt
@@ -10,36 +10,24 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
   'U' could be instantiated with an arbitrary type which could be unrelated to 'V'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(25,5): error TS2322: Type 'U' is not assignable to type 'T'.
   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-    Type 'V' is not assignable to type 'T'.
-      'V' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-        Type 'Date' is not assignable to type 'T'.
-          'Date' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(26,5): error TS2322: Type 'V' is not assignable to type 'T'.
   'V' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(27,5): error TS2322: Type 'Date' is not assignable to type 'T'.
   'Date' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(30,5): error TS2322: Type 'V' is not assignable to type 'U'.
   'V' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Date'.
-    Type 'Date' is not assignable to type 'U'.
-      'Date' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(31,5): error TS2322: Type 'Date' is not assignable to type 'U'.
   'Date' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(35,5): error TS2322: Type 'Date' is not assignable to type 'V'.
   'Date' is assignable to the constraint of type 'V', but 'V' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(45,5): error TS2322: Type 'U' is not assignable to type 'T'.
   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-    Type 'V' is not assignable to type 'T'.
-      'V' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-        Type 'Date' is not assignable to type 'T'.
-          'Date' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(46,5): error TS2322: Type 'V' is not assignable to type 'T'.
   'V' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(47,5): error TS2322: Type 'Date' is not assignable to type 'T'.
   'Date' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(50,5): error TS2322: Type 'V' is not assignable to type 'U'.
   'V' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Date'.
-    Type 'Date' is not assignable to type 'U'.
-      'Date' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(51,5): error TS2322: Type 'Date' is not assignable to type 'U'.
   'Date' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(55,5): error TS2322: Type 'Date' is not assignable to type 'V'.
@@ -100,10 +88,6 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
         ~
 !!! error TS2322: Type 'U' is not assignable to type 'T'.
 !!! error TS2322:   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-!!! error TS2322:     Type 'V' is not assignable to type 'T'.
-!!! error TS2322:       'V' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-!!! error TS2322:         Type 'Date' is not assignable to type 'T'.
-!!! error TS2322:           'Date' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
         t = v; // error
         ~
 !!! error TS2322: Type 'V' is not assignable to type 'T'.
@@ -118,8 +102,6 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
         ~
 !!! error TS2322: Type 'V' is not assignable to type 'U'.
 !!! error TS2322:   'V' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Date'.
-!!! error TS2322:     Type 'Date' is not assignable to type 'U'.
-!!! error TS2322:       'Date' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Date'.
         u = new Date(); // error
         ~
 !!! error TS2322: Type 'Date' is not assignable to type 'U'.
@@ -144,10 +126,6 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
         ~
 !!! error TS2322: Type 'U' is not assignable to type 'T'.
 !!! error TS2322:   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-!!! error TS2322:     Type 'V' is not assignable to type 'T'.
-!!! error TS2322:       'V' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-!!! error TS2322:         Type 'Date' is not assignable to type 'T'.
-!!! error TS2322:           'Date' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
         t = v; // error
         ~
 !!! error TS2322: Type 'V' is not assignable to type 'T'.
@@ -162,8 +140,6 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
         ~
 !!! error TS2322: Type 'V' is not assignable to type 'U'.
 !!! error TS2322:   'V' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Date'.
-!!! error TS2322:     Type 'Date' is not assignable to type 'U'.
-!!! error TS2322:       'Date' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Date'.
         u = new Date(); // error
         ~
 !!! error TS2322: Type 'Date' is not assignable to type 'U'.

--- a/tests/baselines/reference/typeParameterAssignability3.errors.txt
+++ b/tests/baselines/reference/typeParameterAssignability3.errors.txt
@@ -1,19 +1,11 @@
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts(14,5): error TS2322: Type 'U' is not assignable to type 'T'.
   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Foo'.
-    Type 'Foo' is not assignable to type 'T'.
-      'T' could be instantiated with an arbitrary type which could be unrelated to 'Foo'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts(15,5): error TS2322: Type 'T' is not assignable to type 'U'.
   'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Foo'.
-    Type 'Foo' is not assignable to type 'U'.
-      'U' could be instantiated with an arbitrary type which could be unrelated to 'Foo'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts(22,9): error TS2322: Type 'U' is not assignable to type 'T'.
   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Foo'.
-    Type 'Foo' is not assignable to type 'T'.
-      'T' could be instantiated with an arbitrary type which could be unrelated to 'Foo'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts(23,9): error TS2322: Type 'T' is not assignable to type 'U'.
   'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Foo'.
-    Type 'Foo' is not assignable to type 'U'.
-      'U' could be instantiated with an arbitrary type which could be unrelated to 'Foo'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts (4 errors) ====
@@ -34,14 +26,10 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
         ~
 !!! error TS2322: Type 'U' is not assignable to type 'T'.
 !!! error TS2322:   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Foo'.
-!!! error TS2322:     Type 'Foo' is not assignable to type 'T'.
-!!! error TS2322:       'T' could be instantiated with an arbitrary type which could be unrelated to 'Foo'.
         u = t; // error
         ~
 !!! error TS2322: Type 'T' is not assignable to type 'U'.
 !!! error TS2322:   'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Foo'.
-!!! error TS2322:     Type 'Foo' is not assignable to type 'U'.
-!!! error TS2322:       'U' could be instantiated with an arbitrary type which could be unrelated to 'Foo'.
     }
     
     class C<T extends Foo, U extends Foo> {
@@ -52,13 +40,9 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
             ~~~~~~
 !!! error TS2322: Type 'U' is not assignable to type 'T'.
 !!! error TS2322:   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Foo'.
-!!! error TS2322:     Type 'Foo' is not assignable to type 'T'.
-!!! error TS2322:       'T' could be instantiated with an arbitrary type which could be unrelated to 'Foo'.
             this.u = this.t; // error
             ~~~~~~
 !!! error TS2322: Type 'T' is not assignable to type 'U'.
 !!! error TS2322:   'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'Foo'.
-!!! error TS2322:     Type 'Foo' is not assignable to type 'U'.
-!!! error TS2322:       'U' could be instantiated with an arbitrary type which could be unrelated to 'Foo'.
         }
     }

--- a/tests/baselines/reference/typeParametersShouldNotBeEqual2.errors.txt
+++ b/tests/baselines/reference/typeParametersShouldNotBeEqual2.errors.txt
@@ -1,7 +1,5 @@
 tests/cases/compiler/typeParametersShouldNotBeEqual2.ts(4,5): error TS2322: Type 'U' is not assignable to type 'T'.
   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-    Type 'Date' is not assignable to type 'T'.
-      'Date' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
 tests/cases/compiler/typeParametersShouldNotBeEqual2.ts(5,5): error TS2322: Type 'V' is not assignable to type 'T'.
   'T' could be instantiated with an arbitrary type which could be unrelated to 'V'.
 tests/cases/compiler/typeParametersShouldNotBeEqual2.ts(6,5): error TS2322: Type 'T' is not assignable to type 'V'.
@@ -22,8 +20,6 @@ tests/cases/compiler/typeParametersShouldNotBeEqual2.ts(9,5): error TS2322: Type
         ~
 !!! error TS2322: Type 'U' is not assignable to type 'T'.
 !!! error TS2322:   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
-!!! error TS2322:     Type 'Date' is not assignable to type 'T'.
-!!! error TS2322:       'Date' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Date'.
         x = z;  // Error
         ~
 !!! error TS2322: Type 'V' is not assignable to type 'T'.

--- a/tests/baselines/reference/typeParametersShouldNotBeEqual3.errors.txt
+++ b/tests/baselines/reference/typeParametersShouldNotBeEqual3.errors.txt
@@ -1,8 +1,5 @@
 tests/cases/compiler/typeParametersShouldNotBeEqual3.ts(4,5): error TS2322: Type 'U' is not assignable to type 'T'.
   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Object'.
-    Type 'Object' is not assignable to type 'T'.
-      'Object' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Object'.
-        The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/typeParametersShouldNotBeEqual3.ts(5,5): error TS2322: Type 'Object' is not assignable to type 'T'.
   'Object' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Object'.
     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
@@ -16,9 +13,6 @@ tests/cases/compiler/typeParametersShouldNotBeEqual3.ts(5,5): error TS2322: Type
         ~
 !!! error TS2322: Type 'U' is not assignable to type 'T'.
 !!! error TS2322:   'U' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Object'.
-!!! error TS2322:     Type 'Object' is not assignable to type 'T'.
-!!! error TS2322:       'Object' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Object'.
-!!! error TS2322:         The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
         x = z;  // Ok
         ~
 !!! error TS2322: Type 'Object' is not assignable to type 'T'.

--- a/tests/baselines/reference/variadicTuples1.errors.txt
+++ b/tests/baselines/reference/variadicTuples1.errors.txt
@@ -11,8 +11,6 @@ tests/cases/conformance/types/tuple/variadicTuples1.ts(151,5): error TS2322: Typ
 tests/cases/conformance/types/tuple/variadicTuples1.ts(152,5): error TS2322: Type '[string, ...T]' is not assignable to type '[string, ...U]'.
   Type 'T' is not assignable to type 'U'.
     'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'string[]'.
-      Type 'string[]' is not assignable to type 'U'.
-        'U' could be instantiated with an arbitrary type which could be unrelated to 'string[]'.
 tests/cases/conformance/types/tuple/variadicTuples1.ts(160,5): error TS2322: Type 'readonly [...T]' is not assignable to type 'T'.
   'T' could be instantiated with an arbitrary type which could be unrelated to 'readonly [...T]'.
 tests/cases/conformance/types/tuple/variadicTuples1.ts(162,5): error TS4104: The type 'readonly [...T]' is 'readonly' and cannot be assigned to the mutable type '[...T]'.
@@ -27,8 +25,6 @@ tests/cases/conformance/types/tuple/variadicTuples1.ts(181,5): error TS2322: Typ
 tests/cases/conformance/types/tuple/variadicTuples1.ts(182,5): error TS2322: Type '[...T]' is not assignable to type '[...U]'.
   Type 'T' is not assignable to type 'U'.
     'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'string[]'.
-      Type 'string[]' is not assignable to type 'U'.
-        'U' could be instantiated with an arbitrary type which could be unrelated to 'string[]'.
 tests/cases/conformance/types/tuple/variadicTuples1.ts(188,5): error TS2322: Type 'T' is not assignable to type '[...T]'.
   The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type '[...T]'.
 tests/cases/conformance/types/tuple/variadicTuples1.ts(190,5): error TS2322: Type 'T' is not assignable to type '[...U]'.
@@ -36,8 +32,6 @@ tests/cases/conformance/types/tuple/variadicTuples1.ts(190,5): error TS2322: Typ
 tests/cases/conformance/types/tuple/variadicTuples1.ts(191,5): error TS2322: Type '[...T]' is not assignable to type '[...U]'.
   Type 'T' is not assignable to type 'U'.
     'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'readonly string[]'.
-      Type 'readonly string[]' is not assignable to type 'U'.
-        'U' could be instantiated with an arbitrary type which could be unrelated to 'readonly string[]'.
 tests/cases/conformance/types/tuple/variadicTuples1.ts(203,5): error TS2322: Type 'string' is not assignable to type 'keyof [1, 2, ...T]'.
   Type '"2"' is not assignable to type 'number | "0" | keyof T[] | "1"'.
 tests/cases/conformance/types/tuple/variadicTuples1.ts(357,26): error TS2322: Type 'string' is not assignable to type 'number | undefined'.
@@ -220,8 +214,6 @@ tests/cases/conformance/types/tuple/variadicTuples1.ts(397,7): error TS2322: Typ
 !!! error TS2322: Type '[string, ...T]' is not assignable to type '[string, ...U]'.
 !!! error TS2322:   Type 'T' is not assignable to type 'U'.
 !!! error TS2322:     'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'string[]'.
-!!! error TS2322:       Type 'string[]' is not assignable to type 'U'.
-!!! error TS2322:         'U' could be instantiated with an arbitrary type which could be unrelated to 'string[]'.
     }
     
     // For a generic type T, [...T] is assignable to T, T is assignable to readonly [...T], and T is assignable
@@ -273,8 +265,6 @@ tests/cases/conformance/types/tuple/variadicTuples1.ts(397,7): error TS2322: Typ
 !!! error TS2322: Type '[...T]' is not assignable to type '[...U]'.
 !!! error TS2322:   Type 'T' is not assignable to type 'U'.
 !!! error TS2322:     'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'string[]'.
-!!! error TS2322:       Type 'string[]' is not assignable to type 'U'.
-!!! error TS2322:         'U' could be instantiated with an arbitrary type which could be unrelated to 'string[]'.
     }
     
     function f14<T extends readonly string[], U extends T>(t0: T, t1: [...T], t2: [...U]) {
@@ -294,8 +284,6 @@ tests/cases/conformance/types/tuple/variadicTuples1.ts(397,7): error TS2322: Typ
 !!! error TS2322: Type '[...T]' is not assignable to type '[...U]'.
 !!! error TS2322:   Type 'T' is not assignable to type 'U'.
 !!! error TS2322:     'T' is assignable to the constraint of type 'U', but 'U' could be instantiated with a different subtype of constraint 'readonly string[]'.
-!!! error TS2322:       Type 'readonly string[]' is not assignable to type 'U'.
-!!! error TS2322:         'U' could be instantiated with an arbitrary type which could be unrelated to 'readonly string[]'.
     }
     
     function f15<T extends string[], U extends T>(k0: keyof T, k1: keyof [...T], k2: keyof [...U], k3: keyof [1, 2, ...T]) {

--- a/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
+++ b/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
@@ -1,0 +1,8 @@
+/// <reference path="/.lib/react16.d.ts" />
+
+class I<T1 extends keyof JSX.IntrinsicElements, T2 extends keyof JSX.IntrinsicElements> {
+    M() {
+        let c1: JSX.IntrinsicElements[T1] = {};
+        const c2: JSX.IntrinsicElements[T2] = c1;
+    }
+}


### PR DESCRIPTION
This does two things:
1. Indexed accesses now record both the error which may occur when breaking them down algebraically and their constraint error. If both occur, we now only issue the _shorter_ of the two, as measured by how many error chains are present in the error, rather than confusingly stacking a pyramid of both error chains. (Doing this made me reorder the comparisons so the algebraic comparison happens before the constraint comparison, which may help perf in some degenerate cases where constraints are overly complex, while the algebraic comparison succeeds.)
2. Type parameters related to one another no longer elaborate on how their constraints are related when they're unrelated - the "type parameter T1 is not assignable to parameter T2, it may be instantiated with an unrelated subtype" special elaboration is sufficient. No need to further report "Foo isn't assignable to T2", and "FooElem isn't assignable to T2".

Fixes #43471
