### PR TITLE
Enforce `override` precedes `readonly`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40370,6 +40370,9 @@ namespace ts {
                         else if (flags & ModifierFlags.Static) {
                             return grammarErrorOnNode(modifier, Diagnostics._0_modifier_cannot_be_used_with_1_modifier, "static", "override");
                         }
+                        else if (flags & ModifierFlags.Readonly) {
+                            return grammarErrorOnNode(modifier, Diagnostics._0_modifier_must_precede_1_modifier, "override", "readonly");
+                        }
                         if (node.kind === SyntaxKind.Parameter) {
                             return grammarErrorOnNode(modifier, Diagnostics._0_modifier_cannot_appear_on_a_parameter, "override");
                         }

--- a/tests/baselines/reference/override5.errors.txt
+++ b/tests/baselines/reference/override5.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/conformance/override/override5.ts(12,13): error TS4114: This member must have an 'override' modifier because it overrides a member in the base class 'B'.
 tests/cases/conformance/override/override5.ts(14,14): error TS1040: 'override' modifier cannot be used in an ambient context.
+tests/cases/conformance/override/override5.ts(16,14): error TS1029: 'override' modifier must precede 'readonly' modifier.
 tests/cases/conformance/override/override5.ts(20,14): error TS1243: 'static' modifier cannot be used with 'override' modifier.
 tests/cases/conformance/override/override5.ts(22,14): error TS1030: 'override' modifier already seen.
 tests/cases/conformance/override/override5.ts(25,14): error TS1029: 'public' modifier must precede 'override' modifier.
@@ -8,7 +9,7 @@ tests/cases/conformance/override/override5.ts(44,23): error TS4112: This member 
 tests/cases/conformance/override/override5.ts(45,23): error TS4112: This member cannot have an 'override' modifier because its containing class 'AND' does not extend another class.
 
 
-==== tests/cases/conformance/override/override5.ts (8 errors) ====
+==== tests/cases/conformance/override/override5.ts (9 errors) ====
     class B {
         p1: number = 1;
         p2: number = 2;
@@ -29,6 +30,8 @@ tests/cases/conformance/override/override5.ts(45,23): error TS4112: This member 
 !!! error TS1040: 'override' modifier cannot be used in an ambient context.
     
         readonly override p3: number;
+                 ~~~~~~~~
+!!! error TS1029: 'override' modifier must precede 'readonly' modifier.
     
         override readonly p4: number;
     

--- a/tests/baselines/reference/override7.errors.txt
+++ b/tests/baselines/reference/override7.errors.txt
@@ -1,4 +1,5 @@
 tests/cases/conformance/override/override7.ts(11,14): error TS1040: 'override' modifier cannot be used in an ambient context.
+tests/cases/conformance/override/override7.ts(13,14): error TS1029: 'override' modifier must precede 'readonly' modifier.
 tests/cases/conformance/override/override7.ts(17,14): error TS1243: 'static' modifier cannot be used with 'override' modifier.
 tests/cases/conformance/override/override7.ts(19,14): error TS1030: 'override' modifier already seen.
 tests/cases/conformance/override/override7.ts(19,23): error TS4113: This member cannot have an 'override' modifier because it is not declared in the base class 'B'.
@@ -10,7 +11,7 @@ tests/cases/conformance/override/override7.ts(41,23): error TS4112: This member 
 tests/cases/conformance/override/override7.ts(42,23): error TS4112: This member cannot have an 'override' modifier because its containing class 'AND' does not extend another class.
 
 
-==== tests/cases/conformance/override/override7.ts (10 errors) ====
+==== tests/cases/conformance/override/override7.ts (11 errors) ====
     class B {
         p1: number = 1;
         p2: number = 2;
@@ -26,6 +27,8 @@ tests/cases/conformance/override/override7.ts(42,23): error TS4112: This member 
 !!! error TS1040: 'override' modifier cannot be used in an ambient context.
     
         readonly override p3: number;
+                 ~~~~~~~~
+!!! error TS1029: 'override' modifier must precede 'readonly' modifier.
     
         override readonly p4: number;
     


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

This fixes issue as @DanielRosenwasser says: https://github.com/microsoft/TypeScript/issues/43533#issuecomment-813569390 .
