### PR TITLE
Add getYear to Date interface

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -737,6 +737,8 @@ interface Date {
     getUTCDate(): number;
     /** Gets the day of the week, using local time. */
     getDay(): number;
+    /** Gets the years difference from 1900, using local time. */
+    getYear(): number;
     /** Gets the day of the week using Universal Coordinated Time (UTC). */
     getUTCDay(): number;
     /** Gets the hours in a date, using local time. */


### PR DESCRIPTION
`getYear()` missing from Date interface

Closes #43550 