### PR TITLE
Move indirect call substitution to printer

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2417,8 +2417,26 @@ namespace ts {
             emitTokenWithComment(SyntaxKind.CloseBracketToken, node.argumentExpression.end, writePunctuation, node);
         }
 
+        function maybeEmitIndirectCallPrefix(node: CallExpression | TaggedTemplateExpression) {
+            const indirect = getEmitFlags(node) & EmitFlags.IndirectCall;
+            if (indirect) {
+                writeTokenText(SyntaxKind.OpenParenToken, writePunctuation);
+                writeLiteral("0");
+                writeTokenText(SyntaxKind.CommaToken, writePunctuation);
+                writeSpace();
+                return true;
+            }
+            return false;
+        }
+
+        function emitIndirectCallSuffix() {
+            writeTokenText(SyntaxKind.CloseParenToken, writePunctuation);
+        }
+
         function emitCallExpression(node: CallExpression) {
+            const indirect = maybeEmitIndirectCallPrefix(node);
             emit(node.expression);
+            if (indirect) emitIndirectCallSuffix();
             emit(node.questionDotToken);
             emitTypeArguments(node, node.typeArguments);
             emitList(node, node.arguments, ListFormat.CallExpressionArguments);
@@ -2433,7 +2451,9 @@ namespace ts {
         }
 
         function emitTaggedTemplateExpression(node: TaggedTemplateExpression) {
+            const indirect = maybeEmitIndirectCallPrefix(node);
             emit(node.tag);
+            if (indirect) emitIndirectCallSuffix();
             emitTypeArguments(node, node.typeArguments);
             writeSpace();
             emit(node.template);

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -1813,27 +1813,14 @@ namespace ts {
 
         function substituteCallExpression(node: CallExpression) {
             if (isIdentifier(node.expression) && getImportOrExportBindingReference(node.expression, /*removeEntry*/ false)) {
-                return isCallChain(node) ?
-                    factory.updateCallChain(node,
-                        setTextRange(factory.createComma(factory.createNumericLiteral(0), node.expression), node.expression),
-                        node.questionDotToken,
-                        /*typeArguments*/ undefined,
-                        node.arguments) :
-                    factory.updateCallExpression(node,
-                        setTextRange(factory.createComma(factory.createNumericLiteral(0), node.expression), node.expression),
-                        /*typeArguments*/ undefined,
-                        node.arguments);
+                addEmitFlags(node, EmitFlags.IndirectCall);
             }
             return node;
         }
 
         function substituteTaggedTemplateExpression(node: TaggedTemplateExpression) {
             if (isIdentifier(node.tag) && getImportOrExportBindingReference(node.tag, /*removeEntry*/ false)) {
-                return factory.updateTaggedTemplateExpression(
-                    node,
-                    setTextRange(factory.createComma(factory.createNumericLiteral(0), node.tag), node.tag),
-                    /*typeArguments*/ undefined,
-                    node.template);
+                addEmitFlags(node, EmitFlags.IndirectCall);
             }
             return node;
         }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6624,6 +6624,7 @@ namespace ts {
         /*@internal*/ TypeScriptClassWrapper = 1 << 25, // The node is an IIFE class wrapper created by the ts transform.
         /*@internal*/ NeverApplyImportHelper = 1 << 26, // Indicates the node should never be wrapped with an import star helper (because, for example, it imports tslib itself)
         /*@internal*/ IgnoreSourceNewlines = 1 << 27,   // Overrides `printerOptions.preserveSourceNewlines` to print this node (and all descendants) with default whitespace.
+        /*@internal*/ IndirectCall = 1 << 28,   // Write `(0,` before the expression and `)` after the expression of a call to ensure the call is indirect (i.e., no `this` binding)
     }
 
     export interface EmitHelperBase {


### PR DESCRIPTION
An alternative to #43543 to estimate the performance implications of performing the substitution in the printer.