### PR TITLE
Fix getTypeFromJSDocVariadicType in callback tag

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -38404,7 +38404,7 @@ namespace ts {
             if (isJSDocTypeExpression(node.parent) && isJSDocParameterTag(paramTag)) {
                 // Else we will add a diagnostic, see `checkJSDocVariadicType`.
                 const host = getHostSignatureFromJSDoc(paramTag);
-                const isCallbackTag = isJSDocCallbackTag(paramTag.parent.parent)
+                const isCallbackTag = isJSDocCallbackTag(paramTag.parent.parent);
                 if (host || isCallbackTag) {
                     /*
                     Only return an array type if the corresponding parameter is marked as a rest parameter, or if there are no parameters.

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -38404,7 +38404,8 @@ namespace ts {
             if (isJSDocTypeExpression(node.parent) && isJSDocParameterTag(paramTag)) {
                 // Else we will add a diagnostic, see `checkJSDocVariadicType`.
                 const host = getHostSignatureFromJSDoc(paramTag);
-                if (host) {
+                const isCallbackTag = isJSDocCallbackTag(paramTag.parent.parent)
+                if (host || isCallbackTag) {
                     /*
                     Only return an array type if the corresponding parameter is marked as a rest parameter, or if there are no parameters.
                     So in the following situation we will not create an array type:
@@ -38412,7 +38413,9 @@ namespace ts {
                         function f(a) {}
                     Because `a` will just be of type `number | undefined`. A synthetic `...args` will also be added, which *will* get an array type.
                     */
-                    const lastParamDeclaration = lastOrUndefined(host.parameters);
+                    const lastParamDeclaration = isCallbackTag
+                        ? lastOrUndefined((paramTag.parent.parent as unknown as JSDocCallbackTag).typeExpression.parameters)
+                        : lastOrUndefined(host!.parameters);
                     const symbol = getParameterSymbolFromJSDoc(paramTag);
                     if (!lastParamDeclaration ||
                         symbol && lastParamDeclaration.symbol === symbol && isRestParameter(lastParamDeclaration)) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1230,7 +1230,6 @@ namespace ts {
         | FunctionTypeNode
         | ConstructorTypeNode
         | JSDocFunctionType
-        // | JSDocSignature
         | FunctionDeclaration
         | MethodDeclaration
         | ConstructorDeclaration

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1230,6 +1230,7 @@ namespace ts {
         | FunctionTypeNode
         | ConstructorTypeNode
         | JSDocFunctionType
+        // | JSDocSignature
         | FunctionDeclaration
         | MethodDeclaration
         | ConstructorDeclaration

--- a/tests/baselines/reference/callbackTagVariadicType.js
+++ b/tests/baselines/reference/callbackTagVariadicType.js
@@ -1,0 +1,36 @@
+//// [callbackTagVariadicType.js]
+/**
+ * @callback Foo
+ * @param {...string} args
+ * @returns {number}
+ */
+
+/** @type {Foo} */
+export const x = () => 1
+var res = x('a', 'b')
+
+
+//// [callbackTagVariadicType.js]
+"use strict";
+/**
+ * @callback Foo
+ * @param {...string} args
+ * @returns {number}
+ */
+exports.__esModule = true;
+exports.x = void 0;
+/** @type {Foo} */
+var x = function () { return 1; };
+exports.x = x;
+var res = (0, exports.x)('a', 'b');
+
+
+//// [callbackTagVariadicType.d.ts]
+/**
+ * @callback Foo
+ * @param {...string} args
+ * @returns {number}
+ */
+/** @type {Foo} */
+export const x: Foo;
+export type Foo = (...args: string[]) => number;

--- a/tests/baselines/reference/callbackTagVariadicType.symbols
+++ b/tests/baselines/reference/callbackTagVariadicType.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/jsdoc/callbackTagVariadicType.js ===
+/**
+ * @callback Foo
+ * @param {...string} args
+ * @returns {number}
+ */
+
+/** @type {Foo} */
+export const x = () => 1
+>x : Symbol(x, Decl(callbackTagVariadicType.js, 7, 12))
+
+var res = x('a', 'b')
+>res : Symbol(res, Decl(callbackTagVariadicType.js, 8, 3))
+>x : Symbol(x, Decl(callbackTagVariadicType.js, 7, 12))
+

--- a/tests/baselines/reference/callbackTagVariadicType.types
+++ b/tests/baselines/reference/callbackTagVariadicType.types
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/jsdoc/callbackTagVariadicType.js ===
+/**
+ * @callback Foo
+ * @param {...string} args
+ * @returns {number}
+ */
+
+/** @type {Foo} */
+export const x = () => 1
+>x : Foo
+>() => 1 : () => number
+>1 : 1
+
+var res = x('a', 'b')
+>res : number
+>x('a', 'b') : number
+>x : Foo
+>'a' : "a"
+>'b' : "b"
+

--- a/tests/cases/conformance/jsdoc/callbackTagVariadicType.ts
+++ b/tests/cases/conformance/jsdoc/callbackTagVariadicType.ts
@@ -1,0 +1,14 @@
+// @declaration: true
+// @outDir: bin/
+// @checkJs: true
+// @Filename: callbackTagVariadicType.js
+
+/**
+ * @callback Foo
+ * @param {...string} args
+ * @returns {number}
+ */
+
+/** @type {Foo} */
+export const x = () => 1
+var res = x('a', 'b')


### PR DESCRIPTION
As far as I can tell, this never worked, since `@callback` support was added after the last time this code was changed.

There is a much more general change to treat callback tags as jsdoc hosts, or at least host signatures, but the tree shape of callbacks is quite different from those of a normal signature. Specifically, parameters and return types are themselves tags, and their types are buried another two levels down their respective trees.

Fixes #43072
