### PR TITLE
Added recursive check for nested tuple elements

### DIFF
--- a/tests/baselines/reference/namedTupleMembers.js
+++ b/tests/baselines/reference/namedTupleMembers.js
@@ -77,6 +77,7 @@ declare function getArgsForInjection<T extends (...args: any[]) => any>(x: T): P
 export const argumentsOfGAsFirstArgument = f(getArgsForInjection(g)); // one tuple with captures arguments as first member
 export const argumentsOfG = f(...getArgsForInjection(g)); // captured arguments list re-spread
 
+export type NestedRest = [foo: number, ...[bar: number, ...[baz: number]]];
 
 //// [namedTupleMembers.js]
 "use strict";
@@ -138,3 +139,4 @@ export declare type RecusiveRest = [first: string, ...rest: RecusiveRest[]];
 export declare type RecusiveRest2 = [string, ...RecusiveRest2[]];
 export declare const argumentsOfGAsFirstArgument: [[elem: object, index: number]];
 export declare const argumentsOfG: [elem: object, index: number];
+export declare type NestedRest = [foo: number, ...[bar: number, ...[baz: number]]];

--- a/tests/baselines/reference/namedTupleMembers.symbols
+++ b/tests/baselines/reference/namedTupleMembers.symbols
@@ -199,3 +199,6 @@ export const argumentsOfG = f(...getArgsForInjection(g)); // captured arguments 
 >getArgsForInjection : Symbol(getArgsForInjection, Decl(namedTupleMembers.ts, 72, 56))
 >g : Symbol(g, Decl(namedTupleMembers.ts, 71, 48))
 
+export type NestedRest = [foo: number, ...[bar: number, ...[baz: number]]];
+>NestedRest : Symbol(NestedRest, Decl(namedTupleMembers.ts, 76, 57))
+

--- a/tests/baselines/reference/namedTupleMembers.types
+++ b/tests/baselines/reference/namedTupleMembers.types
@@ -202,3 +202,6 @@ export const argumentsOfG = f(...getArgsForInjection(g)); // captured arguments 
 >getArgsForInjection : <T extends (...args: any[]) => any>(x: T) => Parameters<T>
 >g : (elem: object, index: number) => object
 
+export type NestedRest = [foo: number, ...[bar: number, ...[baz: number]]];
+>NestedRest : [number, number, number]
+

--- a/tests/baselines/reference/namedTupleMembersErrors.errors.txt
+++ b/tests/baselines/reference/namedTupleMembersErrors.errors.txt
@@ -12,9 +12,10 @@ tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(16,39): err
 tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(18,44): error TS2574: A rest element type must be an array type.
 tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(20,13): error TS2456: Type alias 'RecusiveRestUnlabeled' circularly references itself.
 tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(21,13): error TS2456: Type alias 'RecusiveRest' circularly references itself.
+tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(23,61): error TS5084: Tuple members must all have names or all not have names.
 
 
-==== tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts (14 errors) ====
+==== tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts (15 errors) ====
     export type Segment1 = [length: number, number]; // partially named, disallowed
                                             ~~~~~~
 !!! error TS5084: Tuple members must all have names or all not have names.
@@ -65,3 +66,6 @@ tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(21,13): err
                 ~~~~~~~~~~~~
 !!! error TS2456: Type alias 'RecusiveRest' circularly references itself.
     
+    export type NestedRest = [foo: number, ...[bar: number, ...[number]]]; // partially named, disallowed
+                                                                ~~~~~~
+!!! error TS5084: Tuple members must all have names or all not have names.

--- a/tests/baselines/reference/namedTupleMembersErrors.js
+++ b/tests/baselines/reference/namedTupleMembersErrors.js
@@ -21,6 +21,7 @@ export type NonArrayRest = [first: string, ...rest: number]; // non-arraylike re
 export type RecusiveRestUnlabeled = [string, ...RecusiveRestUnlabeled];
 export type RecusiveRest = [first: string, ...rest: RecusiveRest]; // marked as incorrect, same as above
 
+export type NestedRest = [foo: number, ...[bar: number, ...[number]]]; // partially named, disallowed
 
 //// [namedTupleMembersErrors.js]
 "use strict";
@@ -41,3 +42,4 @@ export declare type OptRest = [first: string, ...rest?: string[]];
 export declare type NonArrayRest = [first: string, ...rest: number];
 export declare type RecusiveRestUnlabeled = [string, ...RecusiveRestUnlabeled];
 export declare type RecusiveRest = [first: string, ...rest: RecusiveRest];
+export declare type NestedRest = [foo: number, ...[bar: number, ...[number]]];

--- a/tests/baselines/reference/namedTupleMembersErrors.symbols
+++ b/tests/baselines/reference/namedTupleMembersErrors.symbols
@@ -40,3 +40,6 @@ export type RecusiveRest = [first: string, ...rest: RecusiveRest]; // marked as 
 >RecusiveRest : Symbol(RecusiveRest, Decl(namedTupleMembersErrors.ts, 19, 71))
 >RecusiveRest : Symbol(RecusiveRest, Decl(namedTupleMembersErrors.ts, 19, 71))
 
+export type NestedRest = [foo: number, ...[bar: number, ...[number]]]; // partially named, disallowed
+>NestedRest : Symbol(NestedRest, Decl(namedTupleMembersErrors.ts, 20, 66))
+

--- a/tests/baselines/reference/namedTupleMembersErrors.types
+++ b/tests/baselines/reference/namedTupleMembersErrors.types
@@ -38,3 +38,6 @@ export type RecusiveRestUnlabeled = [string, ...RecusiveRestUnlabeled];
 export type RecusiveRest = [first: string, ...rest: RecusiveRest]; // marked as incorrect, same as above
 >RecusiveRest : any
 
+export type NestedRest = [foo: number, ...[bar: number, ...[number]]]; // partially named, disallowed
+>NestedRest : [number, number, number]
+

--- a/tests/cases/conformance/types/tuple/named/namedTupleMembers.ts
+++ b/tests/cases/conformance/types/tuple/named/namedTupleMembers.ts
@@ -77,3 +77,5 @@ declare function getArgsForInjection<T extends (...args: any[]) => any>(x: T): P
 
 export const argumentsOfGAsFirstArgument = f(getArgsForInjection(g)); // one tuple with captures arguments as first member
 export const argumentsOfG = f(...getArgsForInjection(g)); // captured arguments list re-spread
+
+export type NestedRest = [foo: number, ...[bar: number, ...[baz: number]]];

--- a/tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts
+++ b/tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts
@@ -21,3 +21,5 @@ export type NonArrayRest = [first: string, ...rest: number]; // non-arraylike re
 
 export type RecusiveRestUnlabeled = [string, ...RecusiveRestUnlabeled];
 export type RecusiveRest = [first: string, ...rest: RecusiveRest]; // marked as incorrect, same as above
+
+export type NestedRest = [foo: number, ...[bar: number, ...[number]]]; // partially named, disallowed


### PR DESCRIPTION
Fixes #43516

Due to how the checker works, this algorithm will recursively check any nested tuples multiple times. I didn't found yet a way to reduce this unnecessary work. I'm open to ideas.
