### PR TITLE
fix(43559): no-default-lib causes 'You cannot rename elements that are defined in the standard TypeScript library'

### DIFF
--- a/tests/cases/fourslash/renameNoDefaultLib.ts
+++ b/tests/cases/fourslash/renameNoDefaultLib.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts" />
+
+// @checkJs: true
+// @allowJs: true
+
+// @Filename: /foo.js
+//// // @ts-check
+//// /// <reference no-default-lib="true" />
+//// const [|/**/foo|] = 1;
+
+goTo.marker("");
+verify.renameInfoSucceeded("foo")


### PR DESCRIPTION
Fixes #43559