### PR TITLE
Contextual typing checks property assignments for type annotation

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25102,6 +25102,10 @@ namespace ts {
 
         function getContextualTypeForObjectLiteralElement(element: ObjectLiteralElementLike, contextFlags?: ContextFlags) {
             const objectLiteral = <ObjectLiteralExpression>element.parent;
+            const propertyAssignmentType = isPropertyAssignment(element) && getContextualTypeForVariableLikeDeclaration(element);
+            if (propertyAssignmentType) {
+                return propertyAssignmentType;
+            }
             const type = getApparentTypeOfContextualType(objectLiteral, contextFlags);
             if (type) {
                 if (hasBindableName(element)) {

--- a/tests/baselines/reference/typeTagOnPropertyAssignment.symbols
+++ b/tests/baselines/reference/typeTagOnPropertyAssignment.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/jsdoc/typeTagOnPropertyAssignment.js ===
+const o = {
+>o : Symbol(o, Decl(typeTagOnPropertyAssignment.js, 0, 5))
+
+    /**
+     * @type {"a"}
+     */
+    a: "a",
+>a : Symbol(a, Decl(typeTagOnPropertyAssignment.js, 0, 11))
+
+    /** @type {() => 'b'} */
+    n: () => 'b'
+>n : Symbol(n, Decl(typeTagOnPropertyAssignment.js, 4, 11))
+
+};
+o.a
+>o.a : Symbol(a, Decl(typeTagOnPropertyAssignment.js, 0, 11))
+>o : Symbol(o, Decl(typeTagOnPropertyAssignment.js, 0, 5))
+>a : Symbol(a, Decl(typeTagOnPropertyAssignment.js, 0, 11))
+
+o.n
+>o.n : Symbol(n, Decl(typeTagOnPropertyAssignment.js, 4, 11))
+>o : Symbol(o, Decl(typeTagOnPropertyAssignment.js, 0, 5))
+>n : Symbol(n, Decl(typeTagOnPropertyAssignment.js, 4, 11))
+

--- a/tests/baselines/reference/typeTagOnPropertyAssignment.types
+++ b/tests/baselines/reference/typeTagOnPropertyAssignment.types
@@ -1,0 +1,29 @@
+=== tests/cases/conformance/jsdoc/typeTagOnPropertyAssignment.js ===
+const o = {
+>o : { a: "a"; n: () => 'b'; }
+>{    /**     * @type {"a"}     */    a: "a",    /** @type {() => 'b'} */    n: () => 'b'} : { a: "a"; n: () => 'b'; }
+
+    /**
+     * @type {"a"}
+     */
+    a: "a",
+>a : "a"
+>"a" : "a"
+
+    /** @type {() => 'b'} */
+    n: () => 'b'
+>n : () => 'b'
+>() => 'b' : () => 'b'
+>'b' : "b"
+
+};
+o.a
+>o.a : "a"
+>o : { a: "a"; n: () => "b"; }
+>a : "a"
+
+o.n
+>o.n : () => "b"
+>o : { a: "a"; n: () => "b"; }
+>n : () => "b"
+

--- a/tests/cases/conformance/jsdoc/typeTagOnPropertyAssignment.ts
+++ b/tests/cases/conformance/jsdoc/typeTagOnPropertyAssignment.ts
@@ -1,0 +1,13 @@
+// @noEmit: true
+// @checkJs: true
+// @filename: typeTagOnPropertyAssignment.js
+const o = {
+    /**
+     * @type {"a"}
+     */
+    a: "a",
+    /** @type {() => 'b'} */
+    n: () => 'b'
+};
+o.a
+o.n


### PR DESCRIPTION
Property assignments can have a type annotation in JS. This PR adds a check for it in contextual typing.

Fixes #43379