### PR TITLE
Don't start jsdoc tag before whitespace

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7655,8 +7655,9 @@ namespace ts {
                                 indent = 0;
                                 break;
                             case SyntaxKind.AtToken:
-                                if (state === JSDocState.SavingBackticks || !previousWhitespace && state === JSDocState.SavingComments) {
-                                    // @ doesn't start a new tag inside ``, and inside a comment, only after whitespace
+                                if (state === JSDocState.SavingBackticks
+                                    || state === JSDocState.SavingComments && (!previousWhitespace || lookAhead(isNextJSDocTokenWhitespace))) {
+                                    // @ doesn't start a new tag inside ``, and inside a comment, only after whitespace or not before whitespace
                                     comments.push(scanner.getTokenText());
                                     break;
                                 }
@@ -7733,6 +7734,11 @@ namespace ts {
                     else if (comments.length) {
                         return comments.join("");
                     }
+                }
+
+                function isNextJSDocTokenWhitespace() {
+                    const next = nextTokenJSDoc();
+                    return next === SyntaxKind.WhitespaceTrivia || next === SyntaxKind.NewLineTrivia;
                 }
 
                 function parseJSDocLink(start: number) {

--- a/tests/baselines/reference/quickInfoJSDocAtBeforeSpace.baseline
+++ b/tests/baselines/reference/quickInfoJSDocAtBeforeSpace.baseline
@@ -1,0 +1,185 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJSDocAtBeforeSpace.ts",
+      "position": 39,
+      "name": "f"
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 39,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "f",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "return",
+          "text": [
+            {
+              "text": "Don't @ me",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJSDocAtBeforeSpace.ts",
+      "position": 87,
+      "name": "g"
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 87,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "g",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "return",
+          "text": [
+            {
+              "text": "One final @",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoJSDocAtBeforeSpace.ts",
+      "position": 148,
+      "name": "h"
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 148,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "h",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "return",
+          "text": [
+            {
+              "text": "An @\nBut another line",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/fourslash/quickInfoJSDocAtBeforeSpace.ts
+++ b/tests/cases/fourslash/quickInfoJSDocAtBeforeSpace.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+//// /**
+////  * @return Don't @ me
+////  */
+//// function /*f*/f() { }
+//// /**
+////  * @return One final @
+////  */
+//// function /*g*/g() { }
+//// /**
+////  * @return An @
+////  * But another line
+////  */
+//// function /*h*/h() { }
+
+
+verify.baselineQuickInfo()
+


### PR DESCRIPTION
Fixes #43580

I'm not happy that I couldn't avoid lookahead, but I don't see any other way here. The non-whitespace path *decrements* the scanner position, in fact.