### PR TITLE
Loosen up the first argument type for `String.raw`

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -487,11 +487,13 @@ interface StringConstructor {
     fromCodePoint(...codePoints: number[]): string;
 
     /**
-     * String.raw is intended for use as a tag function of a Tagged Template String. When called
-     * as such the first argument will be a well formed template call site object and the rest
-     * parameter will contain the substitution values.
+     * String.raw is usually used as a tag function of a Tagged Template String. When called as
+     * such, the first argument will be a well formed template call site object and the rest
+     * parameter will contain the substitution values. It can also be called directly, for example,
+     * to interleave strings and values from your own tag function, and in this case the only thing
+     * it needs from the first argument is the raw property.
      * @param template A well-formed template string call site representation.
      * @param substitutions A set of substitution values.
      */
-    raw(template: TemplateStringsArray, ...substitutions: any[]): string;
+    raw(template: { raw: readonly string[] | ArrayLike<string>}, ...substitutions: any[]): string;
 }

--- a/tests/baselines/reference/stringRawType.js
+++ b/tests/baselines/reference/stringRawType.js
@@ -1,0 +1,6 @@
+//// [stringRawType.ts]
+String.raw({ raw: ["foo", "bar", "baz"] }, 1, 2);
+
+
+//// [stringRawType.js]
+String.raw({ raw: ["foo", "bar", "baz"] }, 1, 2);

--- a/tests/baselines/reference/stringRawType.symbols
+++ b/tests/baselines/reference/stringRawType.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/stringRawType.ts ===
+String.raw({ raw: ["foo", "bar", "baz"] }, 1, 2);
+>String.raw : Symbol(StringConstructor.raw, Decl(lib.es2015.core.d.ts, --, --))
+>String : Symbol(String, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --) ... and 1 more)
+>raw : Symbol(StringConstructor.raw, Decl(lib.es2015.core.d.ts, --, --))
+>raw : Symbol(raw, Decl(stringRawType.ts, 0, 12))
+

--- a/tests/baselines/reference/stringRawType.types
+++ b/tests/baselines/reference/stringRawType.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/stringRawType.ts ===
+String.raw({ raw: ["foo", "bar", "baz"] }, 1, 2);
+>String.raw({ raw: ["foo", "bar", "baz"] }, 1, 2) : string
+>String.raw : (template: { raw: readonly string[] | ArrayLike<string>; }, ...substitutions: any[]) => string
+>String : StringConstructor
+>raw : (template: { raw: readonly string[] | ArrayLike<string>; }, ...substitutions: any[]) => string
+>{ raw: ["foo", "bar", "baz"] } : { raw: string[]; }
+>raw : string[]
+>["foo", "bar", "baz"] : string[]
+>"foo" : "foo"
+>"bar" : "bar"
+>"baz" : "baz"
+>1 : 1
+>2 : 2
+

--- a/tests/cases/compiler/stringRawType.ts
+++ b/tests/cases/compiler/stringRawType.ts
@@ -1,0 +1,3 @@
+﻿// @target: es6
+
+String.raw({ raw: ["foo", "bar", "baz"] }, 1, 2);


### PR DESCRIPTION
The [String.raw spec](https://tc39.es/ecma262/#sec-string.raw) uses just
the `raw` property of its first argument, which is a useful way of using
it in user-defined tag functions to do the work of interleaving strings
and values as well as converting the values to strings.

Fixes #43609.
