### PR TITLE
Process only existing files and directories in the test harness

### DIFF
--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -72,6 +72,7 @@ namespace Harness {
 
                 for (const file of fs.readdirSync(folder)) {
                     const pathToFile = pathModule.join(folder, file);
+                    if (!fs.existsSync(pathToFile)) continue; // ignore invalid symlinks
                     const stat = fs.statSync(pathToFile);
                     if (options.recursive && stat.isDirectory()) {
                         paths = paths.concat(filesInFolder(pathToFile));


### PR DESCRIPTION
`fs.statSync` throws `ENOENT` if there is a symlink to a nonexistent
target.  `fs.lstatSync` is better since it returns an entry that is
neither `.isDirectory()` nor `.isFile()`, so these things will be
skipped.

(This is annoying when editing tests in Emacs, since it keeps lock files
for modified-but-unsaved files, which are `.#foo` symlinks to a
nonexistent target.)

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
