### PR TITLE
Use single quotes consistently in diagnostic messages.

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1192,7 +1192,7 @@
         "category": "Message",
         "code": 1390
     },
-    "The `bundledPackageName` option must be provided when using outFile and node module resolution with declaration emit.": {
+    "The 'bundledPackageName' option must be provided when using outFile and node module resolution with declaration emit.": {
         "category": "Error",
         "code": 1391
     },
@@ -2362,7 +2362,7 @@
         "category": "Error",
         "code": 2549
     },
-    "Property '{0}' does not exist on type '{1}'. Do you need to change your target library? Try changing the `lib` compiler option to '{2}' or later.": {
+    "Property '{0}' does not exist on type '{1}'. Do you need to change your target library? Try changing the 'lib' compiler option to '{2}' or later.": {
         "category": "Error",
         "code": 2550
     },
@@ -2482,15 +2482,15 @@
         "category": "Error",
         "code": 2582
     },
-    "Cannot find name '{0}'. Do you need to change your target library? Try changing the `lib` compiler option to '{1}' or later.": {
+    "Cannot find name '{0}'. Do you need to change your target library? Try changing the 'lib' compiler option to '{1}' or later.": {
         "category": "Error",
         "code": 2583
     },
-    "Cannot find name '{0}'. Do you need to change your target library? Try changing the `lib` compiler option to include 'dom'.": {
+    "Cannot find name '{0}'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.": {
         "category": "Error",
         "code": 2584
     },
-    "'{0}' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.": {
+    "'{0}' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.": {
         "category": "Error",
         "code": 2585
     },
@@ -2514,15 +2514,15 @@
         "category": "Error",
         "code": 2590
     },
-    "Cannot find name '{0}'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add `node` to the types field in your tsconfig.": {
+    "Cannot find name '{0}'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.": {
         "category": "Error",
         "code": 2591
     },
-    "Cannot find name '{0}'. Do you need to install type definitions for jQuery? Try `npm i --save-dev @types/jquery` and then add `jquery` to the types field in your tsconfig.": {
+    "Cannot find name '{0}'. Do you need to install type definitions for jQuery? Try `npm i --save-dev @types/jquery` and then add 'jquery' to the types field in your tsconfig.": {
         "category": "Error",
         "code": 2592
     },
-    "Cannot find name '{0}'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add `jest` or `mocha` to the types field in your tsconfig.": {
+    "Cannot find name '{0}'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.": {
         "category": "Error",
         "code": 2593
     },
@@ -2864,7 +2864,7 @@
         "category": "Error",
         "code": 2696
     },
-    "An async function or method must return a 'Promise'. Make sure you have a declaration for 'Promise' or include 'ES2015' in your `--lib` option.": {
+    "An async function or method must return a 'Promise'. Make sure you have a declaration for 'Promise' or include 'ES2015' in your '--lib' option.": {
         "category": "Error",
         "code": 2697
     },
@@ -2896,7 +2896,7 @@
         "category": "Error",
         "code": 2704
     },
-    "An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.": {
+    "An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.": {
         "category": "Error",
         "code": 2705
     },
@@ -2920,11 +2920,11 @@
         "category": "Error",
         "code": 2710
     },
-    "A dynamic import call returns a 'Promise'. Make sure you have a declaration for 'Promise' or include 'ES2015' in your `--lib` option.": {
+    "A dynamic import call returns a 'Promise'. Make sure you have a declaration for 'Promise' or include 'ES2015' in your '--lib' option.": {
         "category": "Error",
         "code": 2711
     },
-    "A dynamic import call in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.": {
+    "A dynamic import call in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.": {
         "category": "Error",
         "code": 2712
     },
@@ -3862,7 +3862,7 @@
         "category": "Error",
         "code": 5073
     },
-    "Option '--incremental' can only be specified using tsconfig, emitting to single file or when option `--tsBuildInfoFile` is specified.": {
+    "Option '--incremental' can only be specified using tsconfig, emitting to single file or when option '--tsBuildInfoFile' is specified.": {
         "category": "Error",
         "code": 5074
     },
@@ -3914,7 +3914,7 @@
         "category": "Error",
         "code": 5086
     },
-    "A labeled tuple element is declared as rest with a `...` before the name, rather than before the type.": {
+    "A labeled tuple element is declared as rest with a '...' before the name, rather than before the type.": {
         "category": "Error",
         "code": 5087
     },
@@ -4845,7 +4845,7 @@
         "category": "Message",
         "code": 6237
     },
-    "Specify the module specifier to be used to import the `jsx` and `jsxs` factory functions from. eg, react": {
+    "Specify the module specifier to be used to import the 'jsx' and 'jsxs' factory functions from. eg, react": {
         "category": "Error",
         "code": 6238
     },
@@ -5210,7 +5210,7 @@
         "category": "Error",
         "code": 7039
     },
-    "If the '{0}' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/{1}`": {
+    "If the '{0}' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/{1}'": {
         "category": "Error",
         "code": 7040
     },
@@ -5371,7 +5371,7 @@
         "category": "Error",
         "code": 8024
     },
-    "Class declarations cannot have more than one `@augments` or `@extends` tag.": {
+    "Class declarations cannot have more than one '@augments' or '@extends' tag.": {
         "category": "Error",
         "code": 8025
     },

--- a/tests/baselines/reference/ES5For-ofTypeCheck10.errors.txt
+++ b/tests/baselines/reference/ES5For-ofTypeCheck10.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts(9,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts(9,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts(14,15): error TS2495: Type 'StringIterator' is not an array type or a string type.
 
 
@@ -13,7 +13,7 @@ tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts(14,1
         }
         [Symbol.iterator]() {
          ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
             return this;
         }
     }

--- a/tests/baselines/reference/ES5SymbolProperty2.errors.txt
+++ b/tests/baselines/reference/ES5SymbolProperty2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/Symbols/ES5SymbolProperty2.ts(10,11): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/conformance/Symbols/ES5SymbolProperty2.ts(10,11): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/conformance/Symbols/ES5SymbolProperty2.ts (1 errors) ====
@@ -13,4 +13,4 @@ tests/cases/conformance/Symbols/ES5SymbolProperty2.ts(10,11): error TS2585: 'Sym
     
     (new M.C)[Symbol.iterator];
               ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.

--- a/tests/baselines/reference/ES5SymbolProperty6.errors.txt
+++ b/tests/baselines/reference/ES5SymbolProperty6.errors.txt
@@ -1,14 +1,14 @@
-tests/cases/conformance/Symbols/ES5SymbolProperty6.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/conformance/Symbols/ES5SymbolProperty6.ts(5,9): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/conformance/Symbols/ES5SymbolProperty6.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/conformance/Symbols/ES5SymbolProperty6.ts(5,9): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/conformance/Symbols/ES5SymbolProperty6.ts (2 errors) ====
     class C {
         [Symbol.iterator]() { }
          ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     }
     
     (new C)[Symbol.iterator]
             ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.

--- a/tests/baselines/reference/argumentsObjectIterator02_ES5.errors.txt
+++ b/tests/baselines/reference/argumentsObjectIterator02_ES5.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/compiler/argumentsObjectIterator02_ES5.ts(2,26): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/compiler/argumentsObjectIterator02_ES5.ts(2,26): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/compiler/argumentsObjectIterator02_ES5.ts (1 errors) ====
     function doubleAndReturnAsArray(x: number, y: number, z: number): [number, number, number] {
         let blah = arguments[Symbol.iterator];
                              ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     
         let result = [];
         for (let arg of blah()) {

--- a/tests/baselines/reference/asyncFunctionNoReturnType.errors.txt
+++ b/tests/baselines/reference/asyncFunctionNoReturnType.errors.txt
@@ -1,12 +1,12 @@
 error TS2468: Cannot find global value 'Promise'.
-tests/cases/compiler/asyncFunctionNoReturnType.ts(1,1): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+tests/cases/compiler/asyncFunctionNoReturnType.ts(1,1): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
 
 
 !!! error TS2468: Cannot find global value 'Promise'.
 ==== tests/cases/compiler/asyncFunctionNoReturnType.ts (1 errors) ====
     async () => {
     ~~~~~~~~~~~~~
-!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
         if (window)
             return;
     }

--- a/tests/baselines/reference/asyncFunctionReturnExpressionErrorSpans.errors.txt
+++ b/tests/baselines/reference/asyncFunctionReturnExpressionErrorSpans.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/asyncFunctionReturnExpressionErrorSpans.ts(11,28): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+tests/cases/compiler/asyncFunctionReturnExpressionErrorSpans.ts(11,28): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
 tests/cases/compiler/asyncFunctionReturnExpressionErrorSpans.ts(16,21): error TS2322: Type 'number' is not assignable to type 'string'.
 
 
@@ -15,7 +15,7 @@ tests/cases/compiler/asyncFunctionReturnExpressionErrorSpans.ts(16,21): error TS
     
     async function asyncFoo(): Promise<Foo> {
                                ~~~~~~~~~~~~
-!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
         return {
             bar: {
                 baz: {

--- a/tests/baselines/reference/bigintWithoutLib.errors.txt
+++ b/tests/baselines/reference/bigintWithoutLib.errors.txt
@@ -1,16 +1,16 @@
-tests/cases/compiler/bigintWithoutLib.ts(4,25): error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(5,13): error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(6,5): error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(7,13): error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(4,25): error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(5,13): error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(6,5): error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(7,13): error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
 tests/cases/compiler/bigintWithoutLib.ts(7,30): error TS2737: BigInt literals are not available when targeting lower than ES2020.
-tests/cases/compiler/bigintWithoutLib.ts(8,13): error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(8,13): error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
 tests/cases/compiler/bigintWithoutLib.ts(8,31): error TS2737: BigInt literals are not available when targeting lower than ES2020.
 tests/cases/compiler/bigintWithoutLib.ts(9,1): error TS2322: Type 'Object' is not assignable to type 'bigint'.
 tests/cases/compiler/bigintWithoutLib.ts(11,32): error TS2554: Expected 0 arguments, but got 1.
 tests/cases/compiler/bigintWithoutLib.ts(13,38): error TS2554: Expected 0 arguments, but got 1.
 tests/cases/compiler/bigintWithoutLib.ts(14,38): error TS2554: Expected 0 arguments, but got 2.
 tests/cases/compiler/bigintWithoutLib.ts(15,38): error TS2554: Expected 0 arguments, but got 2.
-tests/cases/compiler/bigintWithoutLib.ts(18,18): error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(18,18): error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
 tests/cases/compiler/bigintWithoutLib.ts(18,38): error TS2552: Cannot find name 'BigInt64Array'. Did you mean 'bigIntArray'?
 tests/cases/compiler/bigintWithoutLib.ts(19,19): error TS2552: Cannot find name 'BigInt64Array'. Did you mean 'bigIntArray'?
 tests/cases/compiler/bigintWithoutLib.ts(20,19): error TS2552: Cannot find name 'BigInt64Array'. Did you mean 'bigIntArray'?
@@ -18,34 +18,34 @@ tests/cases/compiler/bigintWithoutLib.ts(20,34): error TS2737: BigInt literals a
 tests/cases/compiler/bigintWithoutLib.ts(20,38): error TS2737: BigInt literals are not available when targeting lower than ES2020.
 tests/cases/compiler/bigintWithoutLib.ts(20,42): error TS2737: BigInt literals are not available when targeting lower than ES2020.
 tests/cases/compiler/bigintWithoutLib.ts(21,19): error TS2552: Cannot find name 'BigInt64Array'. Did you mean 'bigIntArray'?
-tests/cases/compiler/bigintWithoutLib.ts(22,19): error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(23,19): error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(24,19): error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(30,19): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(30,40): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(31,20): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(32,20): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(22,19): error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(23,19): error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(24,19): error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(30,19): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(30,40): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(31,20): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(32,20): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
 tests/cases/compiler/bigintWithoutLib.ts(32,36): error TS2737: BigInt literals are not available when targeting lower than ES2020.
 tests/cases/compiler/bigintWithoutLib.ts(32,40): error TS2737: BigInt literals are not available when targeting lower than ES2020.
 tests/cases/compiler/bigintWithoutLib.ts(32,44): error TS2737: BigInt literals are not available when targeting lower than ES2020.
-tests/cases/compiler/bigintWithoutLib.ts(33,20): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(34,20): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(35,20): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(36,20): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(43,10): error TS2550: Property 'setBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(33,20): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(34,20): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(35,20): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(36,20): error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(43,10): error TS2550: Property 'setBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
 tests/cases/compiler/bigintWithoutLib.ts(43,26): error TS2737: BigInt literals are not available when targeting lower than ES2020.
-tests/cases/compiler/bigintWithoutLib.ts(44,10): error TS2550: Property 'setBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(44,10): error TS2550: Property 'setBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
 tests/cases/compiler/bigintWithoutLib.ts(44,26): error TS2737: BigInt literals are not available when targeting lower than ES2020.
-tests/cases/compiler/bigintWithoutLib.ts(45,10): error TS2550: Property 'setBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(46,10): error TS2550: Property 'setBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(45,10): error TS2550: Property 'setBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(46,10): error TS2550: Property 'setBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
 tests/cases/compiler/bigintWithoutLib.ts(46,26): error TS2737: BigInt literals are not available when targeting lower than ES2020.
-tests/cases/compiler/bigintWithoutLib.ts(47,10): error TS2550: Property 'setBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(47,10): error TS2550: Property 'setBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
 tests/cases/compiler/bigintWithoutLib.ts(47,26): error TS2737: BigInt literals are not available when targeting lower than ES2020.
-tests/cases/compiler/bigintWithoutLib.ts(48,10): error TS2550: Property 'setBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(49,22): error TS2550: Property 'getBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(50,22): error TS2550: Property 'getBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(51,22): error TS2550: Property 'getBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/bigintWithoutLib.ts(52,22): error TS2550: Property 'getBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(48,10): error TS2550: Property 'setBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(49,22): error TS2550: Property 'getBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(50,22): error TS2550: Property 'getBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(51,22): error TS2550: Property 'getBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/bigintWithoutLib.ts(52,22): error TS2550: Property 'getBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
 tests/cases/compiler/bigintWithoutLib.ts(55,36): error TS2345: Argument of type 'bigint' is not assignable to parameter of type 'number'.
 tests/cases/compiler/bigintWithoutLib.ts(55,36): error TS2737: BigInt literals are not available when targeting lower than ES2020.
 tests/cases/compiler/bigintWithoutLib.ts(56,36): error TS2345: Argument of type 'bigint' is not assignable to parameter of type 'number'.
@@ -57,21 +57,21 @@ tests/cases/compiler/bigintWithoutLib.ts(56,36): error TS2345: Argument of type 
     // Test BigInt functions
     let bigintVal: bigint = BigInt(123);
                             ~~~~~~
-!!! error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     bigintVal = BigInt("456");
                 ~~~~~~
-!!! error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     new BigInt(123);
         ~~~~~~
-!!! error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     bigintVal = BigInt.asIntN(8, 0xFFFFn);
                 ~~~~~~
-!!! error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
                                  ~~~~~~~
 !!! error TS2737: BigInt literals are not available when targeting lower than ES2020.
     bigintVal = BigInt.asUintN(8, 0xFFFFn);
                 ~~~~~~
-!!! error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
                                   ~~~~~~~
 !!! error TS2737: BigInt literals are not available when targeting lower than ES2020.
     bigintVal = bigintVal.valueOf(); // should error - bigintVal inferred as {}
@@ -95,7 +95,7 @@ tests/cases/compiler/bigintWithoutLib.ts(56,36): error TS2345: Argument of type 
     // Test BigInt64Array
     let bigIntArray: BigInt64Array = new BigInt64Array();
                      ~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
                                          ~~~~~~~~~~~~~
 !!! error TS2552: Cannot find name 'BigInt64Array'. Did you mean 'bigIntArray'?
 !!! related TS2728 tests/cases/compiler/bigintWithoutLib.ts:18:5: 'bigIntArray' is declared here.
@@ -119,13 +119,13 @@ tests/cases/compiler/bigintWithoutLib.ts(56,36): error TS2345: Argument of type 
 !!! related TS2728 tests/cases/compiler/bigintWithoutLib.ts:18:5: 'bigIntArray' is declared here.
     bigIntArray = new BigInt64Array(new ArrayBuffer(80));
                       ~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     bigIntArray = new BigInt64Array(new ArrayBuffer(80), 8);
                       ~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     bigIntArray = new BigInt64Array(new ArrayBuffer(80), 8, 3);
                       ~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigInt64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     let len: number = bigIntArray.length;
     bigIntArray.length = 10;
     let arrayBufferLike: ArrayBufferView = bigIntArray;
@@ -133,15 +133,15 @@ tests/cases/compiler/bigintWithoutLib.ts(56,36): error TS2345: Argument of type 
     // Test BigUint64Array
     let bigUintArray: BigUint64Array = new BigUint64Array();
                       ~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
                                            ~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     bigUintArray = new BigUint64Array(10);
                        ~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     bigUintArray = new BigUint64Array([1n, 2n, 3n]);
                        ~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
                                        ~~
 !!! error TS2737: BigInt literals are not available when targeting lower than ES2020.
                                            ~~
@@ -150,16 +150,16 @@ tests/cases/compiler/bigintWithoutLib.ts(56,36): error TS2345: Argument of type 
 !!! error TS2737: BigInt literals are not available when targeting lower than ES2020.
     bigUintArray = new BigUint64Array([1, 2, 3]);
                        ~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     bigUintArray = new BigUint64Array(new ArrayBuffer(80));
                        ~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     bigUintArray = new BigUint64Array(new ArrayBuffer(80), 8);
                        ~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     bigUintArray = new BigUint64Array(new ArrayBuffer(80), 8, 3);
                        ~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigUint64Array'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     len = bigIntArray.length;
     bigIntArray.length = 10;
     arrayBufferLike = bigIntArray;
@@ -168,42 +168,42 @@ tests/cases/compiler/bigintWithoutLib.ts(56,36): error TS2345: Argument of type 
     const dataView = new DataView(new ArrayBuffer(80));
     dataView.setBigInt64(1, -1n);
              ~~~~~~~~~~~
-!!! error TS2550: Property 'setBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2550: Property 'setBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
                              ~~
 !!! error TS2737: BigInt literals are not available when targeting lower than ES2020.
     dataView.setBigInt64(1, -1n, true);
              ~~~~~~~~~~~
-!!! error TS2550: Property 'setBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2550: Property 'setBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
                              ~~
 !!! error TS2737: BigInt literals are not available when targeting lower than ES2020.
     dataView.setBigInt64(1, -1);
              ~~~~~~~~~~~
-!!! error TS2550: Property 'setBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2550: Property 'setBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     dataView.setBigUint64(2, 123n);
              ~~~~~~~~~~~~
-!!! error TS2550: Property 'setBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2550: Property 'setBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
                              ~~~~
 !!! error TS2737: BigInt literals are not available when targeting lower than ES2020.
     dataView.setBigUint64(2, 123n, true);
              ~~~~~~~~~~~~
-!!! error TS2550: Property 'setBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2550: Property 'setBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
                              ~~~~
 !!! error TS2737: BigInt literals are not available when targeting lower than ES2020.
     dataView.setBigUint64(2, 123);
              ~~~~~~~~~~~~
-!!! error TS2550: Property 'setBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2550: Property 'setBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     bigintVal = dataView.getBigInt64(1);
                          ~~~~~~~~~~~
-!!! error TS2550: Property 'getBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2550: Property 'getBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     bigintVal = dataView.getBigInt64(1, true);
                          ~~~~~~~~~~~
-!!! error TS2550: Property 'getBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2550: Property 'getBigInt64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     bigintVal = dataView.getBigUint64(2);
                          ~~~~~~~~~~~~
-!!! error TS2550: Property 'getBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2550: Property 'getBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     bigintVal = dataView.getBigUint64(2, true);
                          ~~~~~~~~~~~~
-!!! error TS2550: Property 'getBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2550: Property 'getBigUint64' does not exist on type 'DataView'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     
     // Test Intl methods with new parameter type
     new Intl.NumberFormat("fr").format(3000n);

--- a/tests/baselines/reference/constructorWithIncompleteTypeAnnotation.errors.txt
+++ b/tests/baselines/reference/constructorWithIncompleteTypeAnnotation.errors.txt
@@ -21,8 +21,8 @@ tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(40,41): error TS
 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(40,45): error TS1002: Unterminated string literal.
 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(41,21): error TS2304: Cannot find name 'retValue'.
 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(46,13): error TS1005: 'try' expected.
-tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(47,17): error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the `lib` compiler option to include 'dom'.
-tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(53,13): error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the `lib` compiler option to include 'dom'.
+tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(47,17): error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.
+tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(53,13): error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.
 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(58,5): error TS1128: Declaration or statement expected.
 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(69,13): error TS1109: Expression expected.
 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(72,37): error TS1127: Invalid character.
@@ -189,7 +189,7 @@ tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(261,1): error TS
 !!! error TS1005: 'try' expected.
                     console.log(e);
                     ~~~~~~~
-!!! error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the `lib` compiler option to include 'dom'.
+!!! error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.
                 }
                 finally {
     
@@ -197,7 +197,7 @@ tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(261,1): error TS
     
                 console.log('Done');
                 ~~~~~~~
-!!! error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the `lib` compiler option to include 'dom'.
+!!! error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.
     
                 return 0;
     

--- a/tests/baselines/reference/decoratorMetadataNoLibIsolatedModulesTypes.errors.txt
+++ b/tests/baselines/reference/decoratorMetadataNoLibIsolatedModulesTypes.errors.txt
@@ -7,7 +7,7 @@ error TS2318: Cannot find global type 'Object'.
 error TS2318: Cannot find global type 'RegExp'.
 error TS2318: Cannot find global type 'String'.
 tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts(2,6): error TS2304: Cannot find name 'Decorate'.
-tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts(3,13): error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts(3,13): error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
 
 
 !!! error TS2318: Cannot find global type 'Array'.
@@ -25,6 +25,6 @@ tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts(3,13): error 
 !!! error TS2304: Cannot find name 'Decorate'.
         member: Map<string, number>;
                 ~~~
-!!! error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     }
     

--- a/tests/baselines/reference/destructuringControlFlowNoCrash.errors.txt
+++ b/tests/baselines/reference/destructuringControlFlowNoCrash.errors.txt
@@ -2,7 +2,7 @@ error TS2468: Cannot find global value 'Promise'.
 tests/cases/compiler/destructuringControlFlowNoCrash.ts(3,3): error TS2339: Property 'date' does not exist on type '(inspectedElement: any) => number'.
 tests/cases/compiler/destructuringControlFlowNoCrash.ts(10,3): error TS2339: Property 'date2' does not exist on type '(inspectedElement: any) => any'.
 tests/cases/compiler/destructuringControlFlowNoCrash.ts(11,28): error TS1005: '=>' expected.
-tests/cases/compiler/destructuringControlFlowNoCrash.ts(16,25): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+tests/cases/compiler/destructuringControlFlowNoCrash.ts(16,25): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
 
 
 !!! error TS2468: Cannot find global value 'Promise'.
@@ -30,5 +30,5 @@ tests/cases/compiler/destructuringControlFlowNoCrash.ts(16,25): error TS2705: An
     // It could also be an async function
     const { constructor } = async () => {};
                             ~~~~~~~~~~~~~~
-!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
     

--- a/tests/baselines/reference/didYouMeanSuggestionErrors.errors.txt
+++ b/tests/baselines/reference/didYouMeanSuggestionErrors.errors.txt
@@ -3,20 +3,20 @@ tests/cases/compiler/didYouMeanSuggestionErrors.ts(2,5): error TS2582: Cannot fi
 tests/cases/compiler/didYouMeanSuggestionErrors.ts(3,19): error TS2581: Cannot find name '$'. Do you need to install type definitions for jQuery? Try `npm i --save-dev @types/jquery`.
 tests/cases/compiler/didYouMeanSuggestionErrors.ts(7,1): error TS2582: Cannot find name 'suite'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.
 tests/cases/compiler/didYouMeanSuggestionErrors.ts(8,5): error TS2582: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.
-tests/cases/compiler/didYouMeanSuggestionErrors.ts(9,9): error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the `lib` compiler option to include 'dom'.
+tests/cases/compiler/didYouMeanSuggestionErrors.ts(9,9): error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.
 tests/cases/compiler/didYouMeanSuggestionErrors.ts(9,21): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
-tests/cases/compiler/didYouMeanSuggestionErrors.ts(10,9): error TS2584: Cannot find name 'document'. Do you need to change your target library? Try changing the `lib` compiler option to include 'dom'.
+tests/cases/compiler/didYouMeanSuggestionErrors.ts(10,9): error TS2584: Cannot find name 'document'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.
 tests/cases/compiler/didYouMeanSuggestionErrors.ts(12,19): error TS2580: Cannot find name 'require'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
 tests/cases/compiler/didYouMeanSuggestionErrors.ts(13,19): error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
 tests/cases/compiler/didYouMeanSuggestionErrors.ts(14,19): error TS2580: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
-tests/cases/compiler/didYouMeanSuggestionErrors.ts(16,23): error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/didYouMeanSuggestionErrors.ts(17,23): error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/didYouMeanSuggestionErrors.ts(18,23): error TS2583: Cannot find name 'WeakMap'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/didYouMeanSuggestionErrors.ts(19,23): error TS2583: Cannot find name 'WeakSet'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/didYouMeanSuggestionErrors.ts(20,19): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/didYouMeanSuggestionErrors.ts(21,19): error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/didYouMeanSuggestionErrors.ts(23,18): error TS2583: Cannot find name 'Iterator'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/didYouMeanSuggestionErrors.ts(24,18): error TS2583: Cannot find name 'AsyncIterator'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+tests/cases/compiler/didYouMeanSuggestionErrors.ts(16,23): error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/didYouMeanSuggestionErrors.ts(17,23): error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/didYouMeanSuggestionErrors.ts(18,23): error TS2583: Cannot find name 'WeakMap'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/didYouMeanSuggestionErrors.ts(19,23): error TS2583: Cannot find name 'WeakSet'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/didYouMeanSuggestionErrors.ts(20,19): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/didYouMeanSuggestionErrors.ts(21,19): error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/didYouMeanSuggestionErrors.ts(23,18): error TS2583: Cannot find name 'Iterator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/didYouMeanSuggestionErrors.ts(24,18): error TS2583: Cannot find name 'AsyncIterator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
 
 
 ==== tests/cases/compiler/didYouMeanSuggestionErrors.ts (19 errors) ====
@@ -40,12 +40,12 @@ tests/cases/compiler/didYouMeanSuggestionErrors.ts(24,18): error TS2583: Cannot 
 !!! error TS2582: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.
             console.log(process.env);
             ~~~~~~~
-!!! error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the `lib` compiler option to include 'dom'.
+!!! error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.
                         ~~~~~~~
 !!! error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
             document.createElement("div");
             ~~~~~~~~
-!!! error TS2584: Cannot find name 'document'. Do you need to change your target library? Try changing the `lib` compiler option to include 'dom'.
+!!! error TS2584: Cannot find name 'document'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.
     
             const x = require("fs");
                       ~~~~~~~
@@ -59,29 +59,29 @@ tests/cases/compiler/didYouMeanSuggestionErrors.ts(24,18): error TS2583: Cannot 
     
             const a = new Map();
                           ~~~
-!!! error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
             const b = new Set();
                           ~~~
-!!! error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
             const c = new WeakMap();
                           ~~~~~~~
-!!! error TS2583: Cannot find name 'WeakMap'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'WeakMap'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
             const d = new WeakSet();
                           ~~~~~~~
-!!! error TS2583: Cannot find name 'WeakSet'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'WeakSet'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
             const e = Symbol();
                       ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
             const f = Promise.resolve(0);
                       ~~~~~~~
-!!! error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     
             const i: Iterator<any> = null as any;
                      ~~~~~~~~
-!!! error TS2583: Cannot find name 'Iterator'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Iterator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
             const j: AsyncIterator<any> = null as any;
                      ~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'AsyncIterator'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'AsyncIterator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
             const k: Symbol = null as any;
             const l: Promise<any> = null as any;
         });

--- a/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2015.errors.txt
+++ b/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2015.errors.txt
@@ -1,87 +1,87 @@
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(3,26): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(4,30): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(5,35): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(6,35): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(7,24): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(8,45): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(9,35): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(10,33): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(11,28): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(12,38): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(13,24): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(14,35): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(15,28): error TS2550: Property 'find' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(18,33): error TS2550: Property 'findIndex' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(21,28): error TS2550: Property 'fill' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(22,34): error TS2550: Property 'copyWithin' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(23,31): error TS2550: Property 'entries' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(24,28): error TS2550: Property 'keys' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(25,30): error TS2550: Property 'values' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(26,40): error TS2550: Property 'from' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(27,38): error TS2550: Property 'of' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(28,44): error TS2550: Property 'assign' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(29,59): error TS2550: Property 'getOwnPropertySymbols' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(31,40): error TS2550: Property 'is' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(32,52): error TS2550: Property 'setPrototypeOf' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(33,46): error TS2550: Property 'isFinite' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(34,47): error TS2550: Property 'isInteger' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(35,43): error TS2550: Property 'isNaN' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(36,51): error TS2550: Property 'isSafeInteger' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(37,48): error TS2550: Property 'parseFloat' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(38,46): error TS2550: Property 'parseInt' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(39,28): error TS2550: Property 'clz32' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(40,27): error TS2550: Property 'imul' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(41,27): error TS2550: Property 'sign' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(42,28): error TS2550: Property 'log10' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(43,27): error TS2550: Property 'log2' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(44,28): error TS2550: Property 'log1p' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(45,28): error TS2550: Property 'expm1' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(46,27): error TS2550: Property 'cosh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(47,27): error TS2550: Property 'sinh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(48,27): error TS2550: Property 'tanh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(49,28): error TS2550: Property 'acosh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(50,28): error TS2550: Property 'asinh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(51,28): error TS2550: Property 'atanh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(52,28): error TS2550: Property 'hypot' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(53,28): error TS2550: Property 'trunc' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(54,29): error TS2550: Property 'fround' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(55,27): error TS2550: Property 'cbrt' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(56,16): error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(57,16): error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(58,24): error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(59,25): error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(60,28): error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(61,27): error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(62,23): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(63,26): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(64,20): error TS2583: Cannot find name 'WeakMap'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(65,20): error TS2583: Cannot find name 'WeakMap'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(66,21): error TS2583: Cannot find name 'Iterator'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(67,26): error TS2583: Cannot find name 'AsyncIterator'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(68,34): error TS2550: Property 'codePointAt' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(69,31): error TS2550: Property 'includes' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(70,31): error TS2550: Property 'endsWith' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(71,32): error TS2550: Property 'normalize' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(72,29): error TS2550: Property 'repeat' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(73,33): error TS2550: Property 'startsWith' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(74,29): error TS2550: Property 'anchor' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(75,26): error TS2550: Property 'big' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(76,28): error TS2550: Property 'blink' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(77,27): error TS2550: Property 'bold' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(78,28): error TS2550: Property 'fixed' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(79,32): error TS2550: Property 'fontcolor' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(80,31): error TS2550: Property 'fontsize' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(81,30): error TS2550: Property 'italics' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(82,27): error TS2550: Property 'link' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(83,28): error TS2550: Property 'small' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(84,29): error TS2550: Property 'strike' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(85,26): error TS2550: Property 'sub' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(86,26): error TS2550: Property 'sup' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(87,51): error TS2550: Property 'fromCodePoint' does not exist on type 'StringConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(88,41): error TS2550: Property 'raw' does not exist on type 'StringConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(89,32): error TS2550: Property 'flags' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(90,33): error TS2550: Property 'sticky' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(91,34): error TS2550: Property 'unicode' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(3,26): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(4,30): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(5,35): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(6,35): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(7,24): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(8,45): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(9,35): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(10,33): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(11,28): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(12,38): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(13,24): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(14,35): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(15,28): error TS2550: Property 'find' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(18,33): error TS2550: Property 'findIndex' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(21,28): error TS2550: Property 'fill' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(22,34): error TS2550: Property 'copyWithin' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(23,31): error TS2550: Property 'entries' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(24,28): error TS2550: Property 'keys' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(25,30): error TS2550: Property 'values' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(26,40): error TS2550: Property 'from' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(27,38): error TS2550: Property 'of' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(28,44): error TS2550: Property 'assign' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(29,59): error TS2550: Property 'getOwnPropertySymbols' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(31,40): error TS2550: Property 'is' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(32,52): error TS2550: Property 'setPrototypeOf' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(33,46): error TS2550: Property 'isFinite' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(34,47): error TS2550: Property 'isInteger' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(35,43): error TS2550: Property 'isNaN' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(36,51): error TS2550: Property 'isSafeInteger' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(37,48): error TS2550: Property 'parseFloat' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(38,46): error TS2550: Property 'parseInt' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(39,28): error TS2550: Property 'clz32' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(40,27): error TS2550: Property 'imul' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(41,27): error TS2550: Property 'sign' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(42,28): error TS2550: Property 'log10' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(43,27): error TS2550: Property 'log2' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(44,28): error TS2550: Property 'log1p' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(45,28): error TS2550: Property 'expm1' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(46,27): error TS2550: Property 'cosh' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(47,27): error TS2550: Property 'sinh' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(48,27): error TS2550: Property 'tanh' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(49,28): error TS2550: Property 'acosh' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(50,28): error TS2550: Property 'asinh' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(51,28): error TS2550: Property 'atanh' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(52,28): error TS2550: Property 'hypot' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(53,28): error TS2550: Property 'trunc' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(54,29): error TS2550: Property 'fround' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(55,27): error TS2550: Property 'cbrt' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(56,16): error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(57,16): error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(58,24): error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(59,25): error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(60,28): error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(61,27): error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(62,23): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(63,26): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(64,20): error TS2583: Cannot find name 'WeakMap'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(65,20): error TS2583: Cannot find name 'WeakMap'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(66,21): error TS2583: Cannot find name 'Iterator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(67,26): error TS2583: Cannot find name 'AsyncIterator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(68,34): error TS2550: Property 'codePointAt' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(69,31): error TS2550: Property 'includes' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(70,31): error TS2550: Property 'endsWith' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(71,32): error TS2550: Property 'normalize' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(72,29): error TS2550: Property 'repeat' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(73,33): error TS2550: Property 'startsWith' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(74,29): error TS2550: Property 'anchor' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(75,26): error TS2550: Property 'big' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(76,28): error TS2550: Property 'blink' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(77,27): error TS2550: Property 'bold' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(78,28): error TS2550: Property 'fixed' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(79,32): error TS2550: Property 'fontcolor' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(80,31): error TS2550: Property 'fontsize' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(81,30): error TS2550: Property 'italics' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(82,27): error TS2550: Property 'link' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(83,28): error TS2550: Property 'small' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(84,29): error TS2550: Property 'strike' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(85,26): error TS2550: Property 'sub' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(86,26): error TS2550: Property 'sup' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(87,51): error TS2550: Property 'fromCodePoint' does not exist on type 'StringConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(88,41): error TS2550: Property 'raw' does not exist on type 'StringConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(89,32): error TS2550: Property 'flags' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(90,33): error TS2550: Property 'sticky' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(91,34): error TS2550: Property 'unicode' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
 
 
 ==== tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts (84 errors) ====
@@ -89,259 +89,259 @@ tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts(91,34): error T
     const noOp = () => {};
     const testReflectApply = Reflect.apply(noOp, this, []);
                              ~~~~~~~
-!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testReflectConstruct = Reflect.construct(noOp, []);
                                  ~~~~~~~
-!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testReflectDefineProperty = Reflect.defineProperty({}, "", {});
                                       ~~~~~~~
-!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testReflectDeleteProperty = Reflect.deleteProperty({}, "");
                                       ~~~~~~~
-!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testReflectGet = Reflect.get({}, "");
                            ~~~~~~~
-!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testReflectGetOwnPropertyDescriptor = Reflect.getOwnPropertyDescriptor({}, "");
                                                 ~~~~~~~
-!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testReflectGetPrototypeOf = Reflect.getPrototypeOf({});
                                       ~~~~~~~
-!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testReflectIsExtensible = Reflect.isExtensible({});
                                     ~~~~~~~
-!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testReflectOwnKeys = Reflect.ownKeys({});
                                ~~~~~~~
-!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testReflectPreventExtensions = Reflect.preventExtensions({});
                                          ~~~~~~~
-!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testReflectSet = Reflect.set({}, "", 0);
                            ~~~~~~~
-!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testReflectSetPrototypeOf = Reflect.setPrototypeOf({}, {}); 
                                       ~~~~~~~
-!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testArrayFind = [""].find((val, idx, obj) => {
                                ~~~~
-!!! error TS2550: Property 'find' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'find' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
         return true;
     });
     const testArrayFindIndex = [""].findIndex((val, idx, obj) => {
                                     ~~~~~~~~~
-!!! error TS2550: Property 'findIndex' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'findIndex' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
         return true;
     });
     const testArrayFill = [""].fill("fill");
                                ~~~~
-!!! error TS2550: Property 'fill' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'fill' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testArrayCopyWithin = [""].copyWithin(0, 0);
                                      ~~~~~~~~~~
-!!! error TS2550: Property 'copyWithin' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'copyWithin' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testArrayEntries = [""].entries();
                                   ~~~~~~~
-!!! error TS2550: Property 'entries' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'entries' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testArrayKeys = [""].keys();
                                ~~~~
-!!! error TS2550: Property 'keys' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'keys' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testArrayValues = [""].values();
                                  ~~~~~~
-!!! error TS2550: Property 'values' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'values' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testArrayConstructorFrom = Array.from([]);
                                            ~~~~
-!!! error TS2550: Property 'from' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'from' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testArrayConstructorOf = Array.of([]);
                                          ~~
-!!! error TS2550: Property 'of' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'of' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testObjectConstructorAssign = Object.assign({}, {});
                                                ~~~~~~
-!!! error TS2550: Property 'assign' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'assign' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testObjectConstructorGetOwnPropertySymbols = Object.getOwnPropertySymbols({});
                                                               ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2550: Property 'getOwnPropertySymbols' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'getOwnPropertySymbols' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testObjectConstructorKeys = Object.keys({});
     const testObjectConstructorIs = Object.is({}, {});
                                            ~~
-!!! error TS2550: Property 'is' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'is' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testObjectConstructorSetPrototypeOf = Object.setPrototypeOf({}, {});
                                                        ~~~~~~~~~~~~~~
-!!! error TS2550: Property 'setPrototypeOf' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'setPrototypeOf' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testNumberConstructorIsFinite = Number.isFinite(0);
                                                  ~~~~~~~~
-!!! error TS2550: Property 'isFinite' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'isFinite' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testNumberConstructorIsInteger = Number.isInteger(0);
                                                   ~~~~~~~~~
-!!! error TS2550: Property 'isInteger' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'isInteger' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testNumberConstructorIsNan = Number.isNaN(0);
                                               ~~~~~
-!!! error TS2550: Property 'isNaN' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'isNaN' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testNumberConstructorIsSafeInteger = Number.isSafeInteger(0);
                                                       ~~~~~~~~~~~~~
-!!! error TS2550: Property 'isSafeInteger' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'isSafeInteger' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testNumberConstructorParseFloat = Number.parseFloat("0");
                                                    ~~~~~~~~~~
-!!! error TS2550: Property 'parseFloat' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'parseFloat' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testNumberConstructorParseInt = Number.parseInt("0");
                                                  ~~~~~~~~
-!!! error TS2550: Property 'parseInt' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'parseInt' does not exist on type 'NumberConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathClz32 = Math.clz32(0);
                                ~~~~~
-!!! error TS2550: Property 'clz32' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'clz32' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathImul = Math.imul(0,0);
                               ~~~~
-!!! error TS2550: Property 'imul' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'imul' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathSign = Math.sign(0);
                               ~~~~
-!!! error TS2550: Property 'sign' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'sign' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathLog10 = Math.log10(0);
                                ~~~~~
-!!! error TS2550: Property 'log10' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'log10' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathLog2 = Math.log2(0);
                               ~~~~
-!!! error TS2550: Property 'log2' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'log2' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathLog1p = Math.log1p(0);
                                ~~~~~
-!!! error TS2550: Property 'log1p' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'log1p' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathExpm1 = Math.expm1(0);
                                ~~~~~
-!!! error TS2550: Property 'expm1' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'expm1' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathCosh = Math.cosh(0);
                               ~~~~
-!!! error TS2550: Property 'cosh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'cosh' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathSinh = Math.sinh(0);
                               ~~~~
-!!! error TS2550: Property 'sinh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'sinh' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathTanh = Math.tanh(0);
                               ~~~~
-!!! error TS2550: Property 'tanh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'tanh' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathAcosh = Math.acosh(0);
                                ~~~~~
-!!! error TS2550: Property 'acosh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'acosh' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathAsinh = Math.asinh(0);
                                ~~~~~
-!!! error TS2550: Property 'asinh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'asinh' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathAtanh = Math.atanh(0);
                                ~~~~~
-!!! error TS2550: Property 'atanh' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'atanh' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathHypot = Math.hypot(0,0);
                                ~~~~~
-!!! error TS2550: Property 'hypot' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'hypot' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathTrunc = Math.trunc(0);
                                ~~~~~
-!!! error TS2550: Property 'trunc' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'trunc' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathFround = Math.fround(0);
                                 ~~~~~~
-!!! error TS2550: Property 'fround' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'fround' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMathCbrt = Math.cbrt(0);
                               ~~~~
-!!! error TS2550: Property 'cbrt' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'cbrt' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testMap: Map<any, any> = null as any;
                    ~~~
-!!! error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testSet: Set<any> = null as any;
                    ~~~
-!!! error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testPromiseAll = Promise.all([]);
                            ~~~~~~~
-!!! error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     const testPromiseRace = Promise.race([]);
                             ~~~~~~~
-!!! error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     const testPromiseResolve = Promise.resolve();
                                ~~~~~~~
-!!! error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     const testPromiseReject = Promise.reject();
                               ~~~~~~~
-!!! error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     const testSymbolFor = Symbol.for('a');
                           ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     const testSymbolKeyFor = Symbol.keyFor(testSymbolFor);
                              ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     const testWeakMap: WeakMap<any, any> = null as any;
                        ~~~~~~~
-!!! error TS2583: Cannot find name 'WeakMap'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'WeakMap'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testWeakSet: WeakMap<any, any> = null as any;
                        ~~~~~~~
-!!! error TS2583: Cannot find name 'WeakMap'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'WeakMap'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testIterator: Iterator<any, any, any> = null as any;
                         ~~~~~~~~
-!!! error TS2583: Cannot find name 'Iterator'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Iterator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testAsyncIterator: AsyncIterator<any, any, any> = null as any;
                              ~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'AsyncIterator'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'AsyncIterator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringCodePointAt = "".codePointAt(0);
                                      ~~~~~~~~~~~
-!!! error TS2550: Property 'codePointAt' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'codePointAt' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringIncludes = "".includes("");
                                   ~~~~~~~~
-!!! error TS2550: Property 'includes' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'includes' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringEndsWith = "".endsWith("");
                                   ~~~~~~~~
-!!! error TS2550: Property 'endsWith' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'endsWith' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringNormalize = "".normalize();
                                    ~~~~~~~~~
-!!! error TS2550: Property 'normalize' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'normalize' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringRepeat = "".repeat(0);
                                 ~~~~~~
-!!! error TS2550: Property 'repeat' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'repeat' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringStartsWith = "".startsWith("");
                                     ~~~~~~~~~~
-!!! error TS2550: Property 'startsWith' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'startsWith' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringAnchor = "".anchor("");
                                 ~~~~~~
-!!! error TS2550: Property 'anchor' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'anchor' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringBig = "".big();
                              ~~~
-!!! error TS2550: Property 'big' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'big' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringBlink = "".blink();
                                ~~~~~
-!!! error TS2550: Property 'blink' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'blink' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringBold = "".bold();
                               ~~~~
-!!! error TS2550: Property 'bold' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'bold' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringFixed = "".fixed();
                                ~~~~~
-!!! error TS2550: Property 'fixed' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'fixed' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringFontColor = "".fontcolor("blue");
                                    ~~~~~~~~~
-!!! error TS2550: Property 'fontcolor' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'fontcolor' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringFontSize = "".fontsize(0);
                                   ~~~~~~~~
-!!! error TS2550: Property 'fontsize' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'fontsize' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringItalics = "".italics();
                                  ~~~~~~~
-!!! error TS2550: Property 'italics' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'italics' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringLink = "".link("");
                               ~~~~
-!!! error TS2550: Property 'link' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'link' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringSmall = "".small();
                                ~~~~~
-!!! error TS2550: Property 'small' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'small' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringStrike = "".strike();
                                 ~~~~~~
-!!! error TS2550: Property 'strike' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'strike' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringSub = "".sub();
                              ~~~
-!!! error TS2550: Property 'sub' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'sub' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringSup = "".sup();
                              ~~~
-!!! error TS2550: Property 'sup' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'sup' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringConstructorFromCodePoint = String.fromCodePoint();
                                                       ~~~~~~~~~~~~~
-!!! error TS2550: Property 'fromCodePoint' does not exist on type 'StringConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'fromCodePoint' does not exist on type 'StringConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testStringConstructorRaw = String.raw``;
                                             ~~~
-!!! error TS2550: Property 'raw' does not exist on type 'StringConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'raw' does not exist on type 'StringConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testRegExpFlags = /abc/g.flags;
                                    ~~~~~
-!!! error TS2550: Property 'flags' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'flags' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testRegExpSticky = /abc/g.sticky;
                                     ~~~~~~
-!!! error TS2550: Property 'sticky' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'sticky' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     const testRegExpUnicode = /abc/g.unicode;
                                      ~~~~~~~
-!!! error TS2550: Property 'unicode' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'unicode' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     

--- a/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2016Plus.errors.txt
+++ b/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2016Plus.errors.txt
@@ -1,149 +1,149 @@
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(2,32): error TS2550: Property 'includes' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2016' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(5,31): error TS2550: Property 'padStart' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(6,29): error TS2550: Property 'padEnd' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(7,44): error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(8,45): error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(9,63): error TS2550: Property 'getOwnPropertyDescriptors' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(10,64): error TS2550: Property 'formatToParts' does not exist on type 'DateTimeFormat'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(11,21): error TS2583: Cannot find name 'Atomics'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(12,35): error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(15,50): error TS2550: Property 'finally' does not exist on type 'Promise<unknown>'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(16,113): error TS2550: Property 'groups' does not exist on type 'RegExpMatchArray'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(17,111): error TS2550: Property 'groups' does not exist on type 'RegExpExecArray'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(18,33): error TS2550: Property 'dotAll' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(19,38): error TS2550: Property 'PluralRules' does not exist on type 'typeof Intl'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(20,27): error TS2583: Cannot find name 'AsyncGenerator'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(21,35): error TS2583: Cannot find name 'AsyncGeneratorFunction'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(22,26): error TS2583: Cannot find name 'AsyncIterable'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(23,34): error TS2583: Cannot find name 'AsyncIterableIterator'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(26,26): error TS2550: Property 'flat' does not exist on type 'undefined[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(27,29): error TS2550: Property 'flatMap' does not exist on type 'undefined[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(28,49): error TS2550: Property 'fromEntries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(29,32): error TS2550: Property 'trimStart' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(30,30): error TS2550: Property 'trimEnd' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(31,31): error TS2550: Property 'trimLeft' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(32,32): error TS2550: Property 'trimRight' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(33,45): error TS2550: Property 'description' does not exist on type 'symbol'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(36,39): error TS2550: Property 'allSettled' does not exist on type 'PromiseConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(37,31): error TS2550: Property 'matchAll' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(38,47): error TS2550: Property 'matchAll' does not exist on type 'SymbolConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(39,20): error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(42,32): error TS2550: Property 'any' does not exist on type 'PromiseConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2021' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(43,33): error TS2550: Property 'replaceAll' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2021' or later.
-tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(46,70): error TS2550: Property 'formatToParts' does not exist on type 'NumberFormat'. Do you need to change your target library? Try changing the `lib` compiler option to 'esnext' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(2,32): error TS2550: Property 'includes' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2016' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(5,31): error TS2550: Property 'padStart' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(6,29): error TS2550: Property 'padEnd' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(7,44): error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(8,45): error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(9,63): error TS2550: Property 'getOwnPropertyDescriptors' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(10,64): error TS2550: Property 'formatToParts' does not exist on type 'DateTimeFormat'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(11,21): error TS2583: Cannot find name 'Atomics'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(12,35): error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(15,50): error TS2550: Property 'finally' does not exist on type 'Promise<unknown>'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(16,113): error TS2550: Property 'groups' does not exist on type 'RegExpMatchArray'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(17,111): error TS2550: Property 'groups' does not exist on type 'RegExpExecArray'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(18,33): error TS2550: Property 'dotAll' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(19,38): error TS2550: Property 'PluralRules' does not exist on type 'typeof Intl'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(20,27): error TS2583: Cannot find name 'AsyncGenerator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(21,35): error TS2583: Cannot find name 'AsyncGeneratorFunction'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(22,26): error TS2583: Cannot find name 'AsyncIterable'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(23,34): error TS2583: Cannot find name 'AsyncIterableIterator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(26,26): error TS2550: Property 'flat' does not exist on type 'undefined[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(27,29): error TS2550: Property 'flatMap' does not exist on type 'undefined[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(28,49): error TS2550: Property 'fromEntries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(29,32): error TS2550: Property 'trimStart' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(30,30): error TS2550: Property 'trimEnd' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(31,31): error TS2550: Property 'trimLeft' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(32,32): error TS2550: Property 'trimRight' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(33,45): error TS2550: Property 'description' does not exist on type 'symbol'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(36,39): error TS2550: Property 'allSettled' does not exist on type 'PromiseConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(37,31): error TS2550: Property 'matchAll' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(38,47): error TS2550: Property 'matchAll' does not exist on type 'SymbolConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(39,20): error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(42,32): error TS2550: Property 'any' does not exist on type 'PromiseConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2021' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(43,33): error TS2550: Property 'replaceAll' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2021' or later.
+tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts(46,70): error TS2550: Property 'formatToParts' does not exist on type 'NumberFormat'. Do you need to change your target library? Try changing the 'lib' compiler option to 'esnext' or later.
 
 
 ==== tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts (33 errors) ====
     // es2016
     const testIncludes = ["hello"].includes("world");
                                    ~~~~~~~~
-!!! error TS2550: Property 'includes' does not exist on type 'string[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2016' or later.
+!!! error TS2550: Property 'includes' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2016' or later.
     
     // es2017
     const testStringPadStart = "".padStart(2);
                                   ~~~~~~~~
-!!! error TS2550: Property 'padStart' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'padStart' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
     const testStringPadEnd = "".padEnd(2);
                                 ~~~~~~
-!!! error TS2550: Property 'padEnd' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'padEnd' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
     const testObjectConstructorValues = Object.values({});
                                                ~~~~~~
-!!! error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
     const testObjectConstructorEntries = Object.entries({});
                                                 ~~~~~~~
-!!! error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
     const testObjectConstructorGetOwnPropertyDescriptors = Object.getOwnPropertyDescriptors({});
                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2550: Property 'getOwnPropertyDescriptors' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'getOwnPropertyDescriptors' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
     const testIntlFormatToParts = new Intl.DateTimeFormat("en-US").formatToParts();
                                                                    ~~~~~~~~~~~~~
-!!! error TS2550: Property 'formatToParts' does not exist on type 'DateTimeFormat'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'formatToParts' does not exist on type 'DateTimeFormat'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
     const testAtomics = Atomics.add(new Uint8Array(0), 0, 0);
                         ~~~~~~~
-!!! error TS2583: Cannot find name 'Atomics'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2583: Cannot find name 'Atomics'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
     const testSharedArrayBuffer = new SharedArrayBuffer(5);
                                       ~~~~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
     
     // es2018
     const testPromiseFinally = new Promise(() => {}).finally();
                                                      ~~~~~~~
-!!! error TS2550: Property 'finally' does not exist on type 'Promise<unknown>'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
+!!! error TS2550: Property 'finally' does not exist on type 'Promise<unknown>'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
     const testRegExpMatchArrayGroups = "2019-04-30".match(/(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})/g).groups;
                                                                                                                     ~~~~~~
-!!! error TS2550: Property 'groups' does not exist on type 'RegExpMatchArray'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
+!!! error TS2550: Property 'groups' does not exist on type 'RegExpMatchArray'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
     const testRegExpExecArrayGroups = /(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})/g.exec("2019-04-30").groups;
                                                                                                                   ~~~~~~
-!!! error TS2550: Property 'groups' does not exist on type 'RegExpExecArray'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
+!!! error TS2550: Property 'groups' does not exist on type 'RegExpExecArray'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
     const testRegExpDotAll = /foo/g.dotAll;
                                     ~~~~~~
-!!! error TS2550: Property 'dotAll' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
+!!! error TS2550: Property 'dotAll' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
     const testIntlPluralRules = new Intl.PluralRules("ar-EG").select(0);
                                          ~~~~~~~~~~~
-!!! error TS2550: Property 'PluralRules' does not exist on type 'typeof Intl'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
+!!! error TS2550: Property 'PluralRules' does not exist on type 'typeof Intl'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
     const testAsyncGenerator: AsyncGenerator<any> = null as any;
                               ~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'AsyncGenerator'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
+!!! error TS2583: Cannot find name 'AsyncGenerator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
     const testAsyncGeneratorFunction: AsyncGeneratorFunction = null as any;
                                       ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'AsyncGeneratorFunction'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
+!!! error TS2583: Cannot find name 'AsyncGeneratorFunction'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
     const testAsyncIterable: AsyncIterable<any> = null as any;
                              ~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'AsyncIterable'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
+!!! error TS2583: Cannot find name 'AsyncIterable'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
     const testAsyncIterableIterator: AsyncIterableIterator<any> = null as any;
                                      ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'AsyncIterableIterator'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
+!!! error TS2583: Cannot find name 'AsyncIterableIterator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
     
     // es2019
     const testArrayFlat = [].flat();
                              ~~~~
-!!! error TS2550: Property 'flat' does not exist on type 'undefined[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
+!!! error TS2550: Property 'flat' does not exist on type 'undefined[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
     const testArrayFlatMap = [].flatMap();
                                 ~~~~~~~
-!!! error TS2550: Property 'flatMap' does not exist on type 'undefined[]'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
+!!! error TS2550: Property 'flatMap' does not exist on type 'undefined[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
     const testObjectConstructorFromEntries = Object.fromEntries({});
                                                     ~~~~~~~~~~~
-!!! error TS2550: Property 'fromEntries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
+!!! error TS2550: Property 'fromEntries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
     const testStringTrimStart = "".trimStart();
                                    ~~~~~~~~~
-!!! error TS2550: Property 'trimStart' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
+!!! error TS2550: Property 'trimStart' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
     const testStringTrimEnd = "".trimEnd();
                                  ~~~~~~~
-!!! error TS2550: Property 'trimEnd' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
+!!! error TS2550: Property 'trimEnd' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
     const testStringTrimLeft = "".trimLeft();
                                   ~~~~~~~~
-!!! error TS2550: Property 'trimLeft' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
+!!! error TS2550: Property 'trimLeft' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
     const testStringTrimRight = "".trimRight();
                                    ~~~~~~~~~
-!!! error TS2550: Property 'trimRight' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
+!!! error TS2550: Property 'trimRight' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
     const testSymbolDescription = Symbol("foo").description;
                                                 ~~~~~~~~~~~
-!!! error TS2550: Property 'description' does not exist on type 'symbol'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2019' or later.
+!!! error TS2550: Property 'description' does not exist on type 'symbol'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.
     
     // es2020
     const testPromiseAllSettled = Promise.allSettled([]);
                                           ~~~~~~~~~~
-!!! error TS2550: Property 'allSettled' does not exist on type 'PromiseConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2550: Property 'allSettled' does not exist on type 'PromiseConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     const testStringMatchAll = "".matchAll();
                                   ~~~~~~~~
-!!! error TS2550: Property 'matchAll' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2550: Property 'matchAll' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     const testRegExpMatchAll = /matchAll/g[Symbol.matchAll]("matchAll");
                                                   ~~~~~~~~
-!!! error TS2550: Property 'matchAll' does not exist on type 'SymbolConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2550: Property 'matchAll' does not exist on type 'SymbolConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     const testBigInt = BigInt(123);
                        ~~~~~~
-!!! error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2020' or later.
+!!! error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
     
     // es2021
     const testPromiseAny = Promise.any([]);
                                    ~~~
-!!! error TS2550: Property 'any' does not exist on type 'PromiseConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2021' or later.
+!!! error TS2550: Property 'any' does not exist on type 'PromiseConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2021' or later.
     const testStringReplaceAll = "".replaceAll();
                                     ~~~~~~~~~~
-!!! error TS2550: Property 'replaceAll' does not exist on type '""'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2021' or later.
+!!! error TS2550: Property 'replaceAll' does not exist on type '""'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2021' or later.
     
     // esnext
     const testNumberFormatFormatToParts = new Intl.NumberFormat("en-US").formatToParts();
                                                                          ~~~~~~~~~~~~~
-!!! error TS2550: Property 'formatToParts' does not exist on type 'NumberFormat'. Do you need to change your target library? Try changing the `lib` compiler option to 'esnext' or later.
+!!! error TS2550: Property 'formatToParts' does not exist on type 'NumberFormat'. Do you need to change your target library? Try changing the 'lib' compiler option to 'esnext' or later.
     

--- a/tests/baselines/reference/forwardDeclaredCommonTypes01.errors.txt
+++ b/tests/baselines/reference/forwardDeclaredCommonTypes01.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/compiler/forwardDeclaredCommonTypes01.ts(9,9): error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/forwardDeclaredCommonTypes01.ts(10,9): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/forwardDeclaredCommonTypes01.ts(10,17): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/forwardDeclaredCommonTypes01.ts(11,9): error TS2585: 'Map' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/forwardDeclaredCommonTypes01.ts(12,9): error TS2585: 'WeakMap' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/forwardDeclaredCommonTypes01.ts(13,9): error TS2585: 'Set' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/forwardDeclaredCommonTypes01.ts(14,9): error TS2585: 'WeakSet' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/compiler/forwardDeclaredCommonTypes01.ts(9,9): error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/forwardDeclaredCommonTypes01.ts(10,9): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/forwardDeclaredCommonTypes01.ts(10,17): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/forwardDeclaredCommonTypes01.ts(11,9): error TS2585: 'Map' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/forwardDeclaredCommonTypes01.ts(12,9): error TS2585: 'WeakMap' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/forwardDeclaredCommonTypes01.ts(13,9): error TS2585: 'Set' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/forwardDeclaredCommonTypes01.ts(14,9): error TS2585: 'WeakSet' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/compiler/forwardDeclaredCommonTypes01.ts (7 errors) ====
@@ -18,23 +18,23 @@ tests/cases/compiler/forwardDeclaredCommonTypes01.ts(14,9): error TS2585: 'WeakS
     (function() {
         new Promise;
             ~~~~~~~
-!!! error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
         new Symbol; Symbol();
             ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
                     ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
         new Map;
             ~~~
-!!! error TS2585: 'Map' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Map' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
         new WeakMap;
             ~~~~~~~
-!!! error TS2585: 'WeakMap' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'WeakMap' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
         new Set;
             ~~~
-!!! error TS2585: 'Set' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Set' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
         new WeakSet;
             ~~~~~~~
-!!! error TS2585: 'WeakSet' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'WeakSet' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     });
     

--- a/tests/baselines/reference/importCallExpressionNoModuleKindSpecified.errors.txt
+++ b/tests/baselines/reference/importCallExpressionNoModuleKindSpecified.errors.txt
@@ -1,8 +1,8 @@
 error TS2468: Cannot find global value 'Promise'.
-tests/cases/conformance/dynamicImport/2.ts(3,24): error TS2712: A dynamic import call in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
-tests/cases/conformance/dynamicImport/2.ts(5,27): error TS2712: A dynamic import call in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
-tests/cases/conformance/dynamicImport/2.ts(8,12): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
-tests/cases/conformance/dynamicImport/2.ts(10,29): error TS2712: A dynamic import call in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+tests/cases/conformance/dynamicImport/2.ts(3,24): error TS2712: A dynamic import call in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
+tests/cases/conformance/dynamicImport/2.ts(5,27): error TS2712: A dynamic import call in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
+tests/cases/conformance/dynamicImport/2.ts(8,12): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
+tests/cases/conformance/dynamicImport/2.ts(10,29): error TS2712: A dynamic import call in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
 
 
 !!! error TS2468: Cannot find global value 'Promise'.
@@ -21,20 +21,20 @@ tests/cases/conformance/dynamicImport/2.ts(10,29): error TS2712: A dynamic impor
     class C {
         private myModule = import("./0");
                            ~~~~~~~~~~~~~
-!!! error TS2712: A dynamic import call in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2712: A dynamic import call in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
         method() {
             const loadAsync = import("./0");
                               ~~~~~~~~~~~~~
-!!! error TS2712: A dynamic import call in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2712: A dynamic import call in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
             this.myModule.then(Zero => {
                 console.log(Zero.foo());
             }, async err => {
                ~~~~~~~~~~~~~~
-!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
                 console.log(err);
                 let one = await import("./1");
                                 ~~~~~~~~~~~~~
-!!! error TS2712: A dynamic import call in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2712: A dynamic import call in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
                 console.log(one.backup());
             });
         }

--- a/tests/baselines/reference/importMeta(module=commonjs,target=es5).errors.txt
+++ b/tests/baselines/reference/importMeta(module=commonjs,target=es5).errors.txt
@@ -7,7 +7,7 @@ tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(1,70): error TS13
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(2,1): error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'esnext', or 'system'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(2,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(11,21): error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'esnext', or 'system'.
-tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
 tests/cases/conformance/es2019/importMeta/example.ts(3,59): error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'esnext', or 'system'.
 tests/cases/conformance/es2019/importMeta/example.ts(6,16): error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'esnext', or 'system'.
 tests/cases/conformance/es2019/importMeta/example.ts(6,28): error TS2339: Property 'scriptElement' does not exist on type 'ImportMeta'.
@@ -28,7 +28,7 @@ tests/cases/conformance/es2019/importMeta/scriptLookingFile01.ts(3,22): error TS
     // Adapted from https://github.com/tc39/proposal-import-meta/tree/c3902a9ffe2e69a7ac42c19d7ea74cbdcea9b7fb#example
     (async () => {
      ~~~~~~~~~~~~~
-!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
       const response = await fetch(new URL("../hamsters.jpg", import.meta.url).toString());
                                                               ~~~~~~~~~~~
 !!! error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'esnext', or 'system'.

--- a/tests/baselines/reference/importMeta(module=commonjs,target=esnext).errors.txt
+++ b/tests/baselines/reference/importMeta(module=commonjs,target=esnext).errors.txt
@@ -7,7 +7,7 @@ tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(1,70): error TS13
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(2,1): error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'esnext', or 'system'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(2,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(11,21): error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'esnext', or 'system'.
-tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
 tests/cases/conformance/es2019/importMeta/example.ts(3,59): error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'esnext', or 'system'.
 tests/cases/conformance/es2019/importMeta/example.ts(6,16): error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'esnext', or 'system'.
 tests/cases/conformance/es2019/importMeta/example.ts(6,28): error TS2339: Property 'scriptElement' does not exist on type 'ImportMeta'.
@@ -28,7 +28,7 @@ tests/cases/conformance/es2019/importMeta/scriptLookingFile01.ts(3,22): error TS
     // Adapted from https://github.com/tc39/proposal-import-meta/tree/c3902a9ffe2e69a7ac42c19d7ea74cbdcea9b7fb#example
     (async () => {
      ~~~~~~~~~~~~~
-!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
       const response = await fetch(new URL("../hamsters.jpg", import.meta.url).toString());
                                                               ~~~~~~~~~~~
 !!! error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'esnext', or 'system'.

--- a/tests/baselines/reference/importMeta(module=es2020,target=es5).errors.txt
+++ b/tests/baselines/reference/importMeta(module=es2020,target=es5).errors.txt
@@ -2,7 +2,7 @@ error TS2468: Cannot find global value 'Promise'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(1,44): error TS2339: Property 'blah' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(1,63): error TS2339: Property 'blue' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(2,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
-tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
 tests/cases/conformance/es2019/importMeta/example.ts(6,28): error TS2339: Property 'scriptElement' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/moduleLookingFile01.ts(2,23): error TS17012: 'metal' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?
 tests/cases/conformance/es2019/importMeta/moduleLookingFile01.ts(3,23): error TS17012: 'import' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?
@@ -15,7 +15,7 @@ tests/cases/conformance/es2019/importMeta/scriptLookingFile01.ts(3,22): error TS
     // Adapted from https://github.com/tc39/proposal-import-meta/tree/c3902a9ffe2e69a7ac42c19d7ea74cbdcea9b7fb#example
     (async () => {
      ~~~~~~~~~~~~~
-!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
       const response = await fetch(new URL("../hamsters.jpg", import.meta.url).toString());
       const blob = await response.blob();
     

--- a/tests/baselines/reference/importMeta(module=es2020,target=esnext).errors.txt
+++ b/tests/baselines/reference/importMeta(module=es2020,target=esnext).errors.txt
@@ -2,7 +2,7 @@ error TS2468: Cannot find global value 'Promise'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(1,44): error TS2339: Property 'blah' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(1,63): error TS2339: Property 'blue' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(2,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
-tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
 tests/cases/conformance/es2019/importMeta/example.ts(6,28): error TS2339: Property 'scriptElement' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/moduleLookingFile01.ts(2,23): error TS17012: 'metal' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?
 tests/cases/conformance/es2019/importMeta/moduleLookingFile01.ts(3,23): error TS17012: 'import' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?
@@ -15,7 +15,7 @@ tests/cases/conformance/es2019/importMeta/scriptLookingFile01.ts(3,22): error TS
     // Adapted from https://github.com/tc39/proposal-import-meta/tree/c3902a9ffe2e69a7ac42c19d7ea74cbdcea9b7fb#example
     (async () => {
      ~~~~~~~~~~~~~
-!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
       const response = await fetch(new URL("../hamsters.jpg", import.meta.url).toString());
       const blob = await response.blob();
     

--- a/tests/baselines/reference/importMeta(module=esnext,target=es5).errors.txt
+++ b/tests/baselines/reference/importMeta(module=esnext,target=es5).errors.txt
@@ -2,7 +2,7 @@ error TS2468: Cannot find global value 'Promise'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(1,44): error TS2339: Property 'blah' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(1,63): error TS2339: Property 'blue' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(2,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
-tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
 tests/cases/conformance/es2019/importMeta/example.ts(6,28): error TS2339: Property 'scriptElement' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/moduleLookingFile01.ts(2,23): error TS17012: 'metal' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?
 tests/cases/conformance/es2019/importMeta/moduleLookingFile01.ts(3,23): error TS17012: 'import' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?
@@ -15,7 +15,7 @@ tests/cases/conformance/es2019/importMeta/scriptLookingFile01.ts(3,22): error TS
     // Adapted from https://github.com/tc39/proposal-import-meta/tree/c3902a9ffe2e69a7ac42c19d7ea74cbdcea9b7fb#example
     (async () => {
      ~~~~~~~~~~~~~
-!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
       const response = await fetch(new URL("../hamsters.jpg", import.meta.url).toString());
       const blob = await response.blob();
     

--- a/tests/baselines/reference/importMeta(module=esnext,target=esnext).errors.txt
+++ b/tests/baselines/reference/importMeta(module=esnext,target=esnext).errors.txt
@@ -2,7 +2,7 @@ error TS2468: Cannot find global value 'Promise'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(1,44): error TS2339: Property 'blah' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(1,63): error TS2339: Property 'blue' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(2,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
-tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
 tests/cases/conformance/es2019/importMeta/example.ts(6,28): error TS2339: Property 'scriptElement' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/moduleLookingFile01.ts(2,23): error TS17012: 'metal' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?
 tests/cases/conformance/es2019/importMeta/moduleLookingFile01.ts(3,23): error TS17012: 'import' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?
@@ -15,7 +15,7 @@ tests/cases/conformance/es2019/importMeta/scriptLookingFile01.ts(3,22): error TS
     // Adapted from https://github.com/tc39/proposal-import-meta/tree/c3902a9ffe2e69a7ac42c19d7ea74cbdcea9b7fb#example
     (async () => {
      ~~~~~~~~~~~~~
-!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
       const response = await fetch(new URL("../hamsters.jpg", import.meta.url).toString());
       const blob = await response.blob();
     

--- a/tests/baselines/reference/importMeta(module=system,target=es5).errors.txt
+++ b/tests/baselines/reference/importMeta(module=system,target=es5).errors.txt
@@ -2,7 +2,7 @@ error TS2468: Cannot find global value 'Promise'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(1,44): error TS2339: Property 'blah' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(1,63): error TS2339: Property 'blue' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(2,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
-tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
 tests/cases/conformance/es2019/importMeta/example.ts(6,28): error TS2339: Property 'scriptElement' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/moduleLookingFile01.ts(2,23): error TS17012: 'metal' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?
 tests/cases/conformance/es2019/importMeta/moduleLookingFile01.ts(3,23): error TS17012: 'import' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?
@@ -15,7 +15,7 @@ tests/cases/conformance/es2019/importMeta/scriptLookingFile01.ts(3,22): error TS
     // Adapted from https://github.com/tc39/proposal-import-meta/tree/c3902a9ffe2e69a7ac42c19d7ea74cbdcea9b7fb#example
     (async () => {
      ~~~~~~~~~~~~~
-!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
       const response = await fetch(new URL("../hamsters.jpg", import.meta.url).toString());
       const blob = await response.blob();
     

--- a/tests/baselines/reference/importMeta(module=system,target=esnext).errors.txt
+++ b/tests/baselines/reference/importMeta(module=system,target=esnext).errors.txt
@@ -2,7 +2,7 @@ error TS2468: Cannot find global value 'Promise'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(1,44): error TS2339: Property 'blah' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(1,63): error TS2339: Property 'blue' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/assignmentTargets.ts(2,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
-tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+tests/cases/conformance/es2019/importMeta/example.ts(2,2): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
 tests/cases/conformance/es2019/importMeta/example.ts(6,28): error TS2339: Property 'scriptElement' does not exist on type 'ImportMeta'.
 tests/cases/conformance/es2019/importMeta/moduleLookingFile01.ts(2,23): error TS17012: 'metal' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?
 tests/cases/conformance/es2019/importMeta/moduleLookingFile01.ts(3,23): error TS17012: 'import' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?
@@ -15,7 +15,7 @@ tests/cases/conformance/es2019/importMeta/scriptLookingFile01.ts(3,22): error TS
     // Adapted from https://github.com/tc39/proposal-import-meta/tree/c3902a9ffe2e69a7ac42c19d7ea74cbdcea9b7fb#example
     (async () => {
      ~~~~~~~~~~~~~
-!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
       const response = await fetch(new URL("../hamsters.jpg", import.meta.url).toString());
       const blob = await response.blob();
     

--- a/tests/baselines/reference/incrementalInvalid.errors.txt
+++ b/tests/baselines/reference/incrementalInvalid.errors.txt
@@ -1,7 +1,7 @@
-error TS5074: Option '--incremental' can only be specified using tsconfig, emitting to single file or when option `--tsBuildInfoFile` is specified.
+error TS5074: Option '--incremental' can only be specified using tsconfig, emitting to single file or when option '--tsBuildInfoFile' is specified.
 
 
-!!! error TS5074: Option '--incremental' can only be specified using tsconfig, emitting to single file or when option `--tsBuildInfoFile` is specified.
+!!! error TS5074: Option '--incremental' can only be specified using tsconfig, emitting to single file or when option '--tsBuildInfoFile' is specified.
 ==== tests/cases/compiler/incrementalInvalid.ts (0 errors) ====
     const x = 10;
     

--- a/tests/baselines/reference/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.errors.txt
+++ b/tests/baselines/reference/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.errors.txt
@@ -1,15 +1,15 @@
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(4,18): error TS2550: Property 'from' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(10,13): error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(4,18): error TS2550: Property 'from' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(10,13): error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(17,5): error TS2339: Property 'name' does not exist on type '() => void'.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(20,6): error TS2550: Property 'sign' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(25,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(29,18): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(20,6): error TS2550: Property 'sign' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(25,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(29,18): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(33,13): error TS2304: Cannot find name 'Proxy'.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(36,1): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(40,5): error TS2550: Property 'flags' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(44,5): error TS2550: Property 'includes' does not exist on type 'string'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(47,9): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(51,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(36,1): error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(40,5): error TS2550: Property 'flags' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(44,5): error TS2550: Property 'includes' does not exist on type 'string'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(47,9): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts(51,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.ts (12 errors) ====
@@ -18,7 +18,7 @@ tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.t
     function f(x: number, y: number, z: number) {
         return Array.from(arguments);
                      ~~~~
-!!! error TS2550: Property 'from' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'from' does not exist on type 'ArrayConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     }
     
     f(1, 2, 3);  // no error
@@ -26,7 +26,7 @@ tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.t
     // Using ES6 collection
     var m = new Map<string, number>();
                 ~~~
-!!! error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     m.clear();
     // Using ES6 iterable
     m.keys();
@@ -40,20 +40,20 @@ tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.t
     // Using ES6 math
     Math.sign(1);
          ~~~~
-!!! error TS2550: Property 'sign' does not exist on type 'Math'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'sign' does not exist on type 'Math'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     
     // Using ES6 object
     var o = {
         a: 2,
         [Symbol.hasInstance](value: any) {
          ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
             return false;
         }
     };
     o.hasOwnProperty(Symbol.hasInstance);
                      ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     
     // Using Es6 proxy
     var t = {}
@@ -64,30 +64,30 @@ tests/cases/compiler/modularizeLibrary_ErrorFromUsingES6FeaturesWithOnlyES5Lib.t
     // Using ES6 reflect
     Reflect.isExtensible({});
     ~~~~~~~
-!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Reflect'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     
     // Using Es6 regexp
     var reg = new RegExp("/s");
     reg.flags;
         ~~~~~
-!!! error TS2550: Property 'flags' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'flags' does not exist on type 'RegExp'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     
     // Using ES6 string
     var str = "Hello world";
     str.includes("hello", 0);
         ~~~~~~~~
-!!! error TS2550: Property 'includes' does not exist on type 'string'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2550: Property 'includes' does not exist on type 'string'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
     
     // Using ES6 symbol
     var s = Symbol();
             ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     
     // Using ES6 wellknown-symbol
     const o1 = {
         [Symbol.hasInstance](value: any) {
          ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
             return false;
         }
     }

--- a/tests/baselines/reference/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.errors.txt
+++ b/tests/baselines/reference/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.ts(7,1): error TS2322: Type 'boolean' is not assignable to type 'string'.
-tests/cases/compiler/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.ts(7,3): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/compiler/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.ts(7,3): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/compiler/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6WellknownSymbolLib.ts (2 errors) ====
@@ -13,4 +13,4 @@ tests/cases/compiler/modularizeLibrary_ErrorFromUsingWellknownSymbolWithOutES6We
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'string'.
       ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.

--- a/tests/baselines/reference/namedTupleMembersErrors.errors.txt
+++ b/tests/baselines/reference/namedTupleMembersErrors.errors.txt
@@ -5,8 +5,8 @@ tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(5,22): erro
 tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(7,32): error TS5084: Tuple members must all have names or all not have names.
 tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(8,22): error TS5084: Tuple members must all have names or all not have names.
 tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(10,29): error TS5086: A labeled tuple element is declared as optional with a question mark after the name and before the colon, rather than after the type.
-tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(12,46): error TS5087: A labeled tuple element is declared as rest with a `...` before the name, rather than before the type.
-tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(14,49): error TS5087: A labeled tuple element is declared as rest with a `...` before the name, rather than before the type.
+tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(12,46): error TS5087: A labeled tuple element is declared as rest with a '...' before the name, rather than before the type.
+tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(14,49): error TS5087: A labeled tuple element is declared as rest with a '...' before the name, rather than before the type.
 tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(14,52): error TS8020: JSDoc types can only be used inside documentation comments.
 tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(16,39): error TS5085: A tuple member cannot be both optional and rest.
 tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(18,44): error TS2574: A rest element type must be an array type.
@@ -42,11 +42,11 @@ tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts(21,13): err
     
     export type Trailing = [first: string, rest: ...string[]]; // dots on element disallowed
                                                  ~~~~~~~~~~~
-!!! error TS5087: A labeled tuple element is declared as rest with a `...` before the name, rather than before the type.
+!!! error TS5087: A labeled tuple element is declared as rest with a '...' before the name, rather than before the type.
     
     export type OptTrailing = [first: string, rest: ...string[]?]; // dots+question on element disallowed
                                                     ~~~~~~~~~~~~
-!!! error TS5087: A labeled tuple element is declared as rest with a `...` before the name, rather than before the type.
+!!! error TS5087: A labeled tuple element is declared as rest with a '...' before the name, rather than before the type.
                                                        ~~~~~~~~~
 !!! error TS8020: JSDoc types can only be used inside documentation comments.
     

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.errors.txt
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.errors.txt
@@ -1,5 +1,5 @@
 error TS2468: Cannot find global value 'Promise'.
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(1,16): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(1,16): error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
 tests/cases/compiler/operationsAvailableOnPromisedType.ts(11,9): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
 tests/cases/compiler/operationsAvailableOnPromisedType.ts(12,5): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
 tests/cases/compiler/operationsAvailableOnPromisedType.ts(13,5): error TS2365: Operator '+' cannot be applied to types 'number' and 'Promise<number>'.
@@ -27,7 +27,7 @@ tests/cases/compiler/operationsAvailableOnPromisedType.ts(27,5): error TS2349: T
 ==== tests/cases/compiler/operationsAvailableOnPromisedType.ts (17 errors) ====
     async function fn(
                    ~~
-!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your `--lib` option.
+!!! error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.
         a: number,
         b: Promise<number>,
         c: Promise<string[]>,

--- a/tests/baselines/reference/parserES5SymbolProperty1.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty1.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty1.ts(2,5): error TS1169: A computed property name in an interface must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty1.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty1.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty1.ts (2 errors) ====
@@ -8,5 +8,5 @@ tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty1.ts(2
         ~~~~~~~~~~~~~~~~~
 !!! error TS1169: A computed property name in an interface must refer to an expression whose type is a literal type or a 'unique symbol' type.
          ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty2.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty2.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty2.ts(2,5): error TS1169: A computed property name in an interface must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty2.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty2.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty2.ts (2 errors) ====
@@ -8,5 +8,5 @@ tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty2.ts(2
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS1169: A computed property name in an interface must refer to an expression whose type is a literal type or a 'unique symbol' type.
          ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty3.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty3.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty3.ts(2,5): error TS1165: A computed property name in an ambient context must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty3.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty3.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty3.ts (2 errors) ====
@@ -8,5 +8,5 @@ tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty3.ts(2
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS1165: A computed property name in an ambient context must refer to an expression whose type is a literal type or a 'unique symbol' type.
          ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty4.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty4.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty4.ts(2,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty4.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty4.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty4.ts (2 errors) ====
@@ -8,5 +8,5 @@ tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty4.ts(2
         ~~~~~~~~~~~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty5.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty5.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty5.ts(2,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty5.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty5.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty5.ts (2 errors) ====
@@ -8,5 +8,5 @@ tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty5.ts(2
         ~~~~~~~~~~~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty6.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty6.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty6.ts(2,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty6.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty6.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty6.ts (2 errors) ====
@@ -8,5 +8,5 @@ tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty6.ts(2
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
          ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty7.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty7.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty7.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty7.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty7.ts (1 errors) ====
     class C {
         [Symbol.toStringTag](): void { }
          ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty8.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty8.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty8.ts(2,5): error TS1170: A computed property name in a type literal must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty8.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty8.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty8.ts (2 errors) ====
@@ -8,5 +8,5 @@ tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty8.ts(2
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS1170: A computed property name in a type literal must refer to an expression whose type is a literal type or a 'unique symbol' type.
          ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     }

--- a/tests/baselines/reference/parserES5SymbolProperty9.errors.txt
+++ b/tests/baselines/reference/parserES5SymbolProperty9.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty9.ts(2,5): error TS1170: A computed property name in a type literal must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty9.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty9.ts(2,6): error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty9.ts (2 errors) ====
@@ -8,5 +8,5 @@ tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty9.ts(2
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS1170: A computed property name in a type literal must refer to an expression whose type is a literal type or a 'unique symbol' type.
          ~~~~~~
-!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
+!!! error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.
     }

--- a/tests/baselines/reference/parserMissingLambdaOpenBrace1.errors.txt
+++ b/tests/baselines/reference/parserMissingLambdaOpenBrace1.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpenBrace1.ts(2,19): error TS2583: Cannot find name 'Iterator'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpenBrace1.ts(2,19): error TS2583: Cannot find name 'Iterator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpenBrace1.ts(2,28): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpenBrace1.ts(2,42): error TS2304: Cannot find name 'Query'.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpenBrace1.ts(2,48): error TS2304: Cannot find name 'T'.
@@ -11,7 +11,7 @@ tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpen
     class C {
         where(filter: Iterator<T, boolean>): Query<T> {
                       ~~~~~~~~
-!!! error TS2583: Cannot find name 'Iterator'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+!!! error TS2583: Cannot find name 'Iterator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
                                ~
 !!! error TS2304: Cannot find name 'T'.
                                              ~~~~~

--- a/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-contains-only-itself-if-a-module-file's-shape-didn't-change,-and-all-files-referencing-it-if-its-shape-changed.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-for-configured-projects/should-contains-only-itself-if-a-module-file's-shape-didn't-change,-and-all-files-referencing-it-if-its-shape-changed.js
@@ -198,7 +198,7 @@ Output::
 >> Screen clear
 [[90m12:00:52 AM[0m] File change detected. Starting incremental compilation...
 
-[96ma/b/moduleFile1.ts[0m:[93m1[0m:[93m46[0m - [91merror[0m[90m TS2584: [0mCannot find name 'console'. Do you need to change your target library? Try changing the `lib` compiler option to include 'dom'.
+[96ma/b/moduleFile1.ts[0m:[93m1[0m:[93m46[0m - [91merror[0m[90m TS2584: [0mCannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.
 
 [7m1[0m export var T: number;export function Foo() { console.log('hi'); };
 [7m [0m [91m                                             ~~~~~~~[0m

--- a/tests/baselines/reference/tscWatch/programUpdates/correctly-handles-changes-in-lib-section-of-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/correctly-handles-changes-in-lib-section-of-config-file.js
@@ -28,7 +28,7 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-[96msrc/app.ts[0m:[93m1[0m:[93m8[0m - [91merror[0m[90m TS2583: [0mCannot find name 'Promise'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2015' or later.
+[96msrc/app.ts[0m:[93m1[0m:[93m8[0m - [91merror[0m[90m TS2583: [0mCannot find name 'Promise'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.
 
 [7m1[0m var x: Promise<string>;
 [7m [0m [91m       ~~~~~~~[0m

--- a/tests/baselines/reference/tscWatch/programUpdates/create-watch-without-config-file.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/create-watch-without-config-file.js
@@ -32,7 +32,7 @@ Output::
 [7m2[0m                 import {f} from "./module"
 [7m [0m [91m                        ~[0m
 
-[96ma/b/c/app.ts[0m:[93m3[0m:[93m17[0m - [91merror[0m[90m TS2584: [0mCannot find name 'console'. Do you need to change your target library? Try changing the `lib` compiler option to include 'dom'.
+[96ma/b/c/app.ts[0m:[93m3[0m:[93m17[0m - [91merror[0m[90m TS2584: [0mCannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.
 
 [7m3[0m                 console.log(f)
 [7m [0m [91m                ~~~~~~~[0m

--- a/tests/baselines/reference/typingsSuggestion1.errors.txt
+++ b/tests/baselines/reference/typingsSuggestion1.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/typings/a.ts(1,1): error TS2591: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add `node` to the types field in your tsconfig.
+tests/cases/conformance/typings/a.ts(1,1): error TS2591: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
 
 
 ==== tests/cases/conformance/typings/tsconfig.json (0 errors) ====
@@ -7,5 +7,5 @@ tests/cases/conformance/typings/a.ts(1,1): error TS2591: Cannot find name 'modul
 ==== tests/cases/conformance/typings/a.ts (1 errors) ====
     module.exports = 1;
     ~~~~~~
-!!! error TS2591: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add `node` to the types field in your tsconfig.
+!!! error TS2591: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
     

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny_typesForPackageExist.errors.txt
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny_typesForPackageExist.errors.txt
@@ -1,9 +1,9 @@
 /a.ts(2,25): error TS7016: Could not find a declaration file for module 'foo/sub'. '/node_modules/foo/sub.js' implicitly has an 'any' type.
-  If the 'foo' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/foo`
+  If the 'foo' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/foo'
 /a.ts(3,25): error TS7016: Could not find a declaration file for module 'bar/sub'. '/node_modules/bar/sub.js' implicitly has an 'any' type.
   Try `npm i --save-dev @types/bar` if it exists or add a new declaration (.d.ts) file containing `declare module 'bar/sub';`
 /a.ts(5,30): error TS7016: Could not find a declaration file for module '@scope/foo/sub'. '/node_modules/@scope/foo/sub.js' implicitly has an 'any' type.
-  If the '@scope/foo' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/scope__foo`
+  If the '@scope/foo' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/scope__foo'
 /a.ts(6,30): error TS7016: Could not find a declaration file for module '@scope/bar/sub'. '/node_modules/@scope/bar/sub.js' implicitly has an 'any' type.
   Try `npm i --save-dev @types/scope__bar` if it exists or add a new declaration (.d.ts) file containing `declare module '@scope/bar/sub';`
 
@@ -13,7 +13,7 @@
     import * as fooSub from "foo/sub";
                             ~~~~~~~~~
 !!! error TS7016: Could not find a declaration file for module 'foo/sub'. '/node_modules/foo/sub.js' implicitly has an 'any' type.
-!!! error TS7016:   If the 'foo' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/foo`
+!!! error TS7016:   If the 'foo' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/foo'
     import * as barSub from "bar/sub";
                             ~~~~~~~~~
 !!! error TS7016: Could not find a declaration file for module 'bar/sub'. '/node_modules/bar/sub.js' implicitly has an 'any' type.
@@ -22,7 +22,7 @@
     import * as scopeFooSub from "@scope/foo/sub";
                                  ~~~~~~~~~~~~~~~~
 !!! error TS7016: Could not find a declaration file for module '@scope/foo/sub'. '/node_modules/@scope/foo/sub.js' implicitly has an 'any' type.
-!!! error TS7016:   If the '@scope/foo' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/scope__foo`
+!!! error TS7016:   If the '@scope/foo' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/scope__foo'
     import * as scopeBarSub from "@scope/bar/sub";
                                  ~~~~~~~~~~~~~~~~
 !!! error TS7016: Could not find a declaration file for module '@scope/bar/sub'. '/node_modules/@scope/bar/sub.js' implicitly has an 'any' type.

--- a/tests/baselines/reference/useObjectValuesAndEntries2.errors.txt
+++ b/tests/baselines/reference/useObjectValuesAndEntries2.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts(3,22): error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts(7,22): error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts(3,22): error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
+tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts(7,22): error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
 
 
 ==== tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts (2 errors) ====
@@ -7,10 +7,10 @@ tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts(7,22): error TS2550
     
     for (var x of Object.values(o)) {
                          ~~~~~~
-!!! error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
         let y = x;
     }
     
     var entries = Object.entries(o);
                          ~~~~~~~
-!!! error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.

--- a/tests/baselines/reference/useObjectValuesAndEntries3.errors.txt
+++ b/tests/baselines/reference/useObjectValuesAndEntries3.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts(3,22): error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
-tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts(7,22): error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts(3,22): error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
+tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts(7,22): error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
 
 
 ==== tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts (2 errors) ====
@@ -7,10 +7,10 @@ tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts(7,22): error TS2550
     
     for (var x of Object.values(o)) {
                          ~~~~~~
-!!! error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'values' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
         let y = x;
     }
     
     var entries = Object.entries(o);
                          ~~~~~~~
-!!! error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.

--- a/tests/baselines/reference/useSharedArrayBuffer2.errors.txt
+++ b/tests/baselines/reference/useSharedArrayBuffer2.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/es2017/useSharedArrayBuffer2.ts(1,16): error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+tests/cases/conformance/es2017/useSharedArrayBuffer2.ts(1,16): error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
 
 
 ==== tests/cases/conformance/es2017/useSharedArrayBuffer2.ts (1 errors) ====
     var foge = new SharedArrayBuffer(1024);
                    ~~~~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
     var bar = foge.slice(1, 10);
     var len = foge.byteLength;

--- a/tests/baselines/reference/useSharedArrayBuffer3.errors.txt
+++ b/tests/baselines/reference/useSharedArrayBuffer3.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/es2017/useSharedArrayBuffer3.ts(1,16): error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+tests/cases/conformance/es2017/useSharedArrayBuffer3.ts(1,16): error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
 
 
 ==== tests/cases/conformance/es2017/useSharedArrayBuffer3.ts (1 errors) ====
     var foge = new SharedArrayBuffer(1024);
                    ~~~~~~~~~~~~~~~~~
-!!! error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2017' or later.
+!!! error TS2583: Cannot find name 'SharedArrayBuffer'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2017' or later.
     var bar = foge.slice(1, 10);
     var len = foge.byteLength;

--- a/tests/cases/fourslash/jsDocAugmentsAndExtends.ts
+++ b/tests/cases/fourslash/jsDocAugmentsAndExtends.ts
@@ -26,6 +26,6 @@
 goTo.marker();
 verify.quickInfoIs("(local var) x: number");
 verify.getSemanticDiagnostics([{
-    message: "Class declarations cannot have more than one \`@augments\` or \`@extends\` tag.",
+    message: "Class declarations cannot have more than one '@augments' or '@extends' tag.",
     code: 8025
 }]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] There is an associated issue in the `Backlog` milestone (**required**)
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `gulp runtests` locally
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #43503 - replacing instances of backticks with single quotes where appropriate.