### PR TITLE
Fix getCodeFixesAtPosition for ts(2339) thows error False expression: Token end is child end

### DIFF
--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -276,11 +276,11 @@ namespace ts.codefix {
             const binaryExpression = token.parent.parent as BinaryExpression;
             const otherExpression = token.parent === binaryExpression.left ? binaryExpression.right : binaryExpression.left;
             const widenedType = checker.getWidenedType(checker.getBaseTypeOfLiteralType(checker.getTypeAtLocation(otherExpression)));
-            typeNode = checker.typeToTypeNode(widenedType, classDeclaration, /*flags*/ undefined);
+            typeNode = checker.typeToTypeNode(widenedType, classDeclaration, NodeBuilderFlags.NoTruncation);
         }
         else {
             const contextualType = checker.getContextualType(token.parent as Expression);
-            typeNode = contextualType ? checker.typeToTypeNode(contextualType, /*enclosingDeclaration*/ undefined, /*flags*/ undefined) : undefined;
+            typeNode = contextualType ? checker.typeToTypeNode(contextualType, /*enclosingDeclaration*/ undefined, NodeBuilderFlags.NoTruncation) : undefined;
         }
         return typeNode || factory.createKeywordTypeNode(SyntaxKind.AnyKeyword);
     }

--- a/tests/cases/fourslash/codeFixAddMissingMember20.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember20.ts
@@ -1,0 +1,64 @@
+/// <reference path='fourslash.ts' />
+
+////class C {
+////    method() {
+////        const {
+////            many01,
+////            many02,
+////            many03,
+////            many04,
+////            many05,
+////            many06,
+////            many07,
+////            many08,
+////            many09,
+////            many10,
+////            many11,
+////            many12,
+////            many13,
+////            many14,
+////            many15,
+////            many16,
+////            many17,
+////            many18,
+////            many19,
+////            many20,
+////            many21,
+////            many22
+////        } = this.foo;
+////    }
+////}
+
+verify.codeFix({
+    description: "Declare property 'foo'",
+    index: 0,
+    newFileContent: `class C {
+    foo: { many01: any; many02: any; many03: any; many04: any; many05: any; many06: any; many07: any; many08: any; many09: any; many10: any; many11: any; many12: any; many13: any; many14: any; many15: any; many16: any; many17: any; many18: any; many19: any; many20: any; many21: any; many22: any; };
+    method() {
+        const {
+            many01,
+            many02,
+            many03,
+            many04,
+            many05,
+            many06,
+            many07,
+            many08,
+            many09,
+            many10,
+            many11,
+            many12,
+            many13,
+            many14,
+            many15,
+            many16,
+            many17,
+            many18,
+            many19,
+            many20,
+            many21,
+            many22
+        } = this.foo;
+    }
+}`
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #43191
