### PR TITLE
Complete `constructor` keyword after property declaration

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2370,8 +2370,10 @@ namespace ts.Completions {
                     return isPropertyDeclaration(contextToken.parent);
             }
 
-            // If `constructor` is totally not present, but we request a completion manually at a space...
-            if (contextToken === previousToken && isPreviousPropertyDeclarationTerminated(contextToken, position)) {
+            // If we are inside a class declaration, and `constructor` is totally not present,
+            // but we request a completion manually at a whitespace...
+            const ancestorClassLike = findAncestor(contextToken.parent, isClassLike);
+            if (ancestorClassLike && contextToken === previousToken && isPreviousPropertyDeclarationTerminated(contextToken, position)) {
                 return false; // Don't block completions.
             }
 
@@ -2862,7 +2864,9 @@ namespace ts.Completions {
 
         if (!contextToken) return undefined;
 
+        // class C { blah; constructor/**/ } and so on
         if (location.kind === SyntaxKind.ConstructorKeyword
+            // class C { blah \n constructor/**/ }
             || (isIdentifier(contextToken) && isPropertyDeclaration(contextToken.parent) && isClassLike(location))) {
             return findAncestor(contextToken, isClassLike) as ObjectTypeDeclaration;
         }

--- a/tests/cases/fourslash/completionConstructorKeywordAfterPropertyDeclaration.ts
+++ b/tests/cases/fourslash/completionConstructorKeywordAfterPropertyDeclaration.ts
@@ -1,6 +1,6 @@
 /// <reference path="fourslash.ts" />
 
-//// // *** situations that `constructor` is partly present ***
+//// // situations that `constructor` is partly present
 //// class A {
 ////   blah; con/*1*/
 //// }
@@ -26,49 +26,78 @@
 //// class G {
 ////   blah = 123; con/*7*/
 //// }
-//// // *** situations that `constructor` is fully present ***
+//// // situations that `constructor` is fully present
 //// class H {
 ////   blah
-////   constructor/*8*/(props) {}
+////   constructor/*8*/
 //// }
 //// class I {
 ////   blah;
-////   constructor/*9*/(props) {}
+////   constructor/*9*/
 //// }
 //// class J {
 ////   blah: number
-////   constructor/*10*/(props) {}
+////   constructor/*10*/
 //// }
 //// class K {
 ////   blah: number;
-////   constructor/*11*/(props) {}
+////   constructor/*11*/
 //// }
 //// class L {
 ////   blah = 123
-////   constructor/*12*/(props) {}
+////   constructor/*12*/
 //// }
 //// class M {
 ////   blah = 123;
-////   constructor/*13*/(props) {}
+////   constructor/*13*/
 //// }
 //// class N {
 ////   blah = [123]
-////   constructor/*14*/(props) {}
+////   constructor/*14*/
 //// }
 //// class O {
 ////   blah = {key: 1}
-////   constructor/*15*/(props) {}
+////   constructor/*15*/
 //// }
 //// function return1() {
 ////   return 1
 //// }
 //// class P {
 ////   blah = return1()
-////   constructor/*16*/(props) {}
+////   constructor/*16*/
+//// }
+//// // situations that `constructor` isn't present
+//// class Q {
+////   blah; /*17*/ 
+//// }
+//// class R {
+////   blah
+////   /*18*/ // dont complete since `blah \n = 123` is legal
+//// }
+//// class R {
+////   blah /*19*/ 
+//// }
+//// // situations that `constructor` should not be suggested
+//// class S {
+////   blah con/*20*/
+//// }
+//// class T {
+////   blah: number con/*21*/
 //// }
 
+const positiveCaseCount = 17; // 1~17
+const negativeCaseCount = 4; // 18~21
+const positiveCases = Array.from(Array(positiveCaseCount), (_, i) => String(i + 1));
+const negativeCases = Array.from(Array(negativeCaseCount), (_, i) => String(i + 1 + positiveCaseCount));
+
 verify.completions({
-  marker: Array.from(Array(16), (_, i) => String(i + 1)),
+  marker: positiveCases,
   includes: { name: "constructor", sortText: completion.SortText.GlobalsOrKeywords },
+  isNewIdentifierLocation: true,
+});
+
+verify.completions({
+  marker: negativeCases,
+  exact: [],
   isNewIdentifierLocation: true,
 });

--- a/tests/cases/fourslash/completionConstructorKeywordAfterPropertyDeclaration.ts
+++ b/tests/cases/fourslash/completionConstructorKeywordAfterPropertyDeclaration.ts
@@ -1,24 +1,74 @@
 /// <reference path="fourslash.ts" />
 
-////class A {
-////  bla
-////  constructor/*1*/(props) {}
-////}
-////class B {
-////  bla;
-////  constructor/*2*/(props) {}
-////}
-////class C {
-////  bla: number
-////  constructor/*3*/(props) {}
-////}
-////class D {
-////  bla: number;
-////  constructor/*4*/(props) {}
-////}
+//// // *** situations that `constructor` is partly present ***
+//// class A {
+////   blah; con/*1*/
+//// }
+//// class B {
+////   blah
+////   con/*2*/
+//// }
+//// class C {
+////   blah;
+////   con/*3*/
+//// }
+//// class D {
+////   blah: number
+////   con/*4*/
+//// }
+//// class E {
+////   blah: number; con/*5*/
+//// }
+//// class F {
+////   blah = 123
+////   con/*6*/
+//// }
+//// class G {
+////   blah = 123; con/*7*/
+//// }
+//// // *** situations that `constructor` is fully present ***
+//// class H {
+////   blah
+////   constructor/*8*/(props) {}
+//// }
+//// class I {
+////   blah;
+////   constructor/*9*/(props) {}
+//// }
+//// class J {
+////   blah: number
+////   constructor/*10*/(props) {}
+//// }
+//// class K {
+////   blah: number;
+////   constructor/*11*/(props) {}
+//// }
+//// class L {
+////   blah = 123
+////   constructor/*12*/(props) {}
+//// }
+//// class M {
+////   blah = 123;
+////   constructor/*13*/(props) {}
+//// }
+//// class N {
+////   blah = [123]
+////   constructor/*14*/(props) {}
+//// }
+//// class O {
+////   blah = {key: 1}
+////   constructor/*15*/(props) {}
+//// }
+//// function return1() {
+////   return 1
+//// }
+//// class P {
+////   blah = return1()
+////   constructor/*16*/(props) {}
+//// }
 
 verify.completions({
-  marker: [1, 2, 3, 4].map(String),
+  marker: Array.from(Array(16), (_, i) => String(i + 1)),
   includes: { name: "constructor", sortText: completion.SortText.GlobalsOrKeywords },
   isNewIdentifierLocation: true,
 });

--- a/tests/cases/fourslash/completionConstructorKeywordAfterPropertyDeclaration.ts
+++ b/tests/cases/fourslash/completionConstructorKeywordAfterPropertyDeclaration.ts
@@ -1,6 +1,5 @@
 /// <reference path="fourslash.ts" />
 
-//// const GlobalWhat = 123
 //// // situations that `constructor` is partly present
 //// class A {
 ////   blah; con/*1*/
@@ -10,85 +9,76 @@
 ////   con/*2*/
 //// }
 //// class C {
-////   blah;
+////   blah: number
 ////   con/*3*/
 //// }
 //// class D {
-////   blah: number
+////   blah = 123
 ////   con/*4*/
 //// }
 //// class E {
-////   blah: number; con/*5*/
+////   blah = [123]
+////   con/*5*/
 //// }
 //// class F {
-////   blah = 123
+////   blah = {key: 123}
 ////   con/*6*/
 //// }
-//// class G {
-////   blah = 123; con/*7*/
-//// }
 //// // situations that `constructor` is fully present
+//// class G {
+////   blah; constructor/*7*/
+//// }
 //// class H {
 ////   blah
 ////   constructor/*8*/
 //// }
 //// class I {
-////   blah;
+////   blah: number
 ////   constructor/*9*/
 //// }
 //// class J {
-////   blah: number
+////   blah = 123
 ////   constructor/*10*/
 //// }
 //// class K {
-////   blah: number;
+////   blah = [123]
 ////   constructor/*11*/
 //// }
 //// class L {
-////   blah = 123
+////   blah = {key: 123}
 ////   constructor/*12*/
 //// }
+//// // situations that `constructor` isn't present, but we should offer it
 //// class M {
-////   blah = 123;
-////   constructor/*13*/
+////   blah; /*13*/ 
 //// }
 //// class N {
-////   blah = [123]
-////   constructor/*14*/
-//// }
-//// class O {
-////   blah = {key: 1}
-////   constructor/*15*/
-//// }
-//// function return1() {
-////   return 1
-//// }
-//// class P {
-////   blah = return1()
-////   constructor/*16*/
-//// }
-//// // situations that `constructor` isn't present
-//// class Q {
-////   blah; /*17*/ 
-//// }
-//// class R {
 ////   blah
-////   /*18*/
+////   /*14*/
 //// }
 //// // situations that `constructor` should not be suggested
+//// class O {
+////   blah /*15*/ 
+//// }
+//// class P {
+////   blah con/*16*/
+//// }
+//// class Q {
+////   blah: number con/*17*/
+//// }
 //// class R {
-////   blah /*19*/ 
+////   blah = 123 con/*18*/
 //// }
 //// class S {
-////   blah con/*20*/
+////   blah = {key: 123} con/*19*/
 //// }
-//// // situations that `constructor` should not be suggested but 
+//// type SomeType = number
 //// class T {
-////   blah: number con/*21*/
+////   blah: SomeType con/*20*/
 //// }
 //// const SomeValue = 123
 //// class U {
-////   blah = SomeValue con/*22*/  
+////   blah = SomeValue con/*21*/
 //// }
 
 function generateRange(l: number, r: number) {
@@ -96,13 +86,13 @@ function generateRange(l: number, r: number) {
 }
 
 verify.completions({
-  marker: generateRange(1, 18),
+  marker: generateRange(1, 14),
   includes: { name: "constructor", sortText: completion.SortText.GlobalsOrKeywords },
   isNewIdentifierLocation: true,
 });
 
 verify.completions({
-  marker: generateRange(19, 20),
+  marker: generateRange(15, 21),
   exact: [],
   isNewIdentifierLocation: true,
 });

--- a/tests/cases/fourslash/completionConstructorKeywordAfterPropertyDeclaration.ts
+++ b/tests/cases/fourslash/completionConstructorKeywordAfterPropertyDeclaration.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts" />
 
+//// const GlobalWhat = 123
 //// // situations that `constructor` is partly present
 //// class A {
 ////   blah; con/*1*/
@@ -72,32 +73,36 @@
 //// }
 //// class R {
 ////   blah
-////   /*18*/ // dont complete since `blah \n = 123` is legal
+////   /*18*/
 //// }
+//// // situations that `constructor` should not be suggested
 //// class R {
 ////   blah /*19*/ 
 //// }
-//// // situations that `constructor` should not be suggested
 //// class S {
 ////   blah con/*20*/
 //// }
+//// // situations that `constructor` should not be suggested but 
 //// class T {
 ////   blah: number con/*21*/
 //// }
+//// const SomeValue = 123
+//// class U {
+////   blah = SomeValue con/*22*/  
+//// }
 
-const positiveCaseCount = 17; // 1~17
-const negativeCaseCount = 4; // 18~21
-const positiveCases = Array.from(Array(positiveCaseCount), (_, i) => String(i + 1));
-const negativeCases = Array.from(Array(negativeCaseCount), (_, i) => String(i + 1 + positiveCaseCount));
+function generateRange(l: number, r: number) {
+  return Array.from(Array(r - l + 1), (_, i) => String(i + l)); // [l, r]
+}
 
 verify.completions({
-  marker: positiveCases,
+  marker: generateRange(1, 18),
   includes: { name: "constructor", sortText: completion.SortText.GlobalsOrKeywords },
   isNewIdentifierLocation: true,
 });
 
 verify.completions({
-  marker: negativeCases,
+  marker: generateRange(19, 20),
   exact: [],
   isNewIdentifierLocation: true,
 });

--- a/tests/cases/fourslash/completionConstructorKeywordAfterPropertyDeclaration.ts
+++ b/tests/cases/fourslash/completionConstructorKeywordAfterPropertyDeclaration.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts" />
+
+////class A {
+////  bla
+////  constructor/*1*/(props) {}
+////}
+////class B {
+////  bla;
+////  constructor/*2*/(props) {}
+////}
+////class C {
+////  bla: number
+////  constructor/*3*/(props) {}
+////}
+////class D {
+////  bla: number;
+////  constructor/*4*/(props) {}
+////}
+
+verify.completions({
+  marker: [1, 2, 3, 4].map(String),
+  includes: { name: "constructor", sortText: completion.SortText.GlobalsOrKeywords },
+  isNewIdentifierLocation: true,
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #43650
and more.

This is my first pull-request here. Help and suggestions are appreciated.

All these various situations are fixed, expanding the case in original issue:

- implicit any property, property with type, property with initializer...
- literal initializer, object initializer, array initializer, identifier initializer, function execution initializer...
- fully present `constructor`, partly present `constructor`, no presence...
- different semicolon styles...
- w/ or w/o semicolon or newline...
- and so on.

Please refer to the test case for detail:

`tests/cases/fourslash/completionConstructorKeywordAfterPropertyDeclaration.ts`