### PR TITLE
Enforce keyword order between override and static/async

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40471,6 +40471,9 @@ namespace ts {
                         else if (flags & ModifierFlags.Readonly) {
                             return grammarErrorOnNode(modifier, Diagnostics._0_modifier_must_precede_1_modifier, "override", "readonly");
                         }
+                        else if (flags & ModifierFlags.Async) {
+                            return grammarErrorOnNode(modifier, Diagnostics._0_modifier_must_precede_1_modifier, "override", "async");
+                        }
                         if (node.kind === SyntaxKind.Parameter) {
                             return grammarErrorOnNode(modifier, Diagnostics._0_modifier_cannot_appear_on_a_parameter, "override");
                         }
@@ -40533,6 +40536,9 @@ namespace ts {
                         }
                         else if (flags & ModifierFlags.Abstract) {
                             return grammarErrorOnNode(modifier, Diagnostics._0_modifier_cannot_be_used_with_1_modifier, "static", "abstract");
+                        }
+                        else if (flags & ModifierFlags.Override) {
+                            return grammarErrorOnNode(modifier, Diagnostics._0_modifier_must_precede_1_modifier, "static", "override");
                         }
                         flags |= ModifierFlags.Static;
                         lastStatic = modifier;

--- a/tests/baselines/reference/override5.errors.txt
+++ b/tests/baselines/reference/override5.errors.txt
@@ -32,7 +32,7 @@ tests/cases/conformance/override/override5.ts(45,23): error TS4112: This member 
     
         override readonly p4: number;
     
-        override static sp: number;
+        static override sp: number;
                         ~~
 !!! error TS4113: This member cannot have an 'override' modifier because it is not declared in the base class 'B'.
     

--- a/tests/baselines/reference/override5.js
+++ b/tests/baselines/reference/override5.js
@@ -18,7 +18,7 @@ class D extends B{
 
     override readonly p4: number;
 
-    override static sp: number;
+    static override sp: number;
 
     override override oop: number;
 

--- a/tests/baselines/reference/override5.symbols
+++ b/tests/baselines/reference/override5.symbols
@@ -40,7 +40,7 @@ class D extends B{
     override readonly p4: number;
 >p4 : Symbol(D.p4, Decl(override5.ts, 15, 33))
 
-    override static sp: number;
+    static override sp: number;
 >sp : Symbol(D.sp, Decl(override5.ts, 17, 33))
 
     override override oop: number;

--- a/tests/baselines/reference/override5.types
+++ b/tests/baselines/reference/override5.types
@@ -44,7 +44,7 @@ class D extends B{
     override readonly p4: number;
 >p4 : number
 
-    override static sp: number;
+    static override sp: number;
 >sp : number
 
     override override oop: number;

--- a/tests/baselines/reference/override7.errors.txt
+++ b/tests/baselines/reference/override7.errors.txt
@@ -32,7 +32,7 @@ tests/cases/conformance/override/override7.ts(42,23): error TS4112: This member 
     
         override readonly p4: number;
     
-        override static sp: number;
+        static override sp: number;
                         ~~
 !!! error TS4113: This member cannot have an 'override' modifier because it is not declared in the base class 'B'.
     

--- a/tests/baselines/reference/override7.js
+++ b/tests/baselines/reference/override7.js
@@ -15,7 +15,7 @@ class D extends B{
 
     override readonly p4: number;
 
-    override static sp: number;
+    static override sp: number;
 
     override override oop: number;
 

--- a/tests/baselines/reference/override7.symbols
+++ b/tests/baselines/reference/override7.symbols
@@ -31,7 +31,7 @@ class D extends B{
     override readonly p4: number;
 >p4 : Symbol(D.p4, Decl(override7.ts, 12, 33))
 
-    override static sp: number;
+    static override sp: number;
 >sp : Symbol(D.sp, Decl(override7.ts, 14, 33))
 
     override override oop: number;

--- a/tests/baselines/reference/override7.types
+++ b/tests/baselines/reference/override7.types
@@ -35,7 +35,7 @@ class D extends B{
     override readonly p4: number;
 >p4 : number
 
-    override static sp: number;
+    static override sp: number;
 >sp : number
 
     override override oop: number;

--- a/tests/baselines/reference/overrideKeywordOrder.errors.txt
+++ b/tests/baselines/reference/overrideKeywordOrder.errors.txt
@@ -1,0 +1,41 @@
+tests/cases/conformance/override/overrideKeywordOrder.ts(12,9): error TS1029: 'override' modifier must precede 'async' modifier.
+tests/cases/conformance/override/overrideKeywordOrder.ts(15,12): error TS1029: 'static' modifier must precede 'override' modifier.
+tests/cases/conformance/override/overrideKeywordOrder.ts(19,12): error TS1029: 'public' modifier must precede 'override' modifier.
+tests/cases/conformance/override/overrideKeywordOrder.ts(24,12): error TS1029: 'override' modifier must precede 'readonly' modifier.
+
+
+==== tests/cases/conformance/override/overrideKeywordOrder.ts (4 errors) ====
+    class Base {
+      static s1() {}
+      static s2() {}
+      m1() {}
+      m2() {}
+      p1: any;
+      p2: any;
+    }
+    
+    class Test1 extends Base {
+      override async m1() {}
+      async override m2() {} // error
+            ~~~~~~~~
+!!! error TS1029: 'override' modifier must precede 'async' modifier.
+    }
+    class Test2 extends Base {
+      override static s1() {} // error
+               ~~~~~~
+!!! error TS1029: 'static' modifier must precede 'override' modifier.
+      static override s2() {}
+    }
+    class Test3 extends Base {
+      override public m1() {} // error
+               ~~~~~~
+!!! error TS1029: 'public' modifier must precede 'override' modifier.
+      public override m2() {}
+    }
+    class Test4 extends Base {
+      override readonly p1: any;
+      readonly override p2: any; // error
+               ~~~~~~~~
+!!! error TS1029: 'override' modifier must precede 'readonly' modifier.
+    }
+    

--- a/tests/cases/conformance/override/override5.ts
+++ b/tests/cases/conformance/override/override5.ts
@@ -19,7 +19,7 @@ class D extends B{
 
     override readonly p4: number;
 
-    override static sp: number;
+    static override sp: number;
 
     override override oop: number;
 

--- a/tests/cases/conformance/override/override7.ts
+++ b/tests/cases/conformance/override/override7.ts
@@ -16,7 +16,7 @@ class D extends B{
 
     override readonly p4: number;
 
-    override static sp: number;
+    static override sp: number;
 
     override override oop: number;
 

--- a/tests/cases/conformance/override/overrideKeywordOrder.ts
+++ b/tests/cases/conformance/override/overrideKeywordOrder.ts
@@ -1,0 +1,28 @@
+// @noTypesAndSymbols: true
+// @noEmit: true
+
+class Base {
+  static s1() {}
+  static s2() {}
+  m1() {}
+  m2() {}
+  p1: any;
+  p2: any;
+}
+
+class Test1 extends Base {
+  override async m1() {}
+  async override m2() {} // error
+}
+class Test2 extends Base {
+  override static s1() {} // error
+  static override s2() {}
+}
+class Test3 extends Base {
+  override public m1() {} // error
+  public override m2() {}
+}
+class Test4 extends Base {
+  override readonly p1: any;
+  readonly override p2: any; // error
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

The order is `static override async`.

Fixes #43606 
