### PR TITLE
Skip up-to-date checks during force build

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -5041,6 +5041,10 @@
         "code": 6387,
         "reportsDeprecated": true
     },
+    "Project '{0}' is being forcibly rebuilt": {
+        "category": "Message",
+        "code": 6388
+    },
 
     "The expected type comes from property '{0}' which is declared here on type '{1}'": {
         "category": "Message",

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -1514,19 +1514,17 @@ namespace ts {
             if (extendedConfigStatus) return extendedConfigStatus;
         }
 
-        if (!state.buildInfoChecked.has(resolvedPath)) {
+        if (!force && !state.buildInfoChecked.has(resolvedPath)) {
             state.buildInfoChecked.set(resolvedPath, true);
-            if (!force) {
-                const buildInfoPath = getTsBuildInfoEmitOutputFilePath(project.options);
-                if (buildInfoPath) {
-                    const value = state.readFileWithCache(buildInfoPath);
-                    const buildInfo = value && getBuildInfo(value);
-                    if (buildInfo && (buildInfo.bundle || buildInfo.program) && buildInfo.version !== version) {
-                        return {
-                            type: UpToDateStatusType.TsVersionOutputOfDate,
-                            version: buildInfo.version
-                        };
-                    }
+            const buildInfoPath = getTsBuildInfoEmitOutputFilePath(project.options);
+            if (buildInfoPath) {
+                const value = state.readFileWithCache(buildInfoPath);
+                const buildInfo = value && getBuildInfo(value);
+                if (buildInfo && (buildInfo.bundle || buildInfo.program) && buildInfo.version !== version) {
+                    return {
+                        type: UpToDateStatusType.TsVersionOutputOfDate,
+                        version: buildInfo.version
+                    };
                 }
             }
         }

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -1464,7 +1464,8 @@ namespace ts {
                 }
 
                 // Check oldest output file name only if there is no missing output file name
-                if (!missingOutputFileName) {
+                // (a check we will have skipped if this is a forced build)
+                if (!force && !missingOutputFileName) {
                     // If the upstream project's newest file is older than our oldest output, we
                     // can't be out of date because of it
                     if (refStatus.newestInputFileTime && refStatus.newestInputFileTime <= oldestOutputFileTime) {

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -2012,6 +2012,14 @@ namespace ts {
     }
 
     function reportUpToDateStatus(state: SolutionBuilderState, configFileName: string, status: UpToDateStatus) {
+        if (state.options.force && (status.type === UpToDateStatusType.UpToDate || status.type === UpToDateStatusType.UpToDateWithUpstreamTypes)) {
+            return reportStatus(
+                state,
+                Diagnostics.Project_0_is_being_forcibly_rebuilt,
+                relName(state, configFileName)
+            );
+        }
+
         switch (status.type) {
             case UpToDateStatusType.OutOfDateWithSelf:
                 return reportStatus(
@@ -2107,7 +2115,7 @@ namespace ts {
      * Report the up-to-date status of a project if we're in verbose mode
      */
     function verboseReportProjectStatus(state: SolutionBuilderState, configFileName: string, status: UpToDateStatus) {
-        if (state.options.verbose && !state.options.force) {
+        if (state.options.verbose) {
             reportUpToDateStatus(state, configFileName, status);
         }
     }

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/rebuilds-from-start-if-force-option-is-set.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/rebuilds-from-start-if-force-option-is-set.js
@@ -8,15 +8,9 @@ Output::
     * src/logic/tsconfig.json
     * src/tests/tsconfig.json
 
-[[90m12:16:00 AM[0m] Project 'src/core/tsconfig.json' is up to date because newest input 'src/core/anotherModule.ts' is older than oldest output 'src/core/anotherModule.js'
-
 [[90m12:16:00 AM[0m] Building project '/src/core/tsconfig.json'...
 
-[[90m12:16:00 AM[0m] Project 'src/logic/tsconfig.json' is up to date with .d.ts files from its dependencies
-
 [[90m12:16:00 AM[0m] Building project '/src/logic/tsconfig.json'...
-
-[[90m12:16:00 AM[0m] Project 'src/tests/tsconfig.json' is up to date with .d.ts files from its dependencies
 
 [[90m12:16:00 AM[0m] Building project '/src/tests/tsconfig.json'...
 

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/rebuilds-from-start-if-force-option-is-set.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/rebuilds-from-start-if-force-option-is-set.js
@@ -8,9 +8,15 @@ Output::
     * src/logic/tsconfig.json
     * src/tests/tsconfig.json
 
+[[90m12:16:00 AM[0m] Project 'src/core/tsconfig.json' is being forcibly rebuilt
+
 [[90m12:16:00 AM[0m] Building project '/src/core/tsconfig.json'...
 
+[[90m12:16:00 AM[0m] Project 'src/logic/tsconfig.json' is being forcibly rebuilt
+
 [[90m12:16:00 AM[0m] Building project '/src/logic/tsconfig.json'...
+
+[[90m12:16:00 AM[0m] Project 'src/tests/tsconfig.json' is being forcibly rebuilt
 
 [[90m12:16:00 AM[0m] Building project '/src/tests/tsconfig.json'...
 


### PR DESCRIPTION
Save work by not checking timestamps or parsing the buildinfo file.
Retain correctness checks (like input file existence).

Suppress project status, which was confusing anyway.