### PR TITLE
Better types for UrlSearchParams

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -16105,7 +16105,11 @@ interface URLSearchParams {
 
 declare var URLSearchParams: {
     prototype: URLSearchParams;
-    new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
+    new(init?: 
+        | string
+        | URLSearchParams
+        | Record<string | number, string | number | boolean | string[] | number[] | boolean[]>
+        | [string | number | boolean, string | number | boolean | string[] | number[] | boolean[]][]): URLSearchParams;
     toString(): string;
 };
 

--- a/lib/lib.webworker.d.ts
+++ b/lib/lib.webworker.d.ts
@@ -3315,7 +3315,11 @@ interface URLSearchParams {
 
 declare var URLSearchParams: {
     prototype: URLSearchParams;
-    new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
+    new(init?:         
+        | string
+        | URLSearchParams
+        | Record<string | number, string | number | boolean | string[] | number[] | boolean[]>
+        | [string | number | boolean, string | number | boolean | string[] | number[] | boolean[]][]): URLSearchParams;
     toString(): string;
 };
 


### PR DESCRIPTION
Fixes: The actual types of UrlSearchParams are more restrictive than the runtime itself.
