### PR TITLE
Stop checking getter/setter compatability twice

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33299,7 +33299,8 @@ namespace ts {
                     const symbol = getSymbolOfNode(node);
                     const getter = getDeclarationOfKind<AccessorDeclaration>(symbol, SyntaxKind.GetAccessor);
                     const setter = getDeclarationOfKind<AccessorDeclaration>(symbol, SyntaxKind.SetAccessor);
-                    if (getter && setter) {
+                    if (getter && setter && !(getNodeCheckFlags(getter) & NodeCheckFlags.TypeChecked)) {
+                        getNodeLinks(getter).flags |= NodeCheckFlags.TypeChecked;
                         const getterFlags = getEffectiveModifierFlags(getter);
                         const setterFlags = getEffectiveModifierFlags(setter);
                         if ((getterFlags & ModifierFlags.Abstract) !== (setterFlags & ModifierFlags.Abstract)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33304,11 +33304,13 @@ namespace ts {
                         const getterFlags = getEffectiveModifierFlags(getter);
                         const setterFlags = getEffectiveModifierFlags(setter);
                         if ((getterFlags & ModifierFlags.Abstract) !== (setterFlags & ModifierFlags.Abstract)) {
-                            error(node.name, Diagnostics.Accessors_must_both_be_abstract_or_non_abstract);
+                            error(getter.name, Diagnostics.Accessors_must_both_be_abstract_or_non_abstract);
+                            error(setter.name, Diagnostics.Accessors_must_both_be_abstract_or_non_abstract);
                         }
                         if (((getterFlags & ModifierFlags.Protected) && !(setterFlags & (ModifierFlags.Protected | ModifierFlags.Private))) ||
                             ((getterFlags & ModifierFlags.Private) && !(setterFlags & ModifierFlags.Private))) {
-                            error(node.name, Diagnostics.A_get_accessor_must_be_at_least_as_accessible_as_the_setter);
+                            error(getter.name, Diagnostics.A_get_accessor_must_be_at_least_as_accessible_as_the_setter);
+                            error(setter.name, Diagnostics.A_get_accessor_must_be_at_least_as_accessible_as_the_setter);
                         }
 
                         const getterType = getAnnotatedAccessorType(getter);

--- a/tests/baselines/reference/getAndSetNotIdenticalType2.errors.txt
+++ b/tests/baselines/reference/getAndSetNotIdenticalType2.errors.txt
@@ -1,6 +1,5 @@
 tests/cases/compiler/getAndSetNotIdenticalType2.ts(5,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/getAndSetNotIdenticalType2.ts(5,9): error TS2380: The return type of a 'get' accessor must be assignable to its 'set' accessor type
-tests/cases/compiler/getAndSetNotIdenticalType2.ts(5,9): error TS2380: The return type of a 'get' accessor must be assignable to its 'set' accessor type
   Type 'T' is not assignable to type 'string'.
 tests/cases/compiler/getAndSetNotIdenticalType2.ts(8,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/getAndSetNotIdenticalType2.ts(9,9): error TS2322: Type 'A<string>' is not assignable to type 'A<T>'.
@@ -10,7 +9,7 @@ tests/cases/compiler/getAndSetNotIdenticalType2.ts(15,1): error TS2322: Type 'A<
   Type 'unknown' is not assignable to type 'string'.
 
 
-==== tests/cases/compiler/getAndSetNotIdenticalType2.ts (6 errors) ====
+==== tests/cases/compiler/getAndSetNotIdenticalType2.ts (5 errors) ====
     class A<T> { foo: T; }
     
     class C<T> {
@@ -18,8 +17,6 @@ tests/cases/compiler/getAndSetNotIdenticalType2.ts(15,1): error TS2322: Type 'A<
         get x(): A<T> {
             ~
 !!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-            ~
-!!! error TS2380: The return type of a 'get' accessor must be assignable to its 'set' accessor type
             ~
 !!! error TS2380: The return type of a 'get' accessor must be assignable to its 'set' accessor type
 !!! error TS2380:   Type 'T' is not assignable to type 'string'.

--- a/tests/baselines/reference/getAndSetNotIdenticalType3.errors.txt
+++ b/tests/baselines/reference/getAndSetNotIdenticalType3.errors.txt
@@ -1,6 +1,5 @@
 tests/cases/compiler/getAndSetNotIdenticalType3.ts(5,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/getAndSetNotIdenticalType3.ts(5,9): error TS2380: The return type of a 'get' accessor must be assignable to its 'set' accessor type
-tests/cases/compiler/getAndSetNotIdenticalType3.ts(5,9): error TS2380: The return type of a 'get' accessor must be assignable to its 'set' accessor type
   Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/getAndSetNotIdenticalType3.ts(8,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/getAndSetNotIdenticalType3.ts(9,9): error TS2322: Type 'A<string>' is not assignable to type 'A<number>'.
@@ -8,7 +7,7 @@ tests/cases/compiler/getAndSetNotIdenticalType3.ts(9,9): error TS2322: Type 'A<s
 tests/cases/compiler/getAndSetNotIdenticalType3.ts(15,1): error TS2322: Type 'A<number>' is not assignable to type 'A<string>'.
 
 
-==== tests/cases/compiler/getAndSetNotIdenticalType3.ts (6 errors) ====
+==== tests/cases/compiler/getAndSetNotIdenticalType3.ts (5 errors) ====
     class A<T> { foo: T; }
     
     class C<T> {
@@ -16,8 +15,6 @@ tests/cases/compiler/getAndSetNotIdenticalType3.ts(15,1): error TS2322: Type 'A<
         get x(): A<number> {
             ~
 !!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-            ~
-!!! error TS2380: The return type of a 'get' accessor must be assignable to its 'set' accessor type
             ~
 !!! error TS2380: The return type of a 'get' accessor must be assignable to its 'set' accessor type
 !!! error TS2380:   Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/getterErrorMessageNotDuplicated.errors.txt
+++ b/tests/baselines/reference/getterErrorMessageNotDuplicated.errors.txt
@@ -1,0 +1,22 @@
+tests/cases/compiler/getterErrorMessageNotDuplicated.ts(2,9): error TS2380: The return type of a 'get' accessor must be assignable to its 'set' accessor type
+  Property 'extra' is missing in type 'Foo' but required in type 'Bar'.
+
+
+==== tests/cases/compiler/getterErrorMessageNotDuplicated.ts (1 errors) ====
+    interface Thing {
+        get style(): Foo;
+            ~~~~~
+!!! error TS2380: The return type of a 'get' accessor must be assignable to its 'set' accessor type
+!!! error TS2380:   Property 'extra' is missing in type 'Foo' but required in type 'Bar'.
+!!! related TS2728 tests/cases/compiler/getterErrorMessageNotDuplicated.ts:12:5: 'extra' is declared here.
+        set style(cssText: string | Bar);
+    }
+    
+    interface Foo {
+        hello: string;
+        world: number;
+    }
+    
+    interface Bar extends Foo {
+        extra: any;
+    }

--- a/tests/baselines/reference/getterErrorMessageNotDuplicated.js
+++ b/tests/baselines/reference/getterErrorMessageNotDuplicated.js
@@ -1,0 +1,16 @@
+//// [getterErrorMessageNotDuplicated.ts]
+interface Thing {
+    get style(): Foo;
+    set style(cssText: string | Bar);
+}
+
+interface Foo {
+    hello: string;
+    world: number;
+}
+
+interface Bar extends Foo {
+    extra: any;
+}
+
+//// [getterErrorMessageNotDuplicated.js]

--- a/tests/baselines/reference/getterErrorMessageNotDuplicated.symbols
+++ b/tests/baselines/reference/getterErrorMessageNotDuplicated.symbols
@@ -1,0 +1,31 @@
+=== tests/cases/compiler/getterErrorMessageNotDuplicated.ts ===
+interface Thing {
+>Thing : Symbol(Thing, Decl(getterErrorMessageNotDuplicated.ts, 0, 0))
+
+    get style(): Foo;
+>style : Symbol(Thing.style, Decl(getterErrorMessageNotDuplicated.ts, 0, 17), Decl(getterErrorMessageNotDuplicated.ts, 1, 21))
+>Foo : Symbol(Foo, Decl(getterErrorMessageNotDuplicated.ts, 3, 1))
+
+    set style(cssText: string | Bar);
+>style : Symbol(Thing.style, Decl(getterErrorMessageNotDuplicated.ts, 0, 17), Decl(getterErrorMessageNotDuplicated.ts, 1, 21))
+>cssText : Symbol(cssText, Decl(getterErrorMessageNotDuplicated.ts, 2, 14))
+>Bar : Symbol(Bar, Decl(getterErrorMessageNotDuplicated.ts, 8, 1))
+}
+
+interface Foo {
+>Foo : Symbol(Foo, Decl(getterErrorMessageNotDuplicated.ts, 3, 1))
+
+    hello: string;
+>hello : Symbol(Foo.hello, Decl(getterErrorMessageNotDuplicated.ts, 5, 15))
+
+    world: number;
+>world : Symbol(Foo.world, Decl(getterErrorMessageNotDuplicated.ts, 6, 18))
+}
+
+interface Bar extends Foo {
+>Bar : Symbol(Bar, Decl(getterErrorMessageNotDuplicated.ts, 8, 1))
+>Foo : Symbol(Foo, Decl(getterErrorMessageNotDuplicated.ts, 3, 1))
+
+    extra: any;
+>extra : Symbol(Bar.extra, Decl(getterErrorMessageNotDuplicated.ts, 10, 27))
+}

--- a/tests/baselines/reference/getterErrorMessageNotDuplicated.types
+++ b/tests/baselines/reference/getterErrorMessageNotDuplicated.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/getterErrorMessageNotDuplicated.ts ===
+interface Thing {
+    get style(): Foo;
+>style : Foo
+
+    set style(cssText: string | Bar);
+>style : Foo
+>cssText : string | Bar
+}
+
+interface Foo {
+    hello: string;
+>hello : string
+
+    world: number;
+>world : number
+}
+
+interface Bar extends Foo {
+    extra: any;
+>extra : any
+}

--- a/tests/cases/compiler/getterErrorMessageNotDuplicated.ts
+++ b/tests/cases/compiler/getterErrorMessageNotDuplicated.ts
@@ -1,0 +1,13 @@
+interface Thing {
+    get style(): Foo;
+    set style(cssText: string | Bar);
+}
+
+interface Foo {
+    hello: string;
+    world: number;
+}
+
+interface Bar extends Foo {
+    extra: any;
+}


### PR DESCRIPTION
The code checking compatibility was invoked twice - one when the getter was checked, and once for the setter. This resulted in the errors being duplicated - normally we dedupe them, so wouldn't notice, but in this case, relation caching makes us issue two different error messages, so they don't get deduplicated.

Fixes #43665
