### PR TITLE
Fix completions of exports elsewhere in same file

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -38832,7 +38832,7 @@ namespace ts {
                             if (!isExternalModule(<SourceFile>location)) break;
                             // falls through
                         case SyntaxKind.ModuleDeclaration:
-                            copyExportedSymbols(getSymbolOfNode(location as ModuleDeclaration | SourceFile).exports!, meaning & SymbolFlags.ModuleMember);
+                            copyLocallyVisibleExportSymbols(getSymbolOfNode(location as ModuleDeclaration | SourceFile).exports!, meaning & SymbolFlags.ModuleMember);
                             break;
                         case SyntaxKind.EnumDeclaration:
                             copySymbols(getSymbolOfNode(location as EnumDeclaration).exports!, meaning & SymbolFlags.EnumMember);
@@ -38902,7 +38902,7 @@ namespace ts {
                 }
             }
 
-            function copyExportedSymbols(source: SymbolTable, meaning: SymbolFlags): void {
+            function copyLocallyVisibleExportSymbols(source: SymbolTable, meaning: SymbolFlags): void {
                 if (meaning) {
                     source.forEach(symbol => {
                         // Similar condition as in `resolveNameHelper`

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25106,9 +25106,8 @@ namespace ts {
         }
 
         function getContextualTypeForThisPropertyAssignment(binaryExpression: BinaryExpression, kind: AssignmentDeclarationKind): Type | undefined {
-            if (kind === AssignmentDeclarationKind.ModuleExports) return undefined;
-            if (!binaryExpression.symbol) return getTypeOfExpression(binaryExpression.left);
-            if (binaryExpression.symbol.valueDeclaration) {
+            if (!binaryExpression.symbol && kind !== AssignmentDeclarationKind.ModuleExports) return getTypeOfExpression(binaryExpression.left);
+            if (binaryExpression.symbol?.valueDeclaration) {
                 const annotated = getEffectiveTypeAnnotationNode(binaryExpression.symbol.valueDeclaration);
                 if (annotated) {
                     const type = getTypeFromTypeNode(annotated);
@@ -25117,6 +25116,7 @@ namespace ts {
                     }
                 }
             }
+            if (kind === AssignmentDeclarationKind.ModuleExports) return undefined;
             const thisAccess = cast(binaryExpression.left, isAccessExpression);
             if (!isObjectLiteralMethod(getThisContainer(thisAccess.expression, /*includeArrowFunctions*/ false))) {
                 return undefined;

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2992,7 +2992,8 @@ namespace ts.Completions {
         if (type) {
             return type;
         }
-        if (isBinaryExpression(node.parent) && node.parent.operatorToken.kind === SyntaxKind.EqualsToken) {
+        if (isBinaryExpression(node.parent) && node.parent.operatorToken.kind === SyntaxKind.EqualsToken && node === node.parent.left) {
+            // Object literal is assignment pattern: ({ | } = x)
             return typeChecker.getTypeAtLocation(node.parent);
         }
         return undefined;

--- a/tests/cases/fourslash/completionsExternalModuleRenamedExports.ts
+++ b/tests/cases/fourslash/completionsExternalModuleRenamedExports.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: other.ts
+//// export {};
+
+// @Filename: index.ts
+//// const c = 0;
+//// export { c as yeahThisIsTotallyInScopeHuh };
+//// export * as alsoNotInScope from "./other";
+//// 
+//// /**/
+
+verify.completions({
+  marker: "",
+  includes: "c",
+  excludes: ["yeahThisIsTotallyInScopeHuh", "alsoNotInScope"],
+});

--- a/tests/cases/fourslash/completionsObjectLiteralModuleExports.ts
+++ b/tests/cases/fourslash/completionsObjectLiteralModuleExports.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: index.js
+//// const almanac = 0;
+//// module.exports = {
+////   a/**/
+//// };
+
+verify.completions({
+  marker: "",
+  isNewIdentifierLocation: true,
+  includes: "almanac",
+  excludes: "a",
+});

--- a/tests/cases/fourslash/completionsSpecialAssignmentNotContextuallyTyped.ts
+++ b/tests/cases/fourslash/completionsSpecialAssignmentNotContextuallyTyped.ts
@@ -33,6 +33,7 @@
 [1, 2, 3, 4, 5, 6].forEach(marker => {
   verify.completions({
     marker: `${marker}`,
-    excludes: "a"
+    excludes: "a",
+    isNewIdentifierLocation: true,
   });
 });

--- a/tests/cases/fourslash/completionsSpecialAssignmentNotContextuallyTyped.ts
+++ b/tests/cases/fourslash/completionsSpecialAssignmentNotContextuallyTyped.ts
@@ -1,0 +1,38 @@
+/// <reference path="fourslash.ts" />
+
+// @checkJs: true
+// @allowJs: true
+
+// @Filename: index.js
+//// module.exports = {
+////   a/*1*/
+//// }
+//// 
+//// exports.foo = {
+////   a/*2*/
+//// }
+//// 
+//// function F() {
+////   this.blah = {
+////       a/*3*/
+////   };
+//// }
+//// 
+//// F.foo = {
+////   a/*4*/
+//// }
+//// 
+//// F.prototype = {
+////   a/*5*/
+//// }
+//// 
+//// F.prototype.x = {
+////   a/*6*/
+//// }
+
+[1, 2, 3, 4, 5, 6].forEach(marker => {
+  verify.completions({
+    marker: `${marker}`,
+    excludes: "a"
+  });
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #43289, along with another bug I found on the way:

```ts
module.exports = { a/**/ } // has a completion for itself
```

and

```ts
const c = 0;
export { c as something };
export * as somethingElse from "./other";

s/**/ // has completions for 'something' and 'somethingElse'
```