### PR TITLE
Compute dervied generic-ness for substitutions and create lower priority inferences for substitutes

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5201,7 +5201,7 @@ namespace ts {
         /* @internal */
         IsClassInstanceClone = 1 << 24, // Type is a clone of a class instance type
 
-        // Flags that require TypeFlags.UnionOrIntersection
+        // Flags that require TypeFlags.UnionOrIntersection or TypeFlags.Substitution
         /* @internal */
         IsGenericObjectTypeComputed = 1 << 22, // IsGenericObjectType flag has been computed
         /* @internal */
@@ -5553,6 +5553,7 @@ namespace ts {
     // Thus, if Foo has a 'string' constraint on its type parameter, T will satisfy it. Substitution
     // types disappear upon instantiation (just like type parameters).
     export interface SubstitutionType extends InstantiableType {
+        objectFlags: ObjectFlags;
         baseType: Type;     // Target type
         substitute: Type;   // Type to substitute for type parameter
     }
@@ -5663,15 +5664,16 @@ namespace ts {
     export const enum InferencePriority {
         NakedTypeVariable            = 1 << 0,  // Naked type variable in union or intersection type
         SpeculativeTuple             = 1 << 1,  // Speculative tuple inference
-        HomomorphicMappedType        = 1 << 2,  // Reverse inference for homomorphic mapped type
-        PartialHomomorphicMappedType = 1 << 3,  // Partial reverse inference for homomorphic mapped type
-        MappedTypeConstraint         = 1 << 4,  // Reverse inference for mapped type
-        ContravariantConditional     = 1 << 5,  // Conditional type in contravariant position
-        ReturnType                   = 1 << 6,  // Inference made from return type of generic function
-        LiteralKeyof                 = 1 << 7,  // Inference made from a string literal to a keyof T
-        NoConstraints                = 1 << 8,  // Don't infer from constraints of instantiable types
-        AlwaysStrict                 = 1 << 9,  // Always use strict rules for contravariant inferences
-        MaxValue                     = 1 << 10, // Seed for inference priority tracking
+        SubstituteSource             = 1 << 2,  // Source of inference originated within a substitution type's substitute
+        HomomorphicMappedType        = 1 << 3,  // Reverse inference for homomorphic mapped type
+        PartialHomomorphicMappedType = 1 << 4,  // Partial reverse inference for homomorphic mapped type
+        MappedTypeConstraint         = 1 << 5,  // Reverse inference for mapped type
+        ContravariantConditional     = 1 << 6,  // Conditional type in contravariant position
+        ReturnType                   = 1 << 7,  // Inference made from return type of generic function
+        LiteralKeyof                 = 1 << 8,  // Inference made from a string literal to a keyof T
+        NoConstraints                = 1 << 9,  // Don't infer from constraints of instantiable types
+        AlwaysStrict                 = 1 << 10,  // Always use strict rules for contravariant inferences
+        MaxValue                     = 1 << 11, // Seed for inference priority tracking
 
         PriorityImpliesCombination = ReturnType | MappedTypeConstraint | LiteralKeyof,  // These priorities imply that the resulting type should be a combination of all candidates
         Circularity = -1,  // Inference circularity (value less than all other priorities)

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2681,6 +2681,7 @@ declare namespace ts {
         type: Type;
     }
     export interface SubstitutionType extends InstantiableType {
+        objectFlags: ObjectFlags;
         baseType: Type;
         substitute: Type;
     }
@@ -2705,16 +2706,17 @@ declare namespace ts {
     export enum InferencePriority {
         NakedTypeVariable = 1,
         SpeculativeTuple = 2,
-        HomomorphicMappedType = 4,
-        PartialHomomorphicMappedType = 8,
-        MappedTypeConstraint = 16,
-        ContravariantConditional = 32,
-        ReturnType = 64,
-        LiteralKeyof = 128,
-        NoConstraints = 256,
-        AlwaysStrict = 512,
-        MaxValue = 1024,
-        PriorityImpliesCombination = 208,
+        SubstituteSource = 4,
+        HomomorphicMappedType = 8,
+        PartialHomomorphicMappedType = 16,
+        MappedTypeConstraint = 32,
+        ContravariantConditional = 64,
+        ReturnType = 128,
+        LiteralKeyof = 256,
+        NoConstraints = 512,
+        AlwaysStrict = 1024,
+        MaxValue = 2048,
+        PriorityImpliesCombination = 416,
         Circularity = -1
     }
     /** @deprecated Use FileExtensionInfo instead. */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2681,6 +2681,7 @@ declare namespace ts {
         type: Type;
     }
     export interface SubstitutionType extends InstantiableType {
+        objectFlags: ObjectFlags;
         baseType: Type;
         substitute: Type;
     }
@@ -2705,16 +2706,17 @@ declare namespace ts {
     export enum InferencePriority {
         NakedTypeVariable = 1,
         SpeculativeTuple = 2,
-        HomomorphicMappedType = 4,
-        PartialHomomorphicMappedType = 8,
-        MappedTypeConstraint = 16,
-        ContravariantConditional = 32,
-        ReturnType = 64,
-        LiteralKeyof = 128,
-        NoConstraints = 256,
-        AlwaysStrict = 512,
-        MaxValue = 1024,
-        PriorityImpliesCombination = 208,
+        SubstituteSource = 4,
+        HomomorphicMappedType = 8,
+        PartialHomomorphicMappedType = 16,
+        MappedTypeConstraint = 32,
+        ContravariantConditional = 64,
+        ReturnType = 128,
+        LiteralKeyof = 256,
+        NoConstraints = 512,
+        AlwaysStrict = 1024,
+        MaxValue = 2048,
+        PriorityImpliesCombination = 416,
         Circularity = -1
     }
     /** @deprecated Use FileExtensionInfo instead. */

--- a/tests/baselines/reference/nongenericConditionalNotPartiallyComputed.js
+++ b/tests/baselines/reference/nongenericConditionalNotPartiallyComputed.js
@@ -1,0 +1,6 @@
+//// [nongenericConditionalNotPartiallyComputed.ts]
+// Expected: type A = number
+// Got: type A = number[] extends (infer T)[] ? T : never
+type A = Array<number> extends Array<any> ? Array<number> extends Array<infer T> ? T : never : never
+
+//// [nongenericConditionalNotPartiallyComputed.js]

--- a/tests/baselines/reference/nongenericConditionalNotPartiallyComputed.symbols
+++ b/tests/baselines/reference/nongenericConditionalNotPartiallyComputed.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/nongenericConditionalNotPartiallyComputed.ts ===
+// Expected: type A = number
+// Got: type A = number[] extends (infer T)[] ? T : never
+type A = Array<number> extends Array<any> ? Array<number> extends Array<infer T> ? T : never : never
+>A : Symbol(A, Decl(nongenericConditionalNotPartiallyComputed.ts, 0, 0))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(nongenericConditionalNotPartiallyComputed.ts, 2, 77))
+>T : Symbol(T, Decl(nongenericConditionalNotPartiallyComputed.ts, 2, 77))
+

--- a/tests/baselines/reference/nongenericConditionalNotPartiallyComputed.types
+++ b/tests/baselines/reference/nongenericConditionalNotPartiallyComputed.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/nongenericConditionalNotPartiallyComputed.ts ===
+// Expected: type A = number
+// Got: type A = number[] extends (infer T)[] ? T : never
+type A = Array<number> extends Array<any> ? Array<number> extends Array<infer T> ? T : never : never
+>A : number
+

--- a/tests/cases/compiler/nongenericConditionalNotPartiallyComputed.ts
+++ b/tests/cases/compiler/nongenericConditionalNotPartiallyComputed.ts
@@ -1,0 +1,3 @@
+// Expected: type A = number
+// Got: type A = number[] extends (infer T)[] ? T : never
+type A = Array<number> extends Array<any> ? Array<number> extends Array<infer T> ? T : never : never


### PR DESCRIPTION
Fixes #43591

We're been making non-generic substitutions for quite awhile now, but haven't handled them appropriately in `isGenericObjectType` or `isGenericIndexType` (they behave as though they're generic, hence the unexecuted conditional in the linked issue). With that in place, the linked issue further makes it obvious that these substitutions can create unwanted inference results - `Array<number> extends Array<infer T>` should clearly infer `number` for `T`, but naively does not in this context, because `Array<number>` actually substitutes to `Array<number> & Array<any>`, which in turn taints the result. By making an inference from the base type of the substitute _first_, and then a lower priority inference from the full substitute, we can preferentially pull the result from the original, un-substituted type where possible (thus allowing the result from the linked issue to be the expected `number`).