### PR TITLE
Adjust Omit's 2nd param to allow autocompletion of 1st param's keys

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1493,7 +1493,7 @@ type Extract<T, U> = T extends U ? T : never;
 /**
  * Construct a type with the properties of T except for those in type K.
  */
-type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 /**
  * Exclude null and undefined from T


### PR DESCRIPTION
Consider this code example when using `Omit`:

```ts
type Person = { 
  firstName: string; 
  lastName: string;
}
type X = Omit<Person, 'lastName'>;
```

Before, no autocompletion would happen when typing out `'lastName'` and after this PR it does autocomplete the keys from `Person`.

Have a nice day! 👋 