### PR TITLE
Improve parser recovery for unclosed/mismatched JSX elements

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5001,7 +5001,13 @@ namespace ts {
                 const child = parseJsxChild(openingTag, currentToken = scanner.reScanJsxToken());
                 if (!child) break;
                 list.push(child);
-                if (isJsxOpeningElement(openingTag) && child?.kind === SyntaxKind.JsxElement && !tagNamesAreEquivalent(child.openingElement.tagName, child.closingElement.tagName) && tagNamesAreEquivalent(openingTag.tagName, child.closingElement.tagName)) break;
+                if (isJsxOpeningElement(openingTag)
+                    && child?.kind === SyntaxKind.JsxElement
+                    && !tagNamesAreEquivalent(child.openingElement.tagName, child.closingElement.tagName)
+                    && tagNamesAreEquivalent(openingTag.tagName, child.closingElement.tagName)) {
+                    // stop after parsing a mismatched child like <div>...(<span></div>) in order to reattach the </div> higher
+                    break;
+                }
             }
 
             parsingContext = saveParsingContext;

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -3171,7 +3171,7 @@ namespace FourSlash {
             for (const markerName in map) {
                 this.goToMarker(markerName);
                 const actual = this.languageService.getJsxClosingTagAtPosition(this.activeFile.fileName, this.currentCaretPosition);
-                assert.deepEqual(actual, map[markerName]);
+                assert.deepEqual(actual, map[markerName], markerName);
             }
         }
 

--- a/tests/baselines/reference/jsFileCompilationTypeArgumentSyntaxOfCall.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationTypeArgumentSyntaxOfCall.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/a.jsx(1,13): error TS1109: Expression expected.
 tests/cases/compiler/a.jsx(4,1): error TS2657: JSX expressions must have one parent element.
 tests/cases/compiler/a.jsx(4,5): error TS1003: Identifier expected.
 tests/cases/compiler/a.jsx(4,13): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
-tests/cases/compiler/a.jsx(4,14): error TS17002: Expected corresponding JSX closing tag for 'number'.
+tests/cases/compiler/a.jsx(4,16): error TS17002: Expected corresponding JSX closing tag for 'number'.
 tests/cases/compiler/a.jsx(5,1): error TS2657: JSX expressions must have one parent element.
 tests/cases/compiler/a.jsx(5,5): error TS1003: Identifier expected.
 tests/cases/compiler/a.jsx(5,6): error TS17008: JSX element 'number' has no corresponding closing tag.
@@ -23,7 +23,7 @@ tests/cases/compiler/a.jsx(6,1): error TS1005: '</' expected.
 !!! error TS1003: Identifier expected.
                 ~
 !!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
-                 ~~~~~~
+                   ~~~
 !!! error TS17002: Expected corresponding JSX closing tag for 'number'.
     <Foo<number>/>;
     ~~~~~~~~~~~~~~~

--- a/tests/baselines/reference/jsxAndTypeAssertion.js
+++ b/tests/baselines/reference/jsxAndTypeAssertion.js
@@ -34,7 +34,7 @@ x = <any><any></any>;
  
 x = <foo>hello {<foo>} </foo>};
 
-x = <foo test={<foo>}>hello</foo>}/>
+x = <foo test={<foo>}>hello</foo>}/>;
 
 x = <foo test={<foo>}>hello{<foo>}</foo>};
 

--- a/tests/baselines/reference/jsxAndTypeAssertion.types
+++ b/tests/baselines/reference/jsxAndTypeAssertion.types
@@ -33,7 +33,7 @@ x = <foo>hello {<foo>{}} </foo>;
 >foo : typeof foo
 
 x = <foo test={<foo>{}}>hello</foo>;
-><foo test={<foo>{}}>hello</foo>; : any
+><foo test={<foo>{}}>hello</foo> : any
 >foo : typeof foo
 >test : any
 ><foo>{}}>hello</foo> : any

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
@@ -8,7 +8,7 @@ tests/cases/conformance/jsx/10.tsx(1,13): error TS1005: '>' expected.
 tests/cases/conformance/jsx/10.tsx(1,14): error TS2304: Cannot find name 'c'.
 tests/cases/conformance/jsx/10.tsx(1,16): error TS1109: Expression expected.
 tests/cases/conformance/jsx/11.tsx(1,2): error TS2304: Cannot find name 'a'.
-tests/cases/conformance/jsx/11.tsx(1,8): error TS17002: Expected corresponding JSX closing tag for 'a.b.c'.
+tests/cases/conformance/jsx/11.tsx(1,10): error TS17002: Expected corresponding JSX closing tag for 'a.b.c'.
 tests/cases/conformance/jsx/12.tsx(1,1): error TS1109: Expression expected.
 tests/cases/conformance/jsx/12.tsx(1,2): error TS1109: Expression expected.
 tests/cases/conformance/jsx/12.tsx(1,5): error TS1109: Expression expected.
@@ -73,9 +73,9 @@ tests/cases/conformance/jsx/31.tsx(1,4): error TS1003: Identifier expected.
 tests/cases/conformance/jsx/4.tsx(1,6): error TS1005: '{' expected.
 tests/cases/conformance/jsx/5.tsx(1,2): error TS17008: JSX element 'a' has no corresponding closing tag.
 tests/cases/conformance/jsx/5.tsx(1,5): error TS1005: '</' expected.
-tests/cases/conformance/jsx/6.tsx(1,4): error TS17002: Expected corresponding JSX closing tag for 'a'.
+tests/cases/conformance/jsx/6.tsx(1,6): error TS17002: Expected corresponding JSX closing tag for 'a'.
 tests/cases/conformance/jsx/7.tsx(1,13): error TS1002: Unterminated string literal.
-tests/cases/conformance/jsx/8.tsx(1,6): error TS17002: Expected corresponding JSX closing tag for 'a:b'.
+tests/cases/conformance/jsx/8.tsx(1,8): error TS17002: Expected corresponding JSX closing tag for 'a:b'.
 tests/cases/conformance/jsx/9.tsx(1,2): error TS2304: Cannot find name 'a:b'.
 tests/cases/conformance/jsx/9.tsx(1,2): error TS2633: JSX property access expressions cannot include JSX namespace names
 tests/cases/conformance/jsx/9.tsx(1,10): error TS2304: Cannot find name 'a:b'.
@@ -119,7 +119,7 @@ tests/cases/conformance/jsx/9.tsx(1,10): error TS2304: Cannot find name 'a:b'.
 !!! error TS1005: '</' expected.
 ==== tests/cases/conformance/jsx/6.tsx (1 errors) ====
     <a></b>;
-       ~~~~
+         ~
 !!! error TS17002: Expected corresponding JSX closing tag for 'a'.
 ==== tests/cases/conformance/jsx/7.tsx (1 errors) ====
     <a foo="bar;
@@ -127,7 +127,7 @@ tests/cases/conformance/jsx/9.tsx(1,10): error TS2304: Cannot find name 'a:b'.
 !!! error TS1002: Unterminated string literal.
 ==== tests/cases/conformance/jsx/8.tsx (1 errors) ====
     <a:b></b>;
-         ~~~~
+           ~
 !!! error TS17002: Expected corresponding JSX closing tag for 'a:b'.
 ==== tests/cases/conformance/jsx/9.tsx (3 errors) ====
     <a:b.c></a:b.c>;
@@ -155,7 +155,7 @@ tests/cases/conformance/jsx/9.tsx(1,10): error TS2304: Cannot find name 'a:b'.
     <a.b.c></a>;
      ~
 !!! error TS2304: Cannot find name 'a'.
-           ~~~~
+             ~
 !!! error TS17002: Expected corresponding JSX closing tag for 'a.b.c'.
 ==== tests/cases/conformance/jsx/12.tsx (6 errors) ====
     <.a></.a>;

--- a/tests/baselines/reference/jsxParsingError2.errors.txt
+++ b/tests/baselines/reference/jsxParsingError2.errors.txt
@@ -1,10 +1,9 @@
-tests/cases/conformance/jsx/Error1.tsx(2,11): error TS17008: JSX element 'div' has no corresponding closing tag.
-tests/cases/conformance/jsx/Error1.tsx(2,21): error TS17002: Expected corresponding JSX closing tag for 'span'.
-tests/cases/conformance/jsx/Error2.tsx(1,15): error TS17002: Expected corresponding JSX closing tag for 'div'.
+tests/cases/conformance/jsx/Error1.tsx(2,16): error TS17008: JSX element 'span' has no corresponding closing tag.
+tests/cases/conformance/jsx/Error2.tsx(1,17): error TS17002: Expected corresponding JSX closing tag for 'div'.
 tests/cases/conformance/jsx/Error3.tsx(1,11): error TS17008: JSX element 'div' has no corresponding closing tag.
 tests/cases/conformance/jsx/Error3.tsx(3,1): error TS1005: '</' expected.
 tests/cases/conformance/jsx/Error4.tsx(1,11): error TS17008: JSX element 'div' has no corresponding closing tag.
-tests/cases/conformance/jsx/Error4.tsx(1,20): error TS17002: Expected corresponding JSX closing tag for 'div'.
+tests/cases/conformance/jsx/Error4.tsx(1,22): error TS17002: Expected corresponding JSX closing tag for 'div'.
 tests/cases/conformance/jsx/Error4.tsx(2,1): error TS1005: '</' expected.
 tests/cases/conformance/jsx/Error5.tsx(1,11): error TS17008: JSX element 'div' has no corresponding closing tag.
 tests/cases/conformance/jsx/Error5.tsx(1,16): error TS17008: JSX element 'span' has no corresponding closing tag.
@@ -19,17 +18,15 @@ tests/cases/conformance/jsx/Error5.tsx(3,1): error TS1005: '</' expected.
     	}
     }
     
-==== tests/cases/conformance/jsx/Error1.tsx (2 errors) ====
+==== tests/cases/conformance/jsx/Error1.tsx (1 errors) ====
     // Issue error about missing span closing tag, not missing div closing tag
     let x1 = <div><span></div>;
-              ~~~
-!!! error TS17008: JSX element 'div' has no corresponding closing tag.
-                        ~~~~~~
-!!! error TS17002: Expected corresponding JSX closing tag for 'span'.
+                   ~~~~
+!!! error TS17008: JSX element 'span' has no corresponding closing tag.
     
 ==== tests/cases/conformance/jsx/Error2.tsx (1 errors) ====
     let x2 = <div></span>;
-                  ~~~~~~~
+                    ~~~~
 !!! error TS17002: Expected corresponding JSX closing tag for 'div'.
     
     
@@ -45,7 +42,7 @@ tests/cases/conformance/jsx/Error5.tsx(3,1): error TS1005: '</' expected.
     let x4 = <div><div></span>;
               ~~~
 !!! error TS17008: JSX element 'div' has no corresponding closing tag.
-                       ~~~~~~~
+                         ~~~~
 !!! error TS17002: Expected corresponding JSX closing tag for 'div'.
     
     

--- a/tests/baselines/reference/jsxParsingError2.errors.txt
+++ b/tests/baselines/reference/jsxParsingError2.errors.txt
@@ -1,6 +1,5 @@
 tests/cases/conformance/jsx/Error1.tsx(2,11): error TS17008: JSX element 'div' has no corresponding closing tag.
 tests/cases/conformance/jsx/Error1.tsx(2,21): error TS17002: Expected corresponding JSX closing tag for 'span'.
-tests/cases/conformance/jsx/Error1.tsx(3,1): error TS1005: '</' expected.
 tests/cases/conformance/jsx/Error2.tsx(1,15): error TS17002: Expected corresponding JSX closing tag for 'div'.
 tests/cases/conformance/jsx/Error3.tsx(1,11): error TS17008: JSX element 'div' has no corresponding closing tag.
 tests/cases/conformance/jsx/Error3.tsx(3,1): error TS1005: '</' expected.
@@ -20,7 +19,7 @@ tests/cases/conformance/jsx/Error5.tsx(3,1): error TS1005: '</' expected.
     	}
     }
     
-==== tests/cases/conformance/jsx/Error1.tsx (3 errors) ====
+==== tests/cases/conformance/jsx/Error1.tsx (2 errors) ====
     // Issue error about missing span closing tag, not missing div closing tag
     let x1 = <div><span></div>;
               ~~~
@@ -28,8 +27,6 @@ tests/cases/conformance/jsx/Error5.tsx(3,1): error TS1005: '</' expected.
                         ~~~~~~
 !!! error TS17002: Expected corresponding JSX closing tag for 'span'.
     
-    
-!!! error TS1005: '</' expected.
 ==== tests/cases/conformance/jsx/Error2.tsx (1 errors) ====
     let x2 = <div></span>;
                   ~~~~~~~

--- a/tests/baselines/reference/jsxParsingError2.js
+++ b/tests/baselines/reference/jsxParsingError2.js
@@ -31,8 +31,7 @@ let x5 = <div><span>
 //// [file.jsx]
 //// [Error1.jsx]
 // Issue error about missing span closing tag, not missing div closing tag
-var x1 = <div><span></div>;
-</>;
+var x1 = <div><span></></div>;
 //// [Error2.jsx]
 var x2 = <div></span>;
 //// [Error3.jsx]

--- a/tests/baselines/reference/jsxParsingError2.types
+++ b/tests/baselines/reference/jsxParsingError2.types
@@ -11,13 +11,12 @@ declare module JSX {
 // Issue error about missing span closing tag, not missing div closing tag
 let x1 = <div><span></div>;
 >x1 : JSX.Element
-><div><span></div>; : JSX.Element
+><div><span></div> : JSX.Element
 >div : any
-><span></div> : JSX.Element
+><span> : JSX.Element
 >span : any
->div : any
-
 > : any
+>div : any
 
 === tests/cases/conformance/jsx/Error2.tsx ===
 let x2 = <div></span>;

--- a/tests/baselines/reference/jsxUnclosedParserRecovery.errors.txt
+++ b/tests/baselines/reference/jsxUnclosedParserRecovery.errors.txt
@@ -8,36 +8,26 @@ tests/cases/conformance/jsx/jsxParserRecovery.tsx(28,1): error TS1003: Identifie
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(32,1): error TS1005: '>' expected.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(35,12): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(36,1): error TS1005: '>' expected.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(38,15): error TS17008: JSX element 'div' has no corresponding closing tag.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(40,1): error TS17002: Expected corresponding JSX closing tag for 'diddy'.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(42,15): error TS17008: JSX element 'div' has no corresponding closing tag.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(39,6): error TS17008: JSX element 'diddy' has no corresponding closing tag.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(43,6): error TS17008: JSX element 'diddy' has no corresponding closing tag.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(43,12): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(44,1): error TS17002: Expected corresponding JSX closing tag for 'diddy'.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(49,5): error TS1003: Identifier expected.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(49,6): error TS2749: 'diddy' refers to a value, but is being used as a type here. Did you mean 'typeof diddy'?
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(49,11): error TS1005: '>' expected.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(49,12): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(54,6): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(54,6): error TS2749: 'diddy' refers to a value, but is being used as a type here. Did you mean 'typeof diddy'?
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(54,11): error TS1005: '>' expected.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(58,12): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(59,5): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(59,12): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(64,5): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(64,12): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(68,12): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(69,5): error TS1003: Identifier expected.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(69,12): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(74,5): error TS1005: '>' expected.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(74,12): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(78,12): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(79,5): error TS1005: '>' expected.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(79,12): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(82,15): error TS17008: JSX element 'div' has no corresponding closing tag.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(85,1): error TS17002: Expected corresponding JSX closing tag for 'diddy'.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(87,15): error TS17008: JSX element 'div' has no corresponding closing tag.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(83,6): error TS17008: JSX element 'diddy' has no corresponding closing tag.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(88,6): error TS17008: JSX element 'diddy' has no corresponding closing tag.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(88,12): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(90,1): error TS17002: Expected corresponding JSX closing tag for 'diddy'.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(95,5): error TS2304: Cannot find name 'Cranky'.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(96,1): error TS1003: Identifier expected.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(101,1): error TS1003: Identifier expected.
@@ -49,14 +39,12 @@ tests/cases/conformance/jsx/jsxParserRecovery.tsx(116,1): error TS1003: Identifi
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(120,5): error TS1005: '>' expected.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(124,12): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(125,5): error TS1005: '>' expected.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(128,15): error TS17008: JSX element 'div' has no corresponding closing tag.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(131,1): error TS17002: Expected corresponding JSX closing tag for 'diddy'.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(133,15): error TS17008: JSX element 'div' has no corresponding closing tag.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(129,6): error TS17008: JSX element 'diddy' has no corresponding closing tag.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(134,6): error TS17008: JSX element 'diddy' has no corresponding closing tag.
 tests/cases/conformance/jsx/jsxParserRecovery.tsx(134,12): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/conformance/jsx/jsxParserRecovery.tsx(136,1): error TS17002: Expected corresponding JSX closing tag for 'diddy'.
 
 
-==== tests/cases/conformance/jsx/jsxParserRecovery.tsx (56 errors) ====
+==== tests/cases/conformance/jsx/jsxParserRecovery.tsx (44 errors) ====
     // should have no errors here; all these functions should parse and resolve
     noName(); noClose(); noCloseTypeArg(); noCloseAttrs(); noCloseTypeArgAttrs(); noCloseBracket(); noCloseBracketTypeArgAttrs(); noSelfclose(); noSelfcloseTypeArgAttrs();
     noNameTrailingTag(); noCloseTrailingTag(); noCloseTypeArgTrailingTag(); noCloseAttrsTrailingTag(); noCloseTypeArgAttrsTrailingTag(); noCloseBracketTrailingTag(); noCloseBracketTypeArgAttrsTrailingTag(); // noSelfcloseTrailingTag(); noSelfcloseTypeArgAttrsTrailingTag();
@@ -115,22 +103,18 @@ tests/cases/conformance/jsx/jsxParserRecovery.tsx(136,1): error TS17002: Expecte
 !!! error TS1005: '>' expected.
     function noCloseBracketTypeArgAttrs() { }
     var donkey = <div>
-                  ~~~
-!!! error TS17008: JSX element 'div' has no corresponding closing tag.
         <diddy>
+         ~~~~~
+!!! error TS17008: JSX element 'diddy' has no corresponding closing tag.
     </div>;
-    ~~~~~~
-!!! error TS17002: Expected corresponding JSX closing tag for 'diddy'.
     function noSelfclose() { }
     var donkey = <div>
-                  ~~~
-!!! error TS17008: JSX element 'div' has no corresponding closing tag.
         <diddy<boolean> bananas="please">
+         ~~~~~
+!!! error TS17008: JSX element 'diddy' has no corresponding closing tag.
                ~~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     </div>;
-    ~~~~~~
-!!! error TS17002: Expected corresponding JSX closing tag for 'diddy'.
     function noSelfcloseTypeArgAttrs() { }
     
     var donkey = <div>
@@ -142,8 +126,6 @@ tests/cases/conformance/jsx/jsxParserRecovery.tsx(136,1): error TS17002: Expecte
 !!! error TS2749: 'diddy' refers to a value, but is being used as a type here. Did you mean 'typeof diddy'?
               ~
 !!! error TS1005: '>' expected.
-               ~
-!!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
     </div>;
     function noNameTrailingTag() { }
     var donkey = <div>
@@ -164,8 +146,6 @@ tests/cases/conformance/jsx/jsxParserRecovery.tsx(136,1): error TS17002: Expecte
         <diddy/>
         ~
 !!! error TS1003: Identifier expected.
-               ~
-!!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
     </div>;
     function noCloseTypeArgTrailingTag() { }
     var donkey = <div>
@@ -173,8 +153,6 @@ tests/cases/conformance/jsx/jsxParserRecovery.tsx(136,1): error TS17002: Expecte
         <diddy/>
         ~
 !!! error TS1003: Identifier expected.
-               ~
-!!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
     </div>;
     function noCloseAttrsTrailingTag() { }
     var donkey = <div>
@@ -184,8 +162,6 @@ tests/cases/conformance/jsx/jsxParserRecovery.tsx(136,1): error TS17002: Expecte
         <diddy/>
         ~
 !!! error TS1003: Identifier expected.
-               ~
-!!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
     </div>;
     function noCloseTypeArgAttrsTrailingTag() { }
     var donkey = <div>
@@ -193,8 +169,6 @@ tests/cases/conformance/jsx/jsxParserRecovery.tsx(136,1): error TS17002: Expecte
         <diddy/>
         ~
 !!! error TS1005: '>' expected.
-               ~
-!!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
     </div>;
     function noCloseBracketTrailingTag() { }
     var donkey = <div>
@@ -204,29 +178,23 @@ tests/cases/conformance/jsx/jsxParserRecovery.tsx(136,1): error TS17002: Expecte
         <diddy/>
         ~
 !!! error TS1005: '>' expected.
-               ~
-!!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
     </div>;
     function noCloseBracketTypeArgAttrsTrailingTag() { }
     var donkey = <div>
-                  ~~~
-!!! error TS17008: JSX element 'div' has no corresponding closing tag.
         <diddy>
+         ~~~~~
+!!! error TS17008: JSX element 'diddy' has no corresponding closing tag.
         <diddy/>
     </div>;
-    ~~~~~~
-!!! error TS17002: Expected corresponding JSX closing tag for 'diddy'.
     function noSelfcloseTrailingTag() { }
     var donkey = <div>
-                  ~~~
-!!! error TS17008: JSX element 'div' has no corresponding closing tag.
         <diddy<boolean> bananas="please">
+         ~~~~~
+!!! error TS17008: JSX element 'diddy' has no corresponding closing tag.
                ~~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
         <diddy/>
     </div>;
-    ~~~~~~
-!!! error TS17002: Expected corresponding JSX closing tag for 'diddy'.
     function noSelfcloseTypeArgAttrsTrailingTag() { }
     
     var donkey = <div>
@@ -287,23 +255,19 @@ tests/cases/conformance/jsx/jsxParserRecovery.tsx(136,1): error TS17002: Expecte
     </div>;
     function noCloseBracketTypeArgAttrsTrailingText() { }
     var donkey = <div>
-                  ~~~
-!!! error TS17008: JSX element 'div' has no corresponding closing tag.
         <diddy>
+         ~~~~~
+!!! error TS17008: JSX element 'diddy' has no corresponding closing tag.
         Cranky Wrinkly Funky
     </div>;
-    ~~~~~~
-!!! error TS17002: Expected corresponding JSX closing tag for 'diddy'.
     function noSelfcloseTrailingText() { }
     var donkey = <div>
-                  ~~~
-!!! error TS17008: JSX element 'div' has no corresponding closing tag.
         <diddy<boolean> bananas="please">
+         ~~~~~
+!!! error TS17008: JSX element 'diddy' has no corresponding closing tag.
                ~~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
         Cranky Wrinkly Funky
     </div>;
-    ~~~~~~
-!!! error TS17002: Expected corresponding JSX closing tag for 'diddy'.
     function noSelfcloseTypeArgAttrsTrailingText() { }
     

--- a/tests/baselines/reference/jsxUnclosedParserRecovery.errors.txt
+++ b/tests/baselines/reference/jsxUnclosedParserRecovery.errors.txt
@@ -1,0 +1,309 @@
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(12,1): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(16,1): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(19,12): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(20,1): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(24,1): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(27,12): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(28,1): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(32,1): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(35,12): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(36,1): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(38,15): error TS17008: JSX element 'div' has no corresponding closing tag.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(40,1): error TS17002: Expected corresponding JSX closing tag for 'diddy'.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(42,15): error TS17008: JSX element 'div' has no corresponding closing tag.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(43,12): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(44,1): error TS17002: Expected corresponding JSX closing tag for 'diddy'.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(49,5): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(49,6): error TS2749: 'diddy' refers to a value, but is being used as a type here. Did you mean 'typeof diddy'?
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(49,11): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(49,12): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(54,6): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(54,6): error TS2749: 'diddy' refers to a value, but is being used as a type here. Did you mean 'typeof diddy'?
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(54,11): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(58,12): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(59,5): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(59,12): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(64,5): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(64,12): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(68,12): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(69,5): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(69,12): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(74,5): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(74,12): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(78,12): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(79,5): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(79,12): error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(82,15): error TS17008: JSX element 'div' has no corresponding closing tag.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(85,1): error TS17002: Expected corresponding JSX closing tag for 'diddy'.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(87,15): error TS17008: JSX element 'div' has no corresponding closing tag.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(88,12): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(90,1): error TS17002: Expected corresponding JSX closing tag for 'diddy'.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(95,5): error TS2304: Cannot find name 'Cranky'.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(96,1): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(101,1): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(104,12): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(106,1): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(111,1): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(114,12): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(116,1): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(120,5): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(124,12): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(125,5): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(128,15): error TS17008: JSX element 'div' has no corresponding closing tag.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(131,1): error TS17002: Expected corresponding JSX closing tag for 'diddy'.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(133,15): error TS17008: JSX element 'div' has no corresponding closing tag.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(134,12): error TS2558: Expected 0 type arguments, but got 1.
+tests/cases/conformance/jsx/jsxParserRecovery.tsx(136,1): error TS17002: Expected corresponding JSX closing tag for 'diddy'.
+
+
+==== tests/cases/conformance/jsx/jsxParserRecovery.tsx (56 errors) ====
+    // should have no errors here; all these functions should parse and resolve
+    noName(); noClose(); noCloseTypeArg(); noCloseAttrs(); noCloseTypeArgAttrs(); noCloseBracket(); noCloseBracketTypeArgAttrs(); noSelfclose(); noSelfcloseTypeArgAttrs();
+    noNameTrailingTag(); noCloseTrailingTag(); noCloseTypeArgTrailingTag(); noCloseAttrsTrailingTag(); noCloseTypeArgAttrsTrailingTag(); noCloseBracketTrailingTag(); noCloseBracketTypeArgAttrsTrailingTag(); // noSelfcloseTrailingTag(); noSelfcloseTypeArgAttrsTrailingTag();
+    noNameTrailingText(); noCloseTrailingText(); noCloseTypeArgTrailingText(); noCloseAttrsTrailingText(); noCloseTypeArgAttrsTrailingText(); noCloseBracketTrailingText(); noCloseBracketTypeArgAttrsTrailingText(); // noSelfcloseTrailingText(); noSelfcloseTypeArgAttrsTrailingText();
+    
+    function diddy() {
+        return null;
+    }
+    
+    var donkey = <div>
+        <
+    </div>;
+    ~~
+!!! error TS1003: Identifier expected.
+    function noName() { }
+    var donkey = <div>
+        <diddy
+    </div>;
+    ~~
+!!! error TS1003: Identifier expected.
+    function noClose() { }
+    var donkey = <div>
+        <diddy<boolean>
+               ~~~~~~~
+!!! error TS2558: Expected 0 type arguments, but got 1.
+    </div>;
+    ~~
+!!! error TS1003: Identifier expected.
+    function noCloseTypeArg() { }
+    var donkey = <div>
+        <diddy bananas="please"
+    </div>;
+    ~~
+!!! error TS1003: Identifier expected.
+    function noCloseAttrs() { }
+    var donkey = <div>
+        <diddy<boolean> bananas="please"
+               ~~~~~~~
+!!! error TS2558: Expected 0 type arguments, but got 1.
+    </div>;
+    ~~
+!!! error TS1003: Identifier expected.
+    function noCloseTypeArgAttrs() { }
+    var donkey = <div>
+        <diddy/
+    </div>;
+    ~~
+!!! error TS1005: '>' expected.
+    function noCloseBracket() { }
+    var donkey = <div>
+        <diddy<boolean> bananas="please"/
+               ~~~~~~~
+!!! error TS2558: Expected 0 type arguments, but got 1.
+    </div>;
+    ~~
+!!! error TS1005: '>' expected.
+    function noCloseBracketTypeArgAttrs() { }
+    var donkey = <div>
+                  ~~~
+!!! error TS17008: JSX element 'div' has no corresponding closing tag.
+        <diddy>
+    </div>;
+    ~~~~~~
+!!! error TS17002: Expected corresponding JSX closing tag for 'diddy'.
+    function noSelfclose() { }
+    var donkey = <div>
+                  ~~~
+!!! error TS17008: JSX element 'div' has no corresponding closing tag.
+        <diddy<boolean> bananas="please">
+               ~~~~~~~
+!!! error TS2558: Expected 0 type arguments, but got 1.
+    </div>;
+    ~~~~~~
+!!! error TS17002: Expected corresponding JSX closing tag for 'diddy'.
+    function noSelfcloseTypeArgAttrs() { }
+    
+    var donkey = <div>
+        <
+        <diddy/>
+        ~
+!!! error TS1003: Identifier expected.
+         ~~~~~
+!!! error TS2749: 'diddy' refers to a value, but is being used as a type here. Did you mean 'typeof diddy'?
+              ~
+!!! error TS1005: '>' expected.
+               ~
+!!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
+    </div>;
+    function noNameTrailingTag() { }
+    var donkey = <div>
+        <diddy
+        <diddy/>
+         ~~~~~
+!!! error TS2558: Expected 0 type arguments, but got 1.
+         ~~~~~
+!!! error TS2749: 'diddy' refers to a value, but is being used as a type here. Did you mean 'typeof diddy'?
+              ~
+!!! error TS1005: '>' expected.
+    </div>;
+    function noCloseTrailingTag() { }
+    var donkey = <div>
+        <diddy<boolean>
+               ~~~~~~~
+!!! error TS2558: Expected 0 type arguments, but got 1.
+        <diddy/>
+        ~
+!!! error TS1003: Identifier expected.
+               ~
+!!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
+    </div>;
+    function noCloseTypeArgTrailingTag() { }
+    var donkey = <div>
+        <diddy bananas="please"
+        <diddy/>
+        ~
+!!! error TS1003: Identifier expected.
+               ~
+!!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
+    </div>;
+    function noCloseAttrsTrailingTag() { }
+    var donkey = <div>
+        <diddy<boolean> bananas="please"
+               ~~~~~~~
+!!! error TS2558: Expected 0 type arguments, but got 1.
+        <diddy/>
+        ~
+!!! error TS1003: Identifier expected.
+               ~
+!!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
+    </div>;
+    function noCloseTypeArgAttrsTrailingTag() { }
+    var donkey = <div>
+        <diddy/
+        <diddy/>
+        ~
+!!! error TS1005: '>' expected.
+               ~
+!!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
+    </div>;
+    function noCloseBracketTrailingTag() { }
+    var donkey = <div>
+        <diddy<boolean> bananas="please"/
+               ~~~~~~~
+!!! error TS2558: Expected 0 type arguments, but got 1.
+        <diddy/>
+        ~
+!!! error TS1005: '>' expected.
+               ~
+!!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
+    </div>;
+    function noCloseBracketTypeArgAttrsTrailingTag() { }
+    var donkey = <div>
+                  ~~~
+!!! error TS17008: JSX element 'div' has no corresponding closing tag.
+        <diddy>
+        <diddy/>
+    </div>;
+    ~~~~~~
+!!! error TS17002: Expected corresponding JSX closing tag for 'diddy'.
+    function noSelfcloseTrailingTag() { }
+    var donkey = <div>
+                  ~~~
+!!! error TS17008: JSX element 'div' has no corresponding closing tag.
+        <diddy<boolean> bananas="please">
+               ~~~~~~~
+!!! error TS2558: Expected 0 type arguments, but got 1.
+        <diddy/>
+    </div>;
+    ~~~~~~
+!!! error TS17002: Expected corresponding JSX closing tag for 'diddy'.
+    function noSelfcloseTypeArgAttrsTrailingTag() { }
+    
+    var donkey = <div>
+        <
+        Cranky Wrinkly Funky
+        ~~~~~~
+!!! error TS2304: Cannot find name 'Cranky'.
+    </div>;
+    ~~
+!!! error TS1003: Identifier expected.
+    function noNameTrailingText() { }
+    var donkey = <div>
+        <diddy
+        Cranky Wrinkly Funky
+    </div>;
+    ~~
+!!! error TS1003: Identifier expected.
+    function noCloseTrailingText() { }
+    var donkey = <div>
+        <diddy<boolean>
+               ~~~~~~~
+!!! error TS2558: Expected 0 type arguments, but got 1.
+        Cranky Wrinkly Funky
+    </div>;
+    ~~
+!!! error TS1003: Identifier expected.
+    function noCloseTypeArgTrailingText() { }
+    var donkey = <div>
+        <diddy bananas="please"
+        Cranky Wrinkly Funky
+    </div>;
+    ~~
+!!! error TS1003: Identifier expected.
+    function noCloseAttrsTrailingText() { }
+    var donkey = <div>
+        <diddy<boolean> bananas="please"
+               ~~~~~~~
+!!! error TS2558: Expected 0 type arguments, but got 1.
+        Cranky Wrinkly Funky
+    </div>;
+    ~~
+!!! error TS1003: Identifier expected.
+    function noCloseTypeArgAttrsTrailingText() { }
+    var donkey = <div>
+        <diddy/
+        Cranky Wrinkly Funky
+        ~~~~~~
+!!! error TS1005: '>' expected.
+    </div>;
+    function noCloseBracketTrailingText() { }
+    var donkey = <div>
+        <diddy<boolean> bananas="please"/
+               ~~~~~~~
+!!! error TS2558: Expected 0 type arguments, but got 1.
+        Cranky Wrinkly Funky
+        ~~~~~~
+!!! error TS1005: '>' expected.
+    </div>;
+    function noCloseBracketTypeArgAttrsTrailingText() { }
+    var donkey = <div>
+                  ~~~
+!!! error TS17008: JSX element 'div' has no corresponding closing tag.
+        <diddy>
+        Cranky Wrinkly Funky
+    </div>;
+    ~~~~~~
+!!! error TS17002: Expected corresponding JSX closing tag for 'diddy'.
+    function noSelfcloseTrailingText() { }
+    var donkey = <div>
+                  ~~~
+!!! error TS17008: JSX element 'div' has no corresponding closing tag.
+        <diddy<boolean> bananas="please">
+               ~~~~~~~
+!!! error TS2558: Expected 0 type arguments, but got 1.
+        Cranky Wrinkly Funky
+    </div>;
+    ~~~~~~
+!!! error TS17002: Expected corresponding JSX closing tag for 'diddy'.
+    function noSelfcloseTypeArgAttrsTrailingText() { }
+    

--- a/tests/baselines/reference/jsxUnclosedParserRecovery.js
+++ b/tests/baselines/reference/jsxUnclosedParserRecovery.js
@@ -201,7 +201,7 @@ var donkey = <div>
     <diddy bananas="please"></></div>;
 function noSelfcloseTypeArgAttrs() { }
 var donkey = <div>
-    < />>
+    < />
 </div>;
 function noNameTrailingTag() { }
 var donkey = <div>
@@ -209,23 +209,28 @@ var donkey = <div>
 </div>;
 function noCloseTrailingTag() { }
 var donkey = <div>
-    <diddy />diddy/>
+    <diddy />
+    <diddy />
 </div>;
 function noCloseTypeArgTrailingTag() { }
 var donkey = <div>
-    <diddy bananas="please"/>diddy/>
+    <diddy bananas="please"/>
+    <diddy />
 </div>;
 function noCloseAttrsTrailingTag() { }
 var donkey = <div>
-    <diddy bananas="please"/>diddy/>
+    <diddy bananas="please"/>
+    <diddy />
 </div>;
 function noCloseTypeArgAttrsTrailingTag() { }
 var donkey = <div>
-    <diddy />diddy/>
+    <diddy />
+    <diddy />
 </div>;
 function noCloseBracketTrailingTag() { }
 var donkey = <div>
-    <diddy bananas="please"/>diddy/>
+    <diddy bananas="please"/>
+    <diddy />
 </div>;
 function noCloseBracketTypeArgAttrsTrailingTag() { }
 var donkey = <div>
@@ -255,11 +260,13 @@ var donkey = <div>
 </div>;
 function noCloseTypeArgAttrsTrailingText() { }
 var donkey = <div>
-    <diddy /> Wrinkly Funky
+    <diddy />
+    Cranky Wrinkly Funky
 </div>;
 function noCloseBracketTrailingText() { }
 var donkey = <div>
-    <diddy bananas="please"/> Wrinkly Funky
+    <diddy bananas="please"/>
+    Cranky Wrinkly Funky
 </div>;
 function noCloseBracketTypeArgAttrsTrailingText() { }
 var donkey = <div>

--- a/tests/baselines/reference/jsxUnclosedParserRecovery.js
+++ b/tests/baselines/reference/jsxUnclosedParserRecovery.js
@@ -1,0 +1,270 @@
+//// [jsxParserRecovery.tsx]
+// should have no errors here; all these functions should parse and resolve
+noName(); noClose(); noCloseTypeArg(); noCloseAttrs(); noCloseTypeArgAttrs(); noCloseBracket(); noCloseBracketTypeArgAttrs(); noSelfclose(); noSelfcloseTypeArgAttrs();
+noNameTrailingTag(); noCloseTrailingTag(); noCloseTypeArgTrailingTag(); noCloseAttrsTrailingTag(); noCloseTypeArgAttrsTrailingTag(); noCloseBracketTrailingTag(); noCloseBracketTypeArgAttrsTrailingTag(); // noSelfcloseTrailingTag(); noSelfcloseTypeArgAttrsTrailingTag();
+noNameTrailingText(); noCloseTrailingText(); noCloseTypeArgTrailingText(); noCloseAttrsTrailingText(); noCloseTypeArgAttrsTrailingText(); noCloseBracketTrailingText(); noCloseBracketTypeArgAttrsTrailingText(); // noSelfcloseTrailingText(); noSelfcloseTypeArgAttrsTrailingText();
+
+function diddy() {
+    return null;
+}
+
+var donkey = <div>
+    <
+</div>;
+function noName() { }
+var donkey = <div>
+    <diddy
+</div>;
+function noClose() { }
+var donkey = <div>
+    <diddy<boolean>
+</div>;
+function noCloseTypeArg() { }
+var donkey = <div>
+    <diddy bananas="please"
+</div>;
+function noCloseAttrs() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please"
+</div>;
+function noCloseTypeArgAttrs() { }
+var donkey = <div>
+    <diddy/
+</div>;
+function noCloseBracket() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please"/
+</div>;
+function noCloseBracketTypeArgAttrs() { }
+var donkey = <div>
+    <diddy>
+</div>;
+function noSelfclose() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please">
+</div>;
+function noSelfcloseTypeArgAttrs() { }
+
+var donkey = <div>
+    <
+    <diddy/>
+</div>;
+function noNameTrailingTag() { }
+var donkey = <div>
+    <diddy
+    <diddy/>
+</div>;
+function noCloseTrailingTag() { }
+var donkey = <div>
+    <diddy<boolean>
+    <diddy/>
+</div>;
+function noCloseTypeArgTrailingTag() { }
+var donkey = <div>
+    <diddy bananas="please"
+    <diddy/>
+</div>;
+function noCloseAttrsTrailingTag() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please"
+    <diddy/>
+</div>;
+function noCloseTypeArgAttrsTrailingTag() { }
+var donkey = <div>
+    <diddy/
+    <diddy/>
+</div>;
+function noCloseBracketTrailingTag() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please"/
+    <diddy/>
+</div>;
+function noCloseBracketTypeArgAttrsTrailingTag() { }
+var donkey = <div>
+    <diddy>
+    <diddy/>
+</div>;
+function noSelfcloseTrailingTag() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please">
+    <diddy/>
+</div>;
+function noSelfcloseTypeArgAttrsTrailingTag() { }
+
+var donkey = <div>
+    <
+    Cranky Wrinkly Funky
+</div>;
+function noNameTrailingText() { }
+var donkey = <div>
+    <diddy
+    Cranky Wrinkly Funky
+</div>;
+function noCloseTrailingText() { }
+var donkey = <div>
+    <diddy<boolean>
+    Cranky Wrinkly Funky
+</div>;
+function noCloseTypeArgTrailingText() { }
+var donkey = <div>
+    <diddy bananas="please"
+    Cranky Wrinkly Funky
+</div>;
+function noCloseAttrsTrailingText() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please"
+    Cranky Wrinkly Funky
+</div>;
+function noCloseTypeArgAttrsTrailingText() { }
+var donkey = <div>
+    <diddy/
+    Cranky Wrinkly Funky
+</div>;
+function noCloseBracketTrailingText() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please"/
+    Cranky Wrinkly Funky
+</div>;
+function noCloseBracketTypeArgAttrsTrailingText() { }
+var donkey = <div>
+    <diddy>
+    Cranky Wrinkly Funky
+</div>;
+function noSelfcloseTrailingText() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please">
+    Cranky Wrinkly Funky
+</div>;
+function noSelfcloseTypeArgAttrsTrailingText() { }
+
+
+//// [jsxParserRecovery.jsx]
+// should have no errors here; all these functions should parse and resolve
+noName();
+noClose();
+noCloseTypeArg();
+noCloseAttrs();
+noCloseTypeArgAttrs();
+noCloseBracket();
+noCloseBracketTypeArgAttrs();
+noSelfclose();
+noSelfcloseTypeArgAttrs();
+noNameTrailingTag();
+noCloseTrailingTag();
+noCloseTypeArgTrailingTag();
+noCloseAttrsTrailingTag();
+noCloseTypeArgAttrsTrailingTag();
+noCloseBracketTrailingTag();
+noCloseBracketTypeArgAttrsTrailingTag(); // noSelfcloseTrailingTag(); noSelfcloseTypeArgAttrsTrailingTag();
+noNameTrailingText();
+noCloseTrailingText();
+noCloseTypeArgTrailingText();
+noCloseAttrsTrailingText();
+noCloseTypeArgAttrsTrailingText();
+noCloseBracketTrailingText();
+noCloseBracketTypeArgAttrsTrailingText(); // noSelfcloseTrailingText(); noSelfcloseTypeArgAttrsTrailingText();
+function diddy() {
+    return null;
+}
+var donkey = <div>
+    < />
+</div>;
+function noName() { }
+var donkey = <div>
+    <diddy />
+</div>;
+function noClose() { }
+var donkey = <div>
+    <diddy />
+</div>;
+function noCloseTypeArg() { }
+var donkey = <div>
+    <diddy bananas="please"/>
+</div>;
+function noCloseAttrs() { }
+var donkey = <div>
+    <diddy bananas="please"/>
+</div>;
+function noCloseTypeArgAttrs() { }
+var donkey = <div>
+    <diddy />
+</div>;
+function noCloseBracket() { }
+var donkey = <div>
+    <diddy bananas="please"/>
+</div>;
+function noCloseBracketTypeArgAttrs() { }
+var donkey = <div>
+    <diddy></></div>;
+function noSelfclose() { }
+var donkey = <div>
+    <diddy bananas="please"></></div>;
+function noSelfcloseTypeArgAttrs() { }
+var donkey = <div>
+    < />>
+</div>;
+function noNameTrailingTag() { }
+var donkey = <div>
+    <diddy />
+</div>;
+function noCloseTrailingTag() { }
+var donkey = <div>
+    <diddy />diddy/>
+</div>;
+function noCloseTypeArgTrailingTag() { }
+var donkey = <div>
+    <diddy bananas="please"/>diddy/>
+</div>;
+function noCloseAttrsTrailingTag() { }
+var donkey = <div>
+    <diddy bananas="please"/>diddy/>
+</div>;
+function noCloseTypeArgAttrsTrailingTag() { }
+var donkey = <div>
+    <diddy />diddy/>
+</div>;
+function noCloseBracketTrailingTag() { }
+var donkey = <div>
+    <diddy bananas="please"/>diddy/>
+</div>;
+function noCloseBracketTypeArgAttrsTrailingTag() { }
+var donkey = <div>
+    <diddy></></div>;
+function noSelfcloseTrailingTag() { }
+var donkey = <div>
+    <diddy bananas="please"></></div>;
+function noSelfcloseTypeArgAttrsTrailingTag() { }
+var donkey = <div>
+    <Cranky Wrinkly Funky/>
+</div>;
+function noNameTrailingText() { }
+var donkey = <div>
+    <diddy Cranky Wrinkly Funky/>
+</div>;
+function noCloseTrailingText() { }
+var donkey = <div>
+    <diddy Cranky Wrinkly Funky/>
+</div>;
+function noCloseTypeArgTrailingText() { }
+var donkey = <div>
+    <diddy bananas="please" Cranky Wrinkly Funky/>
+</div>;
+function noCloseAttrsTrailingText() { }
+var donkey = <div>
+    <diddy bananas="please" Cranky Wrinkly Funky/>
+</div>;
+function noCloseTypeArgAttrsTrailingText() { }
+var donkey = <div>
+    <diddy /> Wrinkly Funky
+</div>;
+function noCloseBracketTrailingText() { }
+var donkey = <div>
+    <diddy bananas="please"/> Wrinkly Funky
+</div>;
+function noCloseBracketTypeArgAttrsTrailingText() { }
+var donkey = <div>
+    <diddy></></div>;
+function noSelfcloseTrailingText() { }
+var donkey = <div>
+    <diddy bananas="please"></></div>;
+function noSelfcloseTypeArgAttrsTrailingText() { }

--- a/tests/baselines/reference/jsxUnclosedParserRecovery.symbols
+++ b/tests/baselines/reference/jsxUnclosedParserRecovery.symbols
@@ -1,0 +1,314 @@
+=== tests/cases/conformance/jsx/jsxParserRecovery.tsx ===
+// should have no errors here; all these functions should parse and resolve
+noName(); noClose(); noCloseTypeArg(); noCloseAttrs(); noCloseTypeArgAttrs(); noCloseBracket(); noCloseBracketTypeArgAttrs(); noSelfclose(); noSelfcloseTypeArgAttrs();
+>noName : Symbol(noName, Decl(jsxParserRecovery.tsx, 11, 7))
+>noClose : Symbol(noClose, Decl(jsxParserRecovery.tsx, 15, 7))
+>noCloseTypeArg : Symbol(noCloseTypeArg, Decl(jsxParserRecovery.tsx, 19, 7))
+>noCloseAttrs : Symbol(noCloseAttrs, Decl(jsxParserRecovery.tsx, 23, 7))
+>noCloseTypeArgAttrs : Symbol(noCloseTypeArgAttrs, Decl(jsxParserRecovery.tsx, 27, 7))
+>noCloseBracket : Symbol(noCloseBracket, Decl(jsxParserRecovery.tsx, 31, 7))
+>noCloseBracketTypeArgAttrs : Symbol(noCloseBracketTypeArgAttrs, Decl(jsxParserRecovery.tsx, 35, 7))
+>noSelfclose : Symbol(noSelfclose, Decl(jsxParserRecovery.tsx, 39, 7))
+>noSelfcloseTypeArgAttrs : Symbol(noSelfcloseTypeArgAttrs, Decl(jsxParserRecovery.tsx, 43, 7))
+
+noNameTrailingTag(); noCloseTrailingTag(); noCloseTypeArgTrailingTag(); noCloseAttrsTrailingTag(); noCloseTypeArgAttrsTrailingTag(); noCloseBracketTrailingTag(); noCloseBracketTypeArgAttrsTrailingTag(); // noSelfcloseTrailingTag(); noSelfcloseTypeArgAttrsTrailingTag();
+>noNameTrailingTag : Symbol(noNameTrailingTag, Decl(jsxParserRecovery.tsx, 49, 7))
+>noCloseTrailingTag : Symbol(noCloseTrailingTag, Decl(jsxParserRecovery.tsx, 54, 7))
+>noCloseTypeArgTrailingTag : Symbol(noCloseTypeArgTrailingTag, Decl(jsxParserRecovery.tsx, 59, 7))
+>noCloseAttrsTrailingTag : Symbol(noCloseAttrsTrailingTag, Decl(jsxParserRecovery.tsx, 64, 7))
+>noCloseTypeArgAttrsTrailingTag : Symbol(noCloseTypeArgAttrsTrailingTag, Decl(jsxParserRecovery.tsx, 69, 7))
+>noCloseBracketTrailingTag : Symbol(noCloseBracketTrailingTag, Decl(jsxParserRecovery.tsx, 74, 7))
+>noCloseBracketTypeArgAttrsTrailingTag : Symbol(noCloseBracketTypeArgAttrsTrailingTag, Decl(jsxParserRecovery.tsx, 79, 7))
+
+noNameTrailingText(); noCloseTrailingText(); noCloseTypeArgTrailingText(); noCloseAttrsTrailingText(); noCloseTypeArgAttrsTrailingText(); noCloseBracketTrailingText(); noCloseBracketTypeArgAttrsTrailingText(); // noSelfcloseTrailingText(); noSelfcloseTypeArgAttrsTrailingText();
+>noNameTrailingText : Symbol(noNameTrailingText, Decl(jsxParserRecovery.tsx, 95, 7))
+>noCloseTrailingText : Symbol(noCloseTrailingText, Decl(jsxParserRecovery.tsx, 100, 7))
+>noCloseTypeArgTrailingText : Symbol(noCloseTypeArgTrailingText, Decl(jsxParserRecovery.tsx, 105, 7))
+>noCloseAttrsTrailingText : Symbol(noCloseAttrsTrailingText, Decl(jsxParserRecovery.tsx, 110, 7))
+>noCloseTypeArgAttrsTrailingText : Symbol(noCloseTypeArgAttrsTrailingText, Decl(jsxParserRecovery.tsx, 115, 7))
+>noCloseBracketTrailingText : Symbol(noCloseBracketTrailingText, Decl(jsxParserRecovery.tsx, 120, 7))
+>noCloseBracketTypeArgAttrsTrailingText : Symbol(noCloseBracketTypeArgAttrsTrailingText, Decl(jsxParserRecovery.tsx, 125, 7))
+
+function diddy() {
+>diddy : Symbol(diddy, Decl(jsxParserRecovery.tsx, 3, 209))
+
+    return null;
+}
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <
+</div>;
+function noName() { }
+>noName : Symbol(noName, Decl(jsxParserRecovery.tsx, 11, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy
+</div>;
+function noClose() { }
+>noClose : Symbol(noClose, Decl(jsxParserRecovery.tsx, 15, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy<boolean>
+</div>;
+function noCloseTypeArg() { }
+>noCloseTypeArg : Symbol(noCloseTypeArg, Decl(jsxParserRecovery.tsx, 19, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy bananas="please"
+>bananas : Symbol(bananas, Decl(jsxParserRecovery.tsx, 22, 10))
+
+</div>;
+function noCloseAttrs() { }
+>noCloseAttrs : Symbol(noCloseAttrs, Decl(jsxParserRecovery.tsx, 23, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy<boolean> bananas="please"
+>bananas : Symbol(bananas, Decl(jsxParserRecovery.tsx, 26, 19))
+
+</div>;
+function noCloseTypeArgAttrs() { }
+>noCloseTypeArgAttrs : Symbol(noCloseTypeArgAttrs, Decl(jsxParserRecovery.tsx, 27, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy/
+</div>;
+function noCloseBracket() { }
+>noCloseBracket : Symbol(noCloseBracket, Decl(jsxParserRecovery.tsx, 31, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy<boolean> bananas="please"/
+>bananas : Symbol(bananas, Decl(jsxParserRecovery.tsx, 34, 19))
+
+</div>;
+function noCloseBracketTypeArgAttrs() { }
+>noCloseBracketTypeArgAttrs : Symbol(noCloseBracketTypeArgAttrs, Decl(jsxParserRecovery.tsx, 35, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy>
+</div>;
+function noSelfclose() { }
+>noSelfclose : Symbol(noSelfclose, Decl(jsxParserRecovery.tsx, 39, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy<boolean> bananas="please">
+>bananas : Symbol(bananas, Decl(jsxParserRecovery.tsx, 42, 19))
+
+</div>;
+function noSelfcloseTypeArgAttrs() { }
+>noSelfcloseTypeArgAttrs : Symbol(noSelfcloseTypeArgAttrs, Decl(jsxParserRecovery.tsx, 43, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <
+    <diddy/>
+</div>;
+function noNameTrailingTag() { }
+>noNameTrailingTag : Symbol(noNameTrailingTag, Decl(jsxParserRecovery.tsx, 49, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy
+    <diddy/>
+</div>;
+function noCloseTrailingTag() { }
+>noCloseTrailingTag : Symbol(noCloseTrailingTag, Decl(jsxParserRecovery.tsx, 54, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy<boolean>
+    <diddy/>
+</div>;
+function noCloseTypeArgTrailingTag() { }
+>noCloseTypeArgTrailingTag : Symbol(noCloseTypeArgTrailingTag, Decl(jsxParserRecovery.tsx, 59, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy bananas="please"
+>bananas : Symbol(bananas, Decl(jsxParserRecovery.tsx, 62, 10))
+
+    <diddy/>
+</div>;
+function noCloseAttrsTrailingTag() { }
+>noCloseAttrsTrailingTag : Symbol(noCloseAttrsTrailingTag, Decl(jsxParserRecovery.tsx, 64, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy<boolean> bananas="please"
+>bananas : Symbol(bananas, Decl(jsxParserRecovery.tsx, 67, 19))
+
+    <diddy/>
+</div>;
+function noCloseTypeArgAttrsTrailingTag() { }
+>noCloseTypeArgAttrsTrailingTag : Symbol(noCloseTypeArgAttrsTrailingTag, Decl(jsxParserRecovery.tsx, 69, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy/
+    <diddy/>
+</div>;
+function noCloseBracketTrailingTag() { }
+>noCloseBracketTrailingTag : Symbol(noCloseBracketTrailingTag, Decl(jsxParserRecovery.tsx, 74, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy<boolean> bananas="please"/
+>bananas : Symbol(bananas, Decl(jsxParserRecovery.tsx, 77, 19))
+
+    <diddy/>
+</div>;
+function noCloseBracketTypeArgAttrsTrailingTag() { }
+>noCloseBracketTypeArgAttrsTrailingTag : Symbol(noCloseBracketTypeArgAttrsTrailingTag, Decl(jsxParserRecovery.tsx, 79, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy>
+    <diddy/>
+</div>;
+function noSelfcloseTrailingTag() { }
+>noSelfcloseTrailingTag : Symbol(noSelfcloseTrailingTag, Decl(jsxParserRecovery.tsx, 84, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy<boolean> bananas="please">
+>bananas : Symbol(bananas, Decl(jsxParserRecovery.tsx, 87, 19))
+
+    <diddy/>
+</div>;
+function noSelfcloseTypeArgAttrsTrailingTag() { }
+>noSelfcloseTypeArgAttrsTrailingTag : Symbol(noSelfcloseTypeArgAttrsTrailingTag, Decl(jsxParserRecovery.tsx, 89, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <
+    Cranky Wrinkly Funky
+>Wrinkly : Symbol(Wrinkly, Decl(jsxParserRecovery.tsx, 94, 10))
+>Funky : Symbol(Funky, Decl(jsxParserRecovery.tsx, 94, 18))
+
+</div>;
+function noNameTrailingText() { }
+>noNameTrailingText : Symbol(noNameTrailingText, Decl(jsxParserRecovery.tsx, 95, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy
+    Cranky Wrinkly Funky
+>Cranky : Symbol(Cranky, Decl(jsxParserRecovery.tsx, 98, 10))
+>Wrinkly : Symbol(Wrinkly, Decl(jsxParserRecovery.tsx, 99, 10))
+>Funky : Symbol(Funky, Decl(jsxParserRecovery.tsx, 99, 18))
+
+</div>;
+function noCloseTrailingText() { }
+>noCloseTrailingText : Symbol(noCloseTrailingText, Decl(jsxParserRecovery.tsx, 100, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy<boolean>
+    Cranky Wrinkly Funky
+>Cranky : Symbol(Cranky, Decl(jsxParserRecovery.tsx, 103, 19))
+>Wrinkly : Symbol(Wrinkly, Decl(jsxParserRecovery.tsx, 104, 10))
+>Funky : Symbol(Funky, Decl(jsxParserRecovery.tsx, 104, 18))
+
+</div>;
+function noCloseTypeArgTrailingText() { }
+>noCloseTypeArgTrailingText : Symbol(noCloseTypeArgTrailingText, Decl(jsxParserRecovery.tsx, 105, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy bananas="please"
+>bananas : Symbol(bananas, Decl(jsxParserRecovery.tsx, 108, 10))
+
+    Cranky Wrinkly Funky
+>Cranky : Symbol(Cranky, Decl(jsxParserRecovery.tsx, 108, 27))
+>Wrinkly : Symbol(Wrinkly, Decl(jsxParserRecovery.tsx, 109, 10))
+>Funky : Symbol(Funky, Decl(jsxParserRecovery.tsx, 109, 18))
+
+</div>;
+function noCloseAttrsTrailingText() { }
+>noCloseAttrsTrailingText : Symbol(noCloseAttrsTrailingText, Decl(jsxParserRecovery.tsx, 110, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy<boolean> bananas="please"
+>bananas : Symbol(bananas, Decl(jsxParserRecovery.tsx, 113, 19))
+
+    Cranky Wrinkly Funky
+>Cranky : Symbol(Cranky, Decl(jsxParserRecovery.tsx, 113, 36))
+>Wrinkly : Symbol(Wrinkly, Decl(jsxParserRecovery.tsx, 114, 10))
+>Funky : Symbol(Funky, Decl(jsxParserRecovery.tsx, 114, 18))
+
+</div>;
+function noCloseTypeArgAttrsTrailingText() { }
+>noCloseTypeArgAttrsTrailingText : Symbol(noCloseTypeArgAttrsTrailingText, Decl(jsxParserRecovery.tsx, 115, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy/
+    Cranky Wrinkly Funky
+</div>;
+function noCloseBracketTrailingText() { }
+>noCloseBracketTrailingText : Symbol(noCloseBracketTrailingText, Decl(jsxParserRecovery.tsx, 120, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy<boolean> bananas="please"/
+>bananas : Symbol(bananas, Decl(jsxParserRecovery.tsx, 123, 19))
+
+    Cranky Wrinkly Funky
+</div>;
+function noCloseBracketTypeArgAttrsTrailingText() { }
+>noCloseBracketTypeArgAttrsTrailingText : Symbol(noCloseBracketTypeArgAttrsTrailingText, Decl(jsxParserRecovery.tsx, 125, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy>
+    Cranky Wrinkly Funky
+</div>;
+function noSelfcloseTrailingText() { }
+>noSelfcloseTrailingText : Symbol(noSelfcloseTrailingText, Decl(jsxParserRecovery.tsx, 130, 7))
+
+var donkey = <div>
+>donkey : Symbol(donkey, Decl(jsxParserRecovery.tsx, 9, 3), Decl(jsxParserRecovery.tsx, 13, 3), Decl(jsxParserRecovery.tsx, 17, 3), Decl(jsxParserRecovery.tsx, 21, 3), Decl(jsxParserRecovery.tsx, 25, 3) ... and 22 more)
+
+    <diddy<boolean> bananas="please">
+>bananas : Symbol(bananas, Decl(jsxParserRecovery.tsx, 133, 19))
+
+    Cranky Wrinkly Funky
+</div>;
+function noSelfcloseTypeArgAttrsTrailingText() { }
+>noSelfcloseTypeArgAttrsTrailingText : Symbol(noSelfcloseTypeArgAttrsTrailingText, Decl(jsxParserRecovery.tsx, 135, 7))
+

--- a/tests/baselines/reference/jsxUnclosedParserRecovery.types
+++ b/tests/baselines/reference/jsxUnclosedParserRecovery.types
@@ -1,0 +1,526 @@
+=== tests/cases/conformance/jsx/jsxParserRecovery.tsx ===
+// should have no errors here; all these functions should parse and resolve
+noName(); noClose(); noCloseTypeArg(); noCloseAttrs(); noCloseTypeArgAttrs(); noCloseBracket(); noCloseBracketTypeArgAttrs(); noSelfclose(); noSelfcloseTypeArgAttrs();
+>noName() : void
+>noName : () => void
+>noClose() : void
+>noClose : () => void
+>noCloseTypeArg() : void
+>noCloseTypeArg : () => void
+>noCloseAttrs() : void
+>noCloseAttrs : () => void
+>noCloseTypeArgAttrs() : void
+>noCloseTypeArgAttrs : () => void
+>noCloseBracket() : void
+>noCloseBracket : () => void
+>noCloseBracketTypeArgAttrs() : void
+>noCloseBracketTypeArgAttrs : () => void
+>noSelfclose() : void
+>noSelfclose : () => void
+>noSelfcloseTypeArgAttrs() : void
+>noSelfcloseTypeArgAttrs : () => void
+
+noNameTrailingTag(); noCloseTrailingTag(); noCloseTypeArgTrailingTag(); noCloseAttrsTrailingTag(); noCloseTypeArgAttrsTrailingTag(); noCloseBracketTrailingTag(); noCloseBracketTypeArgAttrsTrailingTag(); // noSelfcloseTrailingTag(); noSelfcloseTypeArgAttrsTrailingTag();
+>noNameTrailingTag() : void
+>noNameTrailingTag : () => void
+>noCloseTrailingTag() : void
+>noCloseTrailingTag : () => void
+>noCloseTypeArgTrailingTag() : void
+>noCloseTypeArgTrailingTag : () => void
+>noCloseAttrsTrailingTag() : void
+>noCloseAttrsTrailingTag : () => void
+>noCloseTypeArgAttrsTrailingTag() : void
+>noCloseTypeArgAttrsTrailingTag : () => void
+>noCloseBracketTrailingTag() : void
+>noCloseBracketTrailingTag : () => void
+>noCloseBracketTypeArgAttrsTrailingTag() : void
+>noCloseBracketTypeArgAttrsTrailingTag : () => void
+
+noNameTrailingText(); noCloseTrailingText(); noCloseTypeArgTrailingText(); noCloseAttrsTrailingText(); noCloseTypeArgAttrsTrailingText(); noCloseBracketTrailingText(); noCloseBracketTypeArgAttrsTrailingText(); // noSelfcloseTrailingText(); noSelfcloseTypeArgAttrsTrailingText();
+>noNameTrailingText() : void
+>noNameTrailingText : () => void
+>noCloseTrailingText() : void
+>noCloseTrailingText : () => void
+>noCloseTypeArgTrailingText() : void
+>noCloseTypeArgTrailingText : () => void
+>noCloseAttrsTrailingText() : void
+>noCloseAttrsTrailingText : () => void
+>noCloseTypeArgAttrsTrailingText() : void
+>noCloseTypeArgAttrsTrailingText : () => void
+>noCloseBracketTrailingText() : void
+>noCloseBracketTrailingText : () => void
+>noCloseBracketTypeArgAttrsTrailingText() : void
+>noCloseBracketTypeArgAttrsTrailingText : () => void
+
+function diddy() {
+>diddy : () => any
+
+    return null;
+>null : null
+}
+
+var donkey = <div>
+>donkey : any
+><div>    <</div> : any
+>div : any
+
+    <
+>< : any
+
+</div>;
+> : any
+>div : any
+
+function noName() { }
+>noName : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy</div> : any
+>div : any
+
+    <diddy
+><diddy : any
+>diddy : () => any
+
+</div>;
+>div : any
+
+function noClose() { }
+>noClose : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy<boolean></div> : any
+>div : any
+
+    <diddy<boolean>
+><diddy<boolean> : any
+>diddy : () => any
+
+</div>;
+>div : any
+
+function noCloseTypeArg() { }
+>noCloseTypeArg : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy bananas="please"</div> : any
+>div : any
+
+    <diddy bananas="please"
+><diddy bananas="please" : any
+>diddy : () => any
+>bananas : string
+
+</div>;
+>div : any
+
+function noCloseAttrs() { }
+>noCloseAttrs : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy<boolean> bananas="please"</div> : any
+>div : any
+
+    <diddy<boolean> bananas="please"
+><diddy<boolean> bananas="please" : any
+>diddy : () => any
+>bananas : string
+
+</div>;
+>div : any
+
+function noCloseTypeArgAttrs() { }
+>noCloseTypeArgAttrs : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy/</div> : any
+>div : any
+
+    <diddy/
+><diddy/ : any
+>diddy : () => any
+
+</div>;
+>div : any
+
+function noCloseBracket() { }
+>noCloseBracket : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy<boolean> bananas="please"/</div> : any
+>div : any
+
+    <diddy<boolean> bananas="please"/
+><diddy<boolean> bananas="please"/ : any
+>diddy : () => any
+>bananas : string
+
+</div>;
+>div : any
+
+function noCloseBracketTypeArgAttrs() { }
+>noCloseBracketTypeArgAttrs : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy></div> : any
+>div : any
+
+    <diddy>
+><diddy> : any
+>diddy : () => any
+
+</div>;
+> : any
+>div : any
+
+function noSelfclose() { }
+>noSelfclose : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy<boolean> bananas="please"></div> : any
+>div : any
+
+    <diddy<boolean> bananas="please">
+><diddy<boolean> bananas="please"> : any
+>diddy : () => any
+>bananas : string
+
+</div>;
+> : any
+>div : any
+
+function noSelfcloseTypeArgAttrs() { }
+>noSelfcloseTypeArgAttrs : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <    <diddy/></div> : any
+>div : any
+
+    <
+><    <diddy/ : any
+
+    <diddy/>
+> : any
+
+</div>;
+>div : any
+
+function noNameTrailingTag() { }
+>noNameTrailingTag : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy    <diddy/></div> : any
+>div : any
+
+    <diddy
+><diddy    <diddy/> : any
+>diddy : () => any
+
+    <diddy/>
+</div>;
+>div : any
+
+function noCloseTrailingTag() { }
+>noCloseTrailingTag : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy<boolean>    <diddy/></div> : any
+>div : any
+
+    <diddy<boolean>
+><diddy<boolean>    < : any
+>diddy : () => any
+
+    <diddy/>
+</div>;
+>div : any
+
+function noCloseTypeArgTrailingTag() { }
+>noCloseTypeArgTrailingTag : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy bananas="please"    <diddy/></div> : any
+>div : any
+
+    <diddy bananas="please"
+><diddy bananas="please"    < : any
+>diddy : () => any
+>bananas : string
+
+    <diddy/>
+</div>;
+>div : any
+
+function noCloseAttrsTrailingTag() { }
+>noCloseAttrsTrailingTag : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy<boolean> bananas="please"    <diddy/></div> : any
+>div : any
+
+    <diddy<boolean> bananas="please"
+><diddy<boolean> bananas="please"    < : any
+>diddy : () => any
+>bananas : string
+
+    <diddy/>
+</div>;
+>div : any
+
+function noCloseTypeArgAttrsTrailingTag() { }
+>noCloseTypeArgAttrsTrailingTag : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy/    <diddy/></div> : any
+>div : any
+
+    <diddy/
+><diddy/    < : any
+>diddy : () => any
+
+    <diddy/>
+</div>;
+>div : any
+
+function noCloseBracketTrailingTag() { }
+>noCloseBracketTrailingTag : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy<boolean> bananas="please"/    <diddy/></div> : any
+>div : any
+
+    <diddy<boolean> bananas="please"/
+><diddy<boolean> bananas="please"/    < : any
+>diddy : () => any
+>bananas : string
+
+    <diddy/>
+</div>;
+>div : any
+
+function noCloseBracketTypeArgAttrsTrailingTag() { }
+>noCloseBracketTypeArgAttrsTrailingTag : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy>    <diddy/></div> : any
+>div : any
+
+    <diddy>
+><diddy> : any
+>diddy : () => any
+
+    <diddy/>
+> : any
+
+</div>;
+>div : any
+
+function noSelfcloseTrailingTag() { }
+>noSelfcloseTrailingTag : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy<boolean> bananas="please">    <diddy/></div> : any
+>div : any
+
+    <diddy<boolean> bananas="please">
+><diddy<boolean> bananas="please"> : any
+>diddy : () => any
+>bananas : string
+
+    <diddy/>
+> : any
+
+</div>;
+>div : any
+
+function noSelfcloseTypeArgAttrsTrailingTag() { }
+>noSelfcloseTypeArgAttrsTrailingTag : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <    Cranky Wrinkly Funky</div> : any
+>div : any
+
+    <
+><    Cranky Wrinkly Funky : any
+
+    Cranky Wrinkly Funky
+>Cranky : any
+>Wrinkly : true
+>Funky : true
+
+</div>;
+>div : any
+
+function noNameTrailingText() { }
+>noNameTrailingText : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy    Cranky Wrinkly Funky</div> : any
+>div : any
+
+    <diddy
+><diddy    Cranky Wrinkly Funky : any
+>diddy : () => any
+
+    Cranky Wrinkly Funky
+>Cranky : true
+>Wrinkly : true
+>Funky : true
+
+</div>;
+>div : any
+
+function noCloseTrailingText() { }
+>noCloseTrailingText : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy<boolean>    Cranky Wrinkly Funky</div> : any
+>div : any
+
+    <diddy<boolean>
+><diddy<boolean>    Cranky Wrinkly Funky : any
+>diddy : () => any
+
+    Cranky Wrinkly Funky
+>Cranky : true
+>Wrinkly : true
+>Funky : true
+
+</div>;
+>div : any
+
+function noCloseTypeArgTrailingText() { }
+>noCloseTypeArgTrailingText : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy bananas="please"    Cranky Wrinkly Funky</div> : any
+>div : any
+
+    <diddy bananas="please"
+><diddy bananas="please"    Cranky Wrinkly Funky : any
+>diddy : () => any
+>bananas : string
+
+    Cranky Wrinkly Funky
+>Cranky : true
+>Wrinkly : true
+>Funky : true
+
+</div>;
+>div : any
+
+function noCloseAttrsTrailingText() { }
+>noCloseAttrsTrailingText : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy<boolean> bananas="please"    Cranky Wrinkly Funky</div> : any
+>div : any
+
+    <diddy<boolean> bananas="please"
+><diddy<boolean> bananas="please"    Cranky Wrinkly Funky : any
+>diddy : () => any
+>bananas : string
+
+    Cranky Wrinkly Funky
+>Cranky : true
+>Wrinkly : true
+>Funky : true
+
+</div>;
+>div : any
+
+function noCloseTypeArgAttrsTrailingText() { }
+>noCloseTypeArgAttrsTrailingText : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy/    Cranky Wrinkly Funky</div> : any
+>div : any
+
+    <diddy/
+><diddy/    Cranky : any
+>diddy : () => any
+
+    Cranky Wrinkly Funky
+</div>;
+>div : any
+
+function noCloseBracketTrailingText() { }
+>noCloseBracketTrailingText : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy<boolean> bananas="please"/    Cranky Wrinkly Funky</div> : any
+>div : any
+
+    <diddy<boolean> bananas="please"/
+><diddy<boolean> bananas="please"/    Cranky : any
+>diddy : () => any
+>bananas : string
+
+    Cranky Wrinkly Funky
+</div>;
+>div : any
+
+function noCloseBracketTypeArgAttrsTrailingText() { }
+>noCloseBracketTypeArgAttrsTrailingText : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy>    Cranky Wrinkly Funky</div> : any
+>div : any
+
+    <diddy>
+><diddy> : any
+>diddy : () => any
+
+    Cranky Wrinkly Funky
+> : any
+
+</div>;
+>div : any
+
+function noSelfcloseTrailingText() { }
+>noSelfcloseTrailingText : () => void
+
+var donkey = <div>
+>donkey : any
+><div>    <diddy<boolean> bananas="please">    Cranky Wrinkly Funky</div> : any
+>div : any
+
+    <diddy<boolean> bananas="please">
+><diddy<boolean> bananas="please"> : any
+>diddy : () => any
+>bananas : string
+
+    Cranky Wrinkly Funky
+> : any
+
+</div>;
+>div : any
+
+function noSelfcloseTypeArgAttrsTrailingText() { }
+>noSelfcloseTypeArgAttrsTrailingText : () => void
+

--- a/tests/baselines/reference/jsxUnclosedParserRecovery.types
+++ b/tests/baselines/reference/jsxUnclosedParserRecovery.types
@@ -206,7 +206,7 @@ var donkey = <div>
 >div : any
 
     <
-><    <diddy/ : any
+><    <diddy/> : any
 
     <diddy/>
 > : any
@@ -239,10 +239,13 @@ var donkey = <div>
 >div : any
 
     <diddy<boolean>
-><diddy<boolean>    < : any
+><diddy<boolean> : any
 >diddy : () => any
 
     <diddy/>
+><diddy/> : any
+>diddy : () => any
+
 </div>;
 >div : any
 
@@ -255,11 +258,14 @@ var donkey = <div>
 >div : any
 
     <diddy bananas="please"
-><diddy bananas="please"    < : any
+><diddy bananas="please" : any
 >diddy : () => any
 >bananas : string
 
     <diddy/>
+><diddy/> : any
+>diddy : () => any
+
 </div>;
 >div : any
 
@@ -272,11 +278,14 @@ var donkey = <div>
 >div : any
 
     <diddy<boolean> bananas="please"
-><diddy<boolean> bananas="please"    < : any
+><diddy<boolean> bananas="please" : any
 >diddy : () => any
 >bananas : string
 
     <diddy/>
+><diddy/> : any
+>diddy : () => any
+
 </div>;
 >div : any
 
@@ -289,10 +298,13 @@ var donkey = <div>
 >div : any
 
     <diddy/
-><diddy/    < : any
+><diddy/ : any
 >diddy : () => any
 
     <diddy/>
+><diddy/> : any
+>diddy : () => any
+
 </div>;
 >div : any
 
@@ -305,11 +317,14 @@ var donkey = <div>
 >div : any
 
     <diddy<boolean> bananas="please"/
-><diddy<boolean> bananas="please"/    < : any
+><diddy<boolean> bananas="please"/ : any
 >diddy : () => any
 >bananas : string
 
     <diddy/>
+><diddy/> : any
+>diddy : () => any
+
 </div>;
 >div : any
 
@@ -460,7 +475,7 @@ var donkey = <div>
 >div : any
 
     <diddy/
-><diddy/    Cranky : any
+><diddy/ : any
 >diddy : () => any
 
     Cranky Wrinkly Funky
@@ -476,7 +491,7 @@ var donkey = <div>
 >div : any
 
     <diddy<boolean> bananas="please"/
-><diddy<boolean> bananas="please"/    Cranky : any
+><diddy<boolean> bananas="please"/ : any
 >diddy : () => any
 >bananas : string
 

--- a/tests/cases/conformance/jsx/jsxUnclosedParserRecovery.ts
+++ b/tests/cases/conformance/jsx/jsxUnclosedParserRecovery.ts
@@ -1,0 +1,140 @@
+// @Filename: jsxParserRecovery.tsx
+// @jsx: preserve
+
+// should have no errors here; all these functions should parse and resolve
+noName(); noClose(); noCloseTypeArg(); noCloseAttrs(); noCloseTypeArgAttrs(); noCloseBracket(); noCloseBracketTypeArgAttrs(); noSelfclose(); noSelfcloseTypeArgAttrs();
+noNameTrailingTag(); noCloseTrailingTag(); noCloseTypeArgTrailingTag(); noCloseAttrsTrailingTag(); noCloseTypeArgAttrsTrailingTag(); noCloseBracketTrailingTag(); noCloseBracketTypeArgAttrsTrailingTag(); // noSelfcloseTrailingTag(); noSelfcloseTypeArgAttrsTrailingTag();
+noNameTrailingText(); noCloseTrailingText(); noCloseTypeArgTrailingText(); noCloseAttrsTrailingText(); noCloseTypeArgAttrsTrailingText(); noCloseBracketTrailingText(); noCloseBracketTypeArgAttrsTrailingText(); // noSelfcloseTrailingText(); noSelfcloseTypeArgAttrsTrailingText();
+
+function diddy() {
+    return null;
+}
+
+var donkey = <div>
+    <
+</div>;
+function noName() { }
+var donkey = <div>
+    <diddy
+</div>;
+function noClose() { }
+var donkey = <div>
+    <diddy<boolean>
+</div>;
+function noCloseTypeArg() { }
+var donkey = <div>
+    <diddy bananas="please"
+</div>;
+function noCloseAttrs() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please"
+</div>;
+function noCloseTypeArgAttrs() { }
+var donkey = <div>
+    <diddy/
+</div>;
+function noCloseBracket() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please"/
+</div>;
+function noCloseBracketTypeArgAttrs() { }
+var donkey = <div>
+    <diddy>
+</div>;
+function noSelfclose() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please">
+</div>;
+function noSelfcloseTypeArgAttrs() { }
+
+var donkey = <div>
+    <
+    <diddy/>
+</div>;
+function noNameTrailingTag() { }
+var donkey = <div>
+    <diddy
+    <diddy/>
+</div>;
+function noCloseTrailingTag() { }
+var donkey = <div>
+    <diddy<boolean>
+    <diddy/>
+</div>;
+function noCloseTypeArgTrailingTag() { }
+var donkey = <div>
+    <diddy bananas="please"
+    <diddy/>
+</div>;
+function noCloseAttrsTrailingTag() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please"
+    <diddy/>
+</div>;
+function noCloseTypeArgAttrsTrailingTag() { }
+var donkey = <div>
+    <diddy/
+    <diddy/>
+</div>;
+function noCloseBracketTrailingTag() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please"/
+    <diddy/>
+</div>;
+function noCloseBracketTypeArgAttrsTrailingTag() { }
+var donkey = <div>
+    <diddy>
+    <diddy/>
+</div>;
+function noSelfcloseTrailingTag() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please">
+    <diddy/>
+</div>;
+function noSelfcloseTypeArgAttrsTrailingTag() { }
+
+var donkey = <div>
+    <
+    Cranky Wrinkly Funky
+</div>;
+function noNameTrailingText() { }
+var donkey = <div>
+    <diddy
+    Cranky Wrinkly Funky
+</div>;
+function noCloseTrailingText() { }
+var donkey = <div>
+    <diddy<boolean>
+    Cranky Wrinkly Funky
+</div>;
+function noCloseTypeArgTrailingText() { }
+var donkey = <div>
+    <diddy bananas="please"
+    Cranky Wrinkly Funky
+</div>;
+function noCloseAttrsTrailingText() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please"
+    Cranky Wrinkly Funky
+</div>;
+function noCloseTypeArgAttrsTrailingText() { }
+var donkey = <div>
+    <diddy/
+    Cranky Wrinkly Funky
+</div>;
+function noCloseBracketTrailingText() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please"/
+    Cranky Wrinkly Funky
+</div>;
+function noCloseBracketTypeArgAttrsTrailingText() { }
+var donkey = <div>
+    <diddy>
+    Cranky Wrinkly Funky
+</div>;
+function noSelfcloseTrailingText() { }
+var donkey = <div>
+    <diddy<boolean> bananas="please">
+    Cranky Wrinkly Funky
+</div>;
+function noSelfcloseTypeArgAttrsTrailingText() { }


### PR DESCRIPTION
1. Improve recovery for malformed elements: malformed elements not immediately followed by a `<` previously parsed [most of] the rest of the file as JsxText. That's because, nested inside another JSX tag, when attempting to parse a closing `>`, all the functions unconditionally advanced the token, whether or not the `>` was there. This parsed a following `</` (for example) as jsx text, and then the rest of parsing went wrong.

`parseExpected` has a mode that doesn't advance the scanner, but it wasn't used consistently (or understandably) before.

2. Improve recovery for a correctly-formed, but unmatched, opening element that's nested inside a correctly matched open/close pair:

```tsx
<div><span></div>
```

Previously this parsed as `<div>(<span></div>)`, which meant that the first `<div>` was unclosed, which again parsed the rest of the file as jsx text, or at least until another `</div>` was found.

Now, in the code that finalises jsx elements, when there is a mismatched open/close (eg `<span></div>`, and the mismatched close text (`</div>`) **matches** the parent's opening text (`<div>`), the parser creates a new jsx element with the mismatched open (`<span></span>`) and re-attaches the mismatched close to parent open (`<div>...</div>`).

This may not be correct 100% of the time, but it's far better than the old nearest-attach behaviour.

3. Future work: the old way of issuing errors for mismatched open/closes was to parse *the rest of the file* as jsx text, then when the child was EndOfFileToken, issue a "no matching tag" error on the parent. I put an assert in its place and 6 tests failed. So there are 6 tests whose JSX parsing runs to the end of the file.

Edit: I investigated those 6 tests and didn't learn much because the unclosed tags really were at the end of the file. I need to learn more about what can appear in jsx text to see if there are other boundaries that could indicate a runaway unclosed tag.

Fixes #43496
