### PR TITLE
Don’t allow an object literal with a spread as a fallback for destructuring a property not present in all constituents

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11698,7 +11698,7 @@ namespace ts {
                             checkFlags |= CheckFlags.WritePartial | (indexInfo.isReadonly ? CheckFlags.Readonly : 0);
                             indexTypes = append(indexTypes, isTupleType(type) ? getRestTypeOfTupleType(type) || undefinedType : indexInfo.type);
                         }
-                        else if (isObjectLiteralType(type)) {
+                        else if (isObjectLiteralType(type) && !(getObjectFlags(type) & ObjectFlags.ContainsSpread)) {
                             checkFlags |= CheckFlags.WritePartial;
                             indexTypes = append(indexTypes, undefinedType);
                         }

--- a/tests/baselines/reference/destructuringFromUnionSpread.errors.txt
+++ b/tests/baselines/reference/destructuringFromUnionSpread.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/destructuringFromUnionSpread.ts(5,9): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
+
+
+==== tests/cases/compiler/destructuringFromUnionSpread.ts (1 errors) ====
+    interface A { a: string }
+    interface B { b: number }
+    
+    declare const x: A | B;
+    const { a } = { ...x } // error
+            ~
+!!! error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
+    

--- a/tests/baselines/reference/destructuringFromUnionSpread.js
+++ b/tests/baselines/reference/destructuringFromUnionSpread.js
@@ -1,0 +1,21 @@
+//// [destructuringFromUnionSpread.ts]
+interface A { a: string }
+interface B { b: number }
+
+declare const x: A | B;
+const { a } = { ...x } // error
+
+
+//// [destructuringFromUnionSpread.js]
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var a = __assign({}, x).a; // error

--- a/tests/baselines/reference/destructuringFromUnionSpread.symbols
+++ b/tests/baselines/reference/destructuringFromUnionSpread.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/destructuringFromUnionSpread.ts ===
+interface A { a: string }
+>A : Symbol(A, Decl(destructuringFromUnionSpread.ts, 0, 0))
+>a : Symbol(A.a, Decl(destructuringFromUnionSpread.ts, 0, 13))
+
+interface B { b: number }
+>B : Symbol(B, Decl(destructuringFromUnionSpread.ts, 0, 25))
+>b : Symbol(B.b, Decl(destructuringFromUnionSpread.ts, 1, 13))
+
+declare const x: A | B;
+>x : Symbol(x, Decl(destructuringFromUnionSpread.ts, 3, 13))
+>A : Symbol(A, Decl(destructuringFromUnionSpread.ts, 0, 0))
+>B : Symbol(B, Decl(destructuringFromUnionSpread.ts, 0, 25))
+
+const { a } = { ...x } // error
+>a : Symbol(a, Decl(destructuringFromUnionSpread.ts, 4, 7))
+>x : Symbol(x, Decl(destructuringFromUnionSpread.ts, 3, 13))
+

--- a/tests/baselines/reference/destructuringFromUnionSpread.types
+++ b/tests/baselines/reference/destructuringFromUnionSpread.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/destructuringFromUnionSpread.ts ===
+interface A { a: string }
+>a : string
+
+interface B { b: number }
+>b : number
+
+declare const x: A | B;
+>x : A | B
+
+const { a } = { ...x } // error
+>a : any
+>{ ...x } : { a: any; } | { a: any; b: number; }
+>x : A | B
+

--- a/tests/cases/compiler/destructuringFromUnionSpread.ts
+++ b/tests/cases/compiler/destructuringFromUnionSpread.ts
@@ -1,0 +1,11 @@
+interface A { a: string }
+interface B { b: number }
+
+function foo(x: A | B) {
+    const { a } = { ...x } // no error?! 
+    // const a: string | undefined
+    a?.toUpperCase();
+}
+
+const x = { a: 1, b: 2 }
+foo(x); // a.toUpperCase is not a function, oops

--- a/tests/cases/compiler/destructuringFromUnionSpread.ts
+++ b/tests/cases/compiler/destructuringFromUnionSpread.ts
@@ -1,11 +1,5 @@
 interface A { a: string }
 interface B { b: number }
 
-function foo(x: A | B) {
-    const { a } = { ...x } // no error?! 
-    // const a: string | undefined
-    a?.toUpperCase();
-}
-
-const x = { a: 1, b: 2 }
-foo(x); // a.toUpperCase is not a function, oops
+declare const x: A | B;
+const { a } = { ...x } // error


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #43174

#31711 allowed object literals as fallbacks for destructuring, such that `const { x } = foo || {}` was allowed even though `{}` has no property `x`. The only criteria for an object constituent of a union to be considered to have `{ [key: string]: undefined }` index signature was that it be an object literal—the common pattern seems to be an _empty_ object literal, but any object literal ought to avoid excess property pitfalls through aliasing.... _except_, that logic neglected spreads, which could introduce arbitrary extra properties of arbitrary types, as demonstrated in #43174.
