### PR TITLE
Replace non-null assertion with optional chain on assert nodes

### DIFF
--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -221,7 +221,7 @@ namespace ts {
                 assert(
                     node !== undefined && (test === undefined || test(node)),
                     message || "Unexpected node.",
-                    () => `Node ${formatSyntaxKind(node!.kind)} did not pass test '${getFunctionName(test!)}'.`,
+                    () => `Node ${formatSyntaxKind(node?.kind)} did not pass test '${getFunctionName(test!)}'.`,
                     stackCrawlMark || assertNode);
             }
         }
@@ -246,7 +246,7 @@ namespace ts {
                 assert(
                     test === undefined || node === undefined || test(node),
                     message || "Unexpected node.",
-                    () => `Node ${formatSyntaxKind(node!.kind)} did not pass test '${getFunctionName(test!)}'.`,
+                    () => `Node ${formatSyntaxKind(node?.kind)} did not pass test '${getFunctionName(test!)}'.`,
                     stackCrawlMark || assertOptionalNode);
             }
         }
@@ -259,7 +259,7 @@ namespace ts {
                 assert(
                     kind === undefined || node === undefined || node.kind === kind,
                     message || "Unexpected node.",
-                    () => `Node ${formatSyntaxKind(node!.kind)} was not a '${formatSyntaxKind(kind)}' token.`,
+                    () => `Node ${formatSyntaxKind(node?.kind)} was not a '${formatSyntaxKind(kind)}' token.`,
                     stackCrawlMark || assertOptionalToken);
             }
         }


### PR DESCRIPTION
Fixes #43655.

This only fixes that when `undefined` node tries to access a property. 

After this fix the error messsage has been replace with `Verbose Debug Information: Node Unknown did not pass test 'isNamedImportBindings'.` for the example provided in the issue.