### PR TITLE
Omit spaces after https in jsdoc comments

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -159,7 +159,9 @@ namespace ts.JsDoc {
             case SyntaxKind.JSDocParameterTag:
             case SyntaxKind.JSDocSeeTag:
                 const { name } = tag as JSDocTypedefTag | JSDocCallbackTag | JSDocPropertyTag | JSDocParameterTag | JSDocSeeTag;
-                return name ? withNode(name) : comment === undefined ? undefined : getDisplayPartsFromComment(comment, checker);
+                return name ? withNode(name)
+                    : comment === undefined ? undefined
+                    : getDisplayPartsFromComment(comment, checker);
             default:
                 return comment === undefined ? undefined : getDisplayPartsFromComment(comment, checker);
         }
@@ -169,9 +171,17 @@ namespace ts.JsDoc {
         }
 
         function addComment(s: string) {
-            return comment
-                ? [namePart(s), spacePart(), ...getDisplayPartsFromComment(comment, checker)]
-                : [textPart(s)];
+            if (comment) {
+                if (s.match(/^https?$/)) {
+                    return [textPart(s), ...getDisplayPartsFromComment(comment, checker)]
+                }
+                else {
+                    return [namePart(s), spacePart(), ...getDisplayPartsFromComment(comment, checker)]
+                }
+            }
+            else {
+                return [textPart(s)];
+            }
         }
     }
 

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -173,10 +173,10 @@ namespace ts.JsDoc {
         function addComment(s: string) {
             if (comment) {
                 if (s.match(/^https?$/)) {
-                    return [textPart(s), ...getDisplayPartsFromComment(comment, checker)]
+                    return [textPart(s), ...getDisplayPartsFromComment(comment, checker)];
                 }
                 else {
-                    return [namePart(s), spacePart(), ...getDisplayPartsFromComment(comment, checker)]
+                    return [namePart(s), spacePart(), ...getDisplayPartsFromComment(comment, checker)];
                 }
             }
             else {

--- a/tests/baselines/reference/quickInfoForJSDocWithHttpLinks.baseline
+++ b/tests/baselines/reference/quickInfoForJSDocWithHttpLinks.baseline
@@ -1,0 +1,360 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocWithHttpLinks.js",
+      "position": 22,
+      "name": "1"
+    },
+    "quickInfo": {
+      "kind": "type",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 22,
+        "length": 5
+      },
+      "displayParts": [
+        {
+          "text": "type",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "https",
+          "kind": "aliasName"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=",
+          "kind": "operator"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "://wat",
+          "kind": "text"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocWithHttpLinks.js",
+      "position": 88,
+      "name": "2"
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 88,
+        "length": 5
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "https",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "://wass",
+          "kind": "text"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocWithHttpLinks.js",
+      "position": 120,
+      "name": "3"
+    },
+    "quickInfo": {
+      "kind": "type",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 120,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "type",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "http",
+          "kind": "aliasName"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=",
+          "kind": "operator"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "=>",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "any",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "://vad",
+          "kind": "text"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocWithHttpLinks.js",
+      "position": 164,
+      "name": "4"
+    },
+    "quickInfo": {
+      "kind": "var",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 164,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "var",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "see1",
+          "kind": "localName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "boolean",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "see",
+          "text": [
+            {
+              "text": "https",
+              "kind": "text"
+            },
+            {
+              "text": "://hvad",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocWithHttpLinks.js",
+      "position": 213,
+      "name": "5"
+    },
+    "quickInfo": {
+      "kind": "var",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 213,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "var",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "see2",
+          "kind": "localName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "boolean",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "see",
+          "text": [
+            {
+              "text": "",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "https://hva",
+              "kind": "linkText"
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocWithHttpLinks.js",
+      "position": 258,
+      "name": "6"
+    },
+    "quickInfo": {
+      "kind": "var",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 258,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "var",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "see3",
+          "kind": "localName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "boolean",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "https://hvaD",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/fourslash/quickInfoForJSDocWithHttpLinks.ts
+++ b/tests/cases/fourslash/quickInfoForJSDocWithHttpLinks.ts
@@ -1,0 +1,24 @@
+/// <reference path='fourslash.ts' />
+// @checkJs: true
+// @filename: quickInfoForJSDocWithHttpLinks.js
+
+//// /** @typedef {number} /*1*/https://wat */
+////
+//// /**
+//// * @typedef {Object} Oops
+//// * @property {number} /*2*/https://wass
+//// */
+////
+////
+//// /** @callback /*3*/http://vad */
+////
+//// /** @see https://hvad */
+//// var /*4*/see1 = true
+////
+//// /** @see {@link https://hva} */
+//// var /*5*/see2 = true
+////
+//// /** {@link https://hvaD} */
+//// var /*6*/see3 = true
+
+verify.baselineQuickInfo();


### PR DESCRIPTION
Omit spaces after https in jsdoc comments for tags with names.

Fixes #42581

I experimented with a more comprehensive change that made the parser retain all spaces and moved the responsibility to insert (or omit) the space to the language service. But it would have required another parser change to distinguish initial newlines, plus some too-clever code in the language service to handle initial newlines.

I noticed that #42581 doesn't ask for for whitespace-perfect comment preservation in the compiler API, just no spaces after `http` in the `@see` tag, so I decided to make an ad-hoc fix.