### PR TITLE
Update handbook link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ with any additional questions or comments.
 ## Documentation
 
 *  [TypeScript in 5 minutes](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html)
-*  [Programming handbook](https://www.typescriptlang.org/docs/handbook/basic-types.html)
+*  [Programming handbook](https://www.typescriptlang.org/docs/handbook/intro.html)
 *  [Homepage](https://www.typescriptlang.org/)
 
 ## Building


### PR DESCRIPTION
The README was fixed to point to the newest handbook link rather than a deprecated page.

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change