### PR TITLE
Don’t create invalid type-only imports during add missing import

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -420,6 +420,9 @@ namespace ts.codefix {
             const { importClause } = declaration;
             if (!importClause || !isStringLiteralLike(declaration.moduleSpecifier)) return undefined;
             const { name, namedBindings } = importClause;
+            // A type-only import may not have both a default and named imports, so the only way a name can
+            // be added to an existing type-only import is adding a named import to existing named bindings.
+            if (importClause.isTypeOnly && !(importKind === ImportKind.Named && namedBindings)) return undefined;
             return importKind === ImportKind.Default && !name || importKind === ImportKind.Named && (!namedBindings || namedBindings.kind === SyntaxKind.NamedImports)
                 ? { kind: ImportFixKind.AddToExisting, importClauseOrBindingPattern: importClause, importKind, moduleSpecifier: declaration.moduleSpecifier.text, canUseTypeOnlyImport }
                 : undefined;

--- a/tests/cases/fourslash/importNameCodeFix_typeOnly3.ts
+++ b/tests/cases/fourslash/importNameCodeFix_typeOnly3.ts
@@ -1,0 +1,34 @@
+/// <reference path="fourslash.ts" />
+
+// @importsNotUsedAsValues: error
+
+// @Filename: Presenter.ts
+//// export type DisplayStyle = "normal" | "compact";
+//// 
+//// export default class Presenter {
+////     present(displayStyle: DisplayStyle): Element {
+////         return document.createElement("placeholder");
+////     }
+//// }
+
+// @Filename: index.ts
+//// import type Presenter from "./Presenter";
+//// 
+//// function present(
+////     presenter: Presenter,
+////     displayStyle: DisplayStyle,
+//// ) {}
+
+goTo.file("index.ts");
+verify.codeFix({
+  errorCode: ts.Diagnostics.Cannot_find_name_0.code,
+  description: ignoreInterpolations(ts.Diagnostics.Import_0_from_module_1),
+  newFileContent:
+`import type { DisplayStyle } from "./Presenter";
+import type Presenter from "./Presenter";
+
+function present(
+    presenter: Presenter,
+    displayStyle: DisplayStyle,
+) {}`
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #42892
