### PR TITLE
Refrain from attempting to perform parameter fixing on a generic signature multiple times

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30345,7 +30345,14 @@ namespace ts {
         }
 
         function assignContextualParameterTypes(signature: Signature, context: Signature) {
-            signature.typeParameters = context.typeParameters;
+            if (context.typeParameters) {
+                if (!signature.typeParameters) {
+                    signature.typeParameters = context.typeParameters;
+                }
+                else {
+                    return; // This signature has already has a contextual inference performed and cached on it!
+                }
+            }
             if (context.thisParameter) {
                 const parameter = signature.thisParameter;
                 if (!parameter || parameter.valueDeclaration && !(<ParameterDeclaration>parameter.valueDeclaration).type) {
@@ -30394,6 +30401,9 @@ namespace ts {
                     }
                     assignBindingElementTypes(declaration.name);
                 }
+            }
+            else if (type) {
+                Debug.assertEqual(links.type, type);
             }
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30402,9 +30402,6 @@ namespace ts {
                     assignBindingElementTypes(declaration.name);
                 }
             }
-            else if (type) {
-                Debug.assertEqual(links.type, type);
-            }
         }
 
         // When contextual typing assigns a type to a parameter that contains a binding pattern, we also need to push

--- a/tests/baselines/reference/contextuallyTypedGenericAssignment.js
+++ b/tests/baselines/reference/contextuallyTypedGenericAssignment.js
@@ -1,0 +1,10 @@
+//// [contextuallyTypedGenericAssignment.ts]
+function foo<A extends any[]>(
+    arg: <T extends { a: number }>(t: T, ...rest: A) => number
+) { }
+
+foo((t, u: number) => t.a)
+
+//// [contextuallyTypedGenericAssignment.js]
+function foo(arg) { }
+foo(function (t, u) { return t.a; });

--- a/tests/baselines/reference/contextuallyTypedGenericAssignment.symbols
+++ b/tests/baselines/reference/contextuallyTypedGenericAssignment.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/contextuallyTypedGenericAssignment.ts ===
+function foo<A extends any[]>(
+>foo : Symbol(foo, Decl(contextuallyTypedGenericAssignment.ts, 0, 0))
+>A : Symbol(A, Decl(contextuallyTypedGenericAssignment.ts, 0, 13))
+
+    arg: <T extends { a: number }>(t: T, ...rest: A) => number
+>arg : Symbol(arg, Decl(contextuallyTypedGenericAssignment.ts, 0, 30))
+>T : Symbol(T, Decl(contextuallyTypedGenericAssignment.ts, 1, 10))
+>a : Symbol(a, Decl(contextuallyTypedGenericAssignment.ts, 1, 21))
+>t : Symbol(t, Decl(contextuallyTypedGenericAssignment.ts, 1, 35))
+>T : Symbol(T, Decl(contextuallyTypedGenericAssignment.ts, 1, 10))
+>rest : Symbol(rest, Decl(contextuallyTypedGenericAssignment.ts, 1, 40))
+>A : Symbol(A, Decl(contextuallyTypedGenericAssignment.ts, 0, 13))
+
+) { }
+
+foo((t, u: number) => t.a)
+>foo : Symbol(foo, Decl(contextuallyTypedGenericAssignment.ts, 0, 0))
+>t : Symbol(t, Decl(contextuallyTypedGenericAssignment.ts, 4, 5))
+>u : Symbol(u, Decl(contextuallyTypedGenericAssignment.ts, 4, 7))
+>t.a : Symbol(a, Decl(contextuallyTypedGenericAssignment.ts, 1, 21))
+>t : Symbol(t, Decl(contextuallyTypedGenericAssignment.ts, 4, 5))
+>a : Symbol(a, Decl(contextuallyTypedGenericAssignment.ts, 1, 21))
+

--- a/tests/baselines/reference/contextuallyTypedGenericAssignment.types
+++ b/tests/baselines/reference/contextuallyTypedGenericAssignment.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/contextuallyTypedGenericAssignment.ts ===
+function foo<A extends any[]>(
+>foo : <A extends any[]>(arg: <T extends { a: number; }>(t: T, ...rest: A) => number) => void
+
+    arg: <T extends { a: number }>(t: T, ...rest: A) => number
+>arg : <T extends { a: number; }>(t: T, ...rest: A) => number
+>a : number
+>t : T
+>rest : A
+
+) { }
+
+foo((t, u: number) => t.a)
+>foo((t, u: number) => t.a) : void
+>foo : <A extends any[]>(arg: <T extends { a: number; }>(t: T, ...rest: A) => number) => void
+>(t, u: number) => t.a : <T extends { a: number; }>(t: T, u: number) => number
+>t : T
+>u : number
+>t.a : number
+>t : T
+>a : number
+

--- a/tests/cases/compiler/contextuallyTypedGenericAssignment.ts
+++ b/tests/cases/compiler/contextuallyTypedGenericAssignment.ts
@@ -1,0 +1,5 @@
+function foo<A extends any[]>(
+    arg: <T extends { a: number }>(t: T, ...rest: A) => number
+) { }
+
+foo((t, u: number) => t.a)


### PR DESCRIPTION
Fixes #43833

We would perform contextual parameter fixing twice on the same signature (against different instantiations of the target signature) - once during generic propagation, and again later when doing contextual typing. This caused the `typeParameters` of the signature being fixed to get mutated, while the cached calculated type of each parameter was unchanged, causing a type parameter mismatch leading to inference failure. Since signatures are supposed to be immutable-ish, I  disallowed the second fixing pass if the first fixing pass has occurred. Additionally, there is now a debug assertion in parameter fixing for if we attempt to fix a type to a parameter and it already has a cached type which differs from the type we want to fix. Logically, we never want this to happen (since we can only contextually fix a given signature once), so the assertion should only be triggered if we've broken this subtle invariant somewhere.