### PR TITLE
During inference discriminate the target type before falling back to close-matching types

### DIFF
--- a/tests/baselines/reference/classExtendedDiscriminatedUnionInference.js
+++ b/tests/baselines/reference/classExtendedDiscriminatedUnionInference.js
@@ -1,0 +1,45 @@
+//// [classExtendedDiscriminatedUnionInference.ts]
+declare class LocalController<T, U> {
+    isLocal: true;
+    getProps(a: T, b: U): void;
+}
+declare class GlobalController<T, U> {
+    isLocal: false;
+    // N.B.: Parameter type order is reversed
+    getProps(a: U, b: T): void;
+}
+
+class FailWithTS42 extends LocalController<{ foo: any }, { bar: any }> { }
+const p = new FailWithTS42();
+
+declare function createEnhancer1<T, U>(Wrapper: GlobalController<T, U> | LocalController<T, U>): [T, U];
+const q1 = createEnhancer1(p);
+const q2 = createEnhancer1(p as LocalController<{ foo: any }, { bar: any }>); // structurally identical type to the above
+
+
+//// [classExtendedDiscriminatedUnionInference.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var FailWithTS42 = /** @class */ (function (_super) {
+    __extends(FailWithTS42, _super);
+    function FailWithTS42() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return FailWithTS42;
+}(LocalController));
+var p = new FailWithTS42();
+var q1 = createEnhancer1(p);
+var q2 = createEnhancer1(p); // structurally identical type to the above

--- a/tests/baselines/reference/classExtendedDiscriminatedUnionInference.symbols
+++ b/tests/baselines/reference/classExtendedDiscriminatedUnionInference.symbols
@@ -1,0 +1,70 @@
+=== tests/cases/compiler/classExtendedDiscriminatedUnionInference.ts ===
+declare class LocalController<T, U> {
+>LocalController : Symbol(LocalController, Decl(classExtendedDiscriminatedUnionInference.ts, 0, 0))
+>T : Symbol(T, Decl(classExtendedDiscriminatedUnionInference.ts, 0, 30))
+>U : Symbol(U, Decl(classExtendedDiscriminatedUnionInference.ts, 0, 32))
+
+    isLocal: true;
+>isLocal : Symbol(LocalController.isLocal, Decl(classExtendedDiscriminatedUnionInference.ts, 0, 37))
+
+    getProps(a: T, b: U): void;
+>getProps : Symbol(LocalController.getProps, Decl(classExtendedDiscriminatedUnionInference.ts, 1, 18))
+>a : Symbol(a, Decl(classExtendedDiscriminatedUnionInference.ts, 2, 13))
+>T : Symbol(T, Decl(classExtendedDiscriminatedUnionInference.ts, 0, 30))
+>b : Symbol(b, Decl(classExtendedDiscriminatedUnionInference.ts, 2, 18))
+>U : Symbol(U, Decl(classExtendedDiscriminatedUnionInference.ts, 0, 32))
+}
+declare class GlobalController<T, U> {
+>GlobalController : Symbol(GlobalController, Decl(classExtendedDiscriminatedUnionInference.ts, 3, 1))
+>T : Symbol(T, Decl(classExtendedDiscriminatedUnionInference.ts, 4, 31))
+>U : Symbol(U, Decl(classExtendedDiscriminatedUnionInference.ts, 4, 33))
+
+    isLocal: false;
+>isLocal : Symbol(GlobalController.isLocal, Decl(classExtendedDiscriminatedUnionInference.ts, 4, 38))
+
+    // N.B.: Parameter type order is reversed
+    getProps(a: U, b: T): void;
+>getProps : Symbol(GlobalController.getProps, Decl(classExtendedDiscriminatedUnionInference.ts, 5, 19))
+>a : Symbol(a, Decl(classExtendedDiscriminatedUnionInference.ts, 7, 13))
+>U : Symbol(U, Decl(classExtendedDiscriminatedUnionInference.ts, 4, 33))
+>b : Symbol(b, Decl(classExtendedDiscriminatedUnionInference.ts, 7, 18))
+>T : Symbol(T, Decl(classExtendedDiscriminatedUnionInference.ts, 4, 31))
+}
+
+class FailWithTS42 extends LocalController<{ foo: any }, { bar: any }> { }
+>FailWithTS42 : Symbol(FailWithTS42, Decl(classExtendedDiscriminatedUnionInference.ts, 8, 1))
+>LocalController : Symbol(LocalController, Decl(classExtendedDiscriminatedUnionInference.ts, 0, 0))
+>foo : Symbol(foo, Decl(classExtendedDiscriminatedUnionInference.ts, 10, 44))
+>bar : Symbol(bar, Decl(classExtendedDiscriminatedUnionInference.ts, 10, 58))
+
+const p = new FailWithTS42();
+>p : Symbol(p, Decl(classExtendedDiscriminatedUnionInference.ts, 11, 5))
+>FailWithTS42 : Symbol(FailWithTS42, Decl(classExtendedDiscriminatedUnionInference.ts, 8, 1))
+
+declare function createEnhancer1<T, U>(Wrapper: GlobalController<T, U> | LocalController<T, U>): [T, U];
+>createEnhancer1 : Symbol(createEnhancer1, Decl(classExtendedDiscriminatedUnionInference.ts, 11, 29))
+>T : Symbol(T, Decl(classExtendedDiscriminatedUnionInference.ts, 13, 33))
+>U : Symbol(U, Decl(classExtendedDiscriminatedUnionInference.ts, 13, 35))
+>Wrapper : Symbol(Wrapper, Decl(classExtendedDiscriminatedUnionInference.ts, 13, 39))
+>GlobalController : Symbol(GlobalController, Decl(classExtendedDiscriminatedUnionInference.ts, 3, 1))
+>T : Symbol(T, Decl(classExtendedDiscriminatedUnionInference.ts, 13, 33))
+>U : Symbol(U, Decl(classExtendedDiscriminatedUnionInference.ts, 13, 35))
+>LocalController : Symbol(LocalController, Decl(classExtendedDiscriminatedUnionInference.ts, 0, 0))
+>T : Symbol(T, Decl(classExtendedDiscriminatedUnionInference.ts, 13, 33))
+>U : Symbol(U, Decl(classExtendedDiscriminatedUnionInference.ts, 13, 35))
+>T : Symbol(T, Decl(classExtendedDiscriminatedUnionInference.ts, 13, 33))
+>U : Symbol(U, Decl(classExtendedDiscriminatedUnionInference.ts, 13, 35))
+
+const q1 = createEnhancer1(p);
+>q1 : Symbol(q1, Decl(classExtendedDiscriminatedUnionInference.ts, 14, 5))
+>createEnhancer1 : Symbol(createEnhancer1, Decl(classExtendedDiscriminatedUnionInference.ts, 11, 29))
+>p : Symbol(p, Decl(classExtendedDiscriminatedUnionInference.ts, 11, 5))
+
+const q2 = createEnhancer1(p as LocalController<{ foo: any }, { bar: any }>); // structurally identical type to the above
+>q2 : Symbol(q2, Decl(classExtendedDiscriminatedUnionInference.ts, 15, 5))
+>createEnhancer1 : Symbol(createEnhancer1, Decl(classExtendedDiscriminatedUnionInference.ts, 11, 29))
+>p : Symbol(p, Decl(classExtendedDiscriminatedUnionInference.ts, 11, 5))
+>LocalController : Symbol(LocalController, Decl(classExtendedDiscriminatedUnionInference.ts, 0, 0))
+>foo : Symbol(foo, Decl(classExtendedDiscriminatedUnionInference.ts, 15, 49))
+>bar : Symbol(bar, Decl(classExtendedDiscriminatedUnionInference.ts, 15, 63))
+

--- a/tests/baselines/reference/classExtendedDiscriminatedUnionInference.types
+++ b/tests/baselines/reference/classExtendedDiscriminatedUnionInference.types
@@ -1,0 +1,57 @@
+=== tests/cases/compiler/classExtendedDiscriminatedUnionInference.ts ===
+declare class LocalController<T, U> {
+>LocalController : LocalController<T, U>
+
+    isLocal: true;
+>isLocal : true
+>true : true
+
+    getProps(a: T, b: U): void;
+>getProps : (a: T, b: U) => void
+>a : T
+>b : U
+}
+declare class GlobalController<T, U> {
+>GlobalController : GlobalController<T, U>
+
+    isLocal: false;
+>isLocal : false
+>false : false
+
+    // N.B.: Parameter type order is reversed
+    getProps(a: U, b: T): void;
+>getProps : (a: U, b: T) => void
+>a : U
+>b : T
+}
+
+class FailWithTS42 extends LocalController<{ foo: any }, { bar: any }> { }
+>FailWithTS42 : FailWithTS42
+>LocalController : LocalController<{ foo: any; }, { bar: any; }>
+>foo : any
+>bar : any
+
+const p = new FailWithTS42();
+>p : FailWithTS42
+>new FailWithTS42() : FailWithTS42
+>FailWithTS42 : typeof FailWithTS42
+
+declare function createEnhancer1<T, U>(Wrapper: GlobalController<T, U> | LocalController<T, U>): [T, U];
+>createEnhancer1 : <T, U>(Wrapper: GlobalController<T, U> | LocalController<T, U>) => [T, U]
+>Wrapper : GlobalController<T, U> | LocalController<T, U>
+
+const q1 = createEnhancer1(p);
+>q1 : [{ foo: any; }, { bar: any; }]
+>createEnhancer1(p) : [{ foo: any; }, { bar: any; }]
+>createEnhancer1 : <T, U>(Wrapper: GlobalController<T, U> | LocalController<T, U>) => [T, U]
+>p : FailWithTS42
+
+const q2 = createEnhancer1(p as LocalController<{ foo: any }, { bar: any }>); // structurally identical type to the above
+>q2 : [{ foo: any; }, { bar: any; }]
+>createEnhancer1(p as LocalController<{ foo: any }, { bar: any }>) : [{ foo: any; }, { bar: any; }]
+>createEnhancer1 : <T, U>(Wrapper: GlobalController<T, U> | LocalController<T, U>) => [T, U]
+>p as LocalController<{ foo: any }, { bar: any }> : LocalController<{ foo: any; }, { bar: any; }>
+>p : FailWithTS42
+>foo : any
+>bar : any
+

--- a/tests/cases/compiler/classExtendedDiscriminatedUnionInference.ts
+++ b/tests/cases/compiler/classExtendedDiscriminatedUnionInference.ts
@@ -1,0 +1,16 @@
+declare class LocalController<T, U> {
+    isLocal: true;
+    getProps(a: T, b: U): void;
+}
+declare class GlobalController<T, U> {
+    isLocal: false;
+    // N.B.: Parameter type order is reversed
+    getProps(a: U, b: T): void;
+}
+
+class FailWithTS42 extends LocalController<{ foo: any }, { bar: any }> { }
+const p = new FailWithTS42();
+
+declare function createEnhancer1<T, U>(Wrapper: GlobalController<T, U> | LocalController<T, U>): [T, U];
+const q1 = createEnhancer1(p);
+const q2 = createEnhancer1(p as LocalController<{ foo: any }, { bar: any }>); // structurally identical type to the above


### PR DESCRIPTION
Fixes #43753
