### PR TITLE
Fix `node.getStart()` for nodes spanning multiline JSDoc comments

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -478,7 +478,12 @@ namespace ts {
             return getTokenPosOfNode((<SyntaxList>node)._children[0], sourceFile, includeJsDoc);
         }
 
-        return skipTrivia((sourceFile || getSourceFileOfNode(node)).text, node.pos);
+        return skipTrivia(
+            (sourceFile || getSourceFileOfNode(node)).text,
+            node.pos,
+            /*stopAfterLineBreak*/ false,
+            /*stopAtComments*/ false,
+            isInJSDoc(node));
     }
 
     export function getNonDecoratorTokenPosOfNode(node: Node, sourceFile?: SourceFileLike): number {

--- a/tests/cases/fourslash/documentHighlightJSDocTypedef.ts
+++ b/tests/cases/fourslash/documentHighlightJSDocTypedef.ts
@@ -1,0 +1,20 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: index.js
+//// /**
+////  * @typedef {{
+////  *   [|foo|]: string;
+////  *   [|bar|]: number;
+////  * }} Foo
+////  */
+//// 
+//// /** @type {Foo} */
+//// const x = {
+////   [|foo|]: "",
+////   [|bar|]: 42,
+//// };
+
+verify.rangesWithSameTextAreDocumentHighlights();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #43442

`skipTrivia` needs to skip a leading `*` inside JSDoc.
