### PR TITLE
Mark conditional extends as Unmeasurable and use a conditional-opaque wildcard for type erasure

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5074,6 +5074,8 @@ namespace ts {
         IncludesWildcard = IndexedAccess,
         /* @internal */
         IncludesEmptyObject = Conditional,
+        /* @internal */
+        IncludesOpaqueWildcard = StringMapping,
     }
 
     export type DestructuringPattern = BindingPattern | ObjectLiteralExpression | ArrayLiteralExpression;

--- a/tests/baselines/reference/complexRecursiveCollections.types
+++ b/tests/baselines/reference/complexRecursiveCollections.types
@@ -1137,7 +1137,7 @@ declare module Immutable {
 >Seq : typeof Seq
 
     function isSeq(maybeSeq: any): maybeSeq is Seq.Indexed<any> | Seq.Keyed<any, any>;
->isSeq : (maybeSeq: any) => maybeSeq is Indexed<any> | Keyed<any, any>
+>isSeq : (maybeSeq: any) => maybeSeq is Keyed<any, any> | Indexed<any>
 >maybeSeq : any
 >Seq : any
 >Seq : any

--- a/tests/baselines/reference/emptyClassSomehowNeverChecksConditionals.errors.txt
+++ b/tests/baselines/reference/emptyClassSomehowNeverChecksConditionals.errors.txt
@@ -1,0 +1,78 @@
+tests/cases/compiler/emptyClassSomehowNeverChecksConditionals.ts(5,7): error TS2322: Type 'EqualsTest<string>' is not assignable to type 'EqualsTest<number>'.
+  Type 'any extends string ? 1 : 0' is not assignable to type 'any extends number ? 1 : 0'.
+    Type '0 | 1' is not assignable to type 'any extends number ? 1 : 0'.
+      Type '0' is not assignable to type 'any extends number ? 1 : 0'.
+tests/cases/compiler/emptyClassSomehowNeverChecksConditionals.ts(6,7): error TS2322: Type 'EqualsTest1<string>' is not assignable to type 'EqualsTest<number>'.
+  Type 'A extends string ? 1 : 0' is not assignable to type 'A extends number ? 1 : 0'.
+    Type '0 | 1' is not assignable to type 'A extends number ? 1 : 0'.
+      Type '0' is not assignable to type 'A extends number ? 1 : 0'.
+tests/cases/compiler/emptyClassSomehowNeverChecksConditionals.ts(12,27): error TS2344: Type 'this' does not satisfy the constraint 'Model<typeof Model>'.
+  Type 'Model<MClass>' is not assignable to type 'Model<typeof Model>'.
+    Types of property 'set' are incompatible.
+      Type '<K>(value: K extends MClass ? number : string) => void' is not assignable to type '<K>(value: K extends typeof Model ? number : string) => void'.
+        Types of parameters 'value' and 'value' are incompatible.
+          Type 'K extends typeof Model ? number : string' is not assignable to type 'K extends MClass ? number : string'.
+            Type 'string | number' is not assignable to type 'K extends MClass ? number : string'.
+              Type 'string' is not assignable to type 'K extends MClass ? number : string'.
+tests/cases/compiler/emptyClassSomehowNeverChecksConditionals.ts(20,28): error TS2344: Type 'this' does not satisfy the constraint 'ModelSub'.
+  Type 'Model2<MClass>' is not assignable to type 'Model2<typeof ModelSub>'.
+    Types of property 'set' are incompatible.
+      Type '<K>(value: K extends MClass ? number : string) => void' is not assignable to type '<K>(value: K extends typeof ModelSub ? number : string) => void'.
+        Types of parameters 'value' and 'value' are incompatible.
+          Type 'K extends typeof ModelSub ? number : string' is not assignable to type 'K extends MClass ? number : string'.
+            Type 'string | number' is not assignable to type 'K extends MClass ? number : string'.
+              Type 'string' is not assignable to type 'K extends MClass ? number : string'.
+
+
+==== tests/cases/compiler/emptyClassSomehowNeverChecksConditionals.ts (4 errors) ====
+    // quick distillation of conditionals which were previously erased by signature relating
+    type EqualsTest<T> = <A>() => A extends T ? 1 : 0;
+    type EqualsTest1<T> = <A>() => A extends T ? 1 : 0;
+    
+    const x: EqualsTest<number> = undefined as any as EqualsTest<string>; // should error, obviously wrong
+          ~
+!!! error TS2322: Type 'EqualsTest<string>' is not assignable to type 'EqualsTest<number>'.
+!!! error TS2322:   Type 'any extends string ? 1 : 0' is not assignable to type 'any extends number ? 1 : 0'.
+!!! error TS2322:     Type '0 | 1' is not assignable to type 'any extends number ? 1 : 0'.
+!!! error TS2322:       Type '0' is not assignable to type 'any extends number ? 1 : 0'.
+    const y: EqualsTest<number> = undefined as any as EqualsTest1<string>; // same as the above, but seperate type aliases
+          ~
+!!! error TS2322: Type 'EqualsTest1<string>' is not assignable to type 'EqualsTest<number>'.
+!!! error TS2322:   Type 'A extends string ? 1 : 0' is not assignable to type 'A extends number ? 1 : 0'.
+!!! error TS2322:     Type '0 | 1' is not assignable to type 'A extends number ? 1 : 0'.
+!!! error TS2322:       Type '0' is not assignable to type 'A extends number ? 1 : 0'.
+    
+    // Slightly extended example using class inheritance
+    type ModelId<M extends Model> = M; // just validates the input matches the `Model` type to issue an error
+    export declare class Model<MClass extends typeof Model = typeof Model> {
+        class: MClass;
+        readonly ref: ModelId<this>;
+                              ~~~~
+!!! error TS2344: Type 'this' does not satisfy the constraint 'Model<typeof Model>'.
+!!! error TS2344:   Type 'Model<MClass>' is not assignable to type 'Model<typeof Model>'.
+!!! error TS2344:     Types of property 'set' are incompatible.
+!!! error TS2344:       Type '<K>(value: K extends MClass ? number : string) => void' is not assignable to type '<K>(value: K extends typeof Model ? number : string) => void'.
+!!! error TS2344:         Types of parameters 'value' and 'value' are incompatible.
+!!! error TS2344:           Type 'K extends typeof Model ? number : string' is not assignable to type 'K extends MClass ? number : string'.
+!!! error TS2344:             Type 'string | number' is not assignable to type 'K extends MClass ? number : string'.
+!!! error TS2344:               Type 'string' is not assignable to type 'K extends MClass ? number : string'.
+        set<K>(value: K extends MClass ? number : string): void;
+    }
+    
+    // identical to the above, but with a no-op subclass
+    type ModelId2<M extends ModelSub> = M;
+    export declare class Model2<MClass extends typeof ModelSub = typeof ModelSub> {
+        class: MClass;
+        readonly ref: ModelId2<this>;
+                               ~~~~
+!!! error TS2344: Type 'this' does not satisfy the constraint 'ModelSub'.
+!!! error TS2344:   Type 'Model2<MClass>' is not assignable to type 'Model2<typeof ModelSub>'.
+!!! error TS2344:     Types of property 'set' are incompatible.
+!!! error TS2344:       Type '<K>(value: K extends MClass ? number : string) => void' is not assignable to type '<K>(value: K extends typeof ModelSub ? number : string) => void'.
+!!! error TS2344:         Types of parameters 'value' and 'value' are incompatible.
+!!! error TS2344:           Type 'K extends typeof ModelSub ? number : string' is not assignable to type 'K extends MClass ? number : string'.
+!!! error TS2344:             Type 'string | number' is not assignable to type 'K extends MClass ? number : string'.
+!!! error TS2344:               Type 'string' is not assignable to type 'K extends MClass ? number : string'.
+        set<K>(value: K extends MClass ? number : string): void;
+    }
+    export declare class ModelSub extends Model2 {}

--- a/tests/baselines/reference/emptyClassSomehowNeverChecksConditionals.js
+++ b/tests/baselines/reference/emptyClassSomehowNeverChecksConditionals.js
@@ -1,0 +1,30 @@
+//// [emptyClassSomehowNeverChecksConditionals.ts]
+// quick distillation of conditionals which were previously erased by signature relating
+type EqualsTest<T> = <A>() => A extends T ? 1 : 0;
+type EqualsTest1<T> = <A>() => A extends T ? 1 : 0;
+
+const x: EqualsTest<number> = undefined as any as EqualsTest<string>; // should error, obviously wrong
+const y: EqualsTest<number> = undefined as any as EqualsTest1<string>; // same as the above, but seperate type aliases
+
+// Slightly extended example using class inheritance
+type ModelId<M extends Model> = M; // just validates the input matches the `Model` type to issue an error
+export declare class Model<MClass extends typeof Model = typeof Model> {
+    class: MClass;
+    readonly ref: ModelId<this>;
+    set<K>(value: K extends MClass ? number : string): void;
+}
+
+// identical to the above, but with a no-op subclass
+type ModelId2<M extends ModelSub> = M;
+export declare class Model2<MClass extends typeof ModelSub = typeof ModelSub> {
+    class: MClass;
+    readonly ref: ModelId2<this>;
+    set<K>(value: K extends MClass ? number : string): void;
+}
+export declare class ModelSub extends Model2 {}
+
+//// [emptyClassSomehowNeverChecksConditionals.js]
+"use strict";
+exports.__esModule = true;
+var x = undefined; // should error, obviously wrong
+var y = undefined; // same as the above, but seperate type aliases

--- a/tests/baselines/reference/emptyClassSomehowNeverChecksConditionals.symbols
+++ b/tests/baselines/reference/emptyClassSomehowNeverChecksConditionals.symbols
@@ -1,0 +1,89 @@
+=== tests/cases/compiler/emptyClassSomehowNeverChecksConditionals.ts ===
+// quick distillation of conditionals which were previously erased by signature relating
+type EqualsTest<T> = <A>() => A extends T ? 1 : 0;
+>EqualsTest : Symbol(EqualsTest, Decl(emptyClassSomehowNeverChecksConditionals.ts, 0, 0))
+>T : Symbol(T, Decl(emptyClassSomehowNeverChecksConditionals.ts, 1, 16))
+>A : Symbol(A, Decl(emptyClassSomehowNeverChecksConditionals.ts, 1, 22))
+>A : Symbol(A, Decl(emptyClassSomehowNeverChecksConditionals.ts, 1, 22))
+>T : Symbol(T, Decl(emptyClassSomehowNeverChecksConditionals.ts, 1, 16))
+
+type EqualsTest1<T> = <A>() => A extends T ? 1 : 0;
+>EqualsTest1 : Symbol(EqualsTest1, Decl(emptyClassSomehowNeverChecksConditionals.ts, 1, 50))
+>T : Symbol(T, Decl(emptyClassSomehowNeverChecksConditionals.ts, 2, 17))
+>A : Symbol(A, Decl(emptyClassSomehowNeverChecksConditionals.ts, 2, 23))
+>A : Symbol(A, Decl(emptyClassSomehowNeverChecksConditionals.ts, 2, 23))
+>T : Symbol(T, Decl(emptyClassSomehowNeverChecksConditionals.ts, 2, 17))
+
+const x: EqualsTest<number> = undefined as any as EqualsTest<string>; // should error, obviously wrong
+>x : Symbol(x, Decl(emptyClassSomehowNeverChecksConditionals.ts, 4, 5))
+>EqualsTest : Symbol(EqualsTest, Decl(emptyClassSomehowNeverChecksConditionals.ts, 0, 0))
+>undefined : Symbol(undefined)
+>EqualsTest : Symbol(EqualsTest, Decl(emptyClassSomehowNeverChecksConditionals.ts, 0, 0))
+
+const y: EqualsTest<number> = undefined as any as EqualsTest1<string>; // same as the above, but seperate type aliases
+>y : Symbol(y, Decl(emptyClassSomehowNeverChecksConditionals.ts, 5, 5))
+>EqualsTest : Symbol(EqualsTest, Decl(emptyClassSomehowNeverChecksConditionals.ts, 0, 0))
+>undefined : Symbol(undefined)
+>EqualsTest1 : Symbol(EqualsTest1, Decl(emptyClassSomehowNeverChecksConditionals.ts, 1, 50))
+
+// Slightly extended example using class inheritance
+type ModelId<M extends Model> = M; // just validates the input matches the `Model` type to issue an error
+>ModelId : Symbol(ModelId, Decl(emptyClassSomehowNeverChecksConditionals.ts, 5, 70))
+>M : Symbol(M, Decl(emptyClassSomehowNeverChecksConditionals.ts, 8, 13))
+>Model : Symbol(Model, Decl(emptyClassSomehowNeverChecksConditionals.ts, 8, 34))
+>M : Symbol(M, Decl(emptyClassSomehowNeverChecksConditionals.ts, 8, 13))
+
+export declare class Model<MClass extends typeof Model = typeof Model> {
+>Model : Symbol(Model, Decl(emptyClassSomehowNeverChecksConditionals.ts, 8, 34))
+>MClass : Symbol(MClass, Decl(emptyClassSomehowNeverChecksConditionals.ts, 9, 27))
+>Model : Symbol(Model, Decl(emptyClassSomehowNeverChecksConditionals.ts, 8, 34))
+>Model : Symbol(Model, Decl(emptyClassSomehowNeverChecksConditionals.ts, 8, 34))
+
+    class: MClass;
+>class : Symbol(Model.class, Decl(emptyClassSomehowNeverChecksConditionals.ts, 9, 72))
+>MClass : Symbol(MClass, Decl(emptyClassSomehowNeverChecksConditionals.ts, 9, 27))
+
+    readonly ref: ModelId<this>;
+>ref : Symbol(Model.ref, Decl(emptyClassSomehowNeverChecksConditionals.ts, 10, 18))
+>ModelId : Symbol(ModelId, Decl(emptyClassSomehowNeverChecksConditionals.ts, 5, 70))
+
+    set<K>(value: K extends MClass ? number : string): void;
+>set : Symbol(Model.set, Decl(emptyClassSomehowNeverChecksConditionals.ts, 11, 32))
+>K : Symbol(K, Decl(emptyClassSomehowNeverChecksConditionals.ts, 12, 8))
+>value : Symbol(value, Decl(emptyClassSomehowNeverChecksConditionals.ts, 12, 11))
+>K : Symbol(K, Decl(emptyClassSomehowNeverChecksConditionals.ts, 12, 8))
+>MClass : Symbol(MClass, Decl(emptyClassSomehowNeverChecksConditionals.ts, 9, 27))
+}
+
+// identical to the above, but with a no-op subclass
+type ModelId2<M extends ModelSub> = M;
+>ModelId2 : Symbol(ModelId2, Decl(emptyClassSomehowNeverChecksConditionals.ts, 13, 1))
+>M : Symbol(M, Decl(emptyClassSomehowNeverChecksConditionals.ts, 16, 14))
+>ModelSub : Symbol(ModelSub, Decl(emptyClassSomehowNeverChecksConditionals.ts, 21, 1))
+>M : Symbol(M, Decl(emptyClassSomehowNeverChecksConditionals.ts, 16, 14))
+
+export declare class Model2<MClass extends typeof ModelSub = typeof ModelSub> {
+>Model2 : Symbol(Model2, Decl(emptyClassSomehowNeverChecksConditionals.ts, 16, 38))
+>MClass : Symbol(MClass, Decl(emptyClassSomehowNeverChecksConditionals.ts, 17, 28))
+>ModelSub : Symbol(ModelSub, Decl(emptyClassSomehowNeverChecksConditionals.ts, 21, 1))
+>ModelSub : Symbol(ModelSub, Decl(emptyClassSomehowNeverChecksConditionals.ts, 21, 1))
+
+    class: MClass;
+>class : Symbol(Model2.class, Decl(emptyClassSomehowNeverChecksConditionals.ts, 17, 79))
+>MClass : Symbol(MClass, Decl(emptyClassSomehowNeverChecksConditionals.ts, 17, 28))
+
+    readonly ref: ModelId2<this>;
+>ref : Symbol(Model2.ref, Decl(emptyClassSomehowNeverChecksConditionals.ts, 18, 18))
+>ModelId2 : Symbol(ModelId2, Decl(emptyClassSomehowNeverChecksConditionals.ts, 13, 1))
+
+    set<K>(value: K extends MClass ? number : string): void;
+>set : Symbol(Model2.set, Decl(emptyClassSomehowNeverChecksConditionals.ts, 19, 33))
+>K : Symbol(K, Decl(emptyClassSomehowNeverChecksConditionals.ts, 20, 8))
+>value : Symbol(value, Decl(emptyClassSomehowNeverChecksConditionals.ts, 20, 11))
+>K : Symbol(K, Decl(emptyClassSomehowNeverChecksConditionals.ts, 20, 8))
+>MClass : Symbol(MClass, Decl(emptyClassSomehowNeverChecksConditionals.ts, 17, 28))
+}
+export declare class ModelSub extends Model2 {}
+>ModelSub : Symbol(ModelSub, Decl(emptyClassSomehowNeverChecksConditionals.ts, 21, 1))
+>Model2 : Symbol(Model2, Decl(emptyClassSomehowNeverChecksConditionals.ts, 16, 38))
+

--- a/tests/baselines/reference/emptyClassSomehowNeverChecksConditionals.types
+++ b/tests/baselines/reference/emptyClassSomehowNeverChecksConditionals.types
@@ -1,0 +1,63 @@
+=== tests/cases/compiler/emptyClassSomehowNeverChecksConditionals.ts ===
+// quick distillation of conditionals which were previously erased by signature relating
+type EqualsTest<T> = <A>() => A extends T ? 1 : 0;
+>EqualsTest : EqualsTest<T>
+
+type EqualsTest1<T> = <A>() => A extends T ? 1 : 0;
+>EqualsTest1 : EqualsTest1<T>
+
+const x: EqualsTest<number> = undefined as any as EqualsTest<string>; // should error, obviously wrong
+>x : EqualsTest<number>
+>undefined as any as EqualsTest<string> : EqualsTest<string>
+>undefined as any : any
+>undefined : undefined
+
+const y: EqualsTest<number> = undefined as any as EqualsTest1<string>; // same as the above, but seperate type aliases
+>y : EqualsTest<number>
+>undefined as any as EqualsTest1<string> : EqualsTest1<string>
+>undefined as any : any
+>undefined : undefined
+
+// Slightly extended example using class inheritance
+type ModelId<M extends Model> = M; // just validates the input matches the `Model` type to issue an error
+>ModelId : M
+
+export declare class Model<MClass extends typeof Model = typeof Model> {
+>Model : Model<MClass>
+>Model : typeof Model
+>Model : typeof Model
+
+    class: MClass;
+>class : MClass
+
+    readonly ref: ModelId<this>;
+>ref : this
+
+    set<K>(value: K extends MClass ? number : string): void;
+>set : <K>(value: K extends MClass ? number : string) => void
+>value : K extends MClass ? number : string
+}
+
+// identical to the above, but with a no-op subclass
+type ModelId2<M extends ModelSub> = M;
+>ModelId2 : M
+
+export declare class Model2<MClass extends typeof ModelSub = typeof ModelSub> {
+>Model2 : Model2<MClass>
+>ModelSub : typeof ModelSub
+>ModelSub : typeof ModelSub
+
+    class: MClass;
+>class : MClass
+
+    readonly ref: ModelId2<this>;
+>ref : this
+
+    set<K>(value: K extends MClass ? number : string): void;
+>set : <K>(value: K extends MClass ? number : string) => void
+>value : K extends MClass ? number : string
+}
+export declare class ModelSub extends Model2 {}
+>ModelSub : ModelSub
+>Model2 : Model2<typeof ModelSub>
+

--- a/tests/baselines/reference/overloadAssignabilityChecksAllowGenericAssignment.js
+++ b/tests/baselines/reference/overloadAssignabilityChecksAllowGenericAssignment.js
@@ -1,0 +1,9 @@
+//// [overloadAssignabilityChecksAllowGenericAssignment.ts]
+declare function provide<T>(cb: (x: T) => void): void;
+declare function provide<T>(cb: (x: T[keyof T]) => void): void;
+
+declare function provider<T>(provide: (cb: (x: T) => void) => void): void;
+provider(provide); 
+
+//// [overloadAssignabilityChecksAllowGenericAssignment.js]
+provider(provide);

--- a/tests/baselines/reference/overloadAssignabilityChecksAllowGenericAssignment.symbols
+++ b/tests/baselines/reference/overloadAssignabilityChecksAllowGenericAssignment.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/overloadAssignabilityChecksAllowGenericAssignment.ts ===
+declare function provide<T>(cb: (x: T) => void): void;
+>provide : Symbol(provide, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 0), Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 54))
+>T : Symbol(T, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 25))
+>cb : Symbol(cb, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 28))
+>x : Symbol(x, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 33))
+>T : Symbol(T, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 25))
+
+declare function provide<T>(cb: (x: T[keyof T]) => void): void;
+>provide : Symbol(provide, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 0), Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 54))
+>T : Symbol(T, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 1, 25))
+>cb : Symbol(cb, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 1, 28))
+>x : Symbol(x, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 1, 33))
+>T : Symbol(T, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 1, 25))
+>T : Symbol(T, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 1, 25))
+
+declare function provider<T>(provide: (cb: (x: T) => void) => void): void;
+>provider : Symbol(provider, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 1, 63))
+>T : Symbol(T, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 3, 26))
+>provide : Symbol(provide, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 3, 29))
+>cb : Symbol(cb, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 3, 39))
+>x : Symbol(x, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 3, 44))
+>T : Symbol(T, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 3, 26))
+
+provider(provide); 
+>provider : Symbol(provider, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 1, 63))
+>provide : Symbol(provide, Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 0), Decl(overloadAssignabilityChecksAllowGenericAssignment.ts, 0, 54))
+

--- a/tests/baselines/reference/overloadAssignabilityChecksAllowGenericAssignment.types
+++ b/tests/baselines/reference/overloadAssignabilityChecksAllowGenericAssignment.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/overloadAssignabilityChecksAllowGenericAssignment.ts ===
+declare function provide<T>(cb: (x: T) => void): void;
+>provide : { <T>(cb: (x: T) => void): void; <T>(cb: (x: T[keyof T]) => void): void; }
+>cb : (x: T) => void
+>x : T
+
+declare function provide<T>(cb: (x: T[keyof T]) => void): void;
+>provide : { <T>(cb: (x: T) => void): void; <T>(cb: (x: T[keyof T]) => void): void; }
+>cb : (x: T[keyof T]) => void
+>x : T[keyof T]
+
+declare function provider<T>(provide: (cb: (x: T) => void) => void): void;
+>provider : <T>(provide: (cb: (x: T) => void) => void) => void
+>provide : (cb: (x: T) => void) => void
+>cb : (x: T) => void
+>x : T
+
+provider(provide); 
+>provider(provide) : void
+>provider : <T>(provide: (cb: (x: T) => void) => void) => void
+>provide : { <T>(cb: (x: T) => void): void; <T>(cb: (x: T[keyof T]) => void): void; }
+

--- a/tests/baselines/reference/subtypingWithCallSignatures2.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures2.types
@@ -762,8 +762,8 @@ var r15arg1 = <T>(x: T) => <T[]>null
 >null : null
 
 var r15 = foo15(r15arg1); // any
->r15 : any
->foo15(r15arg1) : any
+>r15 : { (x: number): number[]; (x: string): string[]; }
+>foo15(r15arg1) : { (x: number): number[]; (x: string): string[]; }
 >foo15 : { (a: { (x: number): number[]; (x: string): string[]; }): { (x: number): number[]; (x: string): string[]; }; (a: any): any; }
 >r15arg1 : <T>(x: T) => T[]
 
@@ -789,8 +789,8 @@ var r17arg1 = <T>(x: (a: T) => T) => <T[]>null;
 >null : null
 
 var r17 = foo17(r17arg1); // any
->r17 : any
->foo17(r17arg1) : any
+>r17 : { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }
+>foo17(r17arg1) : { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }
 >foo17 : { (a: { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }): { (x: (a: number) => number): number[]; (x: (a: string) => string): string[]; }; (a: any): any; }
 >r17arg1 : <T>(x: (a: T) => T) => T[]
 

--- a/tests/baselines/reference/subtypingWithCallSignatures3.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures3.types
@@ -457,8 +457,8 @@ module Errors {
 >null : null
 
     var r8 = foo16(r8arg); // any
->r8 : any
->foo16(r8arg) : any
+>r8 : { (x: { (a: number): number; (a?: number): number; }): number[]; (x: { (a: boolean): boolean; (a?: boolean): boolean; }): boolean[]; }
+>foo16(r8arg) : { (x: { (a: number): number; (a?: number): number; }): number[]; (x: { (a: boolean): boolean; (a?: boolean): boolean; }): boolean[]; }
 >foo16 : { (a2: { (x: { (a: number): number; (a?: number): number; }): number[]; (x: { (a: boolean): boolean; (a?: boolean): boolean; }): boolean[]; }): { (x: { (a: number): number; (a?: number): number; }): number[]; (x: { (a: boolean): boolean; (a?: boolean): boolean; }): boolean[]; }; (a2: any): any; }
 >r8arg : <T>(x: (a: T) => T) => T[]
 

--- a/tests/baselines/reference/subtypingWithConstructSignatures2.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures2.types
@@ -675,8 +675,8 @@ var r15arg1: new <T>(x: T) => T[];
 >x : T
 
 var r15 = foo15(r15arg1); // any
->r15 : any
->foo15(r15arg1) : any
+>r15 : { new (x: number): number[]; new (x: string): string[]; }
+>foo15(r15arg1) : { new (x: number): number[]; new (x: string): string[]; }
 >foo15 : { (a: { new (x: number): number[]; new (x: string): string[]; }): { new (x: number): number[]; new (x: string): string[]; }; (a: any): any; }
 >r15arg1 : new <T>(x: T) => T[]
 
@@ -696,8 +696,8 @@ var r17arg1: new <T>(x: (a: T) => T) => T[];
 >a : T
 
 var r17 = foo17(r17arg1); // any
->r17 : any
->foo17(r17arg1) : any
+>r17 : { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }
+>foo17(r17arg1) : { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }
 >foo17 : { (a: { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }): { new (x: (a: number) => number): number[]; new (x: (a: string) => string): string[]; }; (a: any): any; }
 >r17arg1 : new <T>(x: (a: T) => T) => T[]
 

--- a/tests/baselines/reference/subtypingWithConstructSignatures3.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures3.types
@@ -406,8 +406,8 @@ module Errors {
 >a : T
 
     var r8 = foo16(r8arg); // any
->r8 : any
->foo16(r8arg) : any
+>r8 : { new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }
+>foo16(r8arg) : { new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }
 >foo16 : { (a2: { new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }): { new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }; (a2: any): any; }
 >r8arg : new <T>(x: new (a: T) => T) => T[]
 

--- a/tests/baselines/reference/variance.js
+++ b/tests/baselines/reference/variance.js
@@ -25,10 +25,46 @@ class Bar<T extends string> {
   }
 }
 
+// from #31277
+interface Set<T> {
+  add(value: T): this;
+}
+
+declare const Set: new <T>() => Set<T>;
+
+// Repro from #31251 (removed getter)
+
+export abstract class Supervisor<N extends string, P = unknown, R = unknown> {
+  private static instances_: Set<Supervisor<string, unknown, unknown>>;
+  private static instances(): typeof Supervisor.instances_ {
+      return this.hasOwnProperty('instances_')
+          ? this.instances_
+          : this.instances_ = new Set();
+  }
+  constructor() {
+      void (this.constructor as typeof Supervisor).instances().add(this);
+  }
+  public abstract call(name: N | ('' extends N ? undefined : never), param: P, timeout?: number): Promise<R>;
+}
+
+
+// Minimal repro for catching variance probing in then extends type.
+
+interface A<T> {
+  x: number extends T ? 1 : 1;
+}
+
+declare let a: A<number>;
+declare let b: A<3>;
+
+a = b; // error
+b = a; // error
 
 //// [variance.js]
 "use strict";
 // Test cases for parameter variances affected by conditional types.
+exports.__esModule = true;
+exports.Supervisor = void 0;
 var foo = { prop: true };
 var x = foo;
 var y = foo;
@@ -43,3 +79,18 @@ var Bar = /** @class */ (function () {
     };
     return Bar;
 }());
+// Repro from #31251 (removed getter)
+var Supervisor = /** @class */ (function () {
+    function Supervisor() {
+        void this.constructor.instances().add(this);
+    }
+    Supervisor.instances = function () {
+        return this.hasOwnProperty('instances_')
+            ? this.instances_
+            : this.instances_ = new Set();
+    };
+    return Supervisor;
+}());
+exports.Supervisor = Supervisor;
+a = b; // error
+b = a; // error

--- a/tests/baselines/reference/variance.symbols
+++ b/tests/baselines/reference/variance.symbols
@@ -60,3 +60,107 @@ class Bar<T extends string> {
   }
 }
 
+// from #31277
+interface Set<T> {
+>Set : Symbol(Set, Decl(variance.ts, 24, 1), Decl(variance.ts, 31, 13))
+>T : Symbol(T, Decl(variance.ts, 27, 14))
+
+  add(value: T): this;
+>add : Symbol(Set.add, Decl(variance.ts, 27, 18))
+>value : Symbol(value, Decl(variance.ts, 28, 6))
+>T : Symbol(T, Decl(variance.ts, 27, 14))
+}
+
+declare const Set: new <T>() => Set<T>;
+>Set : Symbol(Set, Decl(variance.ts, 24, 1), Decl(variance.ts, 31, 13))
+>T : Symbol(T, Decl(variance.ts, 31, 24))
+>Set : Symbol(Set, Decl(variance.ts, 24, 1), Decl(variance.ts, 31, 13))
+>T : Symbol(T, Decl(variance.ts, 31, 24))
+
+// Repro from #31251 (removed getter)
+
+export abstract class Supervisor<N extends string, P = unknown, R = unknown> {
+>Supervisor : Symbol(Supervisor, Decl(variance.ts, 31, 39))
+>N : Symbol(N, Decl(variance.ts, 35, 33))
+>P : Symbol(P, Decl(variance.ts, 35, 50))
+>R : Symbol(R, Decl(variance.ts, 35, 63))
+
+  private static instances_: Set<Supervisor<string, unknown, unknown>>;
+>instances_ : Symbol(Supervisor.instances_, Decl(variance.ts, 35, 78))
+>Set : Symbol(Set, Decl(variance.ts, 24, 1), Decl(variance.ts, 31, 13))
+>Supervisor : Symbol(Supervisor, Decl(variance.ts, 31, 39))
+
+  private static instances(): typeof Supervisor.instances_ {
+>instances : Symbol(Supervisor.instances, Decl(variance.ts, 36, 71))
+>Supervisor.instances_ : Symbol(Supervisor.instances_, Decl(variance.ts, 35, 78))
+>Supervisor : Symbol(Supervisor, Decl(variance.ts, 31, 39))
+>instances_ : Symbol(Supervisor.instances_, Decl(variance.ts, 35, 78))
+
+      return this.hasOwnProperty('instances_')
+>this.hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
+>this : Symbol(Supervisor, Decl(variance.ts, 31, 39))
+>hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
+
+          ? this.instances_
+>this.instances_ : Symbol(Supervisor.instances_, Decl(variance.ts, 35, 78))
+>this : Symbol(Supervisor, Decl(variance.ts, 31, 39))
+>instances_ : Symbol(Supervisor.instances_, Decl(variance.ts, 35, 78))
+
+          : this.instances_ = new Set();
+>this.instances_ : Symbol(Supervisor.instances_, Decl(variance.ts, 35, 78))
+>this : Symbol(Supervisor, Decl(variance.ts, 31, 39))
+>instances_ : Symbol(Supervisor.instances_, Decl(variance.ts, 35, 78))
+>Set : Symbol(Set, Decl(variance.ts, 24, 1), Decl(variance.ts, 31, 13))
+  }
+  constructor() {
+      void (this.constructor as typeof Supervisor).instances().add(this);
+>(this.constructor as typeof Supervisor).instances().add : Symbol(Set.add, Decl(variance.ts, 27, 18))
+>(this.constructor as typeof Supervisor).instances : Symbol(Supervisor.instances, Decl(variance.ts, 36, 71))
+>this.constructor : Symbol(Object.constructor, Decl(lib.es5.d.ts, --, --))
+>this : Symbol(Supervisor, Decl(variance.ts, 31, 39))
+>constructor : Symbol(Object.constructor, Decl(lib.es5.d.ts, --, --))
+>Supervisor : Symbol(Supervisor, Decl(variance.ts, 31, 39))
+>instances : Symbol(Supervisor.instances, Decl(variance.ts, 36, 71))
+>add : Symbol(Set.add, Decl(variance.ts, 27, 18))
+>this : Symbol(Supervisor, Decl(variance.ts, 31, 39))
+  }
+  public abstract call(name: N | ('' extends N ? undefined : never), param: P, timeout?: number): Promise<R>;
+>call : Symbol(Supervisor.call, Decl(variance.ts, 44, 3))
+>name : Symbol(name, Decl(variance.ts, 45, 23))
+>N : Symbol(N, Decl(variance.ts, 35, 33))
+>N : Symbol(N, Decl(variance.ts, 35, 33))
+>param : Symbol(param, Decl(variance.ts, 45, 68))
+>P : Symbol(P, Decl(variance.ts, 35, 50))
+>timeout : Symbol(timeout, Decl(variance.ts, 45, 78))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+>R : Symbol(R, Decl(variance.ts, 35, 63))
+}
+
+
+// Minimal repro for catching variance probing in then extends type.
+
+interface A<T> {
+>A : Symbol(A, Decl(variance.ts, 46, 1))
+>T : Symbol(T, Decl(variance.ts, 51, 12))
+
+  x: number extends T ? 1 : 1;
+>x : Symbol(A.x, Decl(variance.ts, 51, 16))
+>T : Symbol(T, Decl(variance.ts, 51, 12))
+}
+
+declare let a: A<number>;
+>a : Symbol(a, Decl(variance.ts, 55, 11))
+>A : Symbol(A, Decl(variance.ts, 46, 1))
+
+declare let b: A<3>;
+>b : Symbol(b, Decl(variance.ts, 56, 11))
+>A : Symbol(A, Decl(variance.ts, 46, 1))
+
+a = b; // error
+>a : Symbol(a, Decl(variance.ts, 55, 11))
+>b : Symbol(b, Decl(variance.ts, 56, 11))
+
+b = a; // error
+>b : Symbol(b, Decl(variance.ts, 56, 11))
+>a : Symbol(a, Decl(variance.ts, 55, 11))
+

--- a/tests/baselines/reference/variance.types
+++ b/tests/baselines/reference/variance.types
@@ -56,3 +56,96 @@ class Bar<T extends string> {
   }
 }
 
+// from #31277
+interface Set<T> {
+  add(value: T): this;
+>add : (value: T) => this
+>value : T
+}
+
+declare const Set: new <T>() => Set<T>;
+>Set : new <T>() => Set<T>
+
+// Repro from #31251 (removed getter)
+
+export abstract class Supervisor<N extends string, P = unknown, R = unknown> {
+>Supervisor : Supervisor<N, P, R>
+
+  private static instances_: Set<Supervisor<string, unknown, unknown>>;
+>instances_ : Set<Supervisor<string, unknown, unknown>>
+
+  private static instances(): typeof Supervisor.instances_ {
+>instances : () => typeof Supervisor.instances_
+>Supervisor.instances_ : Set<Supervisor<string, unknown, unknown>>
+>Supervisor : typeof Supervisor
+>instances_ : Set<Supervisor<string, unknown, unknown>>
+
+      return this.hasOwnProperty('instances_')
+>this.hasOwnProperty('instances_')          ? this.instances_          : this.instances_ = new Set() : Set<Supervisor<string, unknown, unknown>>
+>this.hasOwnProperty('instances_') : boolean
+>this.hasOwnProperty : (v: PropertyKey) => boolean
+>this : typeof Supervisor
+>hasOwnProperty : (v: PropertyKey) => boolean
+>'instances_' : "instances_"
+
+          ? this.instances_
+>this.instances_ : Set<Supervisor<string, unknown, unknown>>
+>this : typeof Supervisor
+>instances_ : Set<Supervisor<string, unknown, unknown>>
+
+          : this.instances_ = new Set();
+>this.instances_ = new Set() : Set<Supervisor<string, unknown, unknown>>
+>this.instances_ : Set<Supervisor<string, unknown, unknown>>
+>this : typeof Supervisor
+>instances_ : Set<Supervisor<string, unknown, unknown>>
+>new Set() : Set<Supervisor<string, unknown, unknown>>
+>Set : new <T>() => Set<T>
+  }
+  constructor() {
+      void (this.constructor as typeof Supervisor).instances().add(this);
+>void (this.constructor as typeof Supervisor).instances().add(this) : undefined
+>(this.constructor as typeof Supervisor).instances().add(this) : Set<Supervisor<string, unknown, unknown>>
+>(this.constructor as typeof Supervisor).instances().add : (value: Supervisor<string, unknown, unknown>) => Set<Supervisor<string, unknown, unknown>>
+>(this.constructor as typeof Supervisor).instances() : Set<Supervisor<string, unknown, unknown>>
+>(this.constructor as typeof Supervisor).instances : () => Set<Supervisor<string, unknown, unknown>>
+>(this.constructor as typeof Supervisor) : typeof Supervisor
+>this.constructor as typeof Supervisor : typeof Supervisor
+>this.constructor : Function
+>this : this
+>constructor : Function
+>Supervisor : typeof Supervisor
+>instances : () => Set<Supervisor<string, unknown, unknown>>
+>add : (value: Supervisor<string, unknown, unknown>) => Set<Supervisor<string, unknown, unknown>>
+>this : this
+  }
+  public abstract call(name: N | ('' extends N ? undefined : never), param: P, timeout?: number): Promise<R>;
+>call : (name: N | ('' extends N ? undefined : never), param: P, timeout?: number | undefined) => Promise<R>
+>name : N | ("" extends N ? undefined : never)
+>param : P
+>timeout : number | undefined
+}
+
+
+// Minimal repro for catching variance probing in then extends type.
+
+interface A<T> {
+  x: number extends T ? 1 : 1;
+>x : number extends T ? 1 : 1
+}
+
+declare let a: A<number>;
+>a : A<number>
+
+declare let b: A<3>;
+>b : A<3>
+
+a = b; // error
+>a = b : A<3>
+>a : A<number>
+>b : A<3>
+
+b = a; // error
+>b = a : A<number>
+>b : A<3>
+>a : A<number>
+

--- a/tests/cases/compiler/emptyClassSomehowNeverChecksConditionals.ts
+++ b/tests/cases/compiler/emptyClassSomehowNeverChecksConditionals.ts
@@ -1,0 +1,23 @@
+// quick distillation of conditionals which were previously erased by signature relating
+type EqualsTest<T> = <A>() => A extends T ? 1 : 0;
+type EqualsTest1<T> = <A>() => A extends T ? 1 : 0;
+
+const x: EqualsTest<number> = undefined as any as EqualsTest<string>; // should error, obviously wrong
+const y: EqualsTest<number> = undefined as any as EqualsTest1<string>; // same as the above, but seperate type aliases
+
+// Slightly extended example using class inheritance
+type ModelId<M extends Model> = M; // just validates the input matches the `Model` type to issue an error
+export declare class Model<MClass extends typeof Model = typeof Model> {
+    class: MClass;
+    readonly ref: ModelId<this>;
+    set<K>(value: K extends MClass ? number : string): void;
+}
+
+// identical to the above, but with a no-op subclass
+type ModelId2<M extends ModelSub> = M;
+export declare class Model2<MClass extends typeof ModelSub = typeof ModelSub> {
+    class: MClass;
+    readonly ref: ModelId2<this>;
+    set<K>(value: K extends MClass ? number : string): void;
+}
+export declare class ModelSub extends Model2 {}

--- a/tests/cases/compiler/overloadAssignabilityChecksAllowGenericAssignment.ts
+++ b/tests/cases/compiler/overloadAssignabilityChecksAllowGenericAssignment.ts
@@ -1,0 +1,5 @@
+declare function provide<T>(cb: (x: T) => void): void;
+declare function provide<T>(cb: (x: T[keyof T]) => void): void;
+
+declare function provider<T>(provide: (cb: (x: T) => void) => void): void;
+provider(provide); 

--- a/tests/cases/conformance/types/conditional/variance.ts
+++ b/tests/cases/conformance/types/conditional/variance.ts
@@ -25,3 +25,38 @@ class Bar<T extends string> {
     Bar.instance.push(this);
   }
 }
+
+// from #31277
+interface Set<T> {
+  add(value: T): this;
+}
+
+declare const Set: new <T>() => Set<T>;
+
+// Repro from #31251 (removed getter)
+
+export abstract class Supervisor<N extends string, P = unknown, R = unknown> {
+  private static instances_: Set<Supervisor<string, unknown, unknown>>;
+  private static instances(): typeof Supervisor.instances_ {
+      return this.hasOwnProperty('instances_')
+          ? this.instances_
+          : this.instances_ = new Set();
+  }
+  constructor() {
+      void (this.constructor as typeof Supervisor).instances().add(this);
+  }
+  public abstract call(name: N | ('' extends N ? undefined : never), param: P, timeout?: number): Promise<R>;
+}
+
+
+// Minimal repro for catching variance probing in then extends type.
+
+interface A<T> {
+  x: number extends T ? 1 : 1;
+}
+
+declare let a: A<number>;
+declare let b: A<3>;
+
+a = b; // error
+b = a; // error


### PR DESCRIPTION
This PR is essentially #41067 + #31277, with a change added on top so it also fixes #43867.

Fixes #43867 (we always now reliably issue the correct error (which is a new thing), rather than just for variance comparisons, as in `master`)
Fixes  #23352 (we now use a wildcard marker for type erasure that is assignable to `never`, which allows overload resolution to process the overloads as we'd like)
Fixes #31251 (we now force a structural comparison when comparing type parameters which flow into conditional `extends` clauses (which require identical types))
Fixes #44945