### PR TITLE
Unwrap substitutions on conditional check types before comparing them

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15022,7 +15022,7 @@ namespace ts {
             // purposes of resolution. This means such types aren't subject to the instatiation depth limiter.
             while (true) {
                 const isUnwrapped = isTypicalNondistributiveConditional(root);
-                const checkType = instantiateType(unwrapNondistributiveConditionalTuple(root, root.checkType), mapper);
+                const checkType = instantiateType(unwrapNondistributiveConditionalTuple(root, getActualTypeVariable(root.checkType)), mapper);
                 const checkTypeInstantiable = isGenericObjectType(checkType) || isGenericIndexType(checkType);
                 const extendsType = instantiateType(unwrapNondistributiveConditionalTuple(root, root.extendsType), mapper);
                 if (checkType === wildcardType || extendsType === wildcardType) {

--- a/tests/baselines/reference/curiousNestedConditionalEvaluationResult.js
+++ b/tests/baselines/reference/curiousNestedConditionalEvaluationResult.js
@@ -1,0 +1,7 @@
+//// [curiousNestedConditionalEvaluationResult.ts]
+// regression test for #43123
+type Hmm = [0] extends [infer T, any?] ?
+    [T, [0] extends [T] ? true : false]
+    : never
+
+//// [curiousNestedConditionalEvaluationResult.js]

--- a/tests/baselines/reference/curiousNestedConditionalEvaluationResult.symbols
+++ b/tests/baselines/reference/curiousNestedConditionalEvaluationResult.symbols
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/curiousNestedConditionalEvaluationResult.ts ===
+// regression test for #43123
+type Hmm = [0] extends [infer T, any?] ?
+>Hmm : Symbol(Hmm, Decl(curiousNestedConditionalEvaluationResult.ts, 0, 0))
+>T : Symbol(T, Decl(curiousNestedConditionalEvaluationResult.ts, 1, 29))
+
+    [T, [0] extends [T] ? true : false]
+>T : Symbol(T, Decl(curiousNestedConditionalEvaluationResult.ts, 1, 29))
+>T : Symbol(T, Decl(curiousNestedConditionalEvaluationResult.ts, 1, 29))
+
+    : never

--- a/tests/baselines/reference/curiousNestedConditionalEvaluationResult.types
+++ b/tests/baselines/reference/curiousNestedConditionalEvaluationResult.types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/curiousNestedConditionalEvaluationResult.ts ===
+// regression test for #43123
+type Hmm = [0] extends [infer T, any?] ?
+>Hmm : [0, true]
+
+    [T, [0] extends [T] ? true : false]
+>true : true
+>false : false
+
+    : never

--- a/tests/cases/compiler/curiousNestedConditionalEvaluationResult.ts
+++ b/tests/cases/compiler/curiousNestedConditionalEvaluationResult.ts
@@ -1,0 +1,4 @@
+// regression test for #43123
+type Hmm = [0] extends [infer T, any?] ?
+    [T, [0] extends [T] ? true : false]
+    : never


### PR DESCRIPTION
Fixes #43123

The outer conditional was creating a substitution on `[0]`, making it look like `[0] & [0, any?]` at the inner conditional, which 1. didn't unwrap right (since we determine syntactically that we should be able to unwrap the tuple types made), and 2. produces a subtype of what the user actually wrote for the check type, which can alter results unexpectedly. By unwrapping substitutions at check type positions, we avoid this issue.