### PR TITLE
Displayparts resolves non-values in link tags

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2240,8 +2240,9 @@ namespace ts {
         }
         else {
             const symbol = checker?.getSymbolAtLocation(link.name);
-            if (symbol?.valueDeclaration) {
-                parts.push(linkNamePart(link.name, symbol.valueDeclaration));
+            const decl = symbol?.valueDeclaration || symbol?.declarations?.[0];
+            if (decl) {
+                parts.push(linkNamePart(link.name, decl));
                 if (link.text) {parts.push(linkTextPart(link.text));}
             }
             else {

--- a/tests/baselines/reference/jsdocLink4.baseline
+++ b/tests/baselines/reference/jsdocLink4.baseline
@@ -1,0 +1,298 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsdocLink4.ts",
+      "position": 42,
+      "name": "1"
+    },
+    "quickInfo": {
+      "kind": "method",
+      "kindModifiers": "declare",
+      "textSpan": {
+        "start": 39,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "I",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "bar",
+          "kind": "methodName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "I",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/tests/cases/fourslash/jsdocLink4.ts",
+            "textSpan": {
+              "start": 0,
+              "length": 52
+            }
+          }
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsdocLink4.ts",
+      "position": 75,
+      "name": "2"
+    },
+    "quickInfo": {
+      "kind": "var",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 74,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "var",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "n",
+          "kind": "localName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "I",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/tests/cases/fourslash/jsdocLink4.ts",
+            "textSpan": {
+              "start": 0,
+              "length": 52
+            }
+          }
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsdocLink4.ts",
+      "position": 208,
+      "name": "3"
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 207,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "f",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "x",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "any",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "A real, very serious ",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "I",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/tests/cases/fourslash/jsdocLink4.ts",
+            "textSpan": {
+              "start": 0,
+              "length": 52
+            }
+          }
+        },
+        {
+          "text": "to an interface",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": ". Right there.",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "param",
+          "text": [
+            {
+              "text": "x",
+              "kind": "parameterName"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "one ",
+              "kind": "text"
+            },
+            {
+              "text": "{@link ",
+              "kind": "link"
+            },
+            {
+              "text": "Pos",
+              "kind": "linkName",
+              "target": {
+                "fileName": "/tests/cases/fourslash/jsdocLink4.ts",
+                "textSpan": {
+                  "start": 211,
+                  "length": 27
+                }
+              }
+            },
+            {
+              "text": "here too",
+              "kind": "linkText"
+            },
+            {
+              "text": "}",
+              "kind": "link"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/quickInfoForJSDocWithHttpLinks.baseline
+++ b/tests/baselines/reference/quickInfoForJSDocWithHttpLinks.baseline
@@ -286,7 +286,18 @@
               "kind": "link"
             },
             {
-              "text": "https://hva",
+              "text": "https",
+              "kind": "linkName",
+              "target": {
+                "fileName": "/tests/cases/fourslash/quickInfoForJSDocWithHttpLinks.js",
+                "textSpan": {
+                  "start": 4,
+                  "length": 30
+                }
+              }
+            },
+            {
+              "text": "://hva",
               "kind": "linkText"
             },
             {
@@ -347,7 +358,18 @@
           "kind": "link"
         },
         {
-          "text": "https://hvaD",
+          "text": "https",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/tests/cases/fourslash/quickInfoForJSDocWithHttpLinks.js",
+            "textSpan": {
+              "start": 4,
+              "length": 30
+            }
+          }
+        },
+        {
+          "text": "://hvaD",
           "kind": "linkText"
         },
         {

--- a/tests/cases/fourslash/jsdocLink4.ts
+++ b/tests/cases/fourslash/jsdocLink4.ts
@@ -1,0 +1,17 @@
+///<reference path="fourslash.ts" />
+
+//// declare class I {
+////   /** {@link I} */
+////   bar/*1*/(): void
+//// }
+//// /** {@link I} */
+//// var n/*2*/ = 1
+//// /**
+////  * A real, very serious {@link I to an interface}. Right there.
+////  * @param x one {@link Pos here too}
+////  */
+//// function f(x) {
+//// }
+//// f/*3*/()
+//// type Pos = [number, number]
+verify.baselineQuickInfo();


### PR DESCRIPTION
Previously, the name resolution for link tags in displaypart generation mistakenly required a valueDeclaration. Now it uses the first declaration if there is no valueDeclaration, so that types and namespaces will also resolve.

This is another instance of using valueDeclaration as "the default declaration", which doesn't apply to types.

Fixes #43868