### PR TITLE
fix(WeakMapConstructor): readonly iterable items

### DIFF
--- a/src/lib/es2015.iterable.d.ts
+++ b/src/lib/es2015.iterable.d.ts
@@ -143,7 +143,7 @@ interface MapConstructor {
 interface WeakMap<K extends object, V> { }
 
 interface WeakMapConstructor {
-    new <K extends object, V>(iterable: Iterable<[K, V]>): WeakMap<K, V>;
+    new <K extends object, V>(iterable: Iterable<readonly [K, V]>): WeakMap<K, V>;
 }
 
 interface Set<T> {


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #43900
