### PR TITLE
Add single-element fastpath to getSupertypeOrUnion

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19954,6 +19954,9 @@ namespace ts {
         // of those literal types. Otherwise, return the leftmost type for which no type to the
         // right is a supertype.
         function getSupertypeOrUnion(types: Type[]): Type {
+            if (types.length === 1) {
+                return types[0];
+            }
             return literalTypesWithSameBaseType(types) ?
                 getUnionType(types) :
                 reduceLeft(types, (s, t) => isTypeSubtypeOf(s, t) ? t : s)!;


### PR DESCRIPTION
Thus avoiding the expensive calculations in `literalTypesWithSameBaseType` when it isn't actually needed.
Fixes #43899, from what I can tell. Since it's a perf optimization, I don't really have a test, per-sey, other than my observed performance, since I couldn't scale the example in the issue to the point it'd crash even with tens of thousands of elements.