### PR TITLE
Dont allow namespace reexport symbols when looking up valid local names

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1971,6 +1971,10 @@ namespace ts {
         return node.kind === SyntaxKind.TypeQuery;
     }
 
+    export function isNamespaceReexportDeclaration(node: Node): boolean {
+        return isNamespaceExport(node) && !!node.parent.moduleSpecifier;
+    }
+
     export function isExternalModuleImportEqualsDeclaration(node: Node): node is ImportEqualsDeclaration & { moduleReference: ExternalModuleReference } {
         return node.kind === SyntaxKind.ImportEqualsDeclaration && (<ImportEqualsDeclaration>node).moduleReference.kind === SyntaxKind.ExternalModuleReference;
     }

--- a/tests/baselines/reference/declarationEmitDoesNotUseReexportedNamespaceAsLocal.js
+++ b/tests/baselines/reference/declarationEmitDoesNotUseReexportedNamespaceAsLocal.js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/declarationEmitDoesNotUseReexportedNamespaceAsLocal.ts] ////
+
+//// [sub.ts]
+export function a() {}
+//// [index.ts]
+export const x = add(import("./sub"));
+export * as Q from "./sub";
+declare function add<T>(x: Promise<T>): T;
+
+//// [sub.js]
+export function a() { }
+//// [index.js]
+export const x = add(import("./sub"));
+export * as Q from "./sub";
+
+
+//// [sub.d.ts]
+export declare function a(): void;
+//// [index.d.ts]
+export declare const x: typeof import("./sub");
+export * as Q from "./sub";

--- a/tests/baselines/reference/declarationEmitDoesNotUseReexportedNamespaceAsLocal.symbols
+++ b/tests/baselines/reference/declarationEmitDoesNotUseReexportedNamespaceAsLocal.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/sub.ts ===
+export function a() {}
+>a : Symbol(a, Decl(sub.ts, 0, 0))
+
+=== tests/cases/compiler/index.ts ===
+export const x = add(import("./sub"));
+>x : Symbol(x, Decl(index.ts, 0, 12))
+>add : Symbol(add, Decl(index.ts, 1, 27))
+>"./sub" : Symbol("tests/cases/compiler/sub", Decl(sub.ts, 0, 0))
+
+export * as Q from "./sub";
+>Q : Symbol(Q, Decl(index.ts, 1, 6))
+
+declare function add<T>(x: Promise<T>): T;
+>add : Symbol(add, Decl(index.ts, 1, 27))
+>T : Symbol(T, Decl(index.ts, 2, 21))
+>x : Symbol(x, Decl(index.ts, 2, 24))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>T : Symbol(T, Decl(index.ts, 2, 21))
+>T : Symbol(T, Decl(index.ts, 2, 21))
+

--- a/tests/baselines/reference/declarationEmitDoesNotUseReexportedNamespaceAsLocal.types
+++ b/tests/baselines/reference/declarationEmitDoesNotUseReexportedNamespaceAsLocal.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/sub.ts ===
+export function a() {}
+>a : () => void
+
+=== tests/cases/compiler/index.ts ===
+export const x = add(import("./sub"));
+>x : typeof import("tests/cases/compiler/sub")
+>add(import("./sub")) : typeof import("tests/cases/compiler/sub")
+>add : <T>(x: Promise<T>) => T
+>import("./sub") : Promise<typeof import("tests/cases/compiler/sub")>
+>"./sub" : "./sub"
+
+export * as Q from "./sub";
+>Q : typeof import("tests/cases/compiler/sub")
+
+declare function add<T>(x: Promise<T>): T;
+>add : <T>(x: Promise<T>) => T
+>x : Promise<T>
+

--- a/tests/baselines/reference/exportAsNamespace1(module=amd).types
+++ b/tests/baselines/reference/exportAsNamespace1(module=amd).types
@@ -9,7 +9,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : typeof ns
+>ns : typeof import("tests/cases/conformance/es2020/modules/0")
 
 ns.a;
 >ns.a : any

--- a/tests/baselines/reference/exportAsNamespace1(module=commonjs).types
+++ b/tests/baselines/reference/exportAsNamespace1(module=commonjs).types
@@ -9,7 +9,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : typeof ns
+>ns : typeof import("tests/cases/conformance/es2020/modules/0")
 
 ns.a;
 >ns.a : any

--- a/tests/baselines/reference/exportAsNamespace1(module=es2015).types
+++ b/tests/baselines/reference/exportAsNamespace1(module=es2015).types
@@ -9,7 +9,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : typeof ns
+>ns : typeof import("tests/cases/conformance/es2020/modules/0")
 
 ns.a;
 >ns.a : any

--- a/tests/baselines/reference/exportAsNamespace1(module=esnext).types
+++ b/tests/baselines/reference/exportAsNamespace1(module=esnext).types
@@ -9,7 +9,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : typeof ns
+>ns : typeof import("tests/cases/conformance/es2020/modules/0")
 
 ns.a;
 >ns.a : any

--- a/tests/baselines/reference/exportAsNamespace1(module=system).types
+++ b/tests/baselines/reference/exportAsNamespace1(module=system).types
@@ -9,7 +9,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : typeof ns
+>ns : typeof import("tests/cases/conformance/es2020/modules/0")
 
 ns.a;
 >ns.a : any

--- a/tests/baselines/reference/exportAsNamespace1(module=umd).types
+++ b/tests/baselines/reference/exportAsNamespace1(module=umd).types
@@ -9,7 +9,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : typeof ns
+>ns : typeof import("tests/cases/conformance/es2020/modules/0")
 
 ns.a;
 >ns.a : any

--- a/tests/baselines/reference/exportAsNamespace2(module=amd).types
+++ b/tests/baselines/reference/exportAsNamespace2(module=amd).types
@@ -9,7 +9,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : typeof ns
+>ns : typeof import("tests/cases/conformance/es2020/modules/0")
 
 ns.a;
 >ns.a : any

--- a/tests/baselines/reference/exportAsNamespace2(module=commonjs).types
+++ b/tests/baselines/reference/exportAsNamespace2(module=commonjs).types
@@ -9,7 +9,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : typeof ns
+>ns : typeof import("tests/cases/conformance/es2020/modules/0")
 
 ns.a;
 >ns.a : any

--- a/tests/baselines/reference/exportAsNamespace2(module=es2015).types
+++ b/tests/baselines/reference/exportAsNamespace2(module=es2015).types
@@ -9,7 +9,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : typeof ns
+>ns : typeof import("tests/cases/conformance/es2020/modules/0")
 
 ns.a;
 >ns.a : any

--- a/tests/baselines/reference/exportAsNamespace2(module=esnext).types
+++ b/tests/baselines/reference/exportAsNamespace2(module=esnext).types
@@ -9,7 +9,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : typeof ns
+>ns : typeof import("tests/cases/conformance/es2020/modules/0")
 
 ns.a;
 >ns.a : any

--- a/tests/baselines/reference/exportAsNamespace2(module=system).types
+++ b/tests/baselines/reference/exportAsNamespace2(module=system).types
@@ -9,7 +9,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : typeof ns
+>ns : typeof import("tests/cases/conformance/es2020/modules/0")
 
 ns.a;
 >ns.a : any

--- a/tests/baselines/reference/exportAsNamespace2(module=umd).types
+++ b/tests/baselines/reference/exportAsNamespace2(module=umd).types
@@ -9,7 +9,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : typeof ns
+>ns : typeof import("tests/cases/conformance/es2020/modules/0")
 
 ns.a;
 >ns.a : any

--- a/tests/baselines/reference/exportNamespace2.types
+++ b/tests/baselines/reference/exportNamespace2.types
@@ -4,7 +4,7 @@ export class A {}
 
 === tests/cases/conformance/externalModules/typeOnly/b.ts ===
 export * as a from './a';
->a : typeof a
+>a : typeof import("tests/cases/conformance/externalModules/typeOnly/a")
 
 === tests/cases/conformance/externalModules/typeOnly/c.ts ===
 import type { a } from './b';

--- a/tests/baselines/reference/exportNamespace3.types
+++ b/tests/baselines/reference/exportNamespace3.types
@@ -8,7 +8,7 @@ export type { A } from './a';
 
 === tests/cases/conformance/externalModules/typeOnly/c.ts ===
 export * as a from './b';
->a : typeof a
+>a : typeof import("tests/cases/conformance/externalModules/typeOnly/b")
 
 === tests/cases/conformance/externalModules/typeOnly/d.ts ===
 import { a } from './c';

--- a/tests/baselines/reference/exportNamespace4.types
+++ b/tests/baselines/reference/exportNamespace4.types
@@ -7,7 +7,7 @@ export type * from './a'; // Grammar error
 No type information for this code.
 No type information for this code.=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
 export type * as ns from './a'; // Grammar error
->ns : typeof ns
+>ns : typeof import("tests/cases/conformance/externalModules/typeOnly/a")
 
 === tests/cases/conformance/externalModules/typeOnly/d.ts ===
 import { A } from './b';

--- a/tests/baselines/reference/exportStarNotElided.types
+++ b/tests/baselines/reference/exportStarNotElided.types
@@ -27,5 +27,5 @@ register("ok");
 export * from "./register";
 export * from "./data1";
 export * as aliased from "./data1";
->aliased : typeof aliased
+>aliased : typeof import("tests/cases/compiler/data1")
 

--- a/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=false,module=amd).types
+++ b/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=false,module=amd).types
@@ -4,7 +4,7 @@ export class A { }
 
 === tests/cases/compiler/b.ts ===
 export * as a from "./a";
->a : typeof a
+>a : typeof import("tests/cases/compiler/a")
 
 === tests/cases/compiler/tslib.d.ts ===
 declare module "tslib" {

--- a/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=false,module=commonjs).types
+++ b/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=false,module=commonjs).types
@@ -4,7 +4,7 @@ export class A { }
 
 === tests/cases/compiler/b.ts ===
 export * as a from "./a";
->a : typeof a
+>a : typeof import("tests/cases/compiler/a")
 
 === tests/cases/compiler/tslib.d.ts ===
 declare module "tslib" {

--- a/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=false,module=es2015).types
+++ b/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=false,module=es2015).types
@@ -4,7 +4,7 @@ export class A { }
 
 === tests/cases/compiler/b.ts ===
 export * as a from "./a";
->a : typeof a
+>a : typeof import("tests/cases/compiler/a")
 
 === tests/cases/compiler/tslib.d.ts ===
 declare module "tslib" {

--- a/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=false,module=es2020).types
+++ b/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=false,module=es2020).types
@@ -4,7 +4,7 @@ export class A { }
 
 === tests/cases/compiler/b.ts ===
 export * as a from "./a";
->a : typeof a
+>a : typeof import("tests/cases/compiler/a")
 
 === tests/cases/compiler/tslib.d.ts ===
 declare module "tslib" {

--- a/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=false,module=system).types
+++ b/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=false,module=system).types
@@ -4,7 +4,7 @@ export class A { }
 
 === tests/cases/compiler/b.ts ===
 export * as a from "./a";
->a : typeof a
+>a : typeof import("tests/cases/compiler/a")
 
 === tests/cases/compiler/tslib.d.ts ===
 declare module "tslib" {

--- a/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=true,module=amd).types
+++ b/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=true,module=amd).types
@@ -4,7 +4,7 @@ export class A { }
 
 === tests/cases/compiler/b.ts ===
 export * as a from "./a";
->a : typeof a
+>a : typeof import("tests/cases/compiler/a")
 
 === tests/cases/compiler/tslib.d.ts ===
 declare module "tslib" {

--- a/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=true,module=commonjs).types
+++ b/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=true,module=commonjs).types
@@ -4,7 +4,7 @@ export class A { }
 
 === tests/cases/compiler/b.ts ===
 export * as a from "./a";
->a : typeof a
+>a : typeof import("tests/cases/compiler/a")
 
 === tests/cases/compiler/tslib.d.ts ===
 declare module "tslib" {

--- a/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=true,module=es2015).types
+++ b/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=true,module=es2015).types
@@ -4,7 +4,7 @@ export class A { }
 
 === tests/cases/compiler/b.ts ===
 export * as a from "./a";
->a : typeof a
+>a : typeof import("tests/cases/compiler/a")
 
 === tests/cases/compiler/tslib.d.ts ===
 declare module "tslib" {

--- a/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=true,module=es2020).types
+++ b/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=true,module=es2020).types
@@ -4,7 +4,7 @@ export class A { }
 
 === tests/cases/compiler/b.ts ===
 export * as a from "./a";
->a : typeof a
+>a : typeof import("tests/cases/compiler/a")
 
 === tests/cases/compiler/tslib.d.ts ===
 declare module "tslib" {

--- a/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=true,module=system).types
+++ b/tests/baselines/reference/importHelpersWithExportStarAs(esmoduleinterop=true,module=system).types
@@ -4,7 +4,7 @@ export class A { }
 
 === tests/cases/compiler/b.ts ===
 export * as a from "./a";
->a : typeof a
+>a : typeof import("tests/cases/compiler/a")
 
 === tests/cases/compiler/tslib.d.ts ===
 declare module "tslib" {

--- a/tests/cases/compiler/declarationEmitDoesNotUseReexportedNamespaceAsLocal.ts
+++ b/tests/cases/compiler/declarationEmitDoesNotUseReexportedNamespaceAsLocal.ts
@@ -1,0 +1,9 @@
+// @target: esnext
+// @module: esnext
+// @declaration: true
+// @filename: sub.ts
+export function a() {}
+// @filename: index.ts
+export const x = add(import("./sub"));
+export * as Q from "./sub";
+declare function add<T>(x: Promise<T>): T;


### PR DESCRIPTION
Fixes #42981
