### PR TITLE
When directory watcher is invoked with any file from node_modules package, invalidate for file paths in that package

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1150,7 +1150,7 @@ namespace ts {
             }
             const resolvedFromFile = loadModuleFromFile(extensions, candidate, onlyRecordFailures, state);
             if (resolvedFromFile) {
-                const packageDirectory = considerPackageJson ? parseNodeModuleFromPath(resolvedFromFile) : undefined;
+                const packageDirectory = considerPackageJson ? parseNodeModuleFromPath(resolvedFromFile.path) : undefined;
                 const packageInfo = packageDirectory ? getPackageJsonInfo(packageDirectory, /*onlyRecordFailures*/ false, state) : undefined;
                 return withPackageId(packageInfo, resolvedFromFile);
             }
@@ -1184,8 +1184,9 @@ namespace ts {
      *   For `/node_modules/@types/foo/bar/index.d.ts` this is packageDirectory: "@types/foo"
      *   For `/node_modules/foo/bar/index.d.ts` this is packageDirectory: "foo"
      */
-    function parseNodeModuleFromPath(resolved: PathAndExtension): string | undefined {
-        const path = normalizePath(resolved.path);
+    /* @internal */
+    export function parseNodeModuleFromPath(resolved: string): string | undefined {
+        const path = normalizePath(resolved);
         const idx = path.lastIndexOf(nodeModulesPathPart);
         if (idx === -1) {
             return undefined;

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -799,7 +799,9 @@ namespace ts {
                     // Resolution need to be invalidated if failed lookup location is same as the file or directory getting created
                     (failedLookupChecks ||= []).push(fileOrDirectoryPath);
 
-                    // If this is file from package, invalidate package itself since we might not get notification for all files from the package
+                    // If the invalidated file is from a node_modules package, invalidate everything else
+                    // in the package since we might not get notifications for other files in the package.
+                    // This hardens our logic against unreliable file watchers.
                     const packagePath = parseNodeModuleFromPath(fileOrDirectoryPath);
                     if (packagePath) (startsWithPathChecks ||= new Set()).add(packagePath as Path);
                 }

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -153,9 +153,9 @@ namespace ts {
         const resolvedFileToResolution = createMultiMap<ResolutionWithFailedLookupLocations>();
 
         let hasChangedAutomaticTypeDirectiveNames = false;
-        const failedLookupChecks: Path[] = [];
-        const startsWithPathChecks: Path[] = [];
-        const isInDirectoryChecks: Path[] = [];
+        let failedLookupChecks: Path[] | undefined;
+        let startsWithPathChecks: Set<Path> | undefined;
+        let isInDirectoryChecks: Path[] | undefined;
 
         const getCurrentDirectory = memoize(() => resolutionHost.getCurrentDirectory!()); // TODO: GH#18217
         const cachedDirectoryStructureHost = resolutionHost.getCachedDirectoryStructureHost();
@@ -248,9 +248,9 @@ namespace ts {
             resolvedTypeReferenceDirectives.clear();
             resolvedFileToResolution.clear();
             resolutionsWithFailedLookups.length = 0;
-            failedLookupChecks.length = 0;
-            startsWithPathChecks.length = 0;
-            isInDirectoryChecks.length = 0;
+            failedLookupChecks = undefined;
+            startsWithPathChecks = undefined;
+            isInDirectoryChecks = undefined;
             // perDirectoryResolvedModuleNames and perDirectoryResolvedTypeReferenceDirectives could be non empty if there was exception during program update
             // (between startCachingPerDirectoryResolution and finishCachingPerDirectoryResolution)
             clearPerDirectoryResolutions();
@@ -766,7 +766,7 @@ namespace ts {
             if (isCreatingWatchedDirectory) {
                 // Watching directory is created
                 // Invalidate any resolution has failed lookup in this directory
-                isInDirectoryChecks.push(fileOrDirectoryPath);
+                (isInDirectoryChecks ||= []).push(fileOrDirectoryPath);
             }
             else {
                 // If something to do with folder/file starting with "." in node_modules folder, skip it
@@ -785,8 +785,8 @@ namespace ts {
                 if (isNodeModulesAtTypesDirectory(fileOrDirectoryPath) || isNodeModulesDirectory(fileOrDirectoryPath) ||
                     isNodeModulesAtTypesDirectory(dirOfFileOrDirectory) || isNodeModulesDirectory(dirOfFileOrDirectory)) {
                     // Invalidate any resolution from this directory
-                    failedLookupChecks.push(fileOrDirectoryPath);
-                    startsWithPathChecks.push(fileOrDirectoryPath);
+                    (failedLookupChecks ||= []).push(fileOrDirectoryPath);
+                    (startsWithPathChecks ||= new Set()).add(fileOrDirectoryPath);
                 }
                 else {
                     if (!isPathWithDefaultFailedLookupExtension(fileOrDirectoryPath) && !customFailedLookupPaths.has(fileOrDirectoryPath)) {
@@ -797,25 +797,25 @@ namespace ts {
                         return false;
                     }
                     // Resolution need to be invalidated if failed lookup location is same as the file or directory getting created
-                    failedLookupChecks.push(fileOrDirectoryPath);
+                    (failedLookupChecks ||= []).push(fileOrDirectoryPath);
 
                     // If this is file from package, invalidate package itself since we might not get notification for all files from the package
                     const packagePath = parseNodeModuleFromPath(fileOrDirectoryPath);
-                    if (packagePath) startsWithPathChecks.push(packagePath as Path);
+                    if (packagePath) (startsWithPathChecks ||= new Set()).add(packagePath as Path);
                 }
             }
             resolutionHost.scheduleInvalidateResolutionsOfFailedLookupLocations();
         }
 
         function invalidateResolutionsOfFailedLookupLocations() {
-            if (!failedLookupChecks.length && !startsWithPathChecks.length && !isInDirectoryChecks.length) {
+            if (!failedLookupChecks && !startsWithPathChecks && !isInDirectoryChecks) {
                 return false;
             }
 
             const invalidated = invalidateResolutions(resolutionsWithFailedLookups, canInvalidateFailedLookupResolution);
-            failedLookupChecks.length = 0;
-            startsWithPathChecks.length = 0;
-            isInDirectoryChecks.length = 0;
+            failedLookupChecks = undefined;
+            startsWithPathChecks = undefined;
+            isInDirectoryChecks = undefined;
             return invalidated;
         }
 
@@ -823,8 +823,8 @@ namespace ts {
             return resolution.failedLookupLocations.some(location => {
                 const locationPath = resolutionHost.toPath(location);
                 return contains(failedLookupChecks, locationPath) ||
-                    startsWithPathChecks.some(fileOrDirectoryPath => startsWith(locationPath, fileOrDirectoryPath)) ||
-                    isInDirectoryChecks.some(fileOrDirectoryPath => isInDirectoryPath(fileOrDirectoryPath, locationPath));
+                    firstDefinedIterator(startsWithPathChecks?.keys() || emptyIterator, fileOrDirectoryPath => startsWith(locationPath, fileOrDirectoryPath) ? true : undefined) ||
+                    isInDirectoryChecks?.some(fileOrDirectoryPath => isInDirectoryPath(fileOrDirectoryPath, locationPath));
             });
         }
 

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -798,6 +798,10 @@ namespace ts {
                     }
                     // Resolution need to be invalidated if failed lookup location is same as the file or directory getting created
                     failedLookupChecks.push(fileOrDirectoryPath);
+
+                    // If this is file from package, invalidate package itself since we might not get notification for all files from the package
+                    const packagePath = parseNodeModuleFromPath(fileOrDirectoryPath);
+                    if (packagePath) startsWithPathChecks.push(packagePath as Path);
                 }
             }
             resolutionHost.scheduleInvalidateResolutionsOfFailedLookupLocations();

--- a/src/testRunner/unittests/tscWatch/resolutionCache.ts
+++ b/src/testRunner/unittests/tscWatch/resolutionCache.ts
@@ -449,5 +449,81 @@ declare namespace myapp {
             },
             changes: emptyArray
         });
+
+        describe("works when installing something in node_modules or @types when there is no notification from fs for index file", () => {
+            function getNodeAtTypes() {
+                const nodeAtTypesIndex: File = {
+                    path: `${projectRoot}/node_modules/@types/node/index.d.ts`,
+                    content: `/// <reference path="base.d.ts" />`
+                };
+                const nodeAtTypesBase: File = {
+                    path: `${projectRoot}/node_modules/@types/node/base.d.ts`,
+                    content: `// Base definitions for all NodeJS modules that are not specific to any version of TypeScript:
+/// <reference path="ts3.6/base.d.ts" />`
+                };
+                const nodeAtTypes36Base: File = {
+                    path: `${projectRoot}/node_modules/@types/node/ts3.6/base.d.ts`,
+                    content: `/// <reference path="../globals.d.ts" />`
+                };
+                const nodeAtTypesGlobals: File = {
+                    path: `${projectRoot}/node_modules/@types/node/globals.d.ts`,
+                    content: `declare var process: NodeJS.Process;
+declare namespace NodeJS {
+    interface Process {
+        on(msg: string): void;
+    }
+}`
+                };
+                return { nodeAtTypesIndex, nodeAtTypesBase, nodeAtTypes36Base, nodeAtTypesGlobals };
+            }
+            verifyTscWatch({
+                scenario,
+                subScenario: "works when installing something in node_modules or @types when there is no notification from fs for index file",
+                commandLineArgs: ["--w", `--extendedDiagnostics`],
+                sys: () => {
+                    const file: File = {
+                        path: `${projectRoot}/worker.ts`,
+                        content: `process.on("uncaughtException");`
+                    };
+                    const tsconfig: File = {
+                        path: `${projectRoot}/tsconfig.json`,
+                        content: "{}"
+                    };
+                    const { nodeAtTypesIndex, nodeAtTypesBase, nodeAtTypes36Base, nodeAtTypesGlobals } = getNodeAtTypes();
+                    return createWatchedSystem([file, libFile, tsconfig, nodeAtTypesIndex, nodeAtTypesBase, nodeAtTypes36Base, nodeAtTypesGlobals], { currentDirectory: projectRoot });
+                },
+                changes: [
+                    {
+                        caption: "npm ci step one: remove all node_modules files",
+                        change: sys => sys.deleteFolder(`${projectRoot}/node_modules/@types`, /*recursive*/ true),
+                        timeouts: runQueuedTimeoutCallbacks,
+                    },
+                    {
+                        caption: `npm ci step two: create atTypes but something else in the @types folder`,
+                        change: sys => sys.ensureFileOrFolder({
+                            path: `${projectRoot}/node_modules/@types/mocha/index.d.ts`,
+                            content: `export const foo = 10;`
+                        }),
+                        timeouts: runQueuedTimeoutCallbacks
+                    },
+                    {
+                        caption: `npm ci step three: create atTypes node folder`,
+                        change: sys => sys.ensureFileOrFolder({ path: `${projectRoot}/node_modules/@types/node` }),
+                        timeouts: runQueuedTimeoutCallbacks
+                    },
+                    {
+                        caption: `npm ci step four: create atTypes write all the files but dont invoke watcher for index.d.ts`,
+                        change: sys => {
+                            const { nodeAtTypesIndex, nodeAtTypesBase, nodeAtTypes36Base, nodeAtTypesGlobals } = getNodeAtTypes();
+                            sys.ensureFileOrFolder(nodeAtTypesBase);
+                            sys.ensureFileOrFolder(nodeAtTypesIndex, /*ignoreWatchInvokedWithTriggerAsFileCreate*/ true);
+                            sys.ensureFileOrFolder(nodeAtTypes36Base, /*ignoreWatchInvokedWithTriggerAsFileCreate*/ true);
+                            sys.ensureFileOrFolder(nodeAtTypesGlobals, /*ignoreWatchInvokedWithTriggerAsFileCreate*/ true);
+                        },
+                        timeouts: runQueuedTimeoutCallbacks
+                    },
+                ]
+            });
+        });
     });
 }

--- a/src/testRunner/unittests/tscWatch/resolutionCache.ts
+++ b/src/testRunner/unittests/tscWatch/resolutionCache.ts
@@ -520,7 +520,10 @@ declare namespace NodeJS {
                             sys.ensureFileOrFolder(nodeAtTypes36Base, /*ignoreWatchInvokedWithTriggerAsFileCreate*/ true);
                             sys.ensureFileOrFolder(nodeAtTypesGlobals, /*ignoreWatchInvokedWithTriggerAsFileCreate*/ true);
                         },
-                        timeouts: runQueuedTimeoutCallbacks
+                        timeouts: sys => {
+                            sys.runQueuedTimeoutCallbacks(); // update failed lookups
+                            sys.runQueuedTimeoutCallbacks(); // actual program update
+                        },
                     },
                 ]
             });

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-installing-something-in-node_modules-or-@types-when-there-is-no-notification-from-fs-for-index-file.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-installing-something-in-node_modules-or-@types-when-there-is-no-notification-from-fs-for-index-file.js
@@ -450,6 +450,7 @@ Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myprojec
 DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
 Project: /user/username/projects/myproject/tsconfig.json Detected file add/remove of non supported extension: /user/username/projects/myproject/node_modules/@types/node/ts3.6
 Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Scheduling update
 [[90m12:01:15 AM[0m] File change detected. Starting incremental compilation...
 
 Reloading new file names and options
@@ -457,11 +458,11 @@ Synchronizing program
 CreatingProgramWith::
   roots: ["/user/username/projects/myproject/worker.ts"]
   options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
-[91merror[0m[90m TS2688: [0mCannot find type definition file for 'node'.
-  The file is in the program because:
-    Entry point for implicit type library 'node'
-
-[[90m12:01:16 AM[0m] Found 1 error. Watching for file changes.
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/index.d.ts 250 undefined Source file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/base.d.ts 250 undefined Source file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts 250 undefined Source file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/globals.d.ts 250 undefined Source file
+[[90m12:01:19 AM[0m] Found 0 errors. Watching for file changes.
 
 
 
@@ -472,8 +473,19 @@ Program files::
 /a/lib/lib.d.ts
 /user/username/projects/myproject/worker.ts
 /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts
+/user/username/projects/myproject/node_modules/@types/node/globals.d.ts
+/user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts
+/user/username/projects/myproject/node_modules/@types/node/base.d.ts
+/user/username/projects/myproject/node_modules/@types/node/index.d.ts
 
 Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/worker.ts
+/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts
+/user/username/projects/myproject/node_modules/@types/node/globals.d.ts
+/user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts
+/user/username/projects/myproject/node_modules/@types/node/base.d.ts
+/user/username/projects/myproject/node_modules/@types/node/index.d.ts
 
 WatchedFiles::
 /user/username/projects/myproject/tsconfig.json:
@@ -484,6 +496,14 @@ WatchedFiles::
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
 /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts:
   {"fileName":"/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/node/index.d.ts:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/node/index.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/node/base.d.ts:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/node/base.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/node/globals.d.ts:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/node/globals.d.ts","pollingInterval":250}
 
 FsWatches::
 
@@ -497,3 +517,4 @@ FsWatchesRecursive::
 
 exitCode:: ExitStatus.undefined
 
+//// [/user/username/projects/myproject/worker.js] file written with same contents

--- a/tests/baselines/reference/tscWatch/resolutionCache/works-when-installing-something-in-node_modules-or-@types-when-there-is-no-notification-from-fs-for-index-file.js
+++ b/tests/baselines/reference/tscWatch/resolutionCache/works-when-installing-something-in-node_modules-or-@types-when-there-is-no-notification-from-fs-for-index-file.js
@@ -1,0 +1,499 @@
+Input::
+//// [/user/username/projects/myproject/worker.ts]
+process.on("uncaughtException");
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/user/username/projects/myproject/tsconfig.json]
+{}
+
+//// [/user/username/projects/myproject/node_modules/@types/node/index.d.ts]
+/// <reference path="base.d.ts" />
+
+//// [/user/username/projects/myproject/node_modules/@types/node/base.d.ts]
+// Base definitions for all NodeJS modules that are not specific to any version of TypeScript:
+/// <reference path="ts3.6/base.d.ts" />
+
+//// [/user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts]
+/// <reference path="../globals.d.ts" />
+
+//// [/user/username/projects/myproject/node_modules/@types/node/globals.d.ts]
+declare var process: NodeJS.Process;
+declare namespace NodeJS {
+    interface Process {
+        on(msg: string): void;
+    }
+}
+
+
+/a/lib/tsc.js --w --extendedDiagnostics
+Output::
+[[90m12:00:37 AM[0m] Starting compilation in watch mode...
+
+Current directory: /user/username/projects/myproject CaseSensitiveFileNames: false
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/tsconfig.json 2000 undefined Config file
+Synchronizing program
+CreatingProgramWith::
+  roots: ["/user/username/projects/myproject/worker.ts"]
+  options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/worker.ts 250 undefined Source file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/index.d.ts 250 undefined Source file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/base.d.ts 250 undefined Source file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts 250 undefined Source file
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/globals.d.ts 250 undefined Source file
+FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 250 undefined Source file
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+[[90m12:00:40 AM[0m] Found 0 errors. Watching for file changes.
+
+DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+
+
+Program root files: ["/user/username/projects/myproject/worker.ts"]
+Program options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/worker.ts
+/user/username/projects/myproject/node_modules/@types/node/globals.d.ts
+/user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts
+/user/username/projects/myproject/node_modules/@types/node/base.d.ts
+/user/username/projects/myproject/node_modules/@types/node/index.d.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/worker.ts
+/user/username/projects/myproject/node_modules/@types/node/globals.d.ts
+/user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts
+/user/username/projects/myproject/node_modules/@types/node/base.d.ts
+/user/username/projects/myproject/node_modules/@types/node/index.d.ts
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/worker.ts:
+  {"fileName":"/user/username/projects/myproject/worker.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/node/index.d.ts:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/node/index.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/node/base.d.ts:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/node/base.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/node/globals.d.ts:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/node/globals.d.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules:
+  {"directoryName":"/user/username/projects/myproject/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/worker.js]
+process.on("uncaughtException");
+
+
+
+Change:: npm ci step one: remove all node_modules files
+
+Input::
+//// [/user/username/projects/myproject/node_modules/@types/node/index.d.ts] deleted
+//// [/user/username/projects/myproject/node_modules/@types/node/base.d.ts] deleted
+//// [/user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts] deleted
+//// [/user/username/projects/myproject/node_modules/@types/node/globals.d.ts] deleted
+
+Output::
+FileWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/base.d.ts 2:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/base.d.ts 250 undefined Source file
+Scheduling update
+Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/base.d.ts 2:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/base.d.ts 250 undefined Source file
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/base.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Scheduling update
+Scheduling invalidateFailedLookup
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/base.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/base.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/base.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/base.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/base.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+FileWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/globals.d.ts 2:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/globals.d.ts 250 undefined Source file
+Scheduling update
+Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/globals.d.ts 2:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/globals.d.ts 250 undefined Source file
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/globals.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Scheduling update
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/globals.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/globals.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/globals.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/globals.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/globals.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+FileWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/index.d.ts 2:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/index.d.ts 250 undefined Source file
+Scheduling update
+Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/index.d.ts 2:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/index.d.ts 250 undefined Source file
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Scheduling update
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+FileWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts 2:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts 250 undefined Source file
+Scheduling update
+Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts 2:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts 250 undefined Source file
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Scheduling update
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected file add/remove of non supported extension: /user/username/projects/myproject/node_modules/@types/node/ts3.6
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Scheduling update
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Scheduling update
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+[[90m12:00:48 AM[0m] File change detected. Starting incremental compilation...
+
+Reloading new file names and options
+Synchronizing program
+CreatingProgramWith::
+  roots: ["/user/username/projects/myproject/worker.ts"]
+  options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/globals.d.ts 250 undefined Source file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts 250 undefined Source file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/base.d.ts 250 undefined Source file
+FileWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types/node/index.d.ts 250 undefined Source file
+[96mworker.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS2580: [0mCannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+
+[7m1[0m process.on("uncaughtException");
+[7m [0m [91m~~~~~~~[0m
+
+[[90m12:00:52 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/worker.ts"]
+Program options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/worker.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/worker.ts
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/worker.ts:
+  {"fileName":"/user/username/projects/myproject/worker.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules:
+  {"directoryName":"/user/username/projects/myproject/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/user/username/projects/myproject/worker.js] file written with same contents
+
+Change:: npm ci step two: create atTypes but something else in the @types folder
+
+Input::
+//// [/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts]
+export const foo = 10;
+
+
+Output::
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Scheduling update
+Scheduling invalidateFailedLookup
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Scheduling update
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Scheduling update
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+[[90m12:00:59 AM[0m] File change detected. Starting incremental compilation...
+
+Reloading new file names and options
+Synchronizing program
+CreatingProgramWith::
+  roots: ["/user/username/projects/myproject/worker.ts"]
+  options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+FileWatcher:: Added:: WatchInfo: /user/username/projects/myproject/node_modules/@types/mocha/index.d.ts 250 undefined Source file
+[96mworker.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS2580: [0mCannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+
+[7m1[0m process.on("uncaughtException");
+[7m [0m [91m~~~~~~~[0m
+
+[[90m12:01:00 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/worker.ts"]
+Program options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: SafeModules
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/worker.ts
+/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts
+
+Semantic diagnostics in builder refreshed for::
+/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/worker.ts:
+  {"fileName":"/user/username/projects/myproject/worker.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules:
+  {"directoryName":"/user/username/projects/myproject/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+
+Change:: npm ci step three: create atTypes node folder
+
+Input::
+
+Output::
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Scheduling update
+Scheduling invalidateFailedLookup
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+[[90m12:01:03 AM[0m] File change detected. Starting incremental compilation...
+
+Reloading new file names and options
+Synchronizing program
+CreatingProgramWith::
+  roots: ["/user/username/projects/myproject/worker.ts"]
+  options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+[91merror[0m[90m TS2688: [0mCannot find type definition file for 'node'.
+  The file is in the program because:
+    Entry point for implicit type library 'node'
+
+[[90m12:01:04 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/worker.ts"]
+Program options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: SafeModules
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/worker.ts
+/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts
+
+Semantic diagnostics in builder refreshed for::
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/worker.ts:
+  {"fileName":"/user/username/projects/myproject/worker.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules:
+  {"directoryName":"/user/username/projects/myproject/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+
+Change:: npm ci step four: create atTypes write all the files but dont invoke watcher for index.d.ts
+
+Input::
+//// [/user/username/projects/myproject/node_modules/@types/node/base.d.ts]
+// Base definitions for all NodeJS modules that are not specific to any version of TypeScript:
+/// <reference path="ts3.6/base.d.ts" />
+
+//// [/user/username/projects/myproject/node_modules/@types/node/index.d.ts]
+/// <reference path="base.d.ts" />
+
+//// [/user/username/projects/myproject/node_modules/@types/node/ts3.6/base.d.ts]
+/// <reference path="../globals.d.ts" />
+
+//// [/user/username/projects/myproject/node_modules/@types/node/globals.d.ts]
+declare var process: NodeJS.Process;
+declare namespace NodeJS {
+    interface Process {
+        on(msg: string): void;
+    }
+}
+
+
+Output::
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/base.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Scheduling update
+Scheduling invalidateFailedLookup
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/base.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/base.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+Scheduling invalidateFailedLookup, Cancelled earlier one
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/base.d.ts :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/base.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/base.d.ts :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+Scheduling update
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Type roots
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject/node_modules 1 undefined Failed Lookup Locations
+DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+Project: /user/username/projects/myproject/tsconfig.json Detected file add/remove of non supported extension: /user/username/projects/myproject/node_modules/@types/node/ts3.6
+Elapsed:: *ms DirectoryWatcher:: Triggered with /user/username/projects/myproject/node_modules/@types/node/ts3.6 :: WatchInfo: /user/username/projects/myproject 1 undefined Wild card directory
+[[90m12:01:15 AM[0m] File change detected. Starting incremental compilation...
+
+Reloading new file names and options
+Synchronizing program
+CreatingProgramWith::
+  roots: ["/user/username/projects/myproject/worker.ts"]
+  options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+[91merror[0m[90m TS2688: [0mCannot find type definition file for 'node'.
+  The file is in the program because:
+    Entry point for implicit type library 'node'
+
+[[90m12:01:16 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/user/username/projects/myproject/worker.ts"]
+Program options: {"watch":true,"extendedDiagnostics":true,"configFilePath":"/user/username/projects/myproject/tsconfig.json"}
+Program structureReused: SafeModules
+Program files::
+/a/lib/lib.d.ts
+/user/username/projects/myproject/worker.ts
+/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts
+
+Semantic diagnostics in builder refreshed for::
+
+WatchedFiles::
+/user/username/projects/myproject/tsconfig.json:
+  {"fileName":"/user/username/projects/myproject/tsconfig.json","pollingInterval":250}
+/user/username/projects/myproject/worker.ts:
+  {"fileName":"/user/username/projects/myproject/worker.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts:
+  {"fileName":"/user/username/projects/myproject/node_modules/@types/mocha/index.d.ts","pollingInterval":250}
+
+FsWatches::
+
+FsWatchesRecursive::
+/user/username/projects/myproject/node_modules:
+  {"directoryName":"/user/username/projects/myproject/node_modules","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject/node_modules/@types:
+  {"directoryName":"/user/username/projects/myproject/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/user/username/projects/myproject:
+  {"directoryName":"/user/username/projects/myproject","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+


### PR DESCRIPTION
Because watch notifications are so unreliable, this is heuristic that will help with scenarios where we dont get notification for addition of index.d.ts for a package but some other files from it. This was the core issue in #41735 where it would eg get notification for `node_modules/@types/node/assert.d.ts` and some such other files but not the `index.d.ts` but `index.d.ts` is the main file that pulls the types so it would ignore the installation of `@types/node` and there would be error for not finding the types.

Fixes #41735
