### PR TITLE
Generate SourceMap mappings string using array of character codes and fewer String.fromCharCode calls

### DIFF
--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -17,6 +17,7 @@ namespace ts {
 
         const names: string[] = [];
         let nameToNameIndexMap: ESMap<string, number> | undefined;
+        const mappingCharCodes: number[] = [];
         let mappings = "";
 
         // Last recorded and encoded mappings
@@ -221,7 +222,7 @@ namespace ts {
             if (lastGeneratedLine < pendingGeneratedLine) {
                 // Emit line delimiters
                 do {
-                    mappings += ";";
+                    mappingCharCodes.push(CharacterCodes.semicolon); // ';'
                     lastGeneratedLine++;
                     lastGeneratedCharacter = 0;
                 }
@@ -231,30 +232,30 @@ namespace ts {
                 Debug.assertEqual(lastGeneratedLine, pendingGeneratedLine, "generatedLine cannot backtrack");
                 // Emit comma to separate the entry
                 if (hasLast) {
-                    mappings += ",";
+                    mappingCharCodes.push(CharacterCodes.comma); // ','
                 }
             }
 
             // 1. Relative generated character
-            mappings += base64VLQFormatEncode(pendingGeneratedCharacter - lastGeneratedCharacter);
+            appendBase64VLQ(pendingGeneratedCharacter - lastGeneratedCharacter);
             lastGeneratedCharacter = pendingGeneratedCharacter;
 
             if (hasPendingSource) {
                 // 2. Relative sourceIndex
-                mappings += base64VLQFormatEncode(pendingSourceIndex - lastSourceIndex);
+                appendBase64VLQ(pendingSourceIndex - lastSourceIndex);
                 lastSourceIndex = pendingSourceIndex;
 
                 // 3. Relative source line
-                mappings += base64VLQFormatEncode(pendingSourceLine - lastSourceLine);
+                appendBase64VLQ(pendingSourceLine - lastSourceLine);
                 lastSourceLine = pendingSourceLine;
 
                 // 4. Relative source character
-                mappings += base64VLQFormatEncode(pendingSourceCharacter - lastSourceCharacter);
+                appendBase64VLQ(pendingSourceCharacter - lastSourceCharacter);
                 lastSourceCharacter = pendingSourceCharacter;
 
                 if (hasPendingName) {
                     // 5. Relative nameIndex
-                    mappings += base64VLQFormatEncode(pendingNameIndex - lastNameIndex);
+                    appendBase64VLQ(pendingNameIndex - lastNameIndex);
                     lastNameIndex = pendingNameIndex;
                 }
             }
@@ -263,8 +264,16 @@ namespace ts {
             exit();
         }
 
+        function serializeMappings(): void {
+            for (let i = 0, len = mappingCharCodes.length; i < len; i += 1024) {
+                mappings += String.fromCharCode.apply(undefined, mappingCharCodes.slice(i, i + 1024));
+            }
+            mappingCharCodes.length = 0;
+        }
+
         function toJSON(): RawSourceMap {
             commitPendingMapping();
+            serializeMappings();
             return {
                 version: 3,
                 file,
@@ -274,6 +283,31 @@ namespace ts {
                 mappings,
                 sourcesContent,
             };
+        }
+
+        function appendBase64VLQ(inValue: number): void {
+            // Add a new least significant bit that has the sign of the value.
+            // if negative number the least significant bit that gets added to the number has value 1
+            // else least significant bit value that gets added is 0
+            // eg. -1 changes to binary : 01 [1] => 3
+            //     +1 changes to binary : 01 [0] => 2
+            if (inValue < 0) {
+                inValue = ((-inValue) << 1) + 1;
+            }
+            else {
+                inValue = inValue << 1;
+            }
+
+            // Encode 5 bits at a time starting from least significant bits
+            do {
+                let currentDigit = inValue & 31; // 11111
+                inValue = inValue >> 5;
+                if (inValue > 0) {
+                    // There are still more digits to decode, set the msb (6th bit)
+                    currentDigit = currentDigit | 32;
+                }
+                mappingCharCodes.push(base64FormatEncode(currentDigit));
+            } while (inValue > 0);
         }
     }
 
@@ -542,34 +576,6 @@ namespace ts {
             ch === CharacterCodes.plus ? 62 :
             ch === CharacterCodes.slash ? 63 :
             -1;
-    }
-
-    function base64VLQFormatEncode(inValue: number) {
-        // Add a new least significant bit that has the sign of the value.
-        // if negative number the least significant bit that gets added to the number has value 1
-        // else least significant bit value that gets added is 0
-        // eg. -1 changes to binary : 01 [1] => 3
-        //     +1 changes to binary : 01 [0] => 2
-        if (inValue < 0) {
-            inValue = ((-inValue) << 1) + 1;
-        }
-        else {
-            inValue = inValue << 1;
-        }
-
-        // Encode 5 bits at a time starting from least significant bits
-        let encodedStr = "";
-        do {
-            let currentDigit = inValue & 31; // 11111
-            inValue = inValue >> 5;
-            if (inValue > 0) {
-                // There are still more digits to decode, set the msb (6th bit)
-                currentDigit = currentDigit | 32;
-            }
-            encodedStr = encodedStr + String.fromCharCode(base64FormatEncode(currentDigit));
-        } while (inValue > 0);
-
-        return encodedStr;
     }
 
     interface MappedPosition {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

This is an alternate approach to #43987 that works in ES5, for perf comparison.

Ultimately where this is saving CPU cycles is in avoiding native hops for instantiating new strings, and in allocating fewer "cons string" objects from the concatenations.

Fixes #43999 
