### PR TITLE
Use char code array in createTextWriter

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3964,13 +3964,29 @@ namespace ts {
 
         function appendRawSmall(text: string) {
             const len = text.length;
-            for (let pos = 0; pos < len; pos++) {
+            let pos = 0;
+            while (pos < len) {
                 const ch = text.charCodeAt(pos);
                 appendCharCode(ch);
-                // Ignore carriageReturn, since we mark the following lineFeed as the newline anyway
-                if (isLineBreak(ch) && ch !== CharacterCodes.carriageReturn) {
-                    ++lineCount;
-                    linePos = totalChars;
+                pos++;
+                switch (ch) {
+                    case CharacterCodes.carriageReturn:
+                        const nextChar = text.charCodeAt(pos);
+                        if (nextChar === CharacterCodes.lineFeed) {
+                            appendCharCode(nextChar);
+                            pos++;
+                        }
+                    // falls through
+                    case CharacterCodes.lineFeed:
+                        ++lineCount;
+                        linePos = totalChars;
+                        break;
+                    default:
+                        if (ch > CharacterCodes.maxAsciiCharacter && isLineBreak(ch)) {
+                            ++lineCount;
+                            linePos = totalChars;
+                        }
+                        break;
                 }
             }
 
@@ -3981,14 +3997,31 @@ namespace ts {
             flushBuffer();
 
             const len = text.length;
-            for (let pos = 0; pos < len; pos++) {
+            let pos = 0;
+            while (pos < len) {
                 const ch = text.charCodeAt(pos);
                 ++totalChars;
                 lastChar = ch;
-                // Ignore carriageReturn, since we mark the following lineFeed as the newline anyway
-                if (isLineBreak(ch) && ch !== CharacterCodes.carriageReturn) {
-                    ++lineCount;
-                    linePos = totalChars;
+                pos++;
+                switch (ch) {
+                    case CharacterCodes.carriageReturn:
+                        const nextChar = text.charCodeAt(pos);
+                        if (nextChar === CharacterCodes.lineFeed) {
+                            ++totalChars;
+                            lastChar = nextChar;
+                            pos++;
+                        }
+                    // falls through
+                    case CharacterCodes.lineFeed:
+                        ++lineCount;
+                        linePos = totalChars;
+                        break;
+                    default:
+                        if (ch > CharacterCodes.maxAsciiCharacter && isLineBreak(ch)) {
+                            ++lineCount;
+                            linePos = totalChars;
+                        }
+                        break;
                 }
             }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3963,8 +3963,6 @@ namespace ts {
         }
 
         function appendRaw(text: string) {
-            let lastLineStart = -1;
-
             const len = text.length;
             for (let pos = 0; pos < len; pos++) {
                 const ch = text.charCodeAt(pos);
@@ -3972,12 +3970,8 @@ namespace ts {
                 // Ignore carriageReturn, since we mark the following lineFeed as the newline anyway
                 if (ch !== CharacterCodes.carriageReturn && isLineBreak(ch)) {
                     ++lineCount;
-                    lastLineStart = totalChars;
+                    linePos = totalChars;
                 }
-            }
-
-            if (lastLineStart >= 0) {
-                linePos = lastLineStart;
             }
 
             lineStart = linePos === totalChars;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3986,7 +3986,7 @@ namespace ts {
         function writeText(s: string) {
             if (s && s.length) {
                 if (lineStart) {
-                    for (let i = 0; i < indent; i++) {
+                    for (let i = 0, totalIndent = indent * getIndentSize(); i < totalIndent; i++) {
                         appendCharCode(CharacterCodes.space);
                     }
                     // lineStart will be automatically cleared by the append


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Inquiring minds wanted to know, based on the performance savings in #44031 , if the same trick would work in `createTextWriter`. This PR aims to answer that question.

Fixes #44036
