### PR TITLE
Add a failing test for #44005 - Comments leak into transformer-syntesized lists

### DIFF
--- a/tests/baselines/reference/transformApi/transformsCorrectly.issue44005.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.issue44005.js
@@ -1,0 +1,4 @@
+(focus);
+// Doubles
+(focus());
+// No trailing newline really breaks everything


### PR DESCRIPTION
EDIT: Closed this one, I'm making another PR, #44048, that fixes #44005 but has other regressions.

Currently failing test for #44005.

* [X] There is an associated issue in the `Backlog` milestone (**required**)
* [X] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [X] There are new or updated unit tests validating the change

Fixes #44005
