### PR TITLE
Fixes #44005 - Comments leak into transformer-synthesized lists

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4327,7 +4327,7 @@ namespace ts {
                 //          2
                 //          /* end of element 2 */
                 //       ];
-                if (previousSibling && (parentNode ? parentNode.end : -1) !== previousSibling.end && (format & ListFormat.DelimitersMask) && !skipTrailingComments) {
+                if (previousSibling && (parentNode ? parentNode.end : -1) !== previousSibling.end && (format & ListFormat.DelimitersMask) && !skipTrailingComments && !((parentNode?.flags ?? NodeFlags.None) & NodeFlags.Synthesized)) {
                     emitLeadingCommentsOfPosition(hasTrailingComma && children?.end ? children.end : previousSibling.end);
                 }
 

--- a/tests/baselines/reference/transformApi/transformsCorrectly.issue44005.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.issue44005.js
@@ -1,0 +1,4 @@
+(focus);
+// Doubles
+(focus());
+// No trailing newline really breaks everything


### PR DESCRIPTION
This fixes #44005, but breaks two existing tests.
Also includes test case for #44005. #44046 is a PR with only the test without the "fix".

The failing tests:
- `tests/cases/compiler/arrowFunctionErrorSpan.ts`
- `tests/cases/compiler/destructureOfVariableSameAsShorthand.ts`
Both of those have disappearing comments.

Please verify that:
* [X] There is an associated issue in the `Backlog` milestone (**required**)
* [X] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [X] There are new or updated unit tests validating the change

Fixes #44005