### PR TITLE
Change the DocumentFragment global vars type to an interface

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -5053,10 +5053,13 @@ interface DocumentFragment extends Node, NonElementParentNode, ParentNode {
     getElementById(elementId: string): HTMLElement | null;
 }
 
-declare var DocumentFragment: {
+interface DocumentFragmentConstructor
+{
     prototype: DocumentFragment;
     new(): DocumentFragment;
-};
+}
+
+declare var DocumentFragment: DocumentFragmentConstructor;
 
 interface DocumentOrShadowRoot {
     readonly activeElement: Element | null;


### PR DESCRIPTION
this is so that I can expand it in my own code. I want to add some static functions to `DocumentFragment`

I have not opened an issue due to this change being so small. 
And to my knowledge does not break anything.

I can also not find any existing topics regarding changing the global vars to be typed via an interface instead of directly.

So I'm hoping this PR will be allowed/accepted due to it's tiny scale :D
