### PR TITLE
Move some commonly missing required sourceFile fields into the node factory

### DIFF
--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -4972,6 +4972,11 @@ namespace ts {
             node.transformFlags |=
                 propagateChildrenFlags(node.statements) |
                 propagateChildFlags(node.endOfFileToken);
+            node.referencedFiles = [];
+            node.typeReferenceDirectives = [];
+            node.libReferenceDirectives = [];
+            node.amdDependencies = [];
+            node.pragmas = new Map() as ReadonlyPragmaMap;
             return node;
         }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -836,12 +836,6 @@ namespace ts {
             if (scriptKind === ScriptKind.JSON) {
                 const result = parseJsonText(fileName, sourceText, languageVersion, syntaxCursor, setParentNodes);
                 convertToObjectWorker(result, result.statements[0]?.expression, result.parseDiagnostics, /*returnValue*/ false, /*knownRootOptions*/ undefined, /*jsonConversionNotifier*/ undefined);
-                result.referencedFiles = emptyArray;
-                result.typeReferenceDirectives = emptyArray;
-                result.libReferenceDirectives = emptyArray;
-                result.amdDependencies = emptyArray;
-                result.hasNoDefaultLib = false;
-                result.pragmas = emptyMap as ReadonlyPragmaMap;
                 return result;
             }
 


### PR DESCRIPTION
IIRC, the only reason these weren't in the factory is because we didn't always have a factory function for source files that we consistently used - nowadays we do, so we should probably avoid needing to remember to initialize these fields outside the factory.