### PR TITLE
Update lib.es5.d.ts - parseInt and parseFloat

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -33,18 +33,19 @@ declare function eval(x: string): any;
 
 /**
  * Converts a string to an integer.
- * @param s A string to convert into a number.
+ * @param s A value to convert into a number. In most cases string. Other types ex. null are converted on the fly to string and return NaN value.
  * @param radix A value between 2 and 36 that specifies the base of the number in numString.
  * If this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.
  * All other strings are considered decimal.
  */
-declare function parseInt(s: string, radix?: number): number;
+declare function parseInt(s: any, radix?: number): number;
 
 /**
  * Converts a string to a floating-point number.
+ * @param s A value to convert into a floating-point number. In most cases string. Other types ex. null are converted on the fly to string and return NaN value.
  * @param string A string that contains a floating-point number.
  */
-declare function parseFloat(string: string): number;
+declare function parseFloat(string: any): number;
 
 /**
  * Returns a Boolean value that indicates whether a value is the reserved value NaN (not a number).


### PR DESCRIPTION
Currently global methods `parseInt` and `parseFloat` has too strict input type. 
In fact, these functions try to convert each value (also null, undefined, boolean) to a number and return NaN on failure. 
See (https://262.ecma-international.org/5.1/#sec-15.1.2.2) step 1.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
