### PR TITLE
Do not incorrectly add line separators for non-synthetic nodes when emitting node list

### DIFF
--- a/src/testRunner/unittests/transform.ts
+++ b/src/testRunner/unittests/transform.ts
@@ -154,6 +154,26 @@ namespace ts {
             }).outputText;
         });
 
+        testBaseline("issue44068", () => {
+            return transformSourceFile(`
+                const FirstVar = null;
+                const SecondVar = null;
+            `, [
+                context => file => {
+                    const firstVarName = (file.statements[0] as VariableStatement)
+                        .declarationList.declarations[0].name as Identifier;
+                    const secondVarName = (file.statements[0] as VariableStatement)
+                        .declarationList.declarations[0].name as Identifier;
+
+                    return context.factory.updateSourceFile(file, file.statements.concat([
+                        context.factory.createExpressionStatement(
+                            context.factory.createArrayLiteralExpression([firstVarName, secondVarName])
+                        ),
+                    ]));
+                }
+            ]);
+        });
+
         testBaseline("rewrittenNamespace", () => {
             return transpileModule(`namespace Reflect { const x = 1; }`, {
                 transformers: {

--- a/tests/baselines/reference/decoratorOnClassMethodThisParameter.js
+++ b/tests/baselines/reference/decoratorOnClassMethodThisParameter.js
@@ -30,7 +30,8 @@ var C2 = /** @class */ (function () {
     }
     C2.prototype.method = function (allowed) { };
     __decorate([
-        __param(0, dec), __param(1, dec)
+        __param(0, dec),
+        __param(1, dec)
     ], C2.prototype, "method", null);
     return C2;
 }());

--- a/tests/baselines/reference/jsxJsxsCjsTransformNestedSelfClosingChild(jsx=react-jsx).js
+++ b/tests/baselines/reference/jsxJsxsCjsTransformNestedSelfClosingChild(jsx=react-jsx).js
@@ -26,6 +26,5 @@ console.log(
 exports.__esModule = true;
 var jsx_runtime_1 = require("react/jsx-runtime");
 console.log(jsx_runtime_1.jsx("div", { children: jsx_runtime_1.jsx("div", {}, void 0) }, void 0));
-console.log(jsx_runtime_1.jsxs("div", { children: [jsx_runtime_1.jsx("div", {}, void 0),
-        jsx_runtime_1.jsx("div", {}, void 0)] }, void 0));
+console.log(jsx_runtime_1.jsxs("div", { children: [jsx_runtime_1.jsx("div", {}, void 0), jsx_runtime_1.jsx("div", {}, void 0)] }, void 0));
 console.log(jsx_runtime_1.jsx("div", { children: [1, 2].map(function (i) { return jsx_runtime_1.jsx("div", { children: i }, i); }) }, void 0));

--- a/tests/baselines/reference/jsxJsxsCjsTransformNestedSelfClosingChild(jsx=react-jsxdev).js
+++ b/tests/baselines/reference/jsxJsxsCjsTransformNestedSelfClosingChild(jsx=react-jsxdev).js
@@ -28,6 +28,5 @@ exports.__esModule = true;
 var jsx_dev_runtime_1 = require("react/jsx-dev-runtime");
 var _jsxFileName = "tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformNestedSelfClosingChild.tsx";
 console.log(jsx_dev_runtime_1.jsxDEV("div", { children: jsx_dev_runtime_1.jsxDEV("div", {}, void 0, false, { fileName: _jsxFileName, lineNumber: 6, columnNumber: 5 }, this) }, void 0, false, { fileName: _jsxFileName, lineNumber: 4, columnNumber: 13 }, this));
-console.log(jsx_dev_runtime_1.jsxDEV("div", { children: [jsx_dev_runtime_1.jsxDEV("div", {}, void 0, false, { fileName: _jsxFileName, lineNumber: 12, columnNumber: 5 }, this),
-        jsx_dev_runtime_1.jsxDEV("div", {}, void 0, false, { fileName: _jsxFileName, lineNumber: 13, columnNumber: 5 }, this)] }, void 0, true, { fileName: _jsxFileName, lineNumber: 10, columnNumber: 13 }, this));
+console.log(jsx_dev_runtime_1.jsxDEV("div", { children: [jsx_dev_runtime_1.jsxDEV("div", {}, void 0, false, { fileName: _jsxFileName, lineNumber: 12, columnNumber: 5 }, this), jsx_dev_runtime_1.jsxDEV("div", {}, void 0, false, { fileName: _jsxFileName, lineNumber: 13, columnNumber: 5 }, this)] }, void 0, true, { fileName: _jsxFileName, lineNumber: 10, columnNumber: 13 }, this));
 console.log(jsx_dev_runtime_1.jsxDEV("div", { children: [1, 2].map(function (i) { return jsx_dev_runtime_1.jsxDEV("div", { children: i }, i, false, { fileName: _jsxFileName, lineNumber: 19, columnNumber: 21 }, _this); }) }, void 0, false, { fileName: _jsxFileName, lineNumber: 17, columnNumber: 13 }, this));

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.js
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.js
@@ -35,7 +35,8 @@ var y = {
     "typeof": 
 };
 var x = (_a = {
-        a: a, : .b,
+        a: a,
+        : .b,
         a: a
     },
     _a["ss"] = ,

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesErrorWithModule.js
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesErrorWithModule.js
@@ -25,7 +25,8 @@ var n;
 (function (n) {
     var z = 10000;
     n.y = {
-        m: m, : .x // error
+        m: m,
+        : .x // error
     };
 })(n || (n = {}));
 m.y.x;

--- a/tests/baselines/reference/objectTypesWithOptionalProperties2.js
+++ b/tests/baselines/reference/objectTypesWithOptionalProperties2.js
@@ -42,5 +42,6 @@ var C2 = /** @class */ (function () {
     return C2;
 }());
 var b = {
-    x: function () { }, 1:  // error
+    x: function () { },
+    1:  // error
 };

--- a/tests/baselines/reference/parserErrorRecovery_ObjectLiteral2.js
+++ b/tests/baselines/reference/parserErrorRecovery_ObjectLiteral2.js
@@ -3,5 +3,4 @@ var v = { a
 return;
 
 //// [parserErrorRecovery_ObjectLiteral2.js]
-var v = { a: a,
-    "return":  };
+var v = { a: a, "return":  };

--- a/tests/baselines/reference/transformApi/transformsCorrectly.issue44068.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.issue44068.js
@@ -1,0 +1,3 @@
+const FirstVar = null;
+const SecondVar = null;
+[FirstVar, FirstVar];


### PR DESCRIPTION
As of 3c32f6e, a line separator is added between nodes if the nodes are
not synthetic and on separate lines. This is wrong and previously only
happened if the non-synthetic nodes were on different lines but had the same parent.

Fixes #44068.