### PR TITLE
Cache parsed path mapping patterns

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1977,19 +1977,17 @@ namespace ts {
                     declareModuleSymbol(node);
                 }
                 else {
-                    let pattern: Pattern | undefined;
+                    let pattern: string | Pattern | undefined;
                     if (node.name.kind === SyntaxKind.StringLiteral) {
                         const { text } = node.name;
-                        if (hasZeroOrOneAsteriskCharacter(text)) {
-                            pattern = tryParsePattern(text);
-                        }
-                        else {
+                        pattern = tryParsePattern(text);
+                        if (pattern === undefined) {
                             errorOnFirstToken(node.name, Diagnostics.Pattern_0_can_have_at_most_one_Asterisk_character, text);
                         }
                     }
 
                     const symbol = declareSymbolAndAddToSymbolTable(node, SymbolFlags.ValueModule, SymbolFlags.ValueModuleExcludes)!;
-                    file.patternAmbientModules = append<PatternAmbientModule>(file.patternAmbientModules, pattern && { pattern, symbol });
+                    file.patternAmbientModules = append<PatternAmbientModule>(file.patternAmbientModules, pattern && !isString(pattern) ? { pattern, symbol } : undefined);
                 }
             }
             else {

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2533,6 +2533,7 @@ namespace ts {
                 validatedFilesSpec: filter(filesSpecs, isString),
                 validatedIncludeSpecs,
                 validatedExcludeSpecs,
+                pathPatterns: undefined, // Initialized on first use
             };
         }
 

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -961,13 +961,7 @@ namespace ts {
                 trace(state.host, Diagnostics.paths_option_is_specified_looking_for_a_pattern_to_match_module_name_0, moduleName);
             }
             const baseDirectory = getPathsBasePath(state.compilerOptions, state.host)!; // Always defined when 'paths' is defined
-            let pathPatterns: readonly (string | Pattern)[] | undefined;
-            if (configFile?.configFileSpecs) {
-                pathPatterns = configFile.configFileSpecs.pathPatterns;
-                if (!pathPatterns) {
-                    configFile.configFileSpecs.pathPatterns = pathPatterns = tryParsePatterns(paths);
-                }
-            }
+            const pathPatterns = configFile?.configFileSpecs ? configFile.configFileSpecs.pathPatterns ||= tryParsePatterns(paths) : undefined;
             return tryLoadModuleUsingPaths(extensions, moduleName, baseDirectory, paths, pathPatterns, loader, /*onlyRecordFailures*/ false, state);
         }
     }

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1407,8 +1407,7 @@ namespace ts {
             if (state.traceEnabled) {
                 trace(state.host, Diagnostics.package_json_has_a_typesVersions_entry_0_that_matches_compiler_version_1_looking_for_a_pattern_to_match_module_name_2, versionPaths.version, version, moduleName);
             }
-            const paths = versionPaths.paths;
-            const result = tryLoadModuleUsingPaths(extensions, moduleName, candidate, paths, /*pathPatterns*/ undefined, loader, onlyRecordFailuresForPackageFile || onlyRecordFailuresForIndex, state);
+            const result = tryLoadModuleUsingPaths(extensions, moduleName, candidate, versionPaths.paths, /*pathPatterns*/ undefined, loader, onlyRecordFailuresForPackageFile || onlyRecordFailuresForIndex, state);
             if (result) {
                 return removeIgnoredPackageId(result.value);
             }
@@ -1544,8 +1543,7 @@ namespace ts {
                     trace(state.host, Diagnostics.package_json_has_a_typesVersions_entry_0_that_matches_compiler_version_1_looking_for_a_pattern_to_match_module_name_2, packageInfo.versionPaths.version, version, rest);
                 }
                 const packageDirectoryExists = nodeModulesDirectoryExists && directoryProbablyExists(packageDirectory, state.host);
-                const paths = packageInfo.versionPaths.paths;
-                const fromPaths = tryLoadModuleUsingPaths(extensions, rest, packageDirectory, paths, /*pathPatterns*/ undefined, loader, !packageDirectoryExists, state);
+                const fromPaths = tryLoadModuleUsingPaths(extensions, rest, packageDirectory, packageInfo.versionPaths.paths, /*pathPatterns*/ undefined, loader, !packageDirectoryExists, state);
                 if (fromPaths) {
                     return fromPaths.value;
                 }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6195,6 +6195,7 @@ namespace ts {
         validatedFilesSpec: readonly string[] | undefined;
         validatedIncludeSpecs: readonly string[] | undefined;
         validatedExcludeSpecs: readonly string[] | undefined;
+        pathPatterns: readonly (string | Pattern)[] | undefined;
     }
 
     /* @internal */

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6786,6 +6786,10 @@ namespace ts {
             };
     }
 
+    export function tryParsePatterns(paths: MapLike<string[]>): (string | Pattern)[] {
+        return mapDefined(getOwnKeys(paths), path => tryParsePattern(path));
+    }
+
     export function positionIsSynthesized(pos: number): boolean {
         // This is a fast way of testing the following conditions:
         //  pos === undefined || pos === null || isNaN(pos) || pos < 0;

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -553,8 +553,8 @@ namespace ts.Completions.StringCompletions {
             return undefined;
         }
 
-        const parsed = hasZeroOrOneAsteriskCharacter(pattern) ? tryParsePattern(pattern) : undefined;
-        if (!parsed) {
+        const parsed = tryParsePattern(pattern);
+        if (parsed === undefined || isString(parsed)) {
             return undefined;
         }
 


### PR DESCRIPTION
If a project has many of them (e.g. 1800), parsing the patterns repeatedly can take up a lot of time.

Specifically, `getOwnKeys` and `hasZeroOrOneAsteriskCharacter` were showing up as self-time hotspots.