### PR TITLE
Fix the code that checks for variadic signatures

### DIFF
--- a/tests/cases/fourslash/jsSignature-41059.ts
+++ b/tests/cases/fourslash/jsSignature-41059.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts" />
+
+// @lib: esnext
+// @allowNonTsExtensions: true
+
+// @Filename: Foo.js
+//// a.next(/**/);
+
+goTo.marker();
+verify.signatureHelp({ overloadsCount: 2, text: "Generator.next(): IteratorResult<T, TReturn>" });


### PR DESCRIPTION
This code looks strange, like there's a typo in it (eg, using `lists` in
the `parameterList` loop, etc) -- so I also refactored it a bit to look
more intentional.  The new format makes it clearer that `lists` is
checked once *outside* the loop, as well as the role of
`hasEffectiveRestParameter`.

The actual bug fix is checking `pList.length` in the new `isVariadic()`.

Fixes #41059.
