### PR TITLE
Avoid calling replace in normalizeSlashes when it would do nothing

### DIFF
--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -452,7 +452,9 @@ namespace ts {
      * Normalize path separators, converting `\` into `/`.
      */
     export function normalizeSlashes(path: string): string {
-        return path.replace(backslashRegExp, directorySeparator);
+        return path.indexOf(altDirectorySeparator) === -1
+            ? path
+            : path.replace(backslashRegExp, directorySeparator);
     }
 
     /**

--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -452,9 +452,12 @@ namespace ts {
      * Normalize path separators, converting `\` into `/`.
      */
     export function normalizeSlashes(path: string): string {
-        return path.indexOf(altDirectorySeparator) === -1
-            ? path
-            : path.replace(backslashRegExp, directorySeparator);
+        const index = path.indexOf("\\");
+        if (index === -1) {
+            return path;
+        }
+        backslashRegExp.lastIndex = index; // prime regex with known position
+        return path.replace(backslashRegExp, directorySeparator);
     }
 
     /**


### PR DESCRIPTION
On Windows, there will probably be a negligible slowdown, iterating over the pre-slash prefix of each unnormalized path (though we might come out ahead if paths are normalized more than once).

On *nix, this saves work - 1.8s -> 0.4s in the project I'm investigating.