### PR TITLE
Avoid `convertExport` when there's a non-identifier or a bogus one

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -6397,6 +6397,10 @@
         "category": "Message",
         "code": 95163
     },
+    "Can only convert named export": {
+        "category": "Message",
+        "code": 95164
+    },
 
     "No value exists in scope for the shorthand property '{0}'. Either declare one or provide an initializer.": {
         "category": "Error",

--- a/tests/cases/fourslash/refactorConvertExport_onlyValidIdentifiers.ts
+++ b/tests/cases/fourslash/refactorConvertExport_onlyValidIdentifiers.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+
+// @Filename: /a.js
+/////*[| |]*/ /** x */ export default 1;
+
+// @Filename: /b.js
+/////*[| |]*/ /** x */ export default (1);
+
+// @Filename: /c.js
+/////*[| |]*/ /** x */ export default x;
+
+goTo.eachRange(r => {
+    goTo.selectRange(r);
+    verify.not.refactorAvailable("Convert export");
+});
+
+// goTo.selectRange(test.ranges()[0]);
+// edit.applyRefactor({
+//     refactorName: "Convert export",
+//     actionName: "Convert default export to named export",
+//     actionDescription: "Convert default export to named export",
+//     newContent: { "/a.js": `...` },
+// });


### PR DESCRIPTION
Fixes #44105
