### PR TITLE
fix: code fix wrapJsxInFragment not working in new JSX emit

### DIFF
--- a/src/services/codefixes/wrapJsxInFragment.ts
+++ b/src/services/codefixes/wrapJsxInFragment.ts
@@ -5,10 +5,6 @@ namespace ts.codefix {
     registerCodeFix({
         errorCodes,
         getCodeActions: context => {
-            const { jsx } = context.program.getCompilerOptions();
-            if (jsx !== JsxEmit.React && jsx !== JsxEmit.ReactNative) {
-                return undefined;
-            }
             const { sourceFile, span } = context;
             const node = findNodeToFix(sourceFile, span.start);
             if (!node) return undefined;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

I implemented "Wrap in JSX Fragment" in #37917. It explicitly detects if the JSXEmit is `React` or `ReactNative`. When TypeScript supports the new JSX emit comes out, this file didn't be changed to reflect the new change. The result is this code fix is not working when using the new JSX emit.