### PR TITLE
Preserve generics in contextual types for rest arguments

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5502,6 +5502,7 @@ namespace ts {
         ExpressionPosition = 1 << 5,
         ReportDeprecated = 1 << 6,
         SuppressNoImplicitAnyError = 1 << 7,
+        Contextual = 1 << 8,
         Persistent = IncludeUndefined,
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5491,17 +5491,27 @@ namespace ts {
         resolvedDefaultType?: Type;
     }
 
+    /* @internal */
+    export const enum AccessFlags {
+        None = 0,
+        IncludeUndefined = 1 << 0,
+        NoIndexSignatures = 1 << 1,
+        Writing = 1 << 2,
+        CacheSymbol = 1 << 3,
+        NoTupleBoundsCheck = 1 << 4,
+        ExpressionPosition = 1 << 5,
+        ReportDeprecated = 1 << 6,
+        SuppressNoImplicitAnyError = 1 << 7,
+        Persistent = IncludeUndefined,
+    }
+
     // Indexed access types (TypeFlags.IndexedAccess)
     // Possible forms are T[xxx], xxx[T], or xxx[keyof T], where T is a type variable
     export interface IndexedAccessType extends InstantiableType {
         objectType: Type;
         indexType: Type;
-        /**
-         * @internal
-         * Indicates that --noUncheckedIndexedAccess may introduce 'undefined' into
-         * the resulting type, depending on how type variable constraints are resolved.
-         */
-        noUncheckedIndexedAccessCandidate: boolean;
+        /* @internal */
+        accessFlags: AccessFlags;  // Only includes AccessFlags.Persistent
         constraint?: Type;
         simplifiedForReading?: Type;
         simplifiedForWriting?: Type;

--- a/tests/baselines/reference/controlFlowGenericTypes.errors.txt
+++ b/tests/baselines/reference/controlFlowGenericTypes.errors.txt
@@ -150,3 +150,13 @@ tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts(91,11): error TS2
         return 0;
     };
     
+    // Repro from #44093
+    
+    class EventEmitter<ET> {
+        off<K extends keyof ET>(...args: [K, number] | [unknown, string]):void {}
+    }
+    function once<ET, T extends EventEmitter<ET>>(emittingObject: T, eventName: keyof ET): void {
+        emittingObject.off(eventName, 0);
+        emittingObject.off(eventName as typeof eventName, 0);
+    }
+    

--- a/tests/baselines/reference/controlFlowGenericTypes.js
+++ b/tests/baselines/reference/controlFlowGenericTypes.js
@@ -129,6 +129,16 @@ function get<K extends keyof A>(key: K, obj: A): number {
     return 0;
 };
 
+// Repro from #44093
+
+class EventEmitter<ET> {
+    off<K extends keyof ET>(...args: [K, number] | [unknown, string]):void {}
+}
+function once<ET, T extends EventEmitter<ET>>(emittingObject: T, eventName: keyof ET): void {
+    emittingObject.off(eventName, 0);
+    emittingObject.off(eventName as typeof eventName, 0);
+}
+
 
 //// [controlFlowGenericTypes.js]
 "use strict";
@@ -220,3 +230,19 @@ function get(key, obj) {
     return 0;
 }
 ;
+// Repro from #44093
+var EventEmitter = /** @class */ (function () {
+    function EventEmitter() {
+    }
+    EventEmitter.prototype.off = function () {
+        var args = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            args[_i] = arguments[_i];
+        }
+    };
+    return EventEmitter;
+}());
+function once(emittingObject, eventName) {
+    emittingObject.off(eventName, 0);
+    emittingObject.off(eventName, 0);
+}

--- a/tests/baselines/reference/controlFlowGenericTypes.symbols
+++ b/tests/baselines/reference/controlFlowGenericTypes.symbols
@@ -367,3 +367,41 @@ function get<K extends keyof A>(key: K, obj: A): number {
     return 0;
 };
 
+// Repro from #44093
+
+class EventEmitter<ET> {
+>EventEmitter : Symbol(EventEmitter, Decl(controlFlowGenericTypes.ts, 128, 2))
+>ET : Symbol(ET, Decl(controlFlowGenericTypes.ts, 132, 19))
+
+    off<K extends keyof ET>(...args: [K, number] | [unknown, string]):void {}
+>off : Symbol(EventEmitter.off, Decl(controlFlowGenericTypes.ts, 132, 24))
+>K : Symbol(K, Decl(controlFlowGenericTypes.ts, 133, 8))
+>ET : Symbol(ET, Decl(controlFlowGenericTypes.ts, 132, 19))
+>args : Symbol(args, Decl(controlFlowGenericTypes.ts, 133, 28))
+>K : Symbol(K, Decl(controlFlowGenericTypes.ts, 133, 8))
+}
+function once<ET, T extends EventEmitter<ET>>(emittingObject: T, eventName: keyof ET): void {
+>once : Symbol(once, Decl(controlFlowGenericTypes.ts, 134, 1))
+>ET : Symbol(ET, Decl(controlFlowGenericTypes.ts, 135, 14))
+>T : Symbol(T, Decl(controlFlowGenericTypes.ts, 135, 17))
+>EventEmitter : Symbol(EventEmitter, Decl(controlFlowGenericTypes.ts, 128, 2))
+>ET : Symbol(ET, Decl(controlFlowGenericTypes.ts, 135, 14))
+>emittingObject : Symbol(emittingObject, Decl(controlFlowGenericTypes.ts, 135, 46))
+>T : Symbol(T, Decl(controlFlowGenericTypes.ts, 135, 17))
+>eventName : Symbol(eventName, Decl(controlFlowGenericTypes.ts, 135, 64))
+>ET : Symbol(ET, Decl(controlFlowGenericTypes.ts, 135, 14))
+
+    emittingObject.off(eventName, 0);
+>emittingObject.off : Symbol(EventEmitter.off, Decl(controlFlowGenericTypes.ts, 132, 24))
+>emittingObject : Symbol(emittingObject, Decl(controlFlowGenericTypes.ts, 135, 46))
+>off : Symbol(EventEmitter.off, Decl(controlFlowGenericTypes.ts, 132, 24))
+>eventName : Symbol(eventName, Decl(controlFlowGenericTypes.ts, 135, 64))
+
+    emittingObject.off(eventName as typeof eventName, 0);
+>emittingObject.off : Symbol(EventEmitter.off, Decl(controlFlowGenericTypes.ts, 132, 24))
+>emittingObject : Symbol(emittingObject, Decl(controlFlowGenericTypes.ts, 135, 46))
+>off : Symbol(EventEmitter.off, Decl(controlFlowGenericTypes.ts, 132, 24))
+>eventName : Symbol(eventName, Decl(controlFlowGenericTypes.ts, 135, 64))
+>eventName : Symbol(eventName, Decl(controlFlowGenericTypes.ts, 135, 64))
+}
+

--- a/tests/baselines/reference/controlFlowGenericTypes.types
+++ b/tests/baselines/reference/controlFlowGenericTypes.types
@@ -355,3 +355,36 @@ function get<K extends keyof A>(key: K, obj: A): number {
 
 };
 
+// Repro from #44093
+
+class EventEmitter<ET> {
+>EventEmitter : EventEmitter<ET>
+
+    off<K extends keyof ET>(...args: [K, number] | [unknown, string]):void {}
+>off : <K extends keyof ET>(...args: [K, number] | [unknown, string]) => void
+>args : [K, number] | [unknown, string]
+}
+function once<ET, T extends EventEmitter<ET>>(emittingObject: T, eventName: keyof ET): void {
+>once : <ET, T extends EventEmitter<ET>>(emittingObject: T, eventName: keyof ET) => void
+>emittingObject : T
+>eventName : keyof ET
+
+    emittingObject.off(eventName, 0);
+>emittingObject.off(eventName, 0) : void
+>emittingObject.off : <K extends keyof ET>(...args: [unknown, string] | [K, number]) => void
+>emittingObject : T
+>off : <K extends keyof ET>(...args: [unknown, string] | [K, number]) => void
+>eventName : keyof ET
+>0 : 0
+
+    emittingObject.off(eventName as typeof eventName, 0);
+>emittingObject.off(eventName as typeof eventName, 0) : void
+>emittingObject.off : <K extends keyof ET>(...args: [unknown, string] | [K, number]) => void
+>emittingObject : T
+>off : <K extends keyof ET>(...args: [unknown, string] | [K, number]) => void
+>eventName as typeof eventName : keyof ET
+>eventName : keyof ET
+>eventName : keyof ET
+>0 : 0
+}
+

--- a/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
@@ -129,3 +129,13 @@ function get<K extends keyof A>(key: K, obj: A): number {
     }
     return 0;
 };
+
+// Repro from #44093
+
+class EventEmitter<ET> {
+    off<K extends keyof ET>(...args: [K, number] | [unknown, string]):void {}
+}
+function once<ET, T extends EventEmitter<ET>>(emittingObject: T, eventName: keyof ET): void {
+    emittingObject.off(eventName, 0);
+    emittingObject.off(eventName as typeof eventName, 0);
+}


### PR DESCRIPTION
This PR ensures that generics are preserved in contextual types for arguments to rest parameters with union types. The PR additionally cleans up the `getIndexedAccessType` and `getIndexedAccessTypeOrUndefined` functions which had grown quite unwieldy as a result of introducing the `--noUncheckedIndexedAccess` compiler switch. Instead of multiple discreet `boolean` arguments, all modifiers are now passed through the `AccessFlags` enum.

Fixes #44093.
