### PR TITLE
Add `--importsNotUsedAsValues=preserve-exact`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -38095,7 +38095,7 @@ namespace ts {
                             if (compilerOptions.importsNotUsedAsValues === ImportsNotUsedAsValues.PreserveExact) {
                                 const message = isType
                                     ? Diagnostics._0_is_a_type_and_must_be_imported_with_a_type_only_import_when_importsNotUsedAsValues_is_set_to_preserve_exact
-                                    : Diagnostics._0_resolves_to_a_type_only_reference_and_must_be_imported_with_a_type_only_import_when_importsNotUsedAsValues_is_set_to_preserve_exact;
+                                    : Diagnostics._0_resolves_to_a_type_only_declaration_and_must_be_imported_with_a_type_only_import_when_importsNotUsedAsValues_is_set_to_preserve_exact;
                                 const name = idText(node.kind === SyntaxKind.ImportSpecifier ? node.propertyName || node.name : node.name!);
                                 addTypeOnlyDeclarationRelatedInfo(
                                     error(node, message, name),
@@ -38119,9 +38119,9 @@ namespace ts {
                             }
                             const message =
                                 compilerOptions.isolatedModules && isType ? Diagnostics.Re_exporting_a_type_when_the_isolatedModules_flag_is_provided_requires_using_export_type :
-                                compilerOptions.isolatedModules && !isType ? Diagnostics._0_resolves_to_a_type_only_reference_and_must_be_re_exported_with_a_type_only_re_export_when_isolatedModules_is_enabled :
+                                compilerOptions.isolatedModules && !isType ? Diagnostics._0_resolves_to_a_type_only_declaration_and_must_be_re_exported_with_a_type_only_re_export_when_isolatedModules_is_enabled :
                                 isType ? Diagnostics._0_is_a_type_and_must_be_re_exported_with_a_type_only_re_export_when_importsNotUsedAsValues_is_set_to_preserve_exact :
-                                Diagnostics._0_resolves_to_a_type_only_reference_and_must_be_re_exported_with_a_type_only_re_export_when_importsNotUsedAsValues_is_set_to_preserve_exact;
+                                Diagnostics._0_resolves_to_a_type_only_declaration_and_must_be_re_exported_with_a_type_only_re_export_when_importsNotUsedAsValues_is_set_to_preserve_exact;
                             const name = idText(node.propertyName || node.name);
                             addTypeOnlyDeclarationRelatedInfo(
                                 error(node, message, name),

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2166,15 +2166,23 @@ namespace ts {
                     const message = isExport
                         ? Diagnostics._0_cannot_be_used_as_a_value_because_it_was_exported_using_export_type
                         : Diagnostics._0_cannot_be_used_as_a_value_because_it_was_imported_using_import_type;
-                    const relatedMessage = isExport
-                        ? Diagnostics._0_was_exported_here
-                        : Diagnostics._0_was_imported_here;
                     const unescapedName = unescapeLeadingUnderscores(name);
-                    addRelatedInfo(
+                    addTypeOnlyDeclarationRelatedInfo(
                         error(useSite, message, unescapedName),
-                        createDiagnosticForNode(typeOnlyDeclaration, relatedMessage, unescapedName));
+                        typeOnlyDeclaration,
+                        unescapedName);
                 }
             }
+        }
+
+        function addTypeOnlyDeclarationRelatedInfo(diagnostic: Diagnostic, typeOnlyDeclaration: TypeOnlyCompatibleAliasDeclaration | undefined, unescapedName: string) {
+            if (!typeOnlyDeclaration) return diagnostic;
+            return addRelatedInfo(
+                diagnostic,
+                createDiagnosticForNode(
+                    typeOnlyDeclaration,
+                    typeOnlyDeclarationIsExport(typeOnlyDeclaration) ? Diagnostics._0_was_exported_here : Diagnostics._0_was_imported_here,
+                    unescapedName));
         }
 
         function getIsDeferredContext(location: Node, lastLocation: Node | undefined): boolean {
@@ -38072,13 +38080,57 @@ namespace ts {
                     error(node, message, symbolToString(symbol));
                 }
 
-                // Don't allow to re-export something with no value side when `--isolatedModules` is set.
-                if (compilerOptions.isolatedModules
-                    && node.kind === SyntaxKind.ExportSpecifier
-                    && !node.parent.parent.isTypeOnly
-                    && !(target.flags & SymbolFlags.Value)
-                    && !(node.flags & NodeFlags.Ambient)) {
-                    error(node, Diagnostics.Re_exporting_a_type_when_the_isolatedModules_flag_is_provided_requires_using_export_type);
+                const isDeclaredTypeOnly = isTypeOnlyImportOrExportDeclaration(node);
+                if ((compilerOptions.isolatedModules || compilerOptions.importsNotUsedAsValues === ImportsNotUsedAsValues.PreserveExact)
+                    && !isDeclaredTypeOnly
+                    && !(node.flags & NodeFlags.Ambient)
+                    && (!(target.flags & SymbolFlags.Value) || getTypeOnlyAliasDeclaration(symbol))) {
+                    const isType = !(target.flags & SymbolFlags.Value);
+                    const typeOnlyAlias = getTypeOnlyAliasDeclaration(symbol);
+
+                    switch (node.kind) {
+                        case SyntaxKind.ImportClause:
+                        case SyntaxKind.ImportSpecifier:
+                        case SyntaxKind.ImportEqualsDeclaration: {
+                            if (compilerOptions.importsNotUsedAsValues === ImportsNotUsedAsValues.PreserveExact) {
+                                const message = isType
+                                    ? Diagnostics._0_is_a_type_and_must_be_imported_with_a_type_only_import_when_importsNotUsedAsValues_is_set_to_preserve_exact
+                                    : Diagnostics._0_resolves_to_a_type_only_reference_and_must_be_imported_with_a_type_only_import_when_importsNotUsedAsValues_is_set_to_preserve_exact;
+                                const name = idText(node.kind === SyntaxKind.ImportSpecifier ? node.propertyName || node.name : node.name!);
+                                addTypeOnlyDeclarationRelatedInfo(
+                                    error(node, message, name),
+                                    isType ? undefined : typeOnlyAlias,
+                                    name
+                                );
+                            }
+                            break;
+                        }
+                        case SyntaxKind.ExportSpecifier: {
+                            // Don't allow re-exporting an export that will be elided when `--isolatedModules` is set
+                            // or when `--importsNotUsedAsValues` is `preserve-exact`.
+                            if (compilerOptions.isolatedModules &&
+                                compilerOptions.importsNotUsedAsValues !== ImportsNotUsedAsValues.PreserveExact &&
+                                typeOnlyAlias && getSourceFileOfNode(typeOnlyAlias) === getSourceFileOfNode(node)) {
+                                // In `isolatedModules` alone, `import type { A } from './a'; export { A }` is allowed
+                                // because single-file analysis can determine that the export should be dropped.
+                                // `--importsNotUsedAsValues=preserv-exact` is stricter; it refuses to touch non-type-only
+                                // imports and exports, so `export { A }` is not allowed if 'A' is not emitted.
+                                return;
+                            }
+                            const message =
+                                compilerOptions.isolatedModules && isType ? Diagnostics.Re_exporting_a_type_when_the_isolatedModules_flag_is_provided_requires_using_export_type :
+                                compilerOptions.isolatedModules && !isType ? Diagnostics._0_resolves_to_a_type_only_reference_and_must_be_re_exported_with_a_type_only_re_export_when_isolatedModules_is_enabled :
+                                isType ? Diagnostics._0_is_a_type_and_must_be_re_exported_with_a_type_only_re_export_when_importsNotUsedAsValues_is_set_to_preserve_exact :
+                                Diagnostics._0_resolves_to_a_type_only_reference_and_must_be_re_exported_with_a_type_only_re_export_when_importsNotUsedAsValues_is_set_to_preserve_exact;
+                            const name = idText(node.propertyName || node.name);
+                            addTypeOnlyDeclarationRelatedInfo(
+                                error(node, message, name),
+                                isType ? undefined : typeOnlyAlias,
+                                name
+                            );
+                            return;
+                        }
+                    }
                 }
 
                 if (isImportSpecifier(node) && target.declarations?.every(d => !!(getCombinedNodeFlags(d) & NodeFlags.Deprecated))) {

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -536,9 +536,10 @@ namespace ts {
         {
             name: "importsNotUsedAsValues",
             type: new Map(getEntries({
-                remove: ImportsNotUsedAsValues.Remove,
-                preserve: ImportsNotUsedAsValues.Preserve,
-                error: ImportsNotUsedAsValues.Error
+                "remove": ImportsNotUsedAsValues.Remove,
+                "preserve": ImportsNotUsedAsValues.Preserve,
+                "error": ImportsNotUsedAsValues.Error,
+                "preserve-exact": ImportsNotUsedAsValues.PreserveExact,
             })),
             affectsEmit: true,
             affectsSemanticDiagnostics: true,

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3942,6 +3942,10 @@
         "category": "Error",
         "code": 5094
     },
+    "Option 'importsNotUsedAsValues' may only be set to 'preserve-exact' when 'module' is set to 'es2015' or later.": {
+        "category": "Error",
+        "code": 5095
+    },
 
     "Generates a sourcemap for each corresponding '.d.ts' file.": {
         "category": "Message",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1372,15 +1372,15 @@
         "category": "Error",
         "code": 1435
     },
-    "'{0}' resolves to a type-only reference and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.": {
+    "'{0}' resolves to a type-only declaration and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.": {
         "category": "Error",
         "code": 1436
     },
-    "'{0}' resolves to a type-only reference and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.": {
+    "'{0}' resolves to a type-only declaration and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.": {
         "category": "Error",
         "code": 1437
     },
-    "'{0}' resolves to a type-only reference and must be re-exported with a type-only re-export when 'isolatedModules' is enabled.": {
+    "'{0}' resolves to a type-only declaration and must be re-exported with a type-only re-export when 'isolatedModules' is enabled.": {
         "category": "Error",
         "code": 1438
     },
@@ -3962,7 +3962,7 @@
         "category": "Error",
         "code": 5094
     },
-    "Option 'importsNotUsedAsValues' may only be set to 'preserve-exact' when 'module' is set to 'es2015' or later.": {
+    "Option 'importsNotUsedAsValues' may be set to 'preserve-exact' only when 'module' is set to 'es2015' or later.": {
         "category": "Error",
         "code": 5095
     },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1364,6 +1364,26 @@
         "category": "Error",
         "code": 1433
     },
+    "'{0}' is a type and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.": {
+        "category": "Error",
+        "code": 1434
+    },
+    "'{0}' is a type and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.": {
+        "category": "Error",
+        "code": 1435
+    },
+    "'{0}' resolves to a type-only reference and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.": {
+        "category": "Error",
+        "code": 1436
+    },
+    "'{0}' resolves to a type-only reference and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.": {
+        "category": "Error",
+        "code": 1437
+    },
+    "'{0}' resolves to a type-only reference and must be re-exported with a type-only re-export when 'isolatedModules' is enabled.": {
+        "category": "Error",
+        "code": 1438
+    },
 
     "The types of '{0}' are incompatible between these types.": {
         "category": "Error",

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3296,7 +3296,7 @@ namespace ts {
             }
 
             if (options.importsNotUsedAsValues === ImportsNotUsedAsValues.PreserveExact && getEmitModuleKind(options) < ModuleKind.ES2015) {
-                createOptionValueDiagnostic("importsNotUsedAsValues", Diagnostics.Option_importsNotUsedAsValues_may_only_be_set_to_preserve_exact_when_module_is_set_to_es2015_or_later);
+                createOptionValueDiagnostic("importsNotUsedAsValues", Diagnostics.Option_importsNotUsedAsValues_may_be_set_to_preserve_exact_only_when_module_is_set_to_es2015_or_later);
             }
 
             // If the emit is enabled make sure that every output file is unique and not overwriting any of the input files

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3295,6 +3295,10 @@ namespace ts {
                 }
             }
 
+            if (options.importsNotUsedAsValues === ImportsNotUsedAsValues.PreserveExact && getEmitModuleKind(options) < ModuleKind.ES2015) {
+                createOptionValueDiagnostic("importsNotUsedAsValues", Diagnostics.Option_importsNotUsedAsValues_may_only_be_set_to_preserve_exact_when_module_is_set_to_es2015_or_later);
+            }
+
             // If the emit is enabled make sure that every output file is unique and not overwriting any of the input files
             if (!options.noEmit && !options.suppressOutputPathCheck) {
                 const emitHost = getEmitHost();
@@ -3565,7 +3569,7 @@ namespace ts {
             createDiagnosticForOption(/*onKey*/ true, option1, option2, message, option1, option2, option3);
         }
 
-        function createOptionValueDiagnostic(option1: string, message: DiagnosticMessage, arg0: string) {
+        function createOptionValueDiagnostic(option1: string, message: DiagnosticMessage, arg0?: string) {
             createDiagnosticForOption(/*onKey*/ false, option1, /*option2*/ undefined, message, arg0);
         }
 
@@ -3580,7 +3584,7 @@ namespace ts {
             }
         }
 
-        function createDiagnosticForOption(onKey: boolean, option1: string, option2: string | undefined, message: DiagnosticMessage, arg0: string | number, arg1?: string | number, arg2?: string | number) {
+        function createDiagnosticForOption(onKey: boolean, option1: string, option2: string | undefined, message: DiagnosticMessage, arg0?: string | number, arg1?: string | number, arg2?: string | number) {
             const compilerOptionsObjectLiteralSyntax = getCompilerOptionsObjectLiteralSyntax();
             const needCompilerDiagnostic = !compilerOptionsObjectLiteralSyntax ||
                 !createOptionDiagnosticInObjectLiteralSyntax(compilerOptionsObjectLiteralSyntax, onKey, option1, option2, message, arg0, arg1, arg2);
@@ -3606,7 +3610,7 @@ namespace ts {
             return _compilerOptionsObjectLiteralSyntax || undefined;
         }
 
-        function createOptionDiagnosticInObjectLiteralSyntax(objectLiteral: ObjectLiteralExpression, onKey: boolean, key1: string, key2: string | undefined, message: DiagnosticMessage, arg0: string | number, arg1?: string | number, arg2?: string | number): boolean {
+        function createOptionDiagnosticInObjectLiteralSyntax(objectLiteral: ObjectLiteralExpression, onKey: boolean, key1: string, key2: string | undefined, message: DiagnosticMessage, arg0?: string | number, arg1?: string | number, arg2?: string | number): boolean {
             const props = getPropertyAssignment(objectLiteral, key1, key2);
             for (const prop of props) {
                 programDiagnostics.add(createDiagnosticForNodeInSourceFile(options.configFile!, onKey ? prop.name : prop.initializer, message, arg0, arg1, arg2));

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6070,7 +6070,8 @@ namespace ts {
     export const enum ImportsNotUsedAsValues {
         Remove,
         Preserve,
-        Error
+        Error,
+        PreserveExact,
     }
 
     export const enum NewLineKind {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2946,7 +2946,8 @@ declare namespace ts {
     export enum ImportsNotUsedAsValues {
         Remove = 0,
         Preserve = 1,
-        Error = 2
+        Error = 2,
+        PreserveExact = 3
     }
     export enum NewLineKind {
         CarriageReturnLineFeed = 0,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2946,7 +2946,8 @@ declare namespace ts {
     export enum ImportsNotUsedAsValues {
         Remove = 0,
         Preserve = 1,
-        Error = 2
+        Error = 2,
+        PreserveExact = 3
     }
     export enum NewLineKind {
         CarriageReturnLineFeed = 0,

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact.errors.txt
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact.errors.txt
@@ -1,0 +1,35 @@
+tests/cases/conformance/externalModules/typeOnly/d.ts(1,1): error TS1203: Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.
+tests/cases/conformance/externalModules/typeOnly/e.ts(1,1): error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+tests/cases/conformance/externalModules/typeOnly/e.ts(2,1): error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+
+
+==== tests/cases/conformance/externalModules/typeOnly/a.ts (0 errors) ====
+    export default {};
+    export const b = 0;
+    export const c = 1;
+    
+==== tests/cases/conformance/externalModules/typeOnly/b.ts (0 errors) ====
+    import a, { b, c } from "./a";
+    
+==== tests/cases/conformance/externalModules/typeOnly/c.ts (0 errors) ====
+    import * as a from "./a";
+    
+==== tests/cases/conformance/externalModules/typeOnly/d.ts (1 errors) ====
+    export = {};
+    ~~~~~~~~~~~~
+!!! error TS1203: Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.
+    
+==== tests/cases/conformance/externalModules/typeOnly/e.ts (2 errors) ====
+    import D = require("./d");
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+    import DD = require("./d");
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+    DD;
+    
+==== tests/cases/conformance/externalModules/typeOnly/f.ts (0 errors) ====
+    import type a from "./a";
+    import { b, c } from "./a";
+    b;
+    

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact.js
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact.js
@@ -1,0 +1,43 @@
+//// [tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_preserve-exact.ts] ////
+
+//// [a.ts]
+export default {};
+export const b = 0;
+export const c = 1;
+
+//// [b.ts]
+import a, { b, c } from "./a";
+
+//// [c.ts]
+import * as a from "./a";
+
+//// [d.ts]
+export = {};
+
+//// [e.ts]
+import D = require("./d");
+import DD = require("./d");
+DD;
+
+//// [f.ts]
+import type a from "./a";
+import { b, c } from "./a";
+b;
+
+
+//// [a.js]
+export default {};
+export var b = 0;
+export var c = 1;
+//// [b.js]
+import a, { b, c } from "./a";
+//// [c.js]
+import * as a from "./a";
+//// [d.js]
+export {};
+//// [e.js]
+DD;
+export {};
+//// [f.js]
+import { b, c } from "./a";
+b;

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact.symbols
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact.symbols
@@ -1,0 +1,42 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export default {};
+export const b = 0;
+>b : Symbol(b, Decl(a.ts, 1, 12))
+
+export const c = 1;
+>c : Symbol(c, Decl(a.ts, 2, 12))
+
+=== tests/cases/conformance/externalModules/typeOnly/b.ts ===
+import a, { b, c } from "./a";
+>a : Symbol(a, Decl(b.ts, 0, 6))
+>b : Symbol(b, Decl(b.ts, 0, 11))
+>c : Symbol(c, Decl(b.ts, 0, 14))
+
+=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
+import * as a from "./a";
+>a : Symbol(a, Decl(c.ts, 0, 6))
+
+=== tests/cases/conformance/externalModules/typeOnly/d.ts ===
+export = {};
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/externalModules/typeOnly/e.ts ===
+import D = require("./d");
+>D : Symbol(D, Decl(e.ts, 0, 0))
+
+import DD = require("./d");
+>DD : Symbol(DD, Decl(e.ts, 0, 26))
+
+DD;
+>DD : Symbol(DD, Decl(e.ts, 0, 26))
+
+=== tests/cases/conformance/externalModules/typeOnly/f.ts ===
+import type a from "./a";
+>a : Symbol(a, Decl(f.ts, 0, 6))
+
+import { b, c } from "./a";
+>b : Symbol(b, Decl(f.ts, 1, 8))
+>c : Symbol(c, Decl(f.ts, 1, 11))
+
+b;
+>b : Symbol(b, Decl(f.ts, 1, 8))
+

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact.types
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact.types
@@ -1,0 +1,47 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export default {};
+>{} : {}
+
+export const b = 0;
+>b : 0
+>0 : 0
+
+export const c = 1;
+>c : 1
+>1 : 1
+
+=== tests/cases/conformance/externalModules/typeOnly/b.ts ===
+import a, { b, c } from "./a";
+>a : {}
+>b : 0
+>c : 1
+
+=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
+import * as a from "./a";
+>a : typeof a
+
+=== tests/cases/conformance/externalModules/typeOnly/d.ts ===
+export = {};
+>{} : {}
+
+=== tests/cases/conformance/externalModules/typeOnly/e.ts ===
+import D = require("./d");
+>D : {}
+
+import DD = require("./d");
+>DD : {}
+
+DD;
+>DD : {}
+
+=== tests/cases/conformance/externalModules/typeOnly/f.ts ===
+import type a from "./a";
+>a : any
+
+import { b, c } from "./a";
+>b : 0
+>c : 1
+
+b;
+>b : 0
+

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_errors.errors.txt
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_errors.errors.txt
@@ -1,0 +1,81 @@
+tests/cases/conformance/externalModules/typeOnly/c.ts(1,8): error TS1434: 'DefaultA' is a type and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+tests/cases/conformance/externalModules/typeOnly/c.ts(2,10): error TS1434: 'A' is a type and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+tests/cases/conformance/externalModules/typeOnly/c.ts(3,8): error TS1436: 'DefaultB' resolves to a type-only reference and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+tests/cases/conformance/externalModules/typeOnly/c.ts(4,10): error TS1436: 'B' resolves to a type-only reference and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+tests/cases/conformance/externalModules/typeOnly/d.ts(1,10): error TS1435: 'A' is a type and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+tests/cases/conformance/externalModules/typeOnly/d.ts(2,10): error TS1437: 'B' resolves to a type-only reference and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+tests/cases/conformance/externalModules/typeOnly/e.ts(1,10): error TS1434: 'AA' is a type and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+tests/cases/conformance/externalModules/typeOnly/e.ts(1,14): error TS1436: 'BB' resolves to a type-only reference and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+tests/cases/conformance/externalModules/typeOnly/f.ts(3,10): error TS1435: 'A' is a type and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+tests/cases/conformance/externalModules/typeOnly/f.ts(3,13): error TS1437: 'B' resolves to a type-only reference and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+
+
+==== tests/cases/conformance/externalModules/typeOnly/a.ts (0 errors) ====
+    export type A = {};
+    export type { A as default };
+    
+==== tests/cases/conformance/externalModules/typeOnly/b.ts (0 errors) ====
+    class B {};
+    export type { B, B as default };
+    
+==== tests/cases/conformance/externalModules/typeOnly/c.ts (4 errors) ====
+    import DefaultA from "./a";
+           ~~~~~~~~
+!!! error TS1434: 'DefaultA' is a type and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+    import { A } from "./a";
+             ~
+!!! error TS1434: 'A' is a type and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+    import DefaultB from "./b";
+           ~~~~~~~~
+!!! error TS1436: 'DefaultB' resolves to a type-only reference and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+!!! related TS1377 tests/cases/conformance/externalModules/typeOnly/b.ts:2:18: 'DefaultB' was exported here.
+    import { B } from "./b";
+             ~
+!!! error TS1436: 'B' resolves to a type-only reference and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+!!! related TS1377 tests/cases/conformance/externalModules/typeOnly/b.ts:2:15: 'B' was exported here.
+    
+==== tests/cases/conformance/externalModules/typeOnly/c.fixed.ts (0 errors) ====
+    import type DefaultA from "./a";
+    import type { A } from "./a";
+    import type DefaultB from "./b";
+    import type { B } from "./b";
+    
+==== tests/cases/conformance/externalModules/typeOnly/d.ts (2 errors) ====
+    export { A as AA } from "./a";
+             ~~~~~~~
+!!! error TS1435: 'A' is a type and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+    export { B as BB } from "./b";
+             ~~~~~~~
+!!! error TS1437: 'B' resolves to a type-only reference and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+!!! related TS1377 tests/cases/conformance/externalModules/typeOnly/b.ts:2:15: 'B' was exported here.
+    
+==== tests/cases/conformance/externalModules/typeOnly/d.fixed.ts (0 errors) ====
+    export type { A as AA } from "./a";
+    export type { B as BB } from "./b";
+    
+==== tests/cases/conformance/externalModules/typeOnly/e.ts (2 errors) ====
+    import { AA, BB } from "./d";
+             ~~
+!!! error TS1434: 'AA' is a type and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+                 ~~
+!!! error TS1436: 'BB' resolves to a type-only reference and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+!!! related TS1377 tests/cases/conformance/externalModules/typeOnly/b.ts:2:15: 'BB' was exported here.
+    
+==== tests/cases/conformance/externalModules/typeOnly/e.fixed.ts (0 errors) ====
+    import type { AA, BB } from "./d";
+    
+==== tests/cases/conformance/externalModules/typeOnly/f.ts (2 errors) ====
+    import type { A } from "./a";
+    import type { B } from "./b";
+    export { A, B as BB };
+             ~
+!!! error TS1435: 'A' is a type and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+                ~~~~~~~
+!!! error TS1437: 'B' resolves to a type-only reference and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+!!! related TS1376 tests/cases/conformance/externalModules/typeOnly/f.ts:2:15: 'B' was imported here.
+    
+==== tests/cases/conformance/externalModules/typeOnly/f.fixed.ts (0 errors) ====
+    import type { A } from "./a";
+    import type { B } from "./b";
+    export type { A, B as BB };
+    

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_errors.errors.txt
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_errors.errors.txt
@@ -1,13 +1,13 @@
 tests/cases/conformance/externalModules/typeOnly/c.ts(1,8): error TS1434: 'DefaultA' is a type and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
 tests/cases/conformance/externalModules/typeOnly/c.ts(2,10): error TS1434: 'A' is a type and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
-tests/cases/conformance/externalModules/typeOnly/c.ts(3,8): error TS1436: 'DefaultB' resolves to a type-only reference and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
-tests/cases/conformance/externalModules/typeOnly/c.ts(4,10): error TS1436: 'B' resolves to a type-only reference and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+tests/cases/conformance/externalModules/typeOnly/c.ts(3,8): error TS1436: 'DefaultB' resolves to a type-only declaration and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+tests/cases/conformance/externalModules/typeOnly/c.ts(4,10): error TS1436: 'B' resolves to a type-only declaration and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
 tests/cases/conformance/externalModules/typeOnly/d.ts(1,10): error TS1435: 'A' is a type and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
-tests/cases/conformance/externalModules/typeOnly/d.ts(2,10): error TS1437: 'B' resolves to a type-only reference and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+tests/cases/conformance/externalModules/typeOnly/d.ts(2,10): error TS1437: 'B' resolves to a type-only declaration and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
 tests/cases/conformance/externalModules/typeOnly/e.ts(1,10): error TS1434: 'AA' is a type and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
-tests/cases/conformance/externalModules/typeOnly/e.ts(1,14): error TS1436: 'BB' resolves to a type-only reference and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+tests/cases/conformance/externalModules/typeOnly/e.ts(1,14): error TS1436: 'BB' resolves to a type-only declaration and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
 tests/cases/conformance/externalModules/typeOnly/f.ts(3,10): error TS1435: 'A' is a type and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
-tests/cases/conformance/externalModules/typeOnly/f.ts(3,13): error TS1437: 'B' resolves to a type-only reference and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+tests/cases/conformance/externalModules/typeOnly/f.ts(3,13): error TS1437: 'B' resolves to a type-only declaration and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
 
 
 ==== tests/cases/conformance/externalModules/typeOnly/a.ts (0 errors) ====
@@ -27,11 +27,11 @@ tests/cases/conformance/externalModules/typeOnly/f.ts(3,13): error TS1437: 'B' r
 !!! error TS1434: 'A' is a type and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
     import DefaultB from "./b";
            ~~~~~~~~
-!!! error TS1436: 'DefaultB' resolves to a type-only reference and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+!!! error TS1436: 'DefaultB' resolves to a type-only declaration and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
 !!! related TS1377 tests/cases/conformance/externalModules/typeOnly/b.ts:2:18: 'DefaultB' was exported here.
     import { B } from "./b";
              ~
-!!! error TS1436: 'B' resolves to a type-only reference and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+!!! error TS1436: 'B' resolves to a type-only declaration and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
 !!! related TS1377 tests/cases/conformance/externalModules/typeOnly/b.ts:2:15: 'B' was exported here.
     
 ==== tests/cases/conformance/externalModules/typeOnly/c.fixed.ts (0 errors) ====
@@ -46,7 +46,7 @@ tests/cases/conformance/externalModules/typeOnly/f.ts(3,13): error TS1437: 'B' r
 !!! error TS1435: 'A' is a type and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
     export { B as BB } from "./b";
              ~~~~~~~
-!!! error TS1437: 'B' resolves to a type-only reference and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+!!! error TS1437: 'B' resolves to a type-only declaration and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
 !!! related TS1377 tests/cases/conformance/externalModules/typeOnly/b.ts:2:15: 'B' was exported here.
     
 ==== tests/cases/conformance/externalModules/typeOnly/d.fixed.ts (0 errors) ====
@@ -58,7 +58,7 @@ tests/cases/conformance/externalModules/typeOnly/f.ts(3,13): error TS1437: 'B' r
              ~~
 !!! error TS1434: 'AA' is a type and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
                  ~~
-!!! error TS1436: 'BB' resolves to a type-only reference and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+!!! error TS1436: 'BB' resolves to a type-only declaration and must be imported with a type-only import when 'importsNotUsedAsValues' is set to 'preserve-exact'.
 !!! related TS1377 tests/cases/conformance/externalModules/typeOnly/b.ts:2:15: 'BB' was exported here.
     
 ==== tests/cases/conformance/externalModules/typeOnly/e.fixed.ts (0 errors) ====
@@ -71,7 +71,7 @@ tests/cases/conformance/externalModules/typeOnly/f.ts(3,13): error TS1437: 'B' r
              ~
 !!! error TS1435: 'A' is a type and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
                 ~~~~~~~
-!!! error TS1437: 'B' resolves to a type-only reference and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
+!!! error TS1437: 'B' resolves to a type-only declaration and must be re-exported with a type-only re-export when 'importsNotUsedAsValues' is set to 'preserve-exact'.
 !!! related TS1376 tests/cases/conformance/externalModules/typeOnly/f.ts:2:15: 'B' was imported here.
     
 ==== tests/cases/conformance/externalModules/typeOnly/f.fixed.ts (0 errors) ====

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_errors.js
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_errors.js
@@ -1,0 +1,77 @@
+//// [tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_preserve-exact_errors.ts] ////
+
+//// [a.ts]
+export type A = {};
+export type { A as default };
+
+//// [b.ts]
+class B {};
+export type { B, B as default };
+
+//// [c.ts]
+import DefaultA from "./a";
+import { A } from "./a";
+import DefaultB from "./b";
+import { B } from "./b";
+
+//// [c.fixed.ts]
+import type DefaultA from "./a";
+import type { A } from "./a";
+import type DefaultB from "./b";
+import type { B } from "./b";
+
+//// [d.ts]
+export { A as AA } from "./a";
+export { B as BB } from "./b";
+
+//// [d.fixed.ts]
+export type { A as AA } from "./a";
+export type { B as BB } from "./b";
+
+//// [e.ts]
+import { AA, BB } from "./d";
+
+//// [e.fixed.ts]
+import type { AA, BB } from "./d";
+
+//// [f.ts]
+import type { A } from "./a";
+import type { B } from "./b";
+export { A, B as BB };
+
+//// [f.fixed.ts]
+import type { A } from "./a";
+import type { B } from "./b";
+export type { A, B as BB };
+
+
+//// [a.js]
+export {};
+//// [b.js]
+var B = /** @class */ (function () {
+    function B() {
+    }
+    return B;
+}());
+;
+export {};
+//// [c.js]
+import DefaultA from "./a";
+import { A } from "./a";
+import DefaultB from "./b";
+import { B } from "./b";
+//// [c.fixed.js]
+export {};
+//// [d.js]
+export { A as AA } from "./a";
+export { B as BB } from "./b";
+//// [d.fixed.js]
+export {};
+//// [e.js]
+import { AA, BB } from "./d";
+//// [e.fixed.js]
+export {};
+//// [f.js]
+export { A, B as BB };
+//// [f.fixed.js]
+export {};

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_errors.symbols
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_errors.symbols
@@ -1,0 +1,95 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export type A = {};
+>A : Symbol(A, Decl(a.ts, 0, 0))
+
+export type { A as default };
+>A : Symbol(A, Decl(a.ts, 0, 0))
+>default : Symbol(default, Decl(a.ts, 1, 13))
+
+=== tests/cases/conformance/externalModules/typeOnly/b.ts ===
+class B {};
+>B : Symbol(B, Decl(b.ts, 0, 0))
+
+export type { B, B as default };
+>B : Symbol(B, Decl(b.ts, 1, 13))
+>B : Symbol(B, Decl(b.ts, 0, 0))
+>default : Symbol(default, Decl(b.ts, 1, 16))
+
+=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
+import DefaultA from "./a";
+>DefaultA : Symbol(DefaultA, Decl(c.ts, 0, 6))
+
+import { A } from "./a";
+>A : Symbol(A, Decl(c.ts, 1, 8))
+
+import DefaultB from "./b";
+>DefaultB : Symbol(DefaultB, Decl(c.ts, 2, 6))
+
+import { B } from "./b";
+>B : Symbol(B, Decl(c.ts, 3, 8))
+
+=== tests/cases/conformance/externalModules/typeOnly/c.fixed.ts ===
+import type DefaultA from "./a";
+>DefaultA : Symbol(DefaultA, Decl(c.fixed.ts, 0, 6))
+
+import type { A } from "./a";
+>A : Symbol(A, Decl(c.fixed.ts, 1, 13))
+
+import type DefaultB from "./b";
+>DefaultB : Symbol(DefaultB, Decl(c.fixed.ts, 2, 6))
+
+import type { B } from "./b";
+>B : Symbol(B, Decl(c.fixed.ts, 3, 13))
+
+=== tests/cases/conformance/externalModules/typeOnly/d.ts ===
+export { A as AA } from "./a";
+>A : Symbol(A, Decl(a.ts, 0, 0))
+>AA : Symbol(AA, Decl(d.ts, 0, 8))
+
+export { B as BB } from "./b";
+>B : Symbol(B, Decl(b.ts, 1, 13))
+>BB : Symbol(BB, Decl(d.ts, 1, 8))
+
+=== tests/cases/conformance/externalModules/typeOnly/d.fixed.ts ===
+export type { A as AA } from "./a";
+>A : Symbol(A, Decl(a.ts, 0, 0))
+>AA : Symbol(AA, Decl(d.fixed.ts, 0, 13))
+
+export type { B as BB } from "./b";
+>B : Symbol(B, Decl(b.ts, 1, 13))
+>BB : Symbol(BB, Decl(d.fixed.ts, 1, 13))
+
+=== tests/cases/conformance/externalModules/typeOnly/e.ts ===
+import { AA, BB } from "./d";
+>AA : Symbol(AA, Decl(e.ts, 0, 8))
+>BB : Symbol(BB, Decl(e.ts, 0, 12))
+
+=== tests/cases/conformance/externalModules/typeOnly/e.fixed.ts ===
+import type { AA, BB } from "./d";
+>AA : Symbol(AA, Decl(e.fixed.ts, 0, 13))
+>BB : Symbol(BB, Decl(e.fixed.ts, 0, 17))
+
+=== tests/cases/conformance/externalModules/typeOnly/f.ts ===
+import type { A } from "./a";
+>A : Symbol(A, Decl(f.ts, 0, 13))
+
+import type { B } from "./b";
+>B : Symbol(B, Decl(f.ts, 1, 13))
+
+export { A, B as BB };
+>A : Symbol(A, Decl(f.ts, 2, 8))
+>B : Symbol(B, Decl(f.ts, 1, 13))
+>BB : Symbol(BB, Decl(f.ts, 2, 11))
+
+=== tests/cases/conformance/externalModules/typeOnly/f.fixed.ts ===
+import type { A } from "./a";
+>A : Symbol(A, Decl(f.fixed.ts, 0, 13))
+
+import type { B } from "./b";
+>B : Symbol(B, Decl(f.fixed.ts, 1, 13))
+
+export type { A, B as BB };
+>A : Symbol(A, Decl(f.fixed.ts, 2, 13))
+>B : Symbol(B, Decl(f.fixed.ts, 1, 13))
+>BB : Symbol(BB, Decl(f.fixed.ts, 2, 16))
+

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_errors.types
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_errors.types
@@ -1,0 +1,95 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export type A = {};
+>A : A
+
+export type { A as default };
+>A : any
+>default : A
+
+=== tests/cases/conformance/externalModules/typeOnly/b.ts ===
+class B {};
+>B : B
+
+export type { B, B as default };
+>B : B
+>B : typeof B
+>default : B
+
+=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
+import DefaultA from "./a";
+>DefaultA : any
+
+import { A } from "./a";
+>A : any
+
+import DefaultB from "./b";
+>DefaultB : typeof DefaultB
+
+import { B } from "./b";
+>B : typeof DefaultB
+
+=== tests/cases/conformance/externalModules/typeOnly/c.fixed.ts ===
+import type DefaultA from "./a";
+>DefaultA : DefaultA
+
+import type { A } from "./a";
+>A : DefaultA
+
+import type DefaultB from "./b";
+>DefaultB : DefaultB
+
+import type { B } from "./b";
+>B : DefaultB
+
+=== tests/cases/conformance/externalModules/typeOnly/d.ts ===
+export { A as AA } from "./a";
+>A : any
+>AA : any
+
+export { B as BB } from "./b";
+>B : typeof import("tests/cases/conformance/externalModules/typeOnly/b").B
+>BB : typeof import("tests/cases/conformance/externalModules/typeOnly/b").B
+
+=== tests/cases/conformance/externalModules/typeOnly/d.fixed.ts ===
+export type { A as AA } from "./a";
+>A : any
+>AA : import("tests/cases/conformance/externalModules/typeOnly/a").A
+
+export type { B as BB } from "./b";
+>B : typeof import("tests/cases/conformance/externalModules/typeOnly/b").B
+>BB : import("tests/cases/conformance/externalModules/typeOnly/b").B
+
+=== tests/cases/conformance/externalModules/typeOnly/e.ts ===
+import { AA, BB } from "./d";
+>AA : any
+>BB : typeof BB
+
+=== tests/cases/conformance/externalModules/typeOnly/e.fixed.ts ===
+import type { AA, BB } from "./d";
+>AA : AA
+>BB : BB
+
+=== tests/cases/conformance/externalModules/typeOnly/f.ts ===
+import type { A } from "./a";
+>A : A
+
+import type { B } from "./b";
+>B : B
+
+export { A, B as BB };
+>A : any
+>B : typeof B
+>BB : typeof B
+
+=== tests/cases/conformance/externalModules/typeOnly/f.fixed.ts ===
+import type { A } from "./a";
+>A : A
+
+import type { B } from "./b";
+>B : B
+
+export type { A, B as BB };
+>A : A
+>B : typeof B
+>BB : B
+

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=amd).errors.txt
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=amd).errors.txt
@@ -1,0 +1,7 @@
+error TS5095: Option 'importsNotUsedAsValues' may only be set to 'preserve-exact' when 'module' is set to 'es2015' or later.
+
+
+!!! error TS5095: Option 'importsNotUsedAsValues' may only be set to 'preserve-exact' when 'module' is set to 'es2015' or later.
+==== tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_preserve-exact_module.ts (0 errors) ====
+    export {};
+    

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=amd).errors.txt
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=amd).errors.txt
@@ -1,7 +1,7 @@
-error TS5095: Option 'importsNotUsedAsValues' may only be set to 'preserve-exact' when 'module' is set to 'es2015' or later.
+error TS5095: Option 'importsNotUsedAsValues' may be set to 'preserve-exact' only when 'module' is set to 'es2015' or later.
 
 
-!!! error TS5095: Option 'importsNotUsedAsValues' may only be set to 'preserve-exact' when 'module' is set to 'es2015' or later.
+!!! error TS5095: Option 'importsNotUsedAsValues' may be set to 'preserve-exact' only when 'module' is set to 'es2015' or later.
 ==== tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_preserve-exact_module.ts (0 errors) ====
     export {};
     

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=amd).js
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=amd).js
@@ -1,0 +1,9 @@
+//// [importsNotUsedAsValues_preserve-exact_module.ts]
+export {};
+
+
+//// [importsNotUsedAsValues_preserve-exact_module.js]
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    exports.__esModule = true;
+});

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=commonjs).errors.txt
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=commonjs).errors.txt
@@ -1,0 +1,7 @@
+error TS5095: Option 'importsNotUsedAsValues' may only be set to 'preserve-exact' when 'module' is set to 'es2015' or later.
+
+
+!!! error TS5095: Option 'importsNotUsedAsValues' may only be set to 'preserve-exact' when 'module' is set to 'es2015' or later.
+==== tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_preserve-exact_module.ts (0 errors) ====
+    export {};
+    

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=commonjs).errors.txt
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=commonjs).errors.txt
@@ -1,7 +1,7 @@
-error TS5095: Option 'importsNotUsedAsValues' may only be set to 'preserve-exact' when 'module' is set to 'es2015' or later.
+error TS5095: Option 'importsNotUsedAsValues' may be set to 'preserve-exact' only when 'module' is set to 'es2015' or later.
 
 
-!!! error TS5095: Option 'importsNotUsedAsValues' may only be set to 'preserve-exact' when 'module' is set to 'es2015' or later.
+!!! error TS5095: Option 'importsNotUsedAsValues' may be set to 'preserve-exact' only when 'module' is set to 'es2015' or later.
 ==== tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_preserve-exact_module.ts (0 errors) ====
     export {};
     

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=commonjs).js
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=commonjs).js
@@ -1,0 +1,7 @@
+//// [importsNotUsedAsValues_preserve-exact_module.ts]
+export {};
+
+
+//// [importsNotUsedAsValues_preserve-exact_module.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=es2015).js
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=es2015).js
@@ -1,0 +1,6 @@
+//// [importsNotUsedAsValues_preserve-exact_module.ts]
+export {};
+
+
+//// [importsNotUsedAsValues_preserve-exact_module.js]
+export {};

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=system).errors.txt
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=system).errors.txt
@@ -1,0 +1,7 @@
+error TS5095: Option 'importsNotUsedAsValues' may only be set to 'preserve-exact' when 'module' is set to 'es2015' or later.
+
+
+!!! error TS5095: Option 'importsNotUsedAsValues' may only be set to 'preserve-exact' when 'module' is set to 'es2015' or later.
+==== tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_preserve-exact_module.ts (0 errors) ====
+    export {};
+    

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=system).errors.txt
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=system).errors.txt
@@ -1,7 +1,7 @@
-error TS5095: Option 'importsNotUsedAsValues' may only be set to 'preserve-exact' when 'module' is set to 'es2015' or later.
+error TS5095: Option 'importsNotUsedAsValues' may be set to 'preserve-exact' only when 'module' is set to 'es2015' or later.
 
 
-!!! error TS5095: Option 'importsNotUsedAsValues' may only be set to 'preserve-exact' when 'module' is set to 'es2015' or later.
+!!! error TS5095: Option 'importsNotUsedAsValues' may be set to 'preserve-exact' only when 'module' is set to 'es2015' or later.
 ==== tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_preserve-exact_module.ts (0 errors) ====
     export {};
     

--- a/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=system).js
+++ b/tests/baselines/reference/importsNotUsedAsValues_preserve-exact_module(module=system).js
@@ -1,0 +1,14 @@
+//// [importsNotUsedAsValues_preserve-exact_module.ts]
+export {};
+
+
+//// [importsNotUsedAsValues_preserve-exact_module.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+        }
+    };
+});

--- a/tests/baselines/reference/isolatedModulesReExportType.errors.txt
+++ b/tests/baselines/reference/isolatedModulesReExportType.errors.txt
@@ -1,6 +1,6 @@
 /user.ts(2,10): error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
 /user.ts(17,10): error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
-/user.ts(25,10): error TS1438: 'CC' resolves to a type-only reference and must be re-exported with a type-only re-export when 'isolatedModules' is enabled.
+/user.ts(25,10): error TS1438: 'CC' resolves to a type-only declaration and must be re-exported with a type-only re-export when 'isolatedModules' is enabled.
 
 
 ==== /user.ts (3 errors) ====
@@ -34,7 +34,7 @@
     import { C as CC } from "./reExportValueAsTypeOnly";
     export { CC };
              ~~
-!!! error TS1438: 'CC' resolves to a type-only reference and must be re-exported with a type-only re-export when 'isolatedModules' is enabled.
+!!! error TS1438: 'CC' resolves to a type-only declaration and must be re-exported with a type-only re-export when 'isolatedModules' is enabled.
 !!! related TS1377 /reExportValueAsTypeOnly.ts:1:15: 'CC' was exported here.
     
 ==== /exportT.ts (0 errors) ====

--- a/tests/baselines/reference/isolatedModulesReExportType.errors.txt
+++ b/tests/baselines/reference/isolatedModulesReExportType.errors.txt
@@ -1,8 +1,9 @@
 /user.ts(2,10): error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
 /user.ts(17,10): error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
+/user.ts(25,10): error TS1438: 'CC' resolves to a type-only reference and must be re-exported with a type-only re-export when 'isolatedModules' is enabled.
 
 
-==== /user.ts (2 errors) ====
+==== /user.ts (3 errors) ====
     // Error, can't re-export something that's only a type.
     export { T } from "./exportT";
              ~
@@ -25,6 +26,17 @@
              ~~~~~~~
 !!! error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
     
+    // Ok, type-only import indicates that the export can be elided.
+    import type { T as TT } from "./exportT";
+    export { TT };
+    
+    // Error, type-only declaration is in a different file.
+    import { C as CC } from "./reExportValueAsTypeOnly";
+    export { CC };
+             ~~
+!!! error TS1438: 'CC' resolves to a type-only reference and must be re-exported with a type-only re-export when 'isolatedModules' is enabled.
+!!! related TS1377 /reExportValueAsTypeOnly.ts:1:15: 'CC' was exported here.
+    
 ==== /exportT.ts (0 errors) ====
     export type T = number;
     
@@ -45,4 +57,7 @@
     declare module "baz" {
         export { T } from "foo"; // Also allowed.
     }
+    
+==== /reExportValueAsTypeOnly.ts (0 errors) ====
+    export type { C } from "./exportValue";
     

--- a/tests/baselines/reference/isolatedModulesReExportType.js
+++ b/tests/baselines/reference/isolatedModulesReExportType.js
@@ -21,6 +21,9 @@ declare module "baz" {
     export { T } from "foo"; // Also allowed.
 }
 
+//// [reExportValueAsTypeOnly.ts]
+export type { C } from "./exportValue";
+
 //// [user.ts]
 // Error, can't re-export something that's only a type.
 export { T } from "./exportT";
@@ -40,6 +43,14 @@ export type T3 = T;
 import { T } from "./exportT";
 export { T as T4 };
 
+// Ok, type-only import indicates that the export can be elided.
+import type { T as TT } from "./exportT";
+export { TT };
+
+// Error, type-only declaration is in a different file.
+import { C as CC } from "./reExportValueAsTypeOnly";
+export { CC };
+
 
 //// [exportT.js]
 "use strict";
@@ -57,6 +68,9 @@ var C = /** @class */ (function () {
     return C;
 }());
 exports.C = C;
+//// [reExportValueAsTypeOnly.js]
+"use strict";
+exports.__esModule = true;
 //// [user.js]
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {

--- a/tests/baselines/reference/isolatedModulesReExportType.symbols
+++ b/tests/baselines/reference/isolatedModulesReExportType.symbols
@@ -30,6 +30,22 @@ export { T as T4 };
 >T : Symbol(T, Decl(user.ts, 15, 8))
 >T4 : Symbol(T4, Decl(user.ts, 16, 8))
 
+// Ok, type-only import indicates that the export can be elided.
+import type { T as TT } from "./exportT";
+>T : Symbol(NS.T, Decl(exportT.ts, 0, 0))
+>TT : Symbol(TT, Decl(user.ts, 19, 13))
+
+export { TT };
+>TT : Symbol(TT, Decl(user.ts, 20, 8))
+
+// Error, type-only declaration is in a different file.
+import { C as CC } from "./reExportValueAsTypeOnly";
+>C : Symbol(C, Decl(reExportValueAsTypeOnly.ts, 0, 13))
+>CC : Symbol(CC, Decl(user.ts, 23, 8))
+
+export { CC };
+>CC : Symbol(CC, Decl(user.ts, 24, 8))
+
 === /exportT.ts ===
 export type T = number;
 >T : Symbol(T, Decl(exportT.ts, 0, 0))
@@ -44,4 +60,8 @@ declare type T = number;
 
 export = T;
 >T : Symbol(T, Decl(exportEqualsT.ts, 0, 0))
+
+=== /reExportValueAsTypeOnly.ts ===
+export type { C } from "./exportValue";
+>C : Symbol(C, Decl(reExportValueAsTypeOnly.ts, 0, 13))
 

--- a/tests/baselines/reference/isolatedModulesReExportType.types
+++ b/tests/baselines/reference/isolatedModulesReExportType.types
@@ -8,7 +8,7 @@ export import T2 = require("./exportEqualsT");
 
 // OK, has a value side
 export { C } from "./exportValue";
->C : typeof import("/exportValue").C
+>C : typeof CC
 
 // OK, even though the namespace it exports is only types.
 import * as NS from "./exportT";
@@ -29,6 +29,22 @@ export { T as T4 };
 >T : any
 >T4 : any
 
+// Ok, type-only import indicates that the export can be elided.
+import type { T as TT } from "./exportT";
+>T : any
+>TT : number
+
+export { TT };
+>TT : any
+
+// Error, type-only declaration is in a different file.
+import { C as CC } from "./reExportValueAsTypeOnly";
+>C : typeof CC
+>CC : typeof CC
+
+export { CC };
+>CC : typeof CC
+
 === /exportT.ts ===
 export type T = number;
 >T : number
@@ -43,4 +59,8 @@ declare type T = number;
 
 export = T;
 >T : number
+
+=== /reExportValueAsTypeOnly.ts ===
+export type { C } from "./exportValue";
+>C : import("/exportValue").C
 

--- a/tests/cases/compiler/isolatedModulesReExportType.ts
+++ b/tests/cases/compiler/isolatedModulesReExportType.ts
@@ -21,6 +21,9 @@ declare module "baz" {
     export { T } from "foo"; // Also allowed.
 }
 
+// @Filename: /reExportValueAsTypeOnly.ts
+export type { C } from "./exportValue";
+
 // @Filename: /user.ts
 // Error, can't re-export something that's only a type.
 export { T } from "./exportT";
@@ -39,3 +42,11 @@ export type T3 = T;
 // Error, not clear (to an isolated module) whether `T4` is a type.
 import { T } from "./exportT";
 export { T as T4 };
+
+// Ok, type-only import indicates that the export can be elided.
+import type { T as TT } from "./exportT";
+export { TT };
+
+// Error, type-only declaration is in a different file.
+import { C as CC } from "./reExportValueAsTypeOnly";
+export { CC };

--- a/tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_preserve-exact.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_preserve-exact.ts
@@ -1,0 +1,26 @@
+// @importsNotUsedAsValues: preserve-exact
+// @module: esnext
+
+// @Filename: a.ts
+export default {};
+export const b = 0;
+export const c = 1;
+
+// @Filename: b.ts
+import a, { b, c } from "./a";
+
+// @Filename: c.ts
+import * as a from "./a";
+
+// @Filename: d.ts
+export = {};
+
+// @Filename: e.ts
+import D = require("./d");
+import DD = require("./d");
+DD;
+
+// @Filename: f.ts
+import type a from "./a";
+import { b, c } from "./a";
+b;

--- a/tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_preserve-exact_errors.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_preserve-exact_errors.ts
@@ -1,0 +1,46 @@
+// @importsNotUsedAsValues: preserve-exact
+// @module: esnext
+
+// @Filename: a.ts
+export type A = {};
+export type { A as default };
+
+// @Filename: b.ts
+class B {};
+export type { B, B as default };
+
+// @Filename: c.ts
+import DefaultA from "./a";
+import { A } from "./a";
+import DefaultB from "./b";
+import { B } from "./b";
+
+// @Filename: c.fixed.ts
+import type DefaultA from "./a";
+import type { A } from "./a";
+import type DefaultB from "./b";
+import type { B } from "./b";
+
+// @Filename: d.ts
+export { A as AA } from "./a";
+export { B as BB } from "./b";
+
+// @Filename: d.fixed.ts
+export type { A as AA } from "./a";
+export type { B as BB } from "./b";
+
+// @Filename: e.ts
+import { AA, BB } from "./d";
+
+// @Filename: e.fixed.ts
+import type { AA, BB } from "./d";
+
+// @Filename: f.ts
+import type { A } from "./a";
+import type { B } from "./b";
+export { A, B as BB };
+
+// @Filename: f.fixed.ts
+import type { A } from "./a";
+import type { B } from "./b";
+export type { A, B as BB };

--- a/tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_preserve-exact_module.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_preserve-exact_module.ts
@@ -1,0 +1,4 @@
+// @importsNotUsedAsValues: preserve-exact
+// @module: amd,system,commonjs,es2015
+// @noTypesAndSymbols: true
+export {};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #43393 

This adds a new value for `--importsNotUsedAsValues` called `preserve-exact` (name is bikesheddable), which is an emit mode where (non-type-only) imports and exports are never elided or transformed in any way. Every check and diagnostic added simply ensures that your imports and exports are plausibly valid as written at runtime:

* `module` must be set to `es2015` or higher, because asking for them to be converted to another module format and asking for them not to be messed with are obviously incompatible requests
* Types, or values that resolve to type-only imports or exports, must be imported in type-only imports (since preserving an import specifier that doesn't resolve to a runtime export would be a runtime error)
* Types, or values that resolve to type-only imports or exports, that are exported in an export declaration must use a type-only export declaration (an `export` modifier on a type alias or interface declaration is still allowed)

If this PR is merged, a follow-up PR will propose:

* Allowing `import { A, type B } from "./mod"` to make it possible to combine types and values in single import statements under `preserve-exact`
* Adding/editing appropriate code fixes for fixing import/export portability errors
* Updating auto imports to respect the rules of `preserve-exact`

The work is not really complete without these tasks, but I thought splitting it at this point would make  it would make it easier to review, as the code changes at this point are pretty small, but there are some points worth discussing:

* Name of the flag value
* Whether exports should be included in the “exact preservation”—the primary motivation of the emit mode is allowing apparently unused imports to be referenced by code that TypeScript can’t analyze, like Vue/Svelte templates or stringified execution. These concerns don’t apply to exports. However, a secondary effect of the emit mode is that it makes transpilers’ jobs _really easy_ when it comes to determining what needs to be elided—`isolatedModules` ensures that only one file at a time needs to be analyzed, but it still requires some semantic analysis within that file to determine if something is used in an emitting position. With this mode, transpilers could skip that work, for imports, and it seems like it would be convenient to extend that same benefit to exports. That said, it’s not clear how much transpilers really benefit from this convenience anyway, since they’re already set up to elide imports and exports that are not used in emitting positions today, which is presumably not a ton of overhead. (It would be interesting to hear if any Babel, esbuild, or swc folks have opinions on this.)