### PR TITLE
Correct path segment regex

### DIFF
--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -658,7 +658,7 @@ namespace ts {
     //// Path Comparisons
 
     // check path for these segments: '', '.'. '..'
-    const relativePathSegmentRegExp = /(^|\/)\.{0,2}($|\/)/;
+    const relativePathSegmentRegExp = /(?:\/\/)|(?:^|\/)\.\.?(?:$|\/)/;
 
     function comparePathsWorker(a: string, b: string, componentComparer: (a: string, b: string) => Comparison) {
         if (a === b) return Comparison.EqualTo;


### PR DESCRIPTION
The old version incorrectly matched anything with a leading or trailing slash.  The empty segment should only be detected between two slashes.  This made it much less likely that we'd take the fast path, especially on *nix.