### PR TITLE
Kick out of normalizePath if there's nothing to do

### DIFF
--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -552,10 +552,19 @@ namespace ts {
 
     export function normalizePath(path: string): string {
         path = normalizeSlashes(path);
-        path = path.replace(/\/\.\//g, "/");
+        // Most paths don't require normalization
         if (!relativePathSegmentRegExp.test(path)) {
             return path;
         }
+        // Some paths only require cleanup of `/./`
+        const simplified = path.replace(/\/\.\//g, "/");
+        if (simplified !== path) {
+            path = simplified;
+            if (!relativePathSegmentRegExp.test(path)) {
+                return path;
+            }
+        }
+        // Other paths require full normalization
         const normalized = getPathFromPathComponents(reducePathComponents(getPathComponents(path)));
         return normalized && hasTrailingDirectorySeparator(path) ? ensureTrailingDirectorySeparator(normalized) : normalized;
     }

--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -556,8 +556,8 @@ namespace ts {
         if (!relativePathSegmentRegExp.test(path)) {
             return path;
         }
-        // Some paths only require cleanup of `/./`
-        const simplified = path.replace(/\/\.\//g, "/");
+        // Some paths only require cleanup of `/./` or leading `./`
+        const simplified = path.replace(/\/\.\//g, "/").replace(/^\.\//, "");
         if (simplified !== path) {
             path = simplified;
             if (!relativePathSegmentRegExp.test(path)) {

--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -552,6 +552,10 @@ namespace ts {
 
     export function normalizePath(path: string): string {
         path = normalizeSlashes(path);
+        path = path.replace(/\/\.\//g, "/");
+        if (!relativePathSegmentRegExp.test(path)) {
+            return path;
+        }
         const normalized = getPathFromPathComponents(reducePathComponents(getPathComponents(path)));
         return normalized && hasTrailingDirectorySeparator(path) ? ensureTrailingDirectorySeparator(normalized) : normalized;
     }


### PR DESCRIPTION
...using `relativePathSegmentRegExp`.

Bonus: use a regex to handle "/./" to avoid splitting and joining in a common case.

When building the compiler, for example, it looks like ~95% of arguments to `normalizePath` do not require any normalization.