### PR TITLE
Private identifiers use standard identifier scanning

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -2044,18 +2044,7 @@ namespace ts {
                             return token = SyntaxKind.Unknown;
                         }
                         pos++;
-                        if (isIdentifierStart(ch = text.charCodeAt(pos), languageVersion)) {
-                            pos++;
-                            while (pos < end && isIdentifierPart(ch = text.charCodeAt(pos), languageVersion)) pos++;
-                            tokenValue = text.substring(tokenPos, pos);
-                            if (ch === CharacterCodes.backslash) {
-                                tokenValue += scanIdentifierParts();
-                            }
-                        }
-                        else {
-                            tokenValue = "#";
-                            error(Diagnostics.Invalid_character);
-                        }
+                        scanIdentifier(codePointAt(text, pos), languageVersion);
                         return token = SyntaxKind.PrivateIdentifier;
                     default:
                         const identifierKind = scanIdentifier(ch, languageVersion);

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1610,7 +1610,7 @@ namespace ts {
                 if (pos >= end) {
                     return token = SyntaxKind.EndOfFileToken;
                 }
-                let ch = codePointAt(text, pos);
+                const ch = codePointAt(text, pos);
 
                 // Special handling for shebang
                 if (ch === CharacterCodes.hash && pos === 0 && isShebangTrivia(text, pos)) {

--- a/tests/baselines/reference/extendedUnicodePlaneIdentifiers.js
+++ b/tests/baselines/reference/extendedUnicodePlaneIdentifiers.js
@@ -3,6 +3,11 @@ const 𝑚 = 4;
 const 𝑀 = 5;
 console.log(𝑀 + 𝑚); // 9
 
+class K {
+    #𝑚 = 4;
+    #𝑀 = 5;
+}
+
 // lower 8 bits look like 'a'
 const ၡ = 6;
 console.log(ၡ ** ၡ);
@@ -39,9 +44,17 @@ const 𝓮𡚭𓀺ⱱ = "ok";
 
 
 //// [extendedUnicodePlaneIdentifiers.js]
+var _K_𝑚, _K_𝑀;
 const 𝑚 = 4;
 const 𝑀 = 5;
 console.log(𝑀 + 𝑚); // 9
+class K {
+    constructor() {
+        _K_𝑚.set(this, 4);
+        _K_𝑀.set(this, 5);
+    }
+}
+_K_𝑚 = new WeakMap(), _K_𝑀 = new WeakMap();
 // lower 8 bits look like 'a'
 const ၡ = 6;
 console.log(ၡ ** ၡ);

--- a/tests/baselines/reference/extendedUnicodePlaneIdentifiers.symbols
+++ b/tests/baselines/reference/extendedUnicodePlaneIdentifiers.symbols
@@ -12,80 +12,90 @@ console.log(𝑀 + 𝑚); // 9
 >𝑀 : Symbol(𝑀, Decl(extendedUnicodePlaneIdentifiers.ts, 1, 5))
 >𝑚 : Symbol(𝑚, Decl(extendedUnicodePlaneIdentifiers.ts, 0, 5))
 
+class K {
+>K : Symbol(K, Decl(extendedUnicodePlaneIdentifiers.ts, 2, 21))
+
+    #𝑚 = 4;
+>#𝑚 : Symbol(K[#𝑚], Decl(extendedUnicodePlaneIdentifiers.ts, 4, 9))
+
+    #𝑀 = 5;
+>#𝑀 : Symbol(K[#𝑀], Decl(extendedUnicodePlaneIdentifiers.ts, 5, 12))
+}
+
 // lower 8 bits look like 'a'
 const ၡ = 6;
->ၡ : Symbol(ၡ, Decl(extendedUnicodePlaneIdentifiers.ts, 5, 5))
+>ၡ : Symbol(ၡ, Decl(extendedUnicodePlaneIdentifiers.ts, 10, 5))
 
 console.log(ၡ ** ၡ);
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
->ၡ : Symbol(ၡ, Decl(extendedUnicodePlaneIdentifiers.ts, 5, 5))
->ၡ : Symbol(ၡ, Decl(extendedUnicodePlaneIdentifiers.ts, 5, 5))
+>ၡ : Symbol(ၡ, Decl(extendedUnicodePlaneIdentifiers.ts, 10, 5))
+>ၡ : Symbol(ၡ, Decl(extendedUnicodePlaneIdentifiers.ts, 10, 5))
 
 // lower 8 bits aren't a valid unicode character
 const ဒ = 7;
->ဒ : Symbol(ဒ, Decl(extendedUnicodePlaneIdentifiers.ts, 9, 5))
+>ဒ : Symbol(ဒ, Decl(extendedUnicodePlaneIdentifiers.ts, 14, 5))
 
 console.log(ဒ ** ဒ);
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
->ဒ : Symbol(ဒ, Decl(extendedUnicodePlaneIdentifiers.ts, 9, 5))
->ဒ : Symbol(ဒ, Decl(extendedUnicodePlaneIdentifiers.ts, 9, 5))
+>ဒ : Symbol(ဒ, Decl(extendedUnicodePlaneIdentifiers.ts, 14, 5))
+>ဒ : Symbol(ဒ, Decl(extendedUnicodePlaneIdentifiers.ts, 14, 5))
 
 // a mix, for good measure
 const ဒၡ𝑀 = 7;
->ဒၡ𝑀 : Symbol(ဒၡ𝑀, Decl(extendedUnicodePlaneIdentifiers.ts, 13, 5))
+>ဒၡ𝑀 : Symbol(ဒၡ𝑀, Decl(extendedUnicodePlaneIdentifiers.ts, 18, 5))
 
 console.log(ဒၡ𝑀 ** ဒၡ𝑀);
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
->ဒၡ𝑀 : Symbol(ဒၡ𝑀, Decl(extendedUnicodePlaneIdentifiers.ts, 13, 5))
->ဒၡ𝑀 : Symbol(ဒၡ𝑀, Decl(extendedUnicodePlaneIdentifiers.ts, 13, 5))
+>ဒၡ𝑀 : Symbol(ဒၡ𝑀, Decl(extendedUnicodePlaneIdentifiers.ts, 18, 5))
+>ဒၡ𝑀 : Symbol(ဒၡ𝑀, Decl(extendedUnicodePlaneIdentifiers.ts, 18, 5))
 
 const ၡ𝑀ဒ = 7;
->ၡ𝑀ဒ : Symbol(ၡ𝑀ဒ, Decl(extendedUnicodePlaneIdentifiers.ts, 16, 5))
+>ၡ𝑀ဒ : Symbol(ၡ𝑀ဒ, Decl(extendedUnicodePlaneIdentifiers.ts, 21, 5))
 
 console.log(ၡ𝑀ဒ ** ၡ𝑀ဒ);
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
->ၡ𝑀ဒ : Symbol(ၡ𝑀ဒ, Decl(extendedUnicodePlaneIdentifiers.ts, 16, 5))
->ၡ𝑀ဒ : Symbol(ၡ𝑀ဒ, Decl(extendedUnicodePlaneIdentifiers.ts, 16, 5))
+>ၡ𝑀ဒ : Symbol(ၡ𝑀ဒ, Decl(extendedUnicodePlaneIdentifiers.ts, 21, 5))
+>ၡ𝑀ဒ : Symbol(ၡ𝑀ဒ, Decl(extendedUnicodePlaneIdentifiers.ts, 21, 5))
 
 const 𝑀ဒၡ = 7;
->𝑀ဒၡ : Symbol(𝑀ဒၡ, Decl(extendedUnicodePlaneIdentifiers.ts, 19, 5))
+>𝑀ဒၡ : Symbol(𝑀ဒၡ, Decl(extendedUnicodePlaneIdentifiers.ts, 24, 5))
 
 console.log(𝑀ဒၡ ** 𝑀ဒၡ);
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
->𝑀ဒၡ : Symbol(𝑀ဒၡ, Decl(extendedUnicodePlaneIdentifiers.ts, 19, 5))
->𝑀ဒၡ : Symbol(𝑀ဒၡ, Decl(extendedUnicodePlaneIdentifiers.ts, 19, 5))
+>𝑀ဒၡ : Symbol(𝑀ဒၡ, Decl(extendedUnicodePlaneIdentifiers.ts, 24, 5))
+>𝑀ဒၡ : Symbol(𝑀ဒၡ, Decl(extendedUnicodePlaneIdentifiers.ts, 24, 5))
 
 const 𝓱𝓮𝓵𝓵𝓸 = "𝔀𝓸𝓻𝓵𝓭";
->𝓱𝓮𝓵𝓵𝓸 : Symbol(𝓱𝓮𝓵𝓵𝓸, Decl(extendedUnicodePlaneIdentifiers.ts, 22, 5))
+>𝓱𝓮𝓵𝓵𝓸 : Symbol(𝓱𝓮𝓵𝓵𝓸, Decl(extendedUnicodePlaneIdentifiers.ts, 27, 5))
 
 const Ɐⱱ = "ok"; // BMP
->Ɐⱱ : Symbol(Ɐⱱ, Decl(extendedUnicodePlaneIdentifiers.ts, 24, 5))
+>Ɐⱱ : Symbol(Ɐⱱ, Decl(extendedUnicodePlaneIdentifiers.ts, 29, 5))
 
 const 𓀸𓀹𓀺 = "ok"; // SMP
->𓀸𓀹𓀺 : Symbol(𓀸𓀹𓀺, Decl(extendedUnicodePlaneIdentifiers.ts, 26, 5))
+>𓀸𓀹𓀺 : Symbol(𓀸𓀹𓀺, Decl(extendedUnicodePlaneIdentifiers.ts, 31, 5))
 
 const 𡚭𡚮𡚯 = "ok"; // SIP
->𡚭𡚮𡚯 : Symbol(𡚭𡚮𡚯, Decl(extendedUnicodePlaneIdentifiers.ts, 28, 5))
+>𡚭𡚮𡚯 : Symbol(𡚭𡚮𡚯, Decl(extendedUnicodePlaneIdentifiers.ts, 33, 5))
 
 const 𡚭𓀺ⱱ𝓮 = "ok";
->𡚭𓀺ⱱ𝓮 : Symbol(𡚭𓀺ⱱ𝓮, Decl(extendedUnicodePlaneIdentifiers.ts, 30, 5))
+>𡚭𓀺ⱱ𝓮 : Symbol(𡚭𓀺ⱱ𝓮, Decl(extendedUnicodePlaneIdentifiers.ts, 35, 5))
 
 const 𓀺ⱱ𝓮𡚭 = "ok";
->𓀺ⱱ𝓮𡚭 : Symbol(𓀺ⱱ𝓮𡚭, Decl(extendedUnicodePlaneIdentifiers.ts, 32, 5))
+>𓀺ⱱ𝓮𡚭 : Symbol(𓀺ⱱ𝓮𡚭, Decl(extendedUnicodePlaneIdentifiers.ts, 37, 5))
 
 const ⱱ𝓮𡚭𓀺 = "ok";
->ⱱ𝓮𡚭𓀺 : Symbol(ⱱ𝓮𡚭𓀺, Decl(extendedUnicodePlaneIdentifiers.ts, 34, 5))
+>ⱱ𝓮𡚭𓀺 : Symbol(ⱱ𝓮𡚭𓀺, Decl(extendedUnicodePlaneIdentifiers.ts, 39, 5))
 
 const 𝓮𡚭𓀺ⱱ = "ok";
->𝓮𡚭𓀺ⱱ : Symbol(𝓮𡚭𓀺ⱱ, Decl(extendedUnicodePlaneIdentifiers.ts, 36, 5))
+>𝓮𡚭𓀺ⱱ : Symbol(𝓮𡚭𓀺ⱱ, Decl(extendedUnicodePlaneIdentifiers.ts, 41, 5))
 

--- a/tests/baselines/reference/extendedUnicodePlaneIdentifiers.types
+++ b/tests/baselines/reference/extendedUnicodePlaneIdentifiers.types
@@ -16,6 +16,18 @@ console.log(𝑀 + 𝑚); // 9
 >𝑀 : 5
 >𝑚 : 4
 
+class K {
+>K : K
+
+    #𝑚 = 4;
+>#𝑚 : number
+>4 : 4
+
+    #𝑀 = 5;
+>#𝑀 : number
+>5 : 5
+}
+
 // lower 8 bits look like 'a'
 const ၡ = 6;
 >ၡ : 6

--- a/tests/cases/compiler/extendedUnicodePlaneIdentifiers.ts
+++ b/tests/cases/compiler/extendedUnicodePlaneIdentifiers.ts
@@ -3,6 +3,11 @@ const 𝑚 = 4;
 const 𝑀 = 5;
 console.log(𝑀 + 𝑚); // 9
 
+class K {
+    #𝑚 = 4;
+    #𝑀 = 5;
+}
+
 // lower 8 bits look like 'a'
 const ၡ = 6;
 console.log(ၡ ** ၡ);


### PR DESCRIPTION
Previously they used an old copy of the identifier scanning code that didn't handle extended unicode yet. That code was later moved into scanIdentifier and updated to handle extended unicode, so private identifiers should use the same code.

Found by playing around with scanning of private identifiers. 