### PR TITLE
Move class name capture for private state after declaration evaluates

### DIFF
--- a/tests/baselines/reference/privateNameComputedPropertyName4(target=es2015).js
+++ b/tests/baselines/reference/privateNameComputedPropertyName4(target=es2015).js
@@ -1,0 +1,39 @@
+//// [privateNameComputedPropertyName4.ts]
+// https://github.com/microsoft/TypeScript/issues/44113
+class C1 {
+    static #qux = 42;
+    ["bar"] () {}
+}
+class C2 {
+    static #qux = 42;
+    static ["bar"] () {}
+}
+class C3 {
+    static #qux = 42;
+    static ["bar"] = "test";
+}
+
+
+//// [privateNameComputedPropertyName4.js]
+var _a, _C1_qux, _b, _C2_qux, _c, _C3_qux;
+// https://github.com/microsoft/TypeScript/issues/44113
+class C1 {
+    ["bar"]() { }
+}
+_a = C1;
+_C1_qux = { value: 42 };
+class C2 {
+    static ["bar"]() { }
+}
+_b = C2;
+_C2_qux = { value: 42 };
+class C3 {
+}
+_c = C3;
+_C3_qux = { value: 42 };
+Object.defineProperty(C3, "bar", {
+    enumerable: true,
+    configurable: true,
+    writable: true,
+    value: "test"
+});

--- a/tests/baselines/reference/privateNameComputedPropertyName4(target=esnext).js
+++ b/tests/baselines/reference/privateNameComputedPropertyName4(target=esnext).js
@@ -1,0 +1,30 @@
+//// [privateNameComputedPropertyName4.ts]
+// https://github.com/microsoft/TypeScript/issues/44113
+class C1 {
+    static #qux = 42;
+    ["bar"] () {}
+}
+class C2 {
+    static #qux = 42;
+    static ["bar"] () {}
+}
+class C3 {
+    static #qux = 42;
+    static ["bar"] = "test";
+}
+
+
+//// [privateNameComputedPropertyName4.js]
+// https://github.com/microsoft/TypeScript/issues/44113
+class C1 {
+    static #qux = 42;
+    ["bar"]() { }
+}
+class C2 {
+    static #qux = 42;
+    static ["bar"]() { }
+}
+class C3 {
+    static #qux = 42;
+    static ["bar"] = "test";
+}

--- a/tests/cases/conformance/classes/members/privateNames/privateNameComputedPropertyName4.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNameComputedPropertyName4.ts
@@ -1,0 +1,16 @@
+// @target: esnext, es2015
+// @useDefineForClassFields: true
+// @noTypesAndSymbols: true
+// https://github.com/microsoft/TypeScript/issues/44113
+class C1 {
+    static #qux = 42;
+    ["bar"] () {}
+}
+class C2 {
+    static #qux = 42;
+    static ["bar"] () {}
+}
+class C3 {
+    static #qux = 42;
+    static ["bar"] = "test";
+}


### PR DESCRIPTION
Our private field transform inadvertently attempted to capture the class declaration *during* its evaluation when we encountered a computed property name, resulting in a ReferenceError at runtime due to the binding not being initialized.

Fixes #44113

/cc @dragomirtitian, @mkubilayk 