### PR TITLE
Add unqualified JSDoc member references

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -39322,7 +39322,7 @@ namespace ts {
                     }
                     const result = resolveEntityName(name, meaning, /*ignoreErrors*/ false, /*dontResolveAlias*/ !isJSDoc, getHostSignatureFromJSDoc(name));
                     if (!result && isJSDoc) {
-                        const container = findAncestor(name, or(isClassLike, isInterfaceDeclaration, isObjectLiteralExpression, isTypeLiteralNode));
+                        const container = findAncestor(name, or(isClassLike, isInterfaceDeclaration));
                         if (container) {
                             return resolveJSDocMemberName(name, getSymbolOfNode(container));
                         }

--- a/tests/baselines/reference/findAllReferencesLinkTag1.baseline.jsonc
+++ b/tests/baselines/reference/findAllReferencesLinkTag1.baseline.jsonc
@@ -4,8 +4,8 @@
 //     n = 1
 //     static s() { }
 //     /**
-//      * {@link m}
-//      * @see {m}
+//      * {@link [|m|]}
+//      * @see {[|m|]}
 //      * {@link C.[|m|]}
 //      * @see {C.[|m|]}
 //      * {@link C#[|m|]}
@@ -146,6 +146,24 @@
       },
       {
         "textSpan": {
+          "start": 73,
+          "length": 1
+        },
+        "fileName": "/tests/cases/fourslash/findAllReferencesLinkTag1.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      },
+      {
+        "textSpan": {
+          "start": 89,
+          "length": 1
+        },
+        "fileName": "/tests/cases/fourslash/findAllReferencesLinkTag1.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      },
+      {
+        "textSpan": {
           "start": 108,
           "length": 1
         },
@@ -219,8 +237,8 @@
 //      */
 //     p() { }
 //     /**
-//      * {@link n}
-//      * @see {n}
+//      * {@link [|n|]}
+//      * @see {[|n|]}
 //      * {@link C.[|n|]}
 //      * @see {C.[|n|]}
 //      * {@link C#[|n|]}
@@ -342,6 +360,24 @@
       },
       {
         "textSpan": {
+          "start": 265,
+          "length": 1
+        },
+        "fileName": "/tests/cases/fourslash/findAllReferencesLinkTag1.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      },
+      {
+        "textSpan": {
+          "start": 281,
+          "length": 1
+        },
+        "fileName": "/tests/cases/fourslash/findAllReferencesLinkTag1.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      },
+      {
+        "textSpan": {
           "start": 300,
           "length": 1
         },
@@ -426,8 +462,8 @@
 //      */
 //     q() { }
 //     /**
-//      * {@link s}
-//      * @see {s}
+//      * {@link [|s|]}
+//      * @see {[|s|]}
 //      * {@link C.[|s|]}
 //      * @see {C.[|s|]}
 //      */
@@ -546,6 +582,24 @@
       },
       {
         "textSpan": {
+          "start": 457,
+          "length": 1
+        },
+        "fileName": "/tests/cases/fourslash/findAllReferencesLinkTag1.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      },
+      {
+        "textSpan": {
+          "start": 473,
+          "length": 1
+        },
+        "fileName": "/tests/cases/fourslash/findAllReferencesLinkTag1.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      },
+      {
+        "textSpan": {
           "start": 492,
           "length": 1
         },
@@ -606,8 +660,8 @@
 //     [|a|]/*FIND ALL REFS*/()
 //     b: 1
 //     /**
-//      * {@link a}
-//      * @see {a}
+//      * {@link [|a|]}
+//      * @see {[|a|]}
 //      * {@link I.[|a|]}
 //      * @see {I.[|a|]}
 //      * {@link I#[|a|]}
@@ -714,6 +768,24 @@
       },
       {
         "textSpan": {
+          "start": 589,
+          "length": 1
+        },
+        "fileName": "/tests/cases/fourslash/findAllReferencesLinkTag1.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      },
+      {
+        "textSpan": {
+          "start": 605,
+          "length": 1
+        },
+        "fileName": "/tests/cases/fourslash/findAllReferencesLinkTag1.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      },
+      {
+        "textSpan": {
           "start": 624,
           "length": 1
         },
@@ -801,8 +873,8 @@
 //      */
 //     c()
 //     /**
-//      * {@link b}
-//      * @see {b}
+//      * {@link [|b|]}
+//      * @see {[|b|]}
 //      * {@link I.[|b|]}
 //      * @see {I.[|b|]}
 //      */
@@ -889,6 +961,24 @@
         },
         "isWriteAccess": false,
         "isDefinition": true
+      },
+      {
+        "textSpan": {
+          "start": 720,
+          "length": 1
+        },
+        "fileName": "/tests/cases/fourslash/findAllReferencesLinkTag1.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
+      },
+      {
+        "textSpan": {
+          "start": 736,
+          "length": 1
+        },
+        "fileName": "/tests/cases/fourslash/findAllReferencesLinkTag1.ts",
+        "isWriteAccess": false,
+        "isDefinition": false
       },
       {
         "textSpan": {


### PR DESCRIPTION
This allows unqualified references like:

```ts
class Zero {
 /** @param buddy Must be {@link D_HORSE} or {@link D_DOG}. */
 deploy(buddy: number) { }
 static D_HORSE = 1
 static D_DOG = 2
}
```

I surveyed @see and @link again to estimate how common this is. I found a little over 200 uses, which is around 2%. [1] Sorted by frequency, this
*is* the [next feature on the list](https://github.com/microsoft/TypeScript/issues/35524#issuecomment-686698291), along with the `module:` prefix. So I think this is about the right point to stop adding features.

In this case, however, I liked most of the uses -- there were a lot of deprecated functions that referenced a function just below, where it would be wordy to qualify the name, but the reader would benefit from a link.

Note that unqualified references do *not* work inside type or object literals. The code I ended up with is quite complicated and I didn't observe any uses in the wild.

Fixes #43595

[1] The survey code was a hand-written approximation of member resolution, so it probably missed some uses.