### PR TITLE
Implement a two-way mirroring between the wiki and its public repo

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,21 @@
+name: Sync Two Wiki Repos
+
+on: [gollum]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get repo name
+      run: R=${GITHUB_REPOSITORY%?wiki}; echo "BASENAME=${R##*/}" >> $GITHUB_ENV
+    - name: Checkout ${{ env.BASENAME }}-wiki
+      uses: actions/checkout@v2
+      with:
+        repository: "${{ GITHUB.repository_owner }}/${{ env.BASENAME }}-wiki"
+        token: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
+        fetch-depth: 0
+    - name: Run sync
+      run: ./.github/workflows/sync
+      env:
+        PUSHER: typescript-bot <bot@typescriptlang.org>
+        AUTH: ${{ secrets.TS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
> See also the [TS-wiki side](https://github.com/microsoft/TypeScript-wiki/pull/279) of this PR.

Previously, changes to the wiki would get merged to the public repo in a
once-a-week action.  This significantly revises this, making the two
sides be mirrors (up to the few seconds it takes to do a merge).

This is driven by a minimal-ish yaml file in both sides (`TypeScript`
and `TypeScript-wiki`) that *always* works from the script in the public
repo.

The two action specs are nearly identical, but there are some differences:

  - On the main repo, trigger on a `gollum` event, and in the wiki repo
    the usual (pushes, schedule, manual).  (The schedule run is kept as
    a just-in-case, and it's now running twice a week.)
  - The filename is `sync-wiki` on the TS side and just `sync` in the
    wiki.  (Good to avoid confusion if both files somehow find
    themselves in the same neighborhood.)
  - The secret names are different since I used the name that already
    exists in each side.

The script does *not* start with a checkout of its repository.  Doing
this in the TS side would be redundant (it would get the TS tree) and
slow.  Instead, it's always cloning the public wiki repo (`DASHREMOTE`,
since its url is `.../TypeScript-wiki`) and then fetching into it the
repo of the rendered wiki (`DOTREMOTE`, with a `.../TypeScript.wiki`)
url.

Also revised the README, since they should always be mirrored with this
change, and therefore there is no "source of truth".

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
