### PR TITLE
fix(44249): JSX: "extract to constant" generates invalid code when using fragment syntax

### DIFF
--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -2002,6 +2002,6 @@ namespace ts.refactor.extractSymbol {
     }
 
     function isInJSXContent(node: Node) {
-        return (isJsxElement(node) || isJsxSelfClosingElement(node) || isJsxFragment(node)) && isJsxElement(node.parent);
+        return (isJsxElement(node) || isJsxSelfClosingElement(node) || isJsxFragment(node)) && (isJsxElement(node.parent) || isJsxFragment(node.parent));
     }
 }

--- a/tests/cases/fourslash/extract-const_insideJsxFragment1.ts
+++ b/tests/cases/fourslash/extract-const_insideJsxFragment1.ts
@@ -1,0 +1,28 @@
+/// <reference path='fourslash.ts' />
+
+// @jsx: preserve
+// @filename: a.tsx
+////function Foo() {
+////    return (
+////        <>
+////            /*a*/<span></span>/*b*/
+////        </>
+////    );
+////}
+
+goTo.file("a.tsx");
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_1",
+    actionDescription: "Extract to constant in global scope",
+    newContent:
+`const /*RENAME*/newLocal = <span></span>;
+function Foo() {
+    return (
+        <>
+            {newLocal}
+        </>
+    );
+}`
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/44249

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
