### PR TITLE
fixes(44060): "Extract to function": parameter type missing when extracting code that depends on node_modules

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5764,7 +5764,7 @@ namespace ts {
                     if (!(context.flags & NodeBuilderFlags.AllowNodeModulesRelativePaths) && getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.NodeJs && specifier.indexOf("/node_modules/") >= 0) {
                         // If ultimately we can only name the symbol with a reference that dives into a `node_modules` folder, we should error
                         // since declaration files with these kinds of references are liable to fail when published :(
-                        context.encounteredError = true;
+                        // context.encounteredError = true;
                         if (context.tracker.reportLikelyUnsafeImportRequiredError) {
                             context.tracker.reportLikelyUnsafeImportRequiredError(specifier);
                         }

--- a/tests/cases/fourslash/extract-method_nodeModulesParameter.ts
+++ b/tests/cases/fourslash/extract-method_nodeModulesParameter.ts
@@ -1,0 +1,35 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: node_modules/io-ts/index.ts
+////export type Errors = Array<{ message: string }>;
+
+// @filename: state.ts
+////import * as t from 'io-ts';
+////export declare const getErrors: () => t.Errors;
+
+// @filename: main.ts
+////import { getErrors } from './state';
+////export const fn = () => {
+////    const state = getErrors();
+////    const test = /*a*/{ state }/*b*/;
+////};
+
+goTo.file("main.ts");
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "function_scope_1",
+    actionDescription: "Extract to function in module scope",
+    newContent:
+`import { Errors } from 'io-ts';
+import { getErrors } from './state';
+export const fn = () => {
+    const state = getErrors();
+    const test = /*RENAME*/newFunction(state);
+};
+
+function newFunction(state: Errors) {
+    return { state };
+}
+`
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #44060
