### PR TITLE
Ensure AutoImportProviderProject can share source files with main program

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7957,9 +7957,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.13.7",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.7.tgz",
-            "integrity": "sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA==",
+            "version": "3.13.8",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
+            "integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
             "dev": true,
             "optional": true
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7957,9 +7957,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.13.8",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
-            "integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
+            "version": "3.13.7",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.7.tgz",
+            "integrity": "sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA==",
             "dev": true,
             "optional": true
         },

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -879,7 +879,13 @@ namespace FourSlash {
                     nameToEntries.set(entry.name, [entry]);
                 }
                 else {
-                    if (entries.some(e => e.source === entry.source && this.deepEqual(e.data, entry.data))) {
+                    if (entries.some(e =>
+                        e.source === entry.source &&
+                        e.data?.exportName === entry.data?.exportName &&
+                        e.data?.fileName === entry.data?.fileName &&
+                        e.data?.moduleSpecifier === entry.data?.moduleSpecifier &&
+                        e.data?.ambientModuleName === entry.data?.ambientModuleName
+                    )) {
                         this.raiseError(`Duplicate completions for ${entry.name}`);
                     }
                     entries.push(entry);
@@ -1278,16 +1284,6 @@ namespace FourSlash {
             }
             recur(fullActual, fullExpected, "");
 
-        }
-
-        private deepEqual(a: unknown, b: unknown) {
-            try {
-                this.assertObjectsEqual(a, b);
-                return true;
-            }
-            catch {
-                return false;
-            }
         }
 
         public verifyDisplayPartsOfReferencedSymbol(expected: ts.SymbolDisplayPart[]) {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1929,10 +1929,13 @@ namespace ts.server {
         }
 
         /*@internal*/
-        static readonly compilerOptionsOverrides = {
+        static readonly compilerOptionsOverrides: CompilerOptions = {
             diagnostics: false,
             skipLibCheck: true,
             sourceMap: false,
+            types: ts.emptyArray,
+            lib: ts.emptyArray,
+            noLib: true,
         };
 
         /*@internal*/
@@ -1941,7 +1944,7 @@ namespace ts.server {
                 return undefined;
             }
 
-            const compilerOptions: CompilerOptions = {
+            const compilerOptions = {
                 ...hostProject.getCompilerOptions(),
                 ...this.compilerOptionsOverrides,
             };

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1929,6 +1929,13 @@ namespace ts.server {
         }
 
         /*@internal*/
+        static readonly compilerOptionsOverrides = {
+            diagnostics: false,
+            skipLibCheck: true,
+            sourceMap: false,
+        };
+
+        /*@internal*/
         static create(dependencySelection: PackageJsonAutoImportPreference, hostProject: Project, moduleResolutionHost: ModuleResolutionHost, documentRegistry: DocumentRegistry): AutoImportProviderProject | undefined {
             if (dependencySelection === PackageJsonAutoImportPreference.Off) {
                 return undefined;
@@ -1936,12 +1943,7 @@ namespace ts.server {
 
             const compilerOptions: CompilerOptions = {
                 ...hostProject.getCompilerOptions(),
-                noLib: true,
-                diagnostics: false,
-                skipLibCheck: true,
-                types: ts.emptyArray,
-                lib: ts.emptyArray,
-                sourceMap: false,
+                ...this.compilerOptionsOverrides,
             };
 
             const rootNames = this.getRootFileNames(dependencySelection, hostProject, moduleResolutionHost, compilerOptions);

--- a/src/testRunner/unittests/tsserver/autoImportProvider.ts
+++ b/src/testRunner/unittests/tsserver/autoImportProvider.ts
@@ -302,6 +302,15 @@ namespace ts.projectSystem {
             assert.isDefined(projectService.configuredProjects.get("/packages/a/tsconfig.json")!.getPackageJsonAutoImportProvider());
             assert.isDefined(projectService.configuredProjects.get("/packages/a/tsconfig.json")!.getPackageJsonAutoImportProvider());
         });
+
+        it("Can use the same document registry bucket key as main program", () => {
+            for (const option of sourceFileAffectingCompilerOptions) {
+                assert(
+                    !hasProperty(server.AutoImportProviderProject.compilerOptionsOverrides, option.name),
+                    `'${option.name}' may cause AutoImportProviderProject not to share source files with main program`
+                );
+            }
+        });
     });
 
     function setup(files: File[]) {

--- a/tests/cases/fourslash/server/autoImportProvider6.ts
+++ b/tests/cases/fourslash/server/autoImportProvider6.ts
@@ -1,0 +1,36 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// { "compilerOptions": { "module": "commonjs", "lib": ["es2019"] } }
+
+// @Filename: /package.json
+//// { "dependencies": { "antd": "*", "react": "*" } }
+
+// @Filename: /node_modules/@types/react/index.d.ts
+//// export declare function Component(): void;
+
+// @Filename: /node_modules/antd/index.d.ts
+//// import "react";
+
+// @Filename: /index.ts
+//// Component/**/
+
+// react/index.d.ts will be in both the auto import provider program
+// and the main program, and will result in duplicate completions
+// unless the two programs successfully share the same source file.
+// This tests the configuration of the AutoImportProviderProject.
+// See also the 'Can use the same document registry bucket key as main program'
+// unit test in autoImportProvider.ts.
+goTo.marker("");
+verify.completions({
+  marker: "",
+  includes: [{
+    name: "Component",
+    hasAction: true,
+    source: "/node_modules/@types/react/index",
+    sortText: completion.SortText.AutoImportSuggestions,
+  }],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+  },
+});


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes a duplicate auto-import completions bug I noticed while working on #44295, caused by differing compiler options causing the AutoImportProviderProject not to share source files with its host Project.

It looks like those options (`types`, `lib`, and `noLib`) are actually misclassified as affecting module resolution, and @sheetalkamat is opening a PR to fix that (extracting work from #41004). Once that’s fixed, the bug will be fixed, and I can revert the part of this PR that is actually a substantive behavior change. The primary value of this PR is structuring the config in such a way that the overriding options can be tested against `sourceFileAffectingCompilerOptions` and adding that test.
