### PR TITLE
Tighter types for Object.keys/values/entries

### DIFF
--- a/src/lib/es2017.object.d.ts
+++ b/src/lib/es2017.object.d.ts
@@ -3,25 +3,25 @@ interface ObjectConstructor {
      * Returns an array of values of the enumerable properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
-    values<T>(o: { [s: string]: T } | ArrayLike<T>): T[];
+    values<T>(a: ArrayLike<T>): T[];
 
     /**
      * Returns an array of values of the enumerable properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
-    values(o: {}): any[];
+    values<T extends {}>(o: T): T[keyof T][];
 
     /**
      * Returns an array of key/values of the enumerable properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
-    entries<T>(o: { [s: string]: T } | ArrayLike<T>): [string, T][];
+    entries<T>(a: ArrayLike<T>): [string, T][];
 
     /**
      * Returns an array of key/values of the enumerable properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
-    entries(o: {}): [string, any][];
+    entries<T extends {}, K extends keyof T>(o: T): [K, T[K]][];
 
     /**
      * Returns an object containing all own property descriptors of an object

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -238,7 +238,7 @@ interface ObjectConstructor {
      * Returns the names of the enumerable string properties and methods of an object.
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
-    keys(o: object): string[];
+    keys<T extends object>(o: T): (keyof T)[];
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
