### PR TITLE
fix(44273): preserves 'override' modifier in JavaScript output

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -368,6 +368,7 @@ namespace ts {
                 case SyntaxKind.PrivateKeyword:
                 case SyntaxKind.ProtectedKeyword:
                 case SyntaxKind.AbstractKeyword:
+                case SyntaxKind.OverrideKeyword:
                 case SyntaxKind.ConstKeyword:
                 case SyntaxKind.DeclareKeyword:
                 case SyntaxKind.ReadonlyKeyword:

--- a/tests/baselines/reference/override16(target=es2015).js
+++ b/tests/baselines/reference/override16(target=es2015).js
@@ -1,0 +1,19 @@
+//// [override16.ts]
+class A {
+    foo?: string;
+}
+
+class B extends A {
+    override foo = "string";
+}
+
+
+//// [override16.js]
+class A {
+}
+class B extends A {
+    constructor() {
+        super(...arguments);
+        this.foo = "string";
+    }
+}

--- a/tests/baselines/reference/override16(target=es2015).symbols
+++ b/tests/baselines/reference/override16(target=es2015).symbols
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/override/override16.ts ===
+class A {
+>A : Symbol(A, Decl(override16.ts, 0, 0))
+
+    foo?: string;
+>foo : Symbol(A.foo, Decl(override16.ts, 0, 9))
+}
+
+class B extends A {
+>B : Symbol(B, Decl(override16.ts, 2, 1))
+>A : Symbol(A, Decl(override16.ts, 0, 0))
+
+    override foo = "string";
+>foo : Symbol(B.foo, Decl(override16.ts, 4, 19))
+}
+

--- a/tests/baselines/reference/override16(target=es2015).types
+++ b/tests/baselines/reference/override16(target=es2015).types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/override/override16.ts ===
+class A {
+>A : A
+
+    foo?: string;
+>foo : string
+}
+
+class B extends A {
+>B : B
+>A : A
+
+    override foo = "string";
+>foo : string
+>"string" : "string"
+}
+

--- a/tests/baselines/reference/override16(target=esnext).js
+++ b/tests/baselines/reference/override16(target=esnext).js
@@ -1,0 +1,17 @@
+//// [override16.ts]
+class A {
+    foo?: string;
+}
+
+class B extends A {
+    override foo = "string";
+}
+
+
+//// [override16.js]
+class A {
+    foo;
+}
+class B extends A {
+    foo = "string";
+}

--- a/tests/baselines/reference/override16(target=esnext).symbols
+++ b/tests/baselines/reference/override16(target=esnext).symbols
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/override/override16.ts ===
+class A {
+>A : Symbol(A, Decl(override16.ts, 0, 0))
+
+    foo?: string;
+>foo : Symbol(A.foo, Decl(override16.ts, 0, 9))
+}
+
+class B extends A {
+>B : Symbol(B, Decl(override16.ts, 2, 1))
+>A : Symbol(A, Decl(override16.ts, 0, 0))
+
+    override foo = "string";
+>foo : Symbol(B.foo, Decl(override16.ts, 4, 19))
+}
+

--- a/tests/baselines/reference/override16(target=esnext).types
+++ b/tests/baselines/reference/override16(target=esnext).types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/override/override16.ts ===
+class A {
+>A : A
+
+    foo?: string;
+>foo : string
+}
+
+class B extends A {
+>B : B
+>A : A
+
+    override foo = "string";
+>foo : string
+>"string" : "string"
+}
+

--- a/tests/baselines/reference/override16.js
+++ b/tests/baselines/reference/override16.js
@@ -1,0 +1,17 @@
+//// [override16.ts]
+class A {
+    foo?: string;
+}
+
+class B extends A {
+    override foo = "string";
+}
+
+
+//// [override16.js]
+class A {
+    foo;
+}
+class B extends A {
+    foo = "string";
+}

--- a/tests/baselines/reference/override16.symbols
+++ b/tests/baselines/reference/override16.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/override/override16.ts ===
+class A {
+>A : Symbol(A, Decl(override16.ts, 0, 0))
+
+    foo?: string;
+>foo : Symbol(A.foo, Decl(override16.ts, 0, 9))
+}
+
+class B extends A {
+>B : Symbol(B, Decl(override16.ts, 2, 1))
+>A : Symbol(A, Decl(override16.ts, 0, 0))
+
+    override foo = "string";
+>foo : Symbol(B.foo, Decl(override16.ts, 4, 19))
+}
+

--- a/tests/baselines/reference/override16.types
+++ b/tests/baselines/reference/override16.types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/override/override16.ts ===
+class A {
+>A : A
+
+    foo?: string;
+>foo : string
+}
+
+class B extends A {
+>B : B
+>A : A
+
+    override foo = "string";
+>foo : string
+>"string" : "string"
+}
+

--- a/tests/baselines/reference/override17(target=es2015).js
+++ b/tests/baselines/reference/override17(target=es2015).js
@@ -1,0 +1,45 @@
+//// [override17.ts]
+class A {
+    public m1(): number {
+        return 0;
+    }
+
+    public m2(): number {
+        return 0;
+    }
+
+    public m3(): void {}
+}
+
+class B extends A {
+    override m1() {
+        return 10;
+    }
+
+    override m2(): number {
+        return 30;
+    }
+
+    override m3(): void {}
+}
+
+
+//// [override17.js]
+class A {
+    m1() {
+        return 0;
+    }
+    m2() {
+        return 0;
+    }
+    m3() { }
+}
+class B extends A {
+    m1() {
+        return 10;
+    }
+    m2() {
+        return 30;
+    }
+    m3() { }
+}

--- a/tests/baselines/reference/override17(target=es2015).symbols
+++ b/tests/baselines/reference/override17(target=es2015).symbols
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/override/override17.ts ===
+class A {
+>A : Symbol(A, Decl(override17.ts, 0, 0))
+
+    public m1(): number {
+>m1 : Symbol(A.m1, Decl(override17.ts, 0, 9))
+
+        return 0;
+    }
+
+    public m2(): number {
+>m2 : Symbol(A.m2, Decl(override17.ts, 3, 5))
+
+        return 0;
+    }
+
+    public m3(): void {}
+>m3 : Symbol(A.m3, Decl(override17.ts, 7, 5))
+}
+
+class B extends A {
+>B : Symbol(B, Decl(override17.ts, 10, 1))
+>A : Symbol(A, Decl(override17.ts, 0, 0))
+
+    override m1() {
+>m1 : Symbol(B.m1, Decl(override17.ts, 12, 19))
+
+        return 10;
+    }
+
+    override m2(): number {
+>m2 : Symbol(B.m2, Decl(override17.ts, 15, 5))
+
+        return 30;
+    }
+
+    override m3(): void {}
+>m3 : Symbol(B.m3, Decl(override17.ts, 19, 5))
+}
+

--- a/tests/baselines/reference/override17(target=es2015).types
+++ b/tests/baselines/reference/override17(target=es2015).types
@@ -1,0 +1,44 @@
+=== tests/cases/conformance/override/override17.ts ===
+class A {
+>A : A
+
+    public m1(): number {
+>m1 : () => number
+
+        return 0;
+>0 : 0
+    }
+
+    public m2(): number {
+>m2 : () => number
+
+        return 0;
+>0 : 0
+    }
+
+    public m3(): void {}
+>m3 : () => void
+}
+
+class B extends A {
+>B : B
+>A : A
+
+    override m1() {
+>m1 : () => number
+
+        return 10;
+>10 : 10
+    }
+
+    override m2(): number {
+>m2 : () => number
+
+        return 30;
+>30 : 30
+    }
+
+    override m3(): void {}
+>m3 : () => void
+}
+

--- a/tests/baselines/reference/override17(target=esnext).js
+++ b/tests/baselines/reference/override17(target=esnext).js
@@ -1,0 +1,45 @@
+//// [override17.ts]
+class A {
+    public m1(): number {
+        return 0;
+    }
+
+    public m2(): number {
+        return 0;
+    }
+
+    public m3(): void {}
+}
+
+class B extends A {
+    override m1() {
+        return 10;
+    }
+
+    override m2(): number {
+        return 30;
+    }
+
+    override m3(): void {}
+}
+
+
+//// [override17.js]
+class A {
+    m1() {
+        return 0;
+    }
+    m2() {
+        return 0;
+    }
+    m3() { }
+}
+class B extends A {
+    m1() {
+        return 10;
+    }
+    m2() {
+        return 30;
+    }
+    m3() { }
+}

--- a/tests/baselines/reference/override17(target=esnext).symbols
+++ b/tests/baselines/reference/override17(target=esnext).symbols
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/override/override17.ts ===
+class A {
+>A : Symbol(A, Decl(override17.ts, 0, 0))
+
+    public m1(): number {
+>m1 : Symbol(A.m1, Decl(override17.ts, 0, 9))
+
+        return 0;
+    }
+
+    public m2(): number {
+>m2 : Symbol(A.m2, Decl(override17.ts, 3, 5))
+
+        return 0;
+    }
+
+    public m3(): void {}
+>m3 : Symbol(A.m3, Decl(override17.ts, 7, 5))
+}
+
+class B extends A {
+>B : Symbol(B, Decl(override17.ts, 10, 1))
+>A : Symbol(A, Decl(override17.ts, 0, 0))
+
+    override m1() {
+>m1 : Symbol(B.m1, Decl(override17.ts, 12, 19))
+
+        return 10;
+    }
+
+    override m2(): number {
+>m2 : Symbol(B.m2, Decl(override17.ts, 15, 5))
+
+        return 30;
+    }
+
+    override m3(): void {}
+>m3 : Symbol(B.m3, Decl(override17.ts, 19, 5))
+}
+

--- a/tests/baselines/reference/override17(target=esnext).types
+++ b/tests/baselines/reference/override17(target=esnext).types
@@ -1,0 +1,44 @@
+=== tests/cases/conformance/override/override17.ts ===
+class A {
+>A : A
+
+    public m1(): number {
+>m1 : () => number
+
+        return 0;
+>0 : 0
+    }
+
+    public m2(): number {
+>m2 : () => number
+
+        return 0;
+>0 : 0
+    }
+
+    public m3(): void {}
+>m3 : () => void
+}
+
+class B extends A {
+>B : B
+>A : A
+
+    override m1() {
+>m1 : () => number
+
+        return 10;
+>10 : 10
+    }
+
+    override m2(): number {
+>m2 : () => number
+
+        return 30;
+>30 : 30
+    }
+
+    override m3(): void {}
+>m3 : () => void
+}
+

--- a/tests/baselines/reference/override18(target=es2015).js
+++ b/tests/baselines/reference/override18(target=es2015).js
@@ -1,0 +1,32 @@
+//// [override18.ts]
+class A {
+    foo?: string;
+}
+
+class B extends A {
+    override foo = "string";
+}
+
+
+//// [override18.js]
+class A {
+    constructor() {
+        Object.defineProperty(this, "foo", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
+    }
+}
+class B extends A {
+    constructor() {
+        super(...arguments);
+        Object.defineProperty(this, "foo", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: "string"
+        });
+    }
+}

--- a/tests/baselines/reference/override18(target=es2015).symbols
+++ b/tests/baselines/reference/override18(target=es2015).symbols
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/override/override18.ts ===
+class A {
+>A : Symbol(A, Decl(override18.ts, 0, 0))
+
+    foo?: string;
+>foo : Symbol(A.foo, Decl(override18.ts, 0, 9))
+}
+
+class B extends A {
+>B : Symbol(B, Decl(override18.ts, 2, 1))
+>A : Symbol(A, Decl(override18.ts, 0, 0))
+
+    override foo = "string";
+>foo : Symbol(B.foo, Decl(override18.ts, 4, 19))
+}
+

--- a/tests/baselines/reference/override18(target=es2015).types
+++ b/tests/baselines/reference/override18(target=es2015).types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/override/override18.ts ===
+class A {
+>A : A
+
+    foo?: string;
+>foo : string
+}
+
+class B extends A {
+>B : B
+>A : A
+
+    override foo = "string";
+>foo : string
+>"string" : "string"
+}
+

--- a/tests/baselines/reference/override18(target=esnext).js
+++ b/tests/baselines/reference/override18(target=esnext).js
@@ -1,0 +1,17 @@
+//// [override18.ts]
+class A {
+    foo?: string;
+}
+
+class B extends A {
+    override foo = "string";
+}
+
+
+//// [override18.js]
+class A {
+    foo;
+}
+class B extends A {
+    foo = "string";
+}

--- a/tests/baselines/reference/override18(target=esnext).symbols
+++ b/tests/baselines/reference/override18(target=esnext).symbols
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/override/override18.ts ===
+class A {
+>A : Symbol(A, Decl(override18.ts, 0, 0))
+
+    foo?: string;
+>foo : Symbol(A.foo, Decl(override18.ts, 0, 9))
+}
+
+class B extends A {
+>B : Symbol(B, Decl(override18.ts, 2, 1))
+>A : Symbol(A, Decl(override18.ts, 0, 0))
+
+    override foo = "string";
+>foo : Symbol(B.foo, Decl(override18.ts, 4, 19))
+}
+

--- a/tests/baselines/reference/override18(target=esnext).types
+++ b/tests/baselines/reference/override18(target=esnext).types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/override/override18.ts ===
+class A {
+>A : A
+
+    foo?: string;
+>foo : string
+}
+
+class B extends A {
+>B : B
+>A : A
+
+    override foo = "string";
+>foo : string
+>"string" : "string"
+}
+

--- a/tests/cases/conformance/override/override16.ts
+++ b/tests/cases/conformance/override/override16.ts
@@ -1,0 +1,10 @@
+// @target: esnext,es2015
+// @noImplicitOverride: true
+
+class A {
+    foo?: string;
+}
+
+class B extends A {
+    override foo = "string";
+}

--- a/tests/cases/conformance/override/override17.ts
+++ b/tests/cases/conformance/override/override17.ts
@@ -1,0 +1,27 @@
+// @noImplicitOverride: true
+// @useDefineForClassFields: true
+// @target: es2015,esnext
+
+class A {
+    public m1(): number {
+        return 0;
+    }
+
+    public m2(): number {
+        return 0;
+    }
+
+    public m3(): void {}
+}
+
+class B extends A {
+    override m1() {
+        return 10;
+    }
+
+    override m2(): number {
+        return 30;
+    }
+
+    override m3(): void {}
+}

--- a/tests/cases/conformance/override/override18.ts
+++ b/tests/cases/conformance/override/override18.ts
@@ -1,0 +1,11 @@
+// @target: esnext,es2015
+// @noImplicitOverride: true
+// @useDefineForClassFields: true
+
+class A {
+    foo?: string;
+}
+
+class B extends A {
+    override foo = "string";
+}


### PR DESCRIPTION
Fixes #44273