### PR TITLE
Move string trim methods from utilities to core

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2311,4 +2311,34 @@ namespace ts {
         }
         return array.slice(0, index);
     }
+
+    /**
+     * Removes the leading and trailing white space and line terminator characters from a string.
+     */
+    export const trimString = !!String.prototype.trim ? ((s: string) => s.trim()) : (s: string) => trimStringEnd(trimStringStart(s));
+
+    /**
+     * Returns a copy with trailing whitespace removed.
+     */
+    export const trimStringEnd = !!String.prototype.trimEnd ? ((s: string) => s.trimEnd()) : trimEndImpl;
+
+    /**
+     * Returns a copy with leading whitespace removed.
+     */
+    export const trimStringStart = !!String.prototype.trimStart ? ((s: string) => s.trimStart()) : (s: string) => s.replace(/^\s+/g, "");
+
+    /**
+     * https://jsbench.me/gjkoxld4au/1
+     * The simple regex for this, /\s+$/g is O(n^2) in v8.
+     * The native .trimEnd method is by far best, but since that's technically ES2019,
+     * we provide a (still much faster than the simple regex) fallback.
+     */
+    function trimEndImpl(s: string) {
+        let end = s.length - 1;
+        while (end >= 0) {
+            if (!isWhiteSpaceLike(s.charCodeAt(end))) break;
+            end--;
+        }
+        return s.slice(0, end + 1);
+    }
 }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -531,37 +531,6 @@ namespace ts {
         return text;
     }
 
-    /**
-     * Removes the leading and trailing white space and line terminator characters from a string.
-     */
-    export const trimString = !!String.prototype.trim ? ((s: string) => s.trim()) : (s: string) => trimStringEnd(trimStringStart(s));
-
-    /**
-     * Returns a copy with trailing whitespace removed.
-     */
-    export const trimStringEnd = !!String.prototype.trimEnd ? ((s: string) => s.trimEnd()) : trimEndImpl;
-
-
-    /**
-     * Returns a copy with leading whitespace removed.
-     */
-     export const trimStringStart = !!String.prototype.trimStart ? ((s: string) => s.trimStart()) : (s: string) => s.replace(/^\s+/g, "");
-
-    /**
-     * https://jsbench.me/gjkoxld4au/1
-     * The simple regex for this, /\s+$/g is O(n^2) in v8.
-     * The native .trimEnd method is by far best, but since that's technically ES2019,
-     * we provide a (still much faster than the simple regex) fallback.
-     */
-    function trimEndImpl(s: string) {
-        let end = s.length - 1;
-        while (end >= 0) {
-            if (!isWhiteSpaceLike(s.charCodeAt(end))) break;
-            end--;
-        }
-        return s.slice(0, end + 1);
-    }
-
     export function getTextOfNode(node: Node, includeTrivia = false): string {
         return getSourceTextOfNodeFromSourceFile(getSourceFileOfNode(node), node, includeTrivia);
     }


### PR DESCRIPTION
Fixes a build ordering issue on some versions of `node` (`performance` implicitly relies on `semver` which implicitly relies on these `trim` methods).
